### PR TITLE
Import Whitehall JSON into documents

### DIFF
--- a/lib/tasks/import.rake
+++ b/lib/tasks/import.rake
@@ -1,0 +1,11 @@
+# frozen_string_literal: true
+
+require "tasks/whitehall_news_importer"
+
+namespace :import do
+  task :whitehall_news, [:path] => :environment do |_t, args|
+    to_import = JSON.parse(File.read(args[:path]))
+    done = Tasks::WhitehallNewsImporter.new(to_import).import
+    puts "Imported #{done} Whitehall news documents"
+  end
+end

--- a/lib/tasks/whitehall_news_importer.rb
+++ b/lib/tasks/whitehall_news_importer.rb
@@ -1,0 +1,40 @@
+# frozen_string_literal: true
+
+module Tasks
+  class WhitehallNewsImporter
+    def initialize(to_import)
+      @to_import = to_import
+    end
+
+    def import
+      to_import.each do |document|
+        edition = most_recent_edition(document)
+        edition["translations"].each do |translation|
+          create_document(translation, edition, document)
+        end
+      end
+      to_import.count
+    end
+
+  private
+
+    attr_reader :to_import
+
+    def most_recent_edition(document)
+      document["editions"].sort_by { |e| e["created_at"] }.last
+    end
+
+    def create_document(translation, edition, document)
+      Document.create!(
+        base_path: "/government/news/#{document['slug']}",
+        content_id: document["content_id"],
+        contents: {
+          body: translation["body"]
+        },
+        document_type: edition["news_article_type"]["key"],
+        locale: translation["locale"],
+        title: translation["title"],
+      )
+    end
+  end
+end

--- a/spec/tasks/whitehall_news_importer_spec.rb
+++ b/spec/tasks/whitehall_news_importer_spec.rb
@@ -1,0 +1,27 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+require "tasks/whitehall_news_importer"
+
+RSpec.describe Tasks::WhitehallNewsImporter do
+  it "can import JSON data from Whitehall" do
+    import_json = [
+      {
+        content_id: SecureRandom.uuid,
+        slug: "test-page",
+        editions: [
+          {
+            created_at: Time.zone.now,
+            news_article_type: { key: "news_story" },
+            translations: [
+              { locale: "en", title: "Title", summary: "Summary", body: "Body" }
+            ]
+          }
+        ]
+      }
+    ].to_json
+
+    expect { Tasks::WhitehallNewsImporter.new(JSON.parse(import_json)).import }
+      .to change { Document.count }.by(1)
+  end
+end


### PR DESCRIPTION
Trello: https://trello.com/c/Zx8mNyZi/35-investigate-how-could-data-be-exported-from-whitehall-m-1-day

This takes the big wad of JSON that the export:news_documents task produce and imports them as documents. As we don't store much information currently this means that most of that data is ignored.

This relies on: https://github.com/alphagov/whitehall/pull/4238 and can be used like so:

```ssh
cd whitehall
rake export:news_documents ORGS=nuclear-decommissioning-authority OUTPUT=/tmp/nda.json
cd ../content-publisher
rake "import:whitehall_news[/tmp/nda.json]"
```

The test really cuts down the JSON to just the bare minimum for the sake of brevity in the test and may need extending if our required fields increase.

I wasn't quite sure what would be the best place to drop the class for the rake task since there is (as always) not a super intuitive place for it. So went with the lib/tasks directory. Do shout if you have strong opinions on this.