### PR TITLE
Test all formats automatically

### DIFF
--- a/app/views/documents/show.html.erb
+++ b/app/views/documents/show.html.erb
@@ -9,6 +9,10 @@
   Document type: <%= @document.document_type %>
 </p>
 
+<p>
+  Summary: <%= @document.summary %>
+</p>
+
 <% @document.document_type_schema.fields.each do |field| %>
   <%= render "documents/fields/#{field.type}", name: field.id, label: field.label, document: @document %>
 <% end %>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -21,6 +21,6 @@ Rails.application.routes.draw do
   mount GovukPublishingComponents::Engine, at: "/component-guide"
 
   if Rails.env.test?
-    get "/government/admin/consultations/new", to: proc { [200, {}, ["You've been redirected"]] }
+    get "/government/*all", to: proc { [200, {}, ["You've been redirected"]] }
   end
 end

--- a/spec/integration/create_a_document_elsewhere_spec.rb
+++ b/spec/integration/create_a_document_elsewhere_spec.rb
@@ -3,27 +3,31 @@
 require "spec_helper"
 
 RSpec.describe "Create a document that is managed elsewhere", type: :feature do
-  scenario "User creates a document" do
-    when_i_click_on_create_a_document
-    and_i_choose_a_document_that_is_not_managed_in_this_app
-    then_i_am_redirected_to_the_application_that_manages_the_content
-  end
+  DocumentTypeSchema.all.select(&:managed_elsewhere?).each do |schema|
+    scenario "User creates a #{schema.name}" do
+      @schema = schema
 
-  def when_i_click_on_create_a_document
-    visit "/"
-    click_on "New document"
-  end
+      when_i_click_on_create_a_document
+      and_i_choose_a_document_that_is_not_managed_in_this_app
+      then_i_am_redirected_to_the_application_that_manages_the_content
+    end
 
-  def and_i_choose_a_document_that_is_not_managed_in_this_app
-    choose "Consultations"
-    click_on "Continue"
+    def when_i_click_on_create_a_document
+      visit "/"
+      click_on "New document"
+    end
 
-    choose "Consultation (managed elsewhere)"
-    click_on "Continue"
-  end
+    def and_i_choose_a_document_that_is_not_managed_in_this_app
+      choose SupertypeSchema.find(@schema.supertype).label
+      click_on "Continue"
 
-  def then_i_am_redirected_to_the_application_that_manages_the_content
-    expect(page.current_path).to eql "/government/admin/consultations/new"
-    expect(page).to have_content "You've been redirected"
+      choose @schema.name
+      click_on "Continue"
+    end
+
+    def then_i_am_redirected_to_the_application_that_manages_the_content
+      expect(page.current_path).to eql @schema.managed_elsewhere.fetch("path")
+      expect(page).to have_content "You've been redirected"
+    end
   end
 end

--- a/spec/integration/edit_a_document_spec.rb
+++ b/spec/integration/edit_a_document_spec.rb
@@ -3,42 +3,52 @@
 require "spec_helper"
 
 RSpec.describe "Edit a document", type: :feature do
-  scenario "User edits a document" do
-    given_there_is_a_document
-    when_i_go_to_edit_the_document
-    and_i_fill_in_the_fields
-    then_i_see_the_document_is_saved
-    and_the_preview_creation_succeeded
-  end
+  DocumentTypeSchema.all.each do |schema|
+    next if schema.managed_elsewhere?
 
-  def given_there_is_a_document
-    create :document, document_type: "press_release"
-  end
+    scenario "User edits #{schema.name}" do
+      @schema = schema
 
-  def when_i_go_to_edit_the_document
-    visit document_path(Document.last)
-    click_on "Edit document"
-    @request = stub_publishing_api_put_content(Document.last.content_id, {})
-  end
+      given_there_is_a_document
+      when_i_go_to_edit_the_document
+      and_i_fill_in_the_fields
+      then_i_see_the_document_is_saved
+      and_the_preview_creation_succeeded
+    end
 
-  def and_i_fill_in_the_fields
-    fill_in "document[contents][body]", with: "The document body"
-    fill_in "document[summary]", with: "A summary of the release."
-    click_on "Save"
-  end
+    def given_there_is_a_document
+      create :document, document_type: @schema.document_type
+    end
 
-  def then_i_see_the_document_is_saved
-    expect(Document.last.summary).to eql("A summary of the release.")
-    expect(page).to have_content "The document body"
-  end
+    def when_i_go_to_edit_the_document
+      visit document_path(Document.last)
+      click_on "Edit document"
+      @request = stub_publishing_api_put_content(Document.last.content_id, {})
+    end
 
-  def and_the_preview_creation_succeeded
-    expect(@request).to have_been_requested
-    expect(page).to have_content "Preview creation successful"
+    def and_i_fill_in_the_fields
+      @schema.fields do |field|
+        # TODO: this currently works because the only field type (body) accepts
+        # a string. Once there are other field types we'll need to expand on this.
+        fill_in "document[contents][#{field.id}]", with: SecureRandom.hex
+      end
 
-    expect(a_request(:put, /content/).with { |req|
-      expect(req.body).to be_valid_against_schema("news_article")
-      expect(JSON.parse(req.body)["details"]["body"]).to eq "The document body"
-    }).to have_been_requested
+      fill_in "document[summary]", with: "A summary of the release."
+      click_on "Save"
+    end
+
+    def then_i_see_the_document_is_saved
+      expect(page).to have_content "A summary of the release."
+    end
+
+    def and_the_preview_creation_succeeded
+      expect(@request).to have_been_requested
+      expect(page).to have_content "Preview creation successful"
+
+      expect(a_request(:put, /content/).with { |req|
+        expect(req.body).to be_valid_against_schema(@schema.schema_name)
+        expect(JSON.parse(req.body)["description"]).to eq "A summary of the release."
+      }).to have_been_requested
+    end
   end
 end


### PR DESCRIPTION
We currently have integration tests to create and edit a format. We're using the "press release" format as an example for this. This isn't ideal: we're not performing integration tests for the other formats in [document_types.yml](https://github.com/alphagov/content-publisher/blob/master/app/formats/document_types.yml). We might make configuration mistakes like putting in an incorrect `schema_name` for a format, and we have no way to know.

This PR changes the 3 relevant integration tests to instead loop through all the document types we have, and test them as best as we can. Because the formats are pretty much the same at the moment it's pretty easy to do. It might get harder if we introduce new types, but it's probably still worth it.

Best reviewed [without whitespace changes](https://github.com/alphagov/content-publisher/pull/64/files?utf8=%E2%9C%93&w=1).

https://trello.com/c/PxtaaObC
