### PR TITLE
Allow user to specify base_path for now

### DIFF
--- a/app/controllers/documents_controller.rb
+++ b/app/controllers/documents_controller.rb
@@ -14,20 +14,19 @@ class DocumentsController < ApplicationController
   end
 
   def update
-    document = Document.find(params[:id])
-    allowed_field_names_in_contents = document.document_type_schema.fields.map(&:id)
-    document_update_params = params.require(:document).permit(:title, contents: allowed_field_names_in_contents)
-    document.update_attributes(document_update_params)
-    DocumentPublishingService.new.publish_draft(document)
-    redirect_to document, notice: "Preview creation successful"
+    @document = Document.find(params[:id])
+    @document.update_attributes(document_update_params)
+    DocumentPublishingService.new.publish_draft(@document)
+    redirect_to @document, notice: "Preview creation successful"
   rescue GdsApi::HTTPErrorResponse, SocketError => e
     Rails.logger.error(e)
-    redirect_to document, alert: "Error creating preview"
+    redirect_to @document, alert: "Error creating preview"
   end
 
 private
 
   def document_update_params
-    params.require(:document).permit(:title)
+    contents_params = @document.document_type_schema.fields.map(&:id)
+    params.require(:document).permit(:title, :base_path, contents: contents_params)
   end
 end

--- a/app/controllers/documents_controller.rb
+++ b/app/controllers/documents_controller.rb
@@ -14,19 +14,19 @@ class DocumentsController < ApplicationController
   end
 
   def update
-    @document = Document.find(params[:id])
-    @document.update_attributes(document_update_params)
-    DocumentPublishingService.new.publish_draft(@document)
-    redirect_to @document, notice: "Preview creation successful"
+    document = Document.find(params[:id])
+    document.update_attributes(document_update_params(document))
+    DocumentPublishingService.new.publish_draft(document)
+    redirect_to document, notice: "Preview creation successful"
   rescue GdsApi::HTTPErrorResponse, SocketError => e
     Rails.logger.error(e)
-    redirect_to @document, alert: "Error creating preview"
+    redirect_to document, alert: "Error creating preview"
   end
 
 private
 
-  def document_update_params
-    contents_params = @document.document_type_schema.fields.map(&:id)
+  def document_update_params(document)
+    contents_params = document.document_type_schema.fields.map(&:id)
     params.require(:document).permit(:title, :base_path, contents: contents_params)
   end
 end

--- a/app/services/document_publishing_service.rb
+++ b/app/services/document_publishing_service.rb
@@ -15,7 +15,7 @@ private
 
   def payload(document)
     {
-      base_path: "/test/government/foo",
+      base_path: document.base_path,
       title: document.title,
       schema_name: "news_article",
       document_type: document.document_type,
@@ -27,7 +27,7 @@ private
                                        },
                                        political: false),
       routes: [
-        { path: "/test/government/foo", type: "exact" },
+        { path: document.base_path, type: "exact" },
       ]
     }
   end

--- a/app/views/documents/edit.html.erb
+++ b/app/views/documents/edit.html.erb
@@ -5,8 +5,13 @@ Document type: <%= @document.document_type %>.
 <br/><br/>
 
 <%= form_for @document do |f| %>
-  Title:
-  <%= f.text_field :title %>
+  <p>
+    Title: <%= f.text_field :title %>
+  </p>
+
+  <p>
+    Base path: <%= f.text_field :base_path %>
+  </p>
 
   <% @document.document_type_schema.fields.each do |field| %>
     <%= render "documents/fields/#{field.type}_input", name: field.id, label: field.label, document: @document %>

--- a/app/views/documents/show.html.erb
+++ b/app/views/documents/show.html.erb
@@ -1,7 +1,13 @@
 <% content_for :back_link, documents_path %>
 <% content_for :title, @document.title || "No title" %>
 
-<%= @document.document_type %>
+<p>
+  Base path: <%= @document.base_path %>
+</p>
+
+<p>
+  Document type: <%= @document.document_type %>
+</p>
 
 <% @document.document_type_schema.fields.each do |field| %>
   <%= render "documents/fields/#{field.type}", name: field.id, label: field.label, document: @document %>

--- a/db/migrate/20180725095923_add_base_path_to_documents.rb
+++ b/db/migrate/20180725095923_add_base_path_to_documents.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+class AddBasePathToDocuments < ActiveRecord::Migration[5.2]
+  def change
+    add_column :documents, :base_path, :string
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2018_07_25_084729) do
+ActiveRecord::Schema.define(version: 2018_07_25_095923) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -23,6 +23,7 @@ ActiveRecord::Schema.define(version: 2018_07_25_084729) do
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.json "contents", default: {}
+    t.string "base_path"
     t.index ["content_id", "locale"], name: "index_documents_on_content_id_and_locale", unique: true
   end
 

--- a/spec/factories/document_factory.rb
+++ b/spec/factories/document_factory.rb
@@ -4,6 +4,8 @@ FactoryBot.define do
   factory :document do
     content_id { SecureRandom.uuid }
     locale { I18n.available_locales.sample }
+    base_path { "/#{SecureRandom.alphanumeric(8)}" }
+    title { SecureRandom.alphanumeric(8) }
 
     trait :press_release do
       document_type "press_release"

--- a/spec/factories/document_factory.rb
+++ b/spec/factories/document_factory.rb
@@ -5,7 +5,6 @@ FactoryBot.define do
     content_id { SecureRandom.uuid }
     locale { I18n.available_locales.sample }
     base_path { "/#{SecureRandom.alphanumeric(8)}" }
-    title { SecureRandom.alphanumeric(8) }
 
     trait :press_release do
       document_type "press_release"

--- a/spec/integration/create_a_document_spec.rb
+++ b/spec/integration/create_a_document_spec.rb
@@ -7,7 +7,7 @@ RSpec.describe "Create a document", type: :feature do
     when_i_click_on_create_a_document
     and_i_choose_news
     and_i_choose_a_press_release
-    and_i_fill_in_a_title
+    and_i_fill_in_the_form_fields
     then_i_see_the_document_exists
     and_the_preview_creation_succeeded
   end
@@ -27,11 +27,13 @@ RSpec.describe "Create a document", type: :feature do
     click_on "Continue"
   end
 
-  def and_i_fill_in_a_title
+  def and_i_fill_in_the_form_fields
     fill_in "document[title]", with: "A great title"
+    fill_in "document[base_path]", with: "/government/foo"
 
     @request = stub_publishing_api_put_content(Document.last.content_id,
-                                               hash_including(title: "A great title"))
+                                               hash_including(title: "A great title",
+                                                              base_path: "/government/foo"))
 
     click_on "Save"
   end
@@ -40,6 +42,7 @@ RSpec.describe "Create a document", type: :feature do
     expect(Document.last.title).to eq "A great title"
     expect(page).to have_content "press_release"
     expect(page).to have_content "A great title"
+    expect(page).to have_content "/government/foo"
   end
 
   def and_the_preview_creation_succeeded


### PR DESCRIPTION
https://trello.com/c/Vbwd7cye

In order to effectively test publishing, we need to be able to generate
unique URLs for each document. Rather than preempt the intended work of
generating these automatically, for now the user can specify them
manually, without any validation.