### PR TITLE
Fix default for for document contents column

### DIFF
--- a/db/migrate/20180725084729_fix_document_contents_default.rb
+++ b/db/migrate/20180725084729_fix_document_contents_default.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+class FixDocumentContentsDefault < ActiveRecord::Migration[5.2]
+  def change
+    change_column_default :documents, :contents, {}
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2018_07_23_183132) do
+ActiveRecord::Schema.define(version: 2018_07_25_084729) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -22,7 +22,7 @@ ActiveRecord::Schema.define(version: 2018_07_23_183132) do
     t.string "title"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
-    t.json "contents", default: "{}"
+    t.json "contents", default: {}
     t.index ["content_id", "locale"], name: "index_documents_on_content_id_and_locale", unique: true
   end
 


### PR DESCRIPTION
The default value for a JSON column should apparently be expressed as the equivalent ruby object, rather than the JSON string.