### PR TITLE
Add MVP for format-specific content editing

### DIFF
--- a/app/controllers/documents_controller.rb
+++ b/app/controllers/documents_controller.rb
@@ -11,13 +11,9 @@ class DocumentsController < ApplicationController
 
   def update
     document = Document.find(params[:id])
+    allowed_field_names_in_contents = document.document_type_schema.fields.map(&:id)
+    document_update_params = params.require(:document).permit(:title, contents: allowed_field_names_in_contents)
     document.update_attributes(document_update_params)
     redirect_to edit_document_path(document)
-  end
-
-private
-
-  def document_update_params
-    params.require(:document).permit(:title)
   end
 end

--- a/app/formats/document_types.yml
+++ b/app/formats/document_types.yml
@@ -2,6 +2,10 @@
 - document_type: press_release
   name: Press release
   supertype: news
+  fields:
+    - id: body
+      label: Body text for the press release
+      type: govspeak
 
 - document_type: news_article
   name: News article

--- a/app/models/document.rb
+++ b/app/models/document.rb
@@ -1,4 +1,7 @@
 # frozen_string_literal: true
 
 class Document < ApplicationRecord
+  def document_type_schema
+    DocumentTypeSchema.find(document_type)
+  end
 end

--- a/app/services/document_type_schema.rb
+++ b/app/services/document_type_schema.rb
@@ -1,0 +1,27 @@
+# frozen_string_literal: true
+
+class DocumentTypeSchema
+  include ActiveModel::Model
+  attr_accessor :document_type, :name, :supertype, :managed_elsewhere
+  attr_reader :fields
+
+  def self.find(document_type)
+    all.find { |schema| schema.document_type == document_type }
+  end
+
+  def self.all
+    @all ||= begin
+      types = YAML.load_file("app/formats/document_types.yml")
+      types.map { |data| DocumentTypeSchema.new(data) }
+    end
+  end
+
+  def fields=(raw_fields)
+    @fields = raw_fields.to_a.map { |field| Field.new(field) }
+  end
+
+  class Field
+    include ActiveModel::Model
+    attr_accessor :id, :label, :type
+  end
+end

--- a/app/views/documents/edit.html.erb
+++ b/app/views/documents/edit.html.erb
@@ -8,6 +8,10 @@ Document type: <%= @document.document_type %>.
   Title:
   <%= f.text_field :title %>
 
+  <% @document.document_type_schema.fields.each do |field| %>
+    <%= render "documents/input_types/#{field.type}", name: field.id, label: field.label, document: @document %>
+  <% end %>
+
   <br/>
   <br/>
   <br/>

--- a/app/views/documents/input_types/_govspeak.html.erb
+++ b/app/views/documents/input_types/_govspeak.html.erb
@@ -1,0 +1,4 @@
+<p>
+  <%= label %><br/>
+  <%= tag.textarea document.contents[name], class: "govuk-textarea", name: "document[contents][#{name}]" %>
+</p>

--- a/db/migrate/20180723183132_add_contents_to_documents.rb
+++ b/db/migrate/20180723183132_add_contents_to_documents.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+class AddContentsToDocuments < ActiveRecord::Migration[5.2]
+  def change
+    add_column :documents, :contents, :json, default: '{}'
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2018_07_16_161306) do
+ActiveRecord::Schema.define(version: 2018_07_23_183132) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -22,6 +22,7 @@ ActiveRecord::Schema.define(version: 2018_07_16_161306) do
     t.string "title"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
+    t.json "contents", default: "{}"
     t.index ["content_id", "locale"], name: "index_documents_on_content_id_and_locale", unique: true
   end
 

--- a/spec/integration/edit_a_document_spec.rb
+++ b/spec/integration/edit_a_document_spec.rb
@@ -1,0 +1,37 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+
+RSpec.describe "Edit a document", type: :feature do
+  scenario "User edits a document" do
+    when_i_click_on_create_a_document
+    and_i_choose_news
+    and_i_choose_a_press_release
+    and_i_fill_in_a_body_text
+    then_the_document_is_saved
+  end
+
+  def when_i_click_on_create_a_document
+    visit "/"
+    click_on "New document"
+  end
+
+  def and_i_choose_news
+    choose "News"
+    click_on "Continue"
+  end
+
+  def and_i_choose_a_press_release
+    choose "Press release"
+    click_on "Continue"
+  end
+
+  def and_i_fill_in_a_body_text
+    fill_in "document[contents][body]", with: "The document body"
+    click_on "Save"
+  end
+
+  def then_the_document_is_saved
+    expect(Document.last.contents["body"]).to eql("The document body")
+  end
+end


### PR DESCRIPTION
This PR adds the minimum to create a system of format-dependent content editing. It is the first step to allow us to specify the formats in this app in a YAML.

It works like this:

- In the the document types YAML we define `fields` for a type
- Fields have a `id`, `label` and `type`
- Using these fields, we build a form with the correct inputs. In this PR that's just the "govspeak" input, but I imagine we'll have inputs like dates, dropdowns, booleans and more.
- The input of the form is then used in the controller (with an additional param sanitisation step)
- The extracted input is then persisted into the `contents` JSON column, which the forms can access

For future PRs:

- Add more input types
- Add more fields for formats
- Use the `contents` in the payload to the publishing-api
- Use `DocumentTypeSchema` to refactor the controllers

This majority of this work comes from a spike into the system @benthorner and I did last week.

https://trello.com/c/PxtaaObC