### PR TITLE
Add database cleaner for testing

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -20,6 +20,7 @@ group :development do
 end
 
 group :test do
+  gem "database_cleaner"
   gem "simplecov", "~> 0.16"
 end
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -62,6 +62,7 @@ GEM
       highline (~> 1.7.2)
     concurrent-ruby (1.0.5)
     crass (1.0.4)
+    database_cleaner (1.7.0)
     diff-lcs (1.3)
     docile (1.3.1)
     domain_name (0.5.20180417)
@@ -339,6 +340,7 @@ DEPENDENCIES
   bootsnap (~> 1)
   byebug (~> 10)
   capybara
+  database_cleaner
   gds-api-adapters (~> 52)
   gds-sso (~> 13)
   govuk-lint (~> 3)

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -2,6 +2,7 @@
 
 require "byebug"
 require "simplecov"
+require "database_cleaner"
 
 ENV["RAILS_ENV"] ||= "test"
 require File.expand_path("../../config/environment", __FILE__)
@@ -16,5 +17,13 @@ RSpec.configure do |config|
 
   config.before(:suite) do
     User.create!(permissions: ["signin"])
+  end
+
+  config.before(:each) do
+    DatabaseCleaner.start
+  end
+
+  config.after(:each) do
+    DatabaseCleaner.clean
   end
 end


### PR DESCRIPTION
https://trello.com/c/Vbwd7cye/68-allow-sending-news-to-publishing-api-m

This stops the test database filling up with data, which was making the
Capybara page diffs (even) more difficult to read when a feature test
fails. I've left the default strategy (transaction) as-is on the basis
that my tests continue to run fast locally.