### PR TITLE
Redirect users to the correct environment

### DIFF
--- a/app/controllers/new_document_controller.rb
+++ b/app/controllers/new_document_controller.rb
@@ -18,8 +18,8 @@ class NewDocumentController < ApplicationController
   def create
     document_type_schema = DocumentTypeSchema.find(params[:document_type])
 
-    if document_type_schema.managed_elsewhere
-      redirect_to document_type_schema.managed_elsewhere
+    if document_type_schema.managed_elsewhere?
+      redirect_to document_type_schema.managed_elsewhere_url
       return
     end
 

--- a/app/formats/document_types.yml
+++ b/app/formats/document_types.yml
@@ -34,8 +34,13 @@
   rendering_app: government-frontend
   name: Detailed guides
   supertype: guidance
+  managed_elsewhere:
+    hostname: whitehall-admin
+    path: /government/admin/detailed-guides/new
 
 - document_type: consultation
   name: Consultation (managed elsewhere)
   supertype: consultations
-  managed_elsewhere: https://whitehall-admin.publishing.service.gov.uk/government/admin/consultations/new
+  managed_elsewhere:
+    hostname: whitehall-admin
+    path: /government/admin/consultations/new

--- a/app/services/document_type_schema.rb
+++ b/app/services/document_type_schema.rb
@@ -25,6 +25,14 @@ class DocumentTypeSchema
     end
   end
 
+  def managed_elsewhere?
+    managed_elsewhere
+  end
+
+  def managed_elsewhere_url
+    Plek.find(managed_elsewhere.fetch('hostname')) + managed_elsewhere.fetch('path')
+  end
+
   class Field
     include ActiveModel::Model
     attr_accessor :id, :label, :type

--- a/spec/services/document_type_schema_spec.rb
+++ b/spec/services/document_type_schema_spec.rb
@@ -21,4 +21,17 @@ RSpec.describe DocumentTypeSchema do
       expect(schema.fields).to eql([])
     end
   end
+
+  describe '#managed_elsewhere_url' do
+    it 'returns a full URL' do
+      schema = DocumentTypeSchema.new(
+        "managed_elsewhere" => {
+          "hostname" => "whitehall-admin",
+          "path" => "/some/new/document",
+        }
+      )
+
+      expect(schema.managed_elsewhere_url).to eql("https://whitehall-admin.test.gov.uk/some/new/document")
+    end
+  end
 end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,6 +1,8 @@
 # frozen_string_literal: true
 
 ENV["RAILS_ENV"] ||= "test"
+ENV["GOVUK_APP_DOMAIN"] = "test.gov.uk"
+
 require File.expand_path("../../config/environment", __FILE__)
 require "rspec/rails"
 


### PR DESCRIPTION
We currently hard code the entire edit URL. This is surprising to users who expect to be redirected to integration when they use the application in that environment.

https://trello.com/c/PxtaaObC