### PR TITLE
Change edit spec to actually test editing

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -26,6 +26,7 @@ end
 group :development, :test do
   gem "byebug", "~> 10"
   gem "capybara"
+  gem "factory_bot_rails"
   gem "govuk-lint", "~> 3"
   gem "govuk_schemas", "~> 3.2"
   gem "rspec-rails", "~> 3"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -68,6 +68,11 @@ GEM
       unf (>= 0.0.5, < 1.0.0)
     erubi (1.7.1)
     execjs (2.7.0)
+    factory_bot (4.10.0)
+      activesupport (>= 3.0.0)
+    factory_bot_rails (4.10.0)
+      factory_bot (~> 4.10.0)
+      railties (>= 3.0.0)
     faraday (0.12.2)
       multipart-post (>= 1.2, < 3)
     ffi (1.9.25)
@@ -339,6 +344,7 @@ DEPENDENCIES
   bootsnap (~> 1)
   byebug (~> 10)
   capybara
+  factory_bot_rails
   gds-api-adapters (~> 52)
   gds-sso (~> 13)
   govuk-lint (~> 3)

--- a/spec/factories/document_factory.rb
+++ b/spec/factories/document_factory.rb
@@ -1,0 +1,8 @@
+# frozen_string_literal: true
+
+FactoryBot.define do
+  factory :document do
+    content_id { SecureRandom.uuid }
+    locale { I18n.available_locales.sample }
+  end
+end

--- a/spec/integration/edit_a_document_spec.rb
+++ b/spec/integration/edit_a_document_spec.rb
@@ -4,26 +4,18 @@ require "spec_helper"
 
 RSpec.describe "Edit a document", type: :feature do
   scenario "User edits a document" do
-    when_i_click_on_create_a_document
-    and_i_choose_news
-    and_i_choose_a_press_release
+    given_there_is_a_document
+    when_i_go_to_edit_the_document
     and_i_fill_in_a_body_text
     then_the_document_is_saved
   end
 
-  def when_i_click_on_create_a_document
-    visit "/"
-    click_on "New document"
+  def given_there_is_a_document
+    create :document, document_type: "press_release"
   end
 
-  def and_i_choose_news
-    choose "News"
-    click_on "Continue"
-  end
-
-  def and_i_choose_a_press_release
-    choose "Press release"
-    click_on "Continue"
+  def when_i_go_to_edit_the_document
+    visit edit_document_path(Document.last)
   end
 
   def and_i_fill_in_a_body_text

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -13,6 +13,7 @@ SimpleCov.start
 RSpec.configure do |config|
   config.expose_dsl_globally = false
   config.infer_spec_type_from_file_location!
+  config.include FactoryBot::Syntax::Methods
 
   config.before(:suite) do
     User.create!(permissions: ["signin"])


### PR DESCRIPTION
https://trello.com/c/Vbwd7cye/68-allow-sending-news-to-publishing-api-m

The previous edit spec was actually testing the new document
interaction. Rewriting the spec to test the edit path then prompted
adding FactoryBot to avoid assigning boilerplate document fields (like
the content_id) as part of the test.