### PR TITLE
Fix content editing for formats without fields

### DIFF
--- a/app/services/document_type_schema.rb
+++ b/app/services/document_type_schema.rb
@@ -3,7 +3,7 @@
 class DocumentTypeSchema
   include ActiveModel::Model
   attr_accessor :document_type, :name, :supertype, :managed_elsewhere
-  attr_reader :fields
+  attr_writer :fields
 
   def self.find(document_type)
     all.find { |schema| schema.document_type == document_type }
@@ -16,8 +16,8 @@ class DocumentTypeSchema
     end
   end
 
-  def fields=(raw_fields)
-    @fields = raw_fields.to_a.map { |field| Field.new(field) }
+  def fields
+    @fields.to_a.map { |field| Field.new(field) }
   end
 
   class Field

--- a/spec/services/document_type_schema_spec.rb
+++ b/spec/services/document_type_schema_spec.rb
@@ -1,0 +1,13 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+
+RSpec.describe DocumentTypeSchema do
+  describe '#fields' do
+    it 'is an empty array by default' do
+      schema = DocumentTypeSchema.new
+
+      expect(schema.fields).to eql([])
+    end
+  end
+end


### PR DESCRIPTION
This fixes a bug that crashes the edit page for documents with a document type without fields, like news article.

https://sentry.io/govuk/app-content-publisher/issues/618507813

I assumed that having a `fields=` method would make the `ActiveModel` initialiser use it (just like `attr_accessor` does). It doesn't, but it does work if there's a `attr_writer`.