### PR TITLE
Add change_history to API Payload for email alerts

### DIFF
--- a/app/services/document_publishing_service.rb
+++ b/app/services/document_publishing_service.rb
@@ -25,6 +25,7 @@ private
       document_type: document.document_type,
       publishing_app: PUBLISHING_APP,
       rendering_app: document.document_type_schema.rendering_app,
+      change_note: "To support email alerts",
       details: document.contents.merge(government: {
                                          title: "Hey", slug: "what", current: true,
                                        },


### PR DESCRIPTION
https://trello.com/c/Vbwd7cye

This is a required field for email alerts, which gets extracted by the
Publishing API and added to any existing change history i.e. the history
is set and stored incrementally.