### PR TITLE
Fix email alerting (change_note vs change_history)

### DIFF
--- a/app/services/document_publishing_service.rb
+++ b/app/services/document_publishing_service.rb
@@ -25,10 +25,13 @@ private
       document_type: document.document_type,
       publishing_app: PUBLISHING_APP,
       rendering_app: document.document_type_schema.rendering_app,
-      change_note: "To support email alerts",
       details: document.contents.merge(government: {
                                          title: "Hey", slug: "what", current: true,
                                        },
+                                       change_history: [{
+                                         public_timestamp: Time.now.iso8601,
+                                         note: "To support email alerts"
+                                       }],
                                        political: false),
       routes: [
         { path: document.base_path, type: "exact" },


### PR DESCRIPTION
https://trello.com/c/Vbwd7cye

We mistakenly thought that change_note was workable attribute for
Whitehall content, but looking again at the schema shows that only
change_history is a documented part of the schema. We should use this
property for now until we make the change history/note dynamic.