### PR TITLE
Fix environment indicators

### DIFF
--- a/config/application.rb
+++ b/config/application.rb
@@ -34,6 +34,12 @@ module ContentPublisher
 
     # The "acceptance environment" we're in - not the same as Rails env.
     # Can be production, staging, integration, or development
-    config.govuk_environment = ENV["ERRBIT_ENVIRONMENT_NAME"] || "development"
+    govuk_environments = {
+      "production" => "production",
+      "staging" => "staging",
+      "integration-blue-aws" => "integration",
+    }
+
+    config.govuk_environment = govuk_environments.fetch(ENV["ERRBIT_ENVIRONMENT_NAME"], "development")
   end
 end


### PR DESCRIPTION
Currently integration is broken, because we're passing in the `ENV["ERRBIT_ENVIRONMENT_NAME"]` into the layout component, which loads a favicon that doesn't exist:

https://sentry.io/govuk/app-content-publisher/issues/614468696

This commit instead calculates the environment more safely, so that the environment will always be one of production, staging, integration, or development. By default it will be development.
