### PR TITLE
Convert Govspeak to HTML before sending it to publishing-api

### DIFF
--- a/app/services/document_publishing_service.rb
+++ b/app/services/document_publishing_service.rb
@@ -3,10 +3,8 @@
 require 'gds_api/publishing_api_v2'
 
 class DocumentPublishingService
-  PUBLISHING_APP = "content-publisher"
-
   def publish_draft(document)
-    publishing_api.put_content(document.content_id, payload(document))
+    publishing_api.put_content(document.content_id, PublishingApiPayload.new(document).payload)
   end
 
   def publish(document)
@@ -14,30 +12,6 @@ class DocumentPublishingService
   end
 
 private
-
-  def payload(document)
-    {
-      base_path: document.base_path,
-      title: document.title,
-      locale: document.locale,
-      description: document.summary,
-      schema_name: document.document_type_schema.schema_name,
-      document_type: document.document_type,
-      publishing_app: PUBLISHING_APP,
-      rendering_app: document.document_type_schema.rendering_app,
-      details: document.contents.merge(government: {
-                                         title: "Hey", slug: "what", current: true,
-                                       },
-                                       change_history: [{
-                                         public_timestamp: Time.now.iso8601,
-                                         note: "To support email alerts"
-                                       }],
-                                       political: false),
-      routes: [
-        { path: document.base_path, type: "exact" },
-      ]
-    }
-  end
 
   def publishing_api
     GdsApi::PublishingApiV2.new(

--- a/app/services/publishing_api_payload.rb
+++ b/app/services/publishing_api_payload.rb
@@ -32,7 +32,7 @@ private
     details_hash = temporary_defaults_in_details
 
     document.document_type_schema.fields.each do |field|
-      details_hash[field.id] = document.contents[field.id]
+      details_hash[field.id] = perform_input_type_specific_transformations(field)
     end
 
     details_hash
@@ -51,5 +51,15 @@ private
       ],
       political: false
     }
+  end
+
+  # Note: once this grows to a sufficient size, move it over into a new class
+  # or class system.
+  def perform_input_type_specific_transformations(field)
+    if field.type == "govspeak"
+      Govspeak::Document.new(document.contents[field.id]).to_html
+    else
+      document.contents[field.id]
+    end
   end
 end

--- a/app/services/publishing_api_payload.rb
+++ b/app/services/publishing_api_payload.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 class PublishingApiPayload
   PUBLISHING_APP = "content-publisher"
 
@@ -15,14 +17,7 @@ class PublishingApiPayload
       document_type: document.document_type,
       publishing_app: PUBLISHING_APP,
       rendering_app: document.document_type_schema.rendering_app,
-      details: document.contents.merge(government: {
-                                         title: "Hey", slug: "what", current: true,
-                                       },
-                                       change_history: [{
-                                         public_timestamp: Time.now.iso8601,
-                                         note: "To support email alerts"
-                                       }],
-                                       political: false),
+      details: details,
       routes: [
         { path: document.base_path, type: "exact" },
       ]
@@ -32,4 +27,23 @@ class PublishingApiPayload
 private
 
   attr_reader :document
+
+  def details
+    document.contents.merge(temporary_defaults_in_details)
+  end
+
+  def temporary_defaults_in_details
+    {
+      government: {
+        title: "Hey", slug: "what", current: true,
+      },
+      change_history: [
+        {
+          public_timestamp: Time.now.iso8601,
+          note: "To support email alerts"
+        }
+      ],
+      political: false
+    }
+  end
 end

--- a/app/services/publishing_api_payload.rb
+++ b/app/services/publishing_api_payload.rb
@@ -29,7 +29,13 @@ private
   attr_reader :document
 
   def details
-    document.contents.merge(temporary_defaults_in_details)
+    details_hash = temporary_defaults_in_details
+
+    document.document_type_schema.fields.each do |field|
+      details_hash[field.id] = document.contents[field.id]
+    end
+
+    details_hash
   end
 
   def temporary_defaults_in_details

--- a/app/services/publishing_api_payload.rb
+++ b/app/services/publishing_api_payload.rb
@@ -1,0 +1,35 @@
+class PublishingApiPayload
+  PUBLISHING_APP = "content-publisher"
+
+  def initialize(document)
+    @document = document
+  end
+
+  def payload
+    {
+      base_path: document.base_path,
+      title: document.title,
+      locale: document.locale,
+      description: document.summary,
+      schema_name: document.document_type_schema.schema_name,
+      document_type: document.document_type,
+      publishing_app: PUBLISHING_APP,
+      rendering_app: document.document_type_schema.rendering_app,
+      details: document.contents.merge(government: {
+                                         title: "Hey", slug: "what", current: true,
+                                       },
+                                       change_history: [{
+                                         public_timestamp: Time.now.iso8601,
+                                         note: "To support email alerts"
+                                       }],
+                                       political: false),
+      routes: [
+        { path: document.base_path, type: "exact" },
+      ]
+    }
+  end
+
+private
+
+  attr_reader :document
+end

--- a/spec/factories/document_factory.rb
+++ b/spec/factories/document_factory.rb
@@ -6,5 +6,9 @@ FactoryBot.define do
     locale { I18n.available_locales.sample }
     base_path { "/#{SecureRandom.alphanumeric(8)}" }
     document_type { DocumentTypeSchema.all.reject(&:managed_elsewhere?).sample.document_type }
+
+    trait :with_body do
+      document_type { DocumentTypeSchema.all.select { |schema| schema.fields.any? { |field| field.id == "body" } }.sample.document_type }
+    end
   end
 end

--- a/spec/services/publishing_api_payload_spec.rb
+++ b/spec/services/publishing_api_payload_spec.rb
@@ -1,0 +1,15 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+
+RSpec.describe PublishingApiPayload do
+  describe "#payload" do
+    it "transforms Govspeak before sending it to the publishing-api" do
+      document = create(:document, :with_body, contents: { body: "Hey **buddy**!" })
+
+      payload = PublishingApiPayload.new(document).payload
+
+      expect(payload[:details]["body"]).to eql("<p>Hey <strong>buddy</strong>!</p>\n")
+    end
+  end
+end


### PR DESCRIPTION
This converts fields of the type "govspeak" into HTML before sending it to the publishing-api.

The system of transformations is meant to be extensible. if we have more types, they can be added to the `perform_input_type_specific_transformations` method. If it grows sufficiently large, it can be moved into a separate class as well.

I've refactored some payload generation to make this change easier. Those commits can be reviewed separately.

https://trello.com/c/PTR8kN7U