### PR TITLE
Send people who select "Not sure" to guidance page

### DIFF
--- a/app/controllers/new_document_controller.rb
+++ b/app/controllers/new_document_controller.rb
@@ -2,10 +2,15 @@
 
 class NewDocumentController < ApplicationController
   def choose_supertype
-    @supertypes = YAML.load_file("app/formats/supertypes.yml")
+    @supertype_radio_options = SupertypeThing.new.options
   end
 
   def choose_document_type
+    if params[:supertype] == SupertypeThing::NOT_SURE_OPTION.fetch(:value)
+      redirect_to guidance_path
+      return
+    end
+
     @document_types = YAML.load_file("app/formats/document_types.yml").select { |s| s["supertype"] == params[:supertype] }
   end
 
@@ -24,5 +29,33 @@ class NewDocumentController < ApplicationController
     )
 
     redirect_to edit_document_path(document)
+  end
+
+  # TODO: This class has an intentionally silly name, because we don't know if there
+  # will be classes like this and how to organise these.
+  class SupertypeThing
+    NOT_SURE_OPTION = {
+      value: "not-sure",
+      text: "I'm not sure this should be on GOV.UK",
+      hint_text: "View this guide to what should go on GOV.UK and where else we can publish content.",
+      bold: true
+    }.freeze
+
+    def options
+      supertype_options + [NOT_SURE_OPTION]
+    end
+
+  private
+
+    def supertype_options
+      YAML.load_file("app/formats/supertypes.yml").map do |supertype|
+        {
+          value: supertype["id"],
+          text: supertype["label"],
+          hint_text: supertype["description"],
+          bold: true,
+        }
+      end
+    end
   end
 end

--- a/app/formats/supertypes.yml
+++ b/app/formats/supertypes.yml
@@ -19,8 +19,3 @@
   label: Consultations
   description: To request users views or evidence on an issue and to build collective
     agreement.
-
-- id: not-sure
-  label: I'm not sure this should be on GOV.UK
-  description: To request users views or evidence on an issue and to build collective
-    agreement.

--- a/app/views/new_document/choose_supertype.html.erb
+++ b/app/views/new_document/choose_supertype.html.erb
@@ -4,14 +4,7 @@
 <%= form_tag do %>
   <%= render "govuk_publishing_components/components/radio", {
     name: "supertype",
-    items: @supertypes.map { |supertype|
-      {
-        value: supertype["id"],
-        text: supertype["label"],
-        hint_text: supertype["description"],
-        bold: true,
-      }
-    }
+    items: @supertype_radio_options
   } %>
   <br/>
   <br/>

--- a/app/views/new_document/guidance.govspeak.md
+++ b/app/views/new_document/guidance.govspeak.md
@@ -1,0 +1,67 @@
+Content published in Whitehall publisher on www.gov.uk should be either:
+
+* guidance to help users complete a transaction with government
+
+* information to help users understand what government is doing
+
+It should be information only government can provide.
+
+### Check existing content
+
+New content should not significantly repeat existing content.
+
+[Search GOV.UK](https://www.gov.uk/search) to check if the user need is being met elsewhere.
+
+### Ask GDS
+
+If you’re unsure [ask the GOV.UK team at the Government Digital Service](https://support.integration.publishing.service.gov.uk/).
+
+## What to publish elsewhere
+
+### Campaigns
+
+Campaign websites are designed to:
+
+* change behaviour by encouraging people to lead healthy, safer lives
+
+* ensure operational effectiveness of Government by informing people about public services
+
+* enhance the reputation of the UK, promote interests internationally, and respond in times of crisis
+
+* explain government policies and programmes to clarify legal or statutory requirements
+
+Campaign websites can be set up using either:
+
+* the government Campaign Platform
+
+* or a bespoke campaigns microsite
+
+### Intranets
+
+Information exclusively for civil servants with no public interest should be published on internal intranets.
+
+### Parliament.uk
+
+The [Parliament website](https://www.parliament.uk/) covers the work of parliament to scrutinise proposed legislation in the House of Commons, the House of Lords, and committees.
+
+### Hansard
+
+[Hansard](https://hansard.parliament.uk/) is the record of everything said or written during proceedings of the House of Commons and the House of Lords.
+
+### Legislation.gov.uk
+
+Bills which have been approved by the Commons, the Lords, and The Queen become law and are recorded on [Legislation.gov.uk](http://www.legislation.gov.uk/).
+
+### Devolved government
+
+In Scotland, Wales and Northern Ireland, devolved administrations are responsible for many domestic policy issues, and their Parliaments/Assemblies have law-making powers for those areas.
+
+[Read more about how government is run](https://www.gov.uk/government/how-government-works#how-government-is-run)
+
+### Other organisations
+
+Information or services that can be better supplied by organisations outside government should be linked to and not reproduced. For example, Shelter or the NHS.
+
+### Ask GDS
+
+If you’re unsure [ask the GOV.UK team at the Government Digital Service](https://support.integration.publishing.service.gov.uk/).

--- a/app/views/new_document/guidance.html.erb
+++ b/app/views/new_document/guidance.html.erb
@@ -1,0 +1,6 @@
+<% content_for :back_link, new_document_path %>
+<% content_for :title, "What to publish on GOV.UK" %>
+
+<%= render "govuk_publishing_components/components/govspeak" do %>
+  <%= raw Govspeak::Document.new(File.read("app/views/new_document/guidance.govspeak.md")).to_html %>
+<% end %>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -4,6 +4,7 @@ Rails.application.routes.draw do
   root to: redirect('/documents')
   get '/dev' => 'development#index'
 
+  get '/documents/publishing-guidance' => 'new_document#guidance', as: :guidance
   get '/documents/new' => 'new_document#choose_supertype', as: :new_document
   post '/documents/new' => 'new_document#choose_document_type'
   post '/documents/create' => 'new_document#create', as: :create_document

--- a/spec/integration/create_a_document_not_sure_spec.rb
+++ b/spec/integration/create_a_document_not_sure_spec.rb
@@ -1,0 +1,25 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+
+RSpec.describe "User is not sure if the content belongs on GOV.UK", type: :feature do
+  scenario "User selects 'I’m not sure this should be on GOV.UK'" do
+    when_i_click_on_create_a_document
+    and_i_choose_i_am_not_sure_if_it_belongs_on_govuk
+    then_i_see_the_guidance
+  end
+
+  def when_i_click_on_create_a_document
+    visit "/"
+    click_on "New document"
+  end
+
+  def and_i_choose_i_am_not_sure_if_it_belongs_on_govuk
+    choose "I'm not sure this should be on GOV.UK"
+    click_on "Continue"
+  end
+
+  def then_i_see_the_guidance
+    expect(page).to have_title "What to publish on GOV.UK"
+  end
+end


### PR DESCRIPTION
When somebody selects "I'm not sure this should be on GOV.UK", they'll now be redirected to the guidance page.

To achieve this, we've:

- Added a guidance page with the content from https://github.com/alphagov/whitehall-prototype/commit/503d77eb49d0c4e36457039dff23fa7a246ab65f (which is wrong in parts, but that will be fixed later)
- Removed the "I'm not sure this should be on GOV.UK" supertype from the supertypes YAML, because it's unlike the others.
- Created a temporary `SupertypeThing` abstraction that captures some of the logic to generate the radio button input. This will be refactored in a future pull request (likely together with the form
validation).

Paired with @benthorner.

https://trello.com/c/egKyMGRP