### PR TITLE
Fix signon dashboard link for user

### DIFF
--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -3,7 +3,7 @@
   <%= render "govuk_publishing_components/components/layout_header", {
     environment: ENV["ERRBIT_ENVIRONMENT_NAME"] || "development",
     navigation_items: [
-      { text: current_user.name },
+      { text: current_user.name, href: Plek.new.external_url_for("signon") },
       { text: "Log out", href: gds_sign_out_path }
     ]
   }%>


### PR DESCRIPTION
In other apps, it's conventional to be taken back to Signon when you
click on the user name in the navigation bar (unless we've got something
better).