### PR TITLE
Use basic auth on Heroku

### DIFF
--- a/app.json
+++ b/app.json
@@ -9,7 +9,14 @@
     },
     "GOVUK_APP_DOMAIN": {
       "required": true
-    }
+    },
+    "BASIC_AUTH_USERNAME": {
+      "required": true
+    },
+    "BASIC_AUTH_PASSWORD": {
+      "required": true
+    },
+    "REQUIRE_BASIC_AUTH": "true"
   },
   "addons": [
     "heroku-postgresql"

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -3,7 +3,7 @@
 class ApplicationController < ActionController::Base
   include GDS::SSO::ControllerMethods
 
-  if ENV["REQUIRE_BASIC_AUTH"]
+  if ENV["BASIC_AUTH_USERNAME"]
     http_basic_authenticate_with(
       name: ENV.fetch("BASIC_AUTH_USERNAME"),
       password: ENV.fetch("BASIC_AUTH_PASSWORD")

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -3,5 +3,12 @@
 class ApplicationController < ActionController::Base
   include GDS::SSO::ControllerMethods
 
+  if ENV["REQUIRE_BASIC_AUTH"]
+    http_basic_authenticate_with(
+      name: ENV.fetch("BASIC_AUTH_USERNAME"),
+      password: ENV.fetch("BASIC_AUTH_PASSWORD")
+    )
+  end
+
   before_action :authenticate_user!
 end


### PR DESCRIPTION
This prevents confusion for users and prevents search engines from indexing the pages.

https://trello.com/c/CPWJzL9y