### PR TITLE
Raise exception on unknown document types

### DIFF
--- a/app/services/document_type_schema.rb
+++ b/app/services/document_type_schema.rb
@@ -14,7 +14,8 @@ class DocumentTypeSchema
   end
 
   def self.find(document_type)
-    all.find { |schema| schema.document_type == document_type }
+    item = all.find { |schema| schema.document_type == document_type }
+    item || (raise RuntimeError, "Document type #{document_type} not found")
   end
 
   def self.all

--- a/spec/services/document_type_schema_spec.rb
+++ b/spec/services/document_type_schema_spec.rb
@@ -3,6 +3,17 @@
 require 'spec_helper'
 
 RSpec.describe DocumentTypeSchema do
+  describe ".find" do
+    it "returns a DocumentTypeSchema when it's a known document_type" do
+      expect(DocumentTypeSchema.find("press_release")).to be_a(DocumentTypeSchema)
+    end
+
+    it "raises a RuntimeError when we don't know the document_type" do
+      expect { DocumentTypeSchema.find("unknown_document_type") }
+        .to raise_error(RuntimeError, "Document type unknown_document_type not found")
+    end
+  end
+
   describe '#fields' do
     it 'is an empty array by default' do
       schema = DocumentTypeSchema.new


### PR DESCRIPTION
Trello: https://trello.com/c/Zx8mNyZi/35-investigate-how-could-data-be-exported-from-whitehall-m-1-day

I hit an issue experimenting with Whitehall data as the document_type is news_story rather than news_article (which is the schema name) - I've set this up to raise an exception now as it's quite cryptic debugging this without. 

I've also fixed the document_type values to have news_story - note this will cause problems editing documents if you have news_article document_types in your database.