### PR TITLE
Show validations for content

### DIFF
--- a/app/formats/document_types.yml
+++ b/app/formats/document_types.yml
@@ -8,6 +8,8 @@
     - id: body
       label: Body
       type: govspeak
+      validations:
+        min_length: 10
 
 - document_type: news_story
   schema_name: news_article
@@ -18,6 +20,8 @@
     - id: body
       label: Body
       type: govspeak
+      validations:
+        min_length: 10
 
 - document_type: statistical_data_set
   schema_name: statistical_data_set
@@ -28,6 +32,8 @@
     - id: body
       label: Body
       type: govspeak
+      validations:
+        min_length: 10
 
 - document_type: detailed_guide
   schema_name: detailed_guide

--- a/app/services/content_validator.rb
+++ b/app/services/content_validator.rb
@@ -1,0 +1,52 @@
+# frozen_string_literal: true
+
+# Determines whether content should be published to the publishing-api
+class ContentValidator
+  attr_reader :document
+
+  def initialize(document)
+    @document = document
+  end
+
+  def validation_messages
+    messages = []
+    perform_validations_that_apply_to_all_formats(messages)
+    perform_format_specific_validations(messages)
+    messages
+  end
+
+private
+
+  def perform_validations_that_apply_to_all_formats(messages)
+    if document.title.to_s.size < 10
+      # TODO: extract string into locale file
+      messages << "The title needs to be at least 10 characters long"
+    end
+
+    if document.summary.to_s.size < 10
+      # TODO: extract string into locale file
+      messages << "The summary needs to be at least 10 characters long"
+    end
+  end
+
+  def perform_format_specific_validations(messages)
+    schema = document.document_type_schema
+
+    schema.fields.each do |field|
+      # Validations come in pairs, like `min_length: 10`. They should use
+      # a underscored version of JSON Schema's validation system. For example,
+      # `max_length`, `one_of`.
+      #
+      # http://json-schema.org/latest/json-schema-validation.html
+      field.validations.each do |validation_name, value|
+        case validation_name
+        when "min_length"
+          if document.contents[field.id].to_s.size < value
+            # TODO: extract string into locale file
+            messages << "#{field.label} needs to be at least #{value} characters long"
+          end
+        end
+      end
+    end
+  end
+end

--- a/app/services/document_type_schema.rb
+++ b/app/services/document_type_schema.rb
@@ -35,6 +35,6 @@ class DocumentTypeSchema
 
   class Field
     include ActiveModel::Model
-    attr_accessor :id, :label, :type
+    attr_accessor :id, :label, :type, :validations
   end
 end

--- a/app/views/documents/show.html.erb
+++ b/app/views/documents/show.html.erb
@@ -13,6 +13,12 @@
   Summary: <%= @document.summary %>
 </p>
 
+<ul>
+<% ContentValidator.new(@document).validation_messages.each do |message| %>
+  <li><%= message %></li>
+<% end %>
+</ul>
+
 <% @document.document_type_schema.fields.each do |field| %>
   <%= render "documents/fields/#{field.type}", name: field.id, label: field.label, document: @document %>
 <% end %>

--- a/spec/factories/document_factory.rb
+++ b/spec/factories/document_factory.rb
@@ -6,5 +6,9 @@ FactoryBot.define do
     locale { I18n.available_locales.sample }
     base_path { "/#{SecureRandom.alphanumeric(8)}" }
     document_type { DocumentTypeSchema.all.reject(&:managed_elsewhere?).sample.document_type }
+
+    trait :with_body do
+      document_type { DocumentTypeSchema.all.select { |schema| schema.fields.any? { |field| field.id == "body" } }.sample.document_type }
+    end
   end
 end

--- a/spec/integration/publishing_validations_spec.rb
+++ b/spec/integration/publishing_validations_spec.rb
@@ -1,0 +1,45 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+
+RSpec.describe "Publish validations", type: :feature do
+  scenario "A document is validated" do
+    given_there_is_a_document_with_not_enough_info
+    when_i_visit_the_document_page
+    then_i_see_the_warnings
+    when_i_fix_some_warnings
+    then_i_see_fewer_warnings
+  end
+
+  def given_there_is_a_document_with_not_enough_info
+    @document = create :document, :with_body
+  end
+
+  def when_i_visit_the_document_page
+    visit document_path(@document)
+  end
+
+  def then_i_see_the_warnings
+    expect(page).to have_content "The title needs to be at least 10 characters long"
+    expect(page).to have_content "The summary needs to be at least 10 characters long"
+    expect(page).to have_content "Body needs to be at least 10 characters long"
+  end
+
+  def when_i_fix_some_warnings
+    # Clicking save will make a request, but we don't care about the
+    # particulars, which are tested in the feature test of the "edit" flow
+    stub_any_publishing_api_put_content
+
+    click_on "Edit document"
+    fill_in "document[title]", with: "A nice title of considerable length"
+    fill_in "document[contents][body]", with: "A very long body text."
+    click_on "Save"
+  end
+
+  def then_i_see_fewer_warnings
+    expect(page).not_to have_content "The title needs to be at least 10 characters long"
+    expect(page).not_to have_content "Body needs to be at least 10 characters long"
+
+    expect(page).to have_content "The summary needs to be at least 10 characters long"
+  end
+end

--- a/spec/services/content_validator_spec.rb
+++ b/spec/services/content_validator_spec.rb
@@ -1,0 +1,67 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+
+RSpec.describe ContentValidator do
+  describe 'title validation' do
+    it 'raises issue if the title is not set' do
+      document = create(:document, title: nil)
+
+      messages = ContentValidator.new(document).validation_messages
+
+      expect(messages).to include("The title needs to be at least 10 characters long")
+    end
+
+    it 'raises issue if the title is too short' do
+      document = create(:document, title: "Too short")
+
+      messages = ContentValidator.new(document).validation_messages
+
+      expect(messages).to include("The title needs to be at least 10 characters long")
+    end
+
+    it 'does not raise an issue if the title is fine' do
+      document = create(:document, title: "Just long enough to validate.")
+
+      messages = ContentValidator.new(document).validation_messages
+
+      expect(messages).not_to include("The title needs to be at least 10 characters long")
+    end
+  end
+
+  describe 'summary validation' do
+    it 'raises issue if the summary is not set' do
+      document = create(:document, summary: nil)
+
+      messages = ContentValidator.new(document).validation_messages
+
+      expect(messages).to include("The summary needs to be at least 10 characters long")
+    end
+
+    it 'raises issue if the summary is too short' do
+      document = create(:document, summary: "Too short")
+
+      messages = ContentValidator.new(document).validation_messages
+
+      expect(messages).to include("The summary needs to be at least 10 characters long")
+    end
+
+    it 'does not raise an issue if the summary is fine' do
+      document = create(:document, summary: "Just long enough to validate.")
+
+      messages = ContentValidator.new(document).validation_messages
+
+      expect(messages).not_to include("The summary needs to be at least 10 characters long")
+    end
+  end
+
+  describe 'custom validation' do
+    it 'raises issue if the summary is not set' do
+      document = create(:document, :with_body, contents: { body: "Too short" })
+
+      messages = ContentValidator.new(document).validation_messages
+
+      expect(messages).to include("Body needs to be at least 10 characters long")
+    end
+  end
+end


### PR DESCRIPTION
This PR adds validations for content.

There are 2 types:

- Validations that apply to all formats, like title and summary
- Validations that are configured per format. The only example we currently have is the body.

The per-format configuration is intended to use the same syntax as JSON schema. Thus, `min_length` has the same behaviour as `minLength` for strings:

http://json-schema.org/latest/json-schema-validation.html#rfc.section.6.3

Caveats:

- I'm not a 100% sure this pattern of validation will scale well. I think we'll see if it works once we add more format-specific validations.
- The minimum number of characters (10) was chosen completely arbitrarily.

https://trello.com/c/PxtaaObC