### PR TITLE
Beautify the pages again

### DIFF
--- a/app/views/documents/edit.html.erb
+++ b/app/views/documents/edit.html.erb
@@ -1,36 +1,39 @@
+<%= content_for :back_link, document_path(@document) %>
 <% content_for :title, @document.title || "Untitled document" %>
+
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
-
-    Document type: <%= @document.document_type %>.
-
-    <br/><br/>
-
     <%= form_for @document do |f| %>
-      <p>
-        Title:
-        <%= f.text_field :title %>
-      </p>
+      <%= render "govuk_publishing_components/components/input", {
+        label: {
+          text: "Title"
+        },
+        name: "document[title]",
+        value: @document.title
+      } %>
 
-      <p>
-        Summary:<br/>
-        <%= f.text_field :summary %>
-      </p>
+      <%= render "govuk_publishing_components/components/input", {
+        label: {
+          text: "Base path"
+        },
+        name: "document[base_path]",
+        value: @document.base_path
+      } %>
 
-      <p>
-        Base path: <%= f.text_field :base_path %>
-      </p>
+      <%= render "govuk_publishing_components/components/label", {
+        text: "Summary",
+        html_for: "document[summary]"
+      } %>
+
+      <%= tag.textarea @document.summary, rows: 4, class: "govuk-textarea", name: "document[summary]" %>
 
       <% @document.document_type_schema.fields.each do |field| %>
         <%= render "documents/fields/#{field.type}_input", name: field.id, label: field.label, document: @document %>
       <% end %>
 
-      <br/>
-      <br/>
-      <br/>
-
-      <%= f.submit "Save" %>
-
+      <%= render "govuk_publishing_components/components/button", {
+        text: "Save"
+      } %>
     <% end %>
   </div>
 </div>

--- a/app/views/documents/fields/_govspeak.html.erb
+++ b/app/views/documents/fields/_govspeak.html.erb
@@ -1,5 +1,8 @@
 <p>
-  <%= label %><br/>
+  <%= render "govuk_publishing_components/components/heading", {
+    text: name
+  } %>
+
   <%= render "govuk_publishing_components/components/govspeak", {} do %>
     <%= raw Govspeak::Document.new(@document.contents[name]).to_html %>
   <% end %>

--- a/app/views/documents/fields/_govspeak_input.html.erb
+++ b/app/views/documents/fields/_govspeak_input.html.erb
@@ -1,4 +1,8 @@
 <p>
-  <%= label %><br/>
-  <%= tag.textarea document.contents[name], class: "govuk-textarea", name: "document[contents][#{name}]" %>
+  <%= render "govuk_publishing_components/components/label", {
+    text: label,
+    html_for: "document[contents][#{name}]"
+  } %>
+
+  <%= tag.textarea document.contents[name], rows: 15, class: "govuk-textarea", name: "document[contents][#{name}]" %>
 </p>

--- a/app/views/documents/index.html.erb
+++ b/app/views/documents/index.html.erb
@@ -1,14 +1,26 @@
-<%= link_to "New document", new_document_path %>
+<% content_for :title, "Documents" %>
 
-<h3>Documents</h3>
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-two-thirds">
+    <%= render "govuk_publishing_components/components/button", {
+      text: "New document", href: new_document_path
+    } %>
 
-<table>
-<% @documents.each do |document| %>
-  <tr>
-    <td><%= link_to document.title || "No title", document %></td>
-    <td><%= document.updated_at %></td>
-    <td><%= document.document_type %></td>
-    <td><%= link_to "Edit", edit_document_path(document) %></td>
-  </tr>
-<% end %>
-</table>
+    <%= render "govuk_publishing_components/components/document_list", {
+      items: @documents.map do |document|
+        {
+          link: {
+            text: document.title || "No title",
+            path: document_path(document),
+            description: document.summary,
+            context: document.locale
+          },
+          metadata: {
+            public_updated_at: document.updated_at,
+            document_type: document.document_type
+          }
+        }
+      end
+    } %>
+  </div>
+</div>

--- a/app/views/documents/show.html.erb
+++ b/app/views/documents/show.html.erb
@@ -13,5 +13,10 @@
   <%= render "documents/fields/#{field.type}", name: field.id, label: field.label, document: @document %>
 <% end %>
 
-<%= button_to :publish, publish_document_path(@document) %>
-<%= button_to :edit, edit_document_path(@document), method: :get %>
+<%= form_tag publish_document_path(@document) do %>
+  <%= render "govuk_publishing_components/components/button", {
+    text: "Publish"
+  } %>
+<% end %>
+
+<%= link_to "Edit document", edit_document_path(@document) %>

--- a/spec/integration/edit_a_document_spec.rb
+++ b/spec/integration/edit_a_document_spec.rb
@@ -17,7 +17,7 @@ RSpec.describe "Edit a document", type: :feature do
 
   def when_i_go_to_edit_the_document
     visit document_path(Document.last)
-    click_on "edit"
+    click_on "Edit document"
     @request = stub_publishing_api_put_content(Document.last.content_id, {})
   end
 

--- a/spec/integration/publish_a_document_api_down_spec.rb
+++ b/spec/integration/publish_a_document_api_down_spec.rb
@@ -21,7 +21,7 @@ RSpec.describe "Publishing a document when the API is down", type: :feature do
 
   def when_i_try_to_publish_the_document
     visit document_path(@document)
-    click_on "publish"
+    click_on "Publish"
   end
 
   def then_i_see_the_publish_failed

--- a/spec/integration/publish_a_document_spec.rb
+++ b/spec/integration/publish_a_document_spec.rb
@@ -20,7 +20,7 @@ RSpec.describe "Publishing a document", type: :feature do
 
   def and_i_click_on_the_publish_button
     @request = stub_publishing_api_publish(@document.content_id, update_type: "major", locale: @document.locale)
-    click_on "publish"
+    click_on "Publish"
   end
 
   def then_i_see_the_publish_succeeded


### PR DESCRIPTION
This is another attempt to beautify the app - feel free to modify the branch and discuss :-)

   * We should have a way of showing label+value for the show page (currently abusing the label component); similarly for govspeak
   * Some of the buttons and text have the wrong font, except for the Publish button - presumably because it's type=submit
   *  The Publish button doing a post request is a bit of a hack - should be able to do this by setting the method like rails button_to
   * The document list indentation for the index page is messed up, and we should be translating the document_type to look nice
   * The flash messages are hard-coded and not very informative in the case of an error - we should expose more detailed info
   * The error_message component has an orange and a red outline when it first appears - probably shouldn't allow it to be focusable