### PR TITLE
Don't send `first_public_at` in the details

### DIFF
--- a/app/services/document_publishing_service.rb
+++ b/app/services/document_publishing_service.rb
@@ -24,8 +24,7 @@ private
       document_type: document.document_type,
       publishing_app: PUBLISHING_APP,
       rendering_app: document.document_type_schema.rendering_app,
-      details: document.contents.merge(first_public_at: Time.now.iso8601,
-                                       government: {
+      details: document.contents.merge(government: {
                                          title: "Hey", slug: "what", current: true,
                                        },
                                        political: false),


### PR DESCRIPTION
This is covered by the top-level `first_published_at` field.

Depends on https://github.com/alphagov/govuk-content-schemas/pull/801 for the tests to pass, and https://github.com/alphagov/government-frontend/pull/996 for the frontend.

https://trello.com/c/bMv5Tkgp/77-solve-firstpublicat-issue