### PR TITLE
Refactor Document type / Super type concepts

### DIFF
--- a/app/controllers/new_document_controller.rb
+++ b/app/controllers/new_document_controller.rb
@@ -11,7 +11,8 @@ class NewDocumentController < ApplicationController
       return
     end
 
-    @document_types = YAML.load_file("app/formats/document_types.yml").select { |s| s["supertype"] == params[:supertype] }
+    supertype_schema = SupertypeSchema.find(params[:supertype])
+    @document_types = supertype_schema.document_types
   end
 
   def create
@@ -48,11 +49,11 @@ class NewDocumentController < ApplicationController
   private
 
     def supertype_options
-      YAML.load_file("app/formats/supertypes.yml").map do |supertype|
+      SupertypeSchema.all.map do |supertype|
         {
-          value: supertype["id"],
-          text: supertype["label"],
-          hint_text: supertype["description"],
+          value: supertype.id,
+          text: supertype.label,
+          hint_text: supertype.description,
           bold: true,
         }
       end

--- a/app/controllers/new_document_controller.rb
+++ b/app/controllers/new_document_controller.rb
@@ -15,10 +15,10 @@ class NewDocumentController < ApplicationController
   end
 
   def create
-    document_type_schema = YAML.load_file("app/formats/document_types.yml").find { |s| s["document_type"] == params[:document_type] }
+    document_type_schema = DocumentTypeSchema.find(params[:document_type])
 
-    if document_type_schema["managed_elsewhere"]
-      redirect_to document_type_schema["managed_elsewhere"]
+    if document_type_schema.managed_elsewhere
+      redirect_to document_type_schema.managed_elsewhere
       return
     end
 

--- a/app/services/document_type_schema.rb
+++ b/app/services/document_type_schema.rb
@@ -1,9 +1,15 @@
 # frozen_string_literal: true
 
 class DocumentTypeSchema
-  include ActiveModel::Model
-  attr_accessor :document_type, :name, :supertype, :managed_elsewhere
-  attr_reader :fields
+  attr_reader :fields, :document_type, :name, :supertype, :managed_elsewhere
+
+  def initialize(params = {})
+    @document_type = params["document_type"]
+    @name = params["name"]
+    @supertype = params["supertype"]
+    @managed_elsewhere = params["managed_elsewhere"]
+    @fields = params["fields"].to_a.map { |field| Field.new(field) }
+  end
 
   def self.find(document_type)
     all.find { |schema| schema.document_type == document_type }
@@ -14,10 +20,6 @@ class DocumentTypeSchema
       types = YAML.load_file("app/formats/document_types.yml")
       types.map { |data| DocumentTypeSchema.new(data) }
     end
-  end
-
-  def fields=(raw_fields)
-    @fields = raw_fields.to_a.map { |field| Field.new(field) }
   end
 
   class Field

--- a/app/services/supertype_schema.rb
+++ b/app/services/supertype_schema.rb
@@ -1,0 +1,21 @@
+# frozen_string_literal: true
+
+class SupertypeSchema
+  include ActiveModel::Model
+  attr_accessor :id, :label, :description
+
+  def self.all
+    @all ||= begin
+      raw = YAML.load_file("app/formats/supertypes.yml")
+      raw.map { |r| SupertypeSchema.new(r) }
+    end
+  end
+
+  def self.find(type_id)
+    all.find { |schema| schema.id == type_id }
+  end
+
+  def document_types
+    DocumentTypeSchema.all.select { |schema| schema.supertype == id }
+  end
+end

--- a/app/services/supertype_schema.rb
+++ b/app/services/supertype_schema.rb
@@ -1,8 +1,13 @@
 # frozen_string_literal: true
 
 class SupertypeSchema
-  include ActiveModel::Model
-  attr_accessor :id, :label, :description
+  attr_reader :id, :label, :description
+
+  def initialize(params = {})
+    @id = params["id"]
+    @label = params["label"]
+    @description = params["description"]
+  end
 
   def self.all
     @all ||= begin

--- a/app/views/new_document/choose_document_type.html.erb
+++ b/app/views/new_document/choose_document_type.html.erb
@@ -6,8 +6,8 @@
     name: "document_type",
     items: @document_types.map { |document_type|
       {
-        value: document_type.fetch("document_type"),
-        text: document_type.fetch("name"),
+        value: document_type.document_type,
+        text: document_type.name,
       }
     }
   } %>

--- a/spec/services/document_type_schema_spec.rb
+++ b/spec/services/document_type_schema_spec.rb
@@ -1,0 +1,13 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+
+RSpec.describe DocumentTypeSchema do
+  describe '#fields' do
+    it 'is an empty array by default' do
+      schema = DocumentTypeSchema.new
+
+      expect(schema.fields).to eql([])
+    end
+  end
+end


### PR DESCRIPTION
This refactors the app to use the `DocumentTypeSchema` and `SupertypeSchema` classes. Also fixes the bug that we tried to fix in https://github.com/alphagov/content-publisher/pull/36.

Best reviewed per-commit, and with reading the commit message about ActiveModel.

https://trello.com/c/PxtaaObC/69-how-can-we-define-format-rules-l
