### PR TITLE
Add the component guide to the application

### DIFF
--- a/config/initializers/govuk_publishing_components.rb
+++ b/config/initializers/govuk_publishing_components.rb
@@ -1,0 +1,8 @@
+# config/initializers/govuk_publishing_components.rb
+GovukPublishingComponents.configure do |c|
+  c.component_guide_title = "Content Publisher"
+  c.application_print_stylesheet = nil
+
+  c.application_stylesheet = "govuk_publishing_components/admin_styles"
+  c.application_javascript = nil
+end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -18,6 +18,8 @@ Rails.application.routes.draw do
 
   get "/healthcheck", to: proc { [200, {}, ["OK"]] }
 
+  mount GovukPublishingComponents::Engine, at: "/component-guide"
+
   if Rails.env.test?
     get "/government/admin/consultations/new", to: proc { [200, {}, ["You've been redirected"]] }
   end


### PR DESCRIPTION
This adds the component guide to the application. This means we can start developing components that are only in this application.

Because we've disabled Static in this app, the normal GOV.UK styling won't work:

https://github.com/alphagov/content-publisher/blob/fee9dbc6c25f4b9f71903daa3cc3284be6599cae/config/application.rb#L30-L33

This is not a big issue, because the components preview correctly. Alex will look at tidying up the component guide so it's better usable in admin apps as well.

https://trello.com/c/YWkUAjtN/45-make-sure-everything-is-documented