### PR TITLE
Add a summary field to documents

### DIFF
--- a/app/controllers/documents_controller.rb
+++ b/app/controllers/documents_controller.rb
@@ -27,6 +27,6 @@ private
 
   def document_update_params(document)
     contents_params = document.document_type_schema.fields.map(&:id)
-    params.require(:document).permit(:title, :base_path, contents: contents_params)
+    params.require(:document).permit(:title, :summary, :base_path, contents: contents_params)
   end
 end

--- a/app/services/document_publishing_service.rb
+++ b/app/services/document_publishing_service.rb
@@ -20,6 +20,7 @@ private
       base_path: document.base_path,
       title: document.title,
       locale: document.locale,
+      description: document.summary,
       schema_name: document.document_type_schema.schema_name,
       document_type: document.document_type,
       publishing_app: PUBLISHING_APP,

--- a/app/views/documents/edit.html.erb
+++ b/app/views/documents/edit.html.erb
@@ -6,7 +6,13 @@ Document type: <%= @document.document_type %>.
 
 <%= form_for @document do |f| %>
   <p>
-    Title: <%= f.text_field :title %>
+    Title:
+    <%= f.text_field :title %>
+  </p>
+
+  <p>
+    Summary:<br/>
+    <%= f.text_field :summary %>
   </p>
 
   <p>

--- a/db/migrate/20180725091148_add_summary_to_documents.rb
+++ b/db/migrate/20180725091148_add_summary_to_documents.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+class AddSummaryToDocuments < ActiveRecord::Migration[5.2]
+  def change
+    add_column :documents, :summary, :text
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -23,6 +23,7 @@ ActiveRecord::Schema.define(version: 2018_07_25_095923) do
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.json "contents", default: {}
+    t.text "summary"
     t.string "base_path"
     t.index ["content_id", "locale"], name: "index_documents_on_content_id_and_locale", unique: true
   end

--- a/spec/integration/edit_a_document_spec.rb
+++ b/spec/integration/edit_a_document_spec.rb
@@ -6,7 +6,7 @@ RSpec.describe "Edit a document", type: :feature do
   scenario "User edits a document" do
     given_there_is_a_document
     when_i_go_to_edit_the_document
-    and_i_fill_in_a_body_text
+    and_i_fill_in_the_fields
     then_i_see_the_document_is_saved
     and_the_preview_creation_succeeded
   end
@@ -21,12 +21,14 @@ RSpec.describe "Edit a document", type: :feature do
     @request = stub_publishing_api_put_content(Document.last.content_id, {})
   end
 
-  def and_i_fill_in_a_body_text
+  def and_i_fill_in_the_fields
     fill_in "document[contents][body]", with: "The document body"
+    fill_in "document[summary]", with: "A summary of the release."
     click_on "Save"
   end
 
   def then_i_see_the_document_is_saved
+    expect(Document.last.summary).to eql("A summary of the release.")
     expect(page).to have_content "The document body"
   end
 


### PR DESCRIPTION
This field contains a summary of the document. All of the formats will have this field.

https://trello.com/c/PxtaaObC