### PR TITLE
Use unicorn when starting the app from startup.sh

### DIFF
--- a/startup.sh
+++ b/startup.sh
@@ -1,4 +1,4 @@
 #!/bin/bash
 
 bundle install
-bundle exec rails s -p 3221 
+bundle exec unicorn -p 3221 


### PR DESCRIPTION
Since introducing Puma via govuk_test, we're accidently running Puma when using startup.sh. This makes it use Unicorn like we do in production.