### PR TITLE
Avoid relying on specific formats in tests

### DIFF
--- a/spec/factories/document_factory.rb
+++ b/spec/factories/document_factory.rb
@@ -5,9 +5,6 @@ FactoryBot.define do
     content_id { SecureRandom.uuid }
     locale { I18n.available_locales.sample }
     base_path { "/#{SecureRandom.alphanumeric(8)}" }
-
-    trait :press_release do
-      document_type "press_release"
-    end
+    document_type { DocumentTypeSchema.all.reject(&:managed_elsewhere?).sample.document_type }
   end
 end

--- a/spec/integration/publish_a_document_api_down_spec.rb
+++ b/spec/integration/publish_a_document_api_down_spec.rb
@@ -11,7 +11,7 @@ RSpec.describe "Publishing a document when the API is down", type: :feature do
   end
 
   def given_there_is_a_document
-    @document = create :document, :press_release
+    @document = create :document
   end
 
   def and_the_publishing_api_is_down

--- a/spec/integration/publish_a_document_spec.rb
+++ b/spec/integration/publish_a_document_spec.rb
@@ -11,7 +11,7 @@ RSpec.describe "Publishing a document", type: :feature do
   end
 
   def given_there_is_a_document
-    @document = create :document, :press_release
+    @document = create :document
   end
 
   def when_i_visit_the_document_page

--- a/spec/integration/show_a_document_spec.rb
+++ b/spec/integration/show_a_document_spec.rb
@@ -10,7 +10,7 @@ RSpec.describe "Showing a document summary", type: :feature do
   end
 
   def given_there_is_a_document
-    @document = create :document, :press_release, title: "Title"
+    @document = create :document, title: "Title"
   end
 
   def when_i_visit_the_document_page


### PR DESCRIPTION
We should avoid using specific document types in the tests, because we'll implicitly rely on format-specific configuration. We should either test against all formats (https://github.com/alphagov/content-publisher/pull/64) or randomise the document type as is done here.

https://trello.com/c/PxtaaObC