### PR TITLE
Create the choose a format page

### DIFF
--- a/app/controllers/documents_controller.rb
+++ b/app/controllers/documents_controller.rb
@@ -5,16 +5,6 @@ class DocumentsController < ApplicationController
     @documents = Document.all
   end
 
-  def create
-    document = Document.create!(
-      content_id: SecureRandom.uuid,
-      locale: "en",
-      document_type: params[:document_type],
-    )
-
-    redirect_to edit_document_path(document)
-  end
-
   def edit
     @document = Document.find(params[:id])
   end

--- a/app/controllers/documents_controller.rb
+++ b/app/controllers/documents_controller.rb
@@ -5,8 +5,6 @@ class DocumentsController < ApplicationController
     @documents = Document.all
   end
 
-  def choose_format; end
-
   def create
     document = Document.create!(
       content_id: SecureRandom.uuid,

--- a/app/controllers/new_document_controller.rb
+++ b/app/controllers/new_document_controller.rb
@@ -10,6 +10,13 @@ class NewDocumentController < ApplicationController
   end
 
   def create
+    document_type_schema = YAML.load_file("app/formats/document_types.yml").find { |s| s["document_type"] == params[:document_type] }
+
+    if document_type_schema["managed_elsewhere"]
+      redirect_to document_type_schema["managed_elsewhere"]
+      return
+    end
+
     document = Document.create!(
       content_id: SecureRandom.uuid,
       locale: "en",

--- a/app/controllers/new_document_controller.rb
+++ b/app/controllers/new_document_controller.rb
@@ -1,0 +1,11 @@
+# frozen_string_literal: true
+
+class NewDocumentController < ApplicationController
+  def choose_supertype
+    @supertypes = YAML.load_file("app/formats/supertypes.yml")
+  end
+
+  def choose_document_type
+    @document_types = YAML.load_file("app/formats/document_types.yml").select { |s| s["supertype"] == params[:supertype] }
+  end
+end

--- a/app/controllers/new_document_controller.rb
+++ b/app/controllers/new_document_controller.rb
@@ -8,4 +8,14 @@ class NewDocumentController < ApplicationController
   def choose_document_type
     @document_types = YAML.load_file("app/formats/document_types.yml").select { |s| s["supertype"] == params[:supertype] }
   end
+
+  def create
+    document = Document.create!(
+      content_id: SecureRandom.uuid,
+      locale: "en",
+      document_type: params[:document_type],
+    )
+
+    redirect_to edit_document_path(document)
+  end
 end

--- a/app/formats/document_types.yml
+++ b/app/formats/document_types.yml
@@ -1,0 +1,24 @@
+---
+- document_type: press_release
+  name: Press release
+  supertype: news
+
+- document_type: news_article
+  name: News article
+  supertype: news
+
+- document_type: statistical_data_set
+  name: Statistical data set
+  supertype: transparancy
+
+- document_type: publication
+  name: Publication
+  supertype: news
+
+- document_type: detailed_guides
+  name: Detailed guides
+  supertype: guidance
+
+- document_type: consultation
+  name: Consultation
+  supertype: consultations

--- a/app/formats/document_types.yml
+++ b/app/formats/document_types.yml
@@ -20,5 +20,6 @@
   supertype: guidance
 
 - document_type: consultation
-  name: Consultation
+  name: Consultation (managed elsewhere)
   supertype: consultations
+  managed_elsewhere: https://whitehall-admin.publishing.service.gov.uk/government/admin/consultations/new

--- a/app/formats/supertypes.yml
+++ b/app/formats/supertypes.yml
@@ -1,0 +1,26 @@
+---
+- id: news
+  label: News
+  description: To tell users about something that government has done or will do.
+
+- id: transparancy
+  label: Transparancy
+  description: To provide information that helps users hold government to account.
+
+- id: guidance
+  label: Guidance
+  description: To help users do something or understand what they need to do.
+
+- id: policy
+  label: Policy
+  description: To explain the government's position on something.
+
+- id: consultations
+  label: Consultations
+  description: To request users views or evidence on an issue and to build collective
+    agreement.
+
+- id: not-sure
+  label: I'm not sure this should be on GOV.UK
+  description: To request users views or evidence on an issue and to build collective
+    agreement.

--- a/app/views/documents/choose_format.html.erb
+++ b/app/views/documents/choose_format.html.erb
@@ -1,1 +1,0 @@
-<%= button_to "Create news article", create_document_path(document_type: "news_article") %>

--- a/app/views/documents/edit.html.erb
+++ b/app/views/documents/edit.html.erb
@@ -1,3 +1,9 @@
+<% content_for :title, @document.title || "Untitled document" %>
+
+Document type: <%= @document.document_type %>.
+
+<br/><br/>
+
 <%= form_for @document do |f| %>
   Title:
   <%= f.text_field :title %>

--- a/app/views/documents/index.html.erb
+++ b/app/views/documents/index.html.erb
@@ -7,6 +7,7 @@
   <tr>
     <td><%= document.title || "No title" %></td>
     <td><%= document.updated_at %></td>
+    <td><%= document.document_type %></td>
     <td><%= link_to "Edit", edit_document_path(document) %></td>
   </tr>
 <% end %>

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -13,6 +13,10 @@
   }%>
 
   <div class="govuk-width-container">
+    <% if yield(:back_link).present? %>
+      <%= render "govuk_publishing_components/components/back_link", href: yield(:back_link) %>
+    <% end %>
+
     <main class="govuk-main-wrapper " id="main-content" role="main">
       <%= render "govuk_publishing_components/components/title", title: yield(:title) %>
       <%= yield %>

--- a/app/views/new_document/choose_document_type.html.erb
+++ b/app/views/new_document/choose_document_type.html.erb
@@ -1,3 +1,4 @@
+<% content_for :back_link, new_document_path %>
 <% content_for :title, "Document type" %>
 
 <%= form_tag create_document_path do %>

--- a/app/views/new_document/choose_document_type.html.erb
+++ b/app/views/new_document/choose_document_type.html.erb
@@ -1,0 +1,16 @@
+<% content_for :title, "Document type" %>
+
+<%= form_tag create_document_path do %>
+  <%= render "govuk_publishing_components/components/radio", {
+    name: "document_type",
+    items: @document_types.map { |document_type|
+      {
+        value: document_type.fetch("document_type"),
+        text: document_type.fetch("name"),
+      }
+    }
+  } %>
+  <br/>
+  <br/>
+  <%= render "govuk_publishing_components/components/button", text: "Continue" %>
+<% end %>

--- a/app/views/new_document/choose_supertype.html.erb
+++ b/app/views/new_document/choose_supertype.html.erb
@@ -1,3 +1,4 @@
+<% content_for :back_link, root_path %>
 <% content_for :title, "Content type" %>
 
 <%= form_tag do %>

--- a/app/views/new_document/choose_supertype.html.erb
+++ b/app/views/new_document/choose_supertype.html.erb
@@ -1,0 +1,18 @@
+<% content_for :title, "Content type" %>
+
+<%= form_tag do %>
+  <%= render "govuk_publishing_components/components/radio", {
+    name: "supertype",
+    items: @supertypes.map { |supertype|
+      {
+        value: supertype["id"],
+        text: supertype["label"],
+        hint_text: supertype["description"],
+        bold: true,
+      }
+    }
+  } %>
+  <br/>
+  <br/>
+  <%= render "govuk_publishing_components/components/button", text: "Continue" %>
+<% end %>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -4,8 +4,10 @@ Rails.application.routes.draw do
   root to: redirect('/documents')
   get '/dev' => 'development#index'
 
+  get '/documents/new' => 'new_document#choose_supertype', as: :new_document
+  post '/documents/new' => 'new_document#choose_document_type'
+
   get '/documents' => 'documents#index'
-  get '/documents/new' => 'documents#choose_format', as: :new_document
   post '/documents/create' => 'documents#create', as: :create_document
   get '/documents/:id/edit' => 'documents#edit', as: :edit_document
   patch '/documents/:id' => 'documents#update', as: :document

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -13,4 +13,8 @@ Rails.application.routes.draw do
   patch '/documents/:id' => 'documents#update', as: :document
 
   get "/healthcheck", to: proc { [200, {}, ["OK"]] }
+
+  if Rails.env.test?
+    get "/government/admin/consultations/new", to: proc { [200, {}, ["You've been redirected"]] }
+  end
 end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -6,9 +6,9 @@ Rails.application.routes.draw do
 
   get '/documents/new' => 'new_document#choose_supertype', as: :new_document
   post '/documents/new' => 'new_document#choose_document_type'
+  post '/documents/create' => 'new_document#create', as: :create_document
 
   get '/documents' => 'documents#index'
-  post '/documents/create' => 'documents#create', as: :create_document
   get '/documents/:id/edit' => 'documents#edit', as: :edit_document
   patch '/documents/:id' => 'documents#update', as: :document
 

--- a/spec/integration/create_a_document_elsewhere_spec.rb
+++ b/spec/integration/create_a_document_elsewhere_spec.rb
@@ -1,0 +1,29 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+
+RSpec.describe "Create a document that is managed elsewhere", type: :feature do
+  scenario "User creates a document" do
+    when_i_click_on_create_a_document
+    and_i_choose_a_document_that_is_not_managed_in_this_app
+    then_i_am_redirected_to_the_application_that_manages_the_content
+  end
+
+  def when_i_click_on_create_a_document
+    visit "/"
+    click_on "New document"
+  end
+
+  def and_i_choose_a_document_that_is_not_managed_in_this_app
+    choose "Consultations"
+    click_on "Continue"
+
+    choose "Consultation (managed elsewhere)"
+    click_on "Continue"
+  end
+
+  def then_i_am_redirected_to_the_application_that_manages_the_content
+    expect(page.current_path).to eql "/government/admin/consultations/new"
+    expect(page).to have_content "You've been redirected"
+  end
+end

--- a/spec/integration/create_a_document_spec.rb
+++ b/spec/integration/create_a_document_spec.rb
@@ -5,7 +5,8 @@ require "spec_helper"
 RSpec.describe "Create a document", type: :feature do
   scenario "User creates a document" do
     when_i_click_on_create_a_document
-    and_i_choose_news_article
+    and_i_choose_news
+    and_i_choose_a_press_release
     and_i_fill_in_a_title
     then_the_document_exists
   end
@@ -15,8 +16,14 @@ RSpec.describe "Create a document", type: :feature do
     click_on "New document"
   end
 
-  def and_i_choose_news_article
-    click_on "Create news article"
+  def and_i_choose_news
+    choose "News"
+    click_on "Continue"
+  end
+
+  def and_i_choose_a_press_release
+    choose "Press release"
+    click_on "Continue"
   end
 
   def and_i_fill_in_a_title
@@ -27,6 +34,7 @@ RSpec.describe "Create a document", type: :feature do
   def then_the_document_exists
     expect(Document.last.title).to eql("A great title")
     visit "/"
+    expect(page).to have_content "press_release"
     expect(page).to have_content "A great title"
   end
 end


### PR DESCRIPTION
This implements the 2-step flow of choosing a document type. The designs for this I found [on the Google Drive for Q1][1], so the copy might not match the latest thinking. It should be easy enough to change though.

![jul-20-2018 09-57-33](https://user-images.githubusercontent.com/233676/42993574-9aff3bb0-8c03-11e8-9b3a-112ad5b0e46a.gif)

The commits contain all the details, but I expect a few follow up PRs to this one:

- Refactor YAML handling. I've resisted the temptation to refactor the `YAML.load_file` stuff into classes at this time, because I want to avoid making the decisions about naming / placing stuff now. For what it's worth, I'm thinking about something like `DocumentType.all` and `DocumentType.find("press_release")`.
- Start validating the YAML files and testing them against the schemas.
- Add error handling for when a user doesn't select an option and submits
- Implement whatever happens when you select "I'm not sure this should be on GOV.UK"
- And add all the document types and redirects!

[1]: https://drive.google.com/drive/u/1/folders/1lKOFRdHGV00bM33p-Pgf6iYxJB2gvj0w

https://trello.com/c/egKyMGRP/31-create-the-choose-a-format-page-m