### PR TITLE
Publish the content in the correct language

### DIFF
--- a/app/services/document_publishing_service.rb
+++ b/app/services/document_publishing_service.rb
@@ -10,7 +10,7 @@ class DocumentPublishingService
   end
 
   def publish(document)
-    publishing_api.publish(document.content_id, "major")
+    publishing_api.publish(document.content_id, "major", locale: document.locale)
   end
 
 private
@@ -19,6 +19,7 @@ private
     {
       base_path: document.base_path,
       title: document.title,
+      locale: document.locale,
       schema_name: document.document_type_schema.schema_name,
       document_type: document.document_type,
       publishing_app: PUBLISHING_APP,

--- a/spec/integration/publish_a_document_spec.rb
+++ b/spec/integration/publish_a_document_spec.rb
@@ -19,7 +19,7 @@ RSpec.describe "Publishing a document", type: :feature do
   end
 
   def and_i_click_on_the_publish_button
-    @request = stub_publishing_api_publish(@document.content_id, {})
+    @request = stub_publishing_api_publish(@document.content_id, update_type: "major", locale: @document.locale)
     click_on "publish"
   end
 


### PR DESCRIPTION
By default, the `publish` endpoint assumes an english locale. This works in this app because we're defaulting to english as well. But in the future we'll have other translations, this PR prepares us for that.

@benthorner 