### PR TITLE
Change production log level to info

### DIFF
--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -46,7 +46,7 @@ Rails.application.configure do
 
   # Use the lowest log level to ensure availability of diagnostic information
   # when problems arise.
-  config.log_level = :debug
+  config.log_level = :info
 
   # Prepend all log lines with the following tags.
   config.log_tags = [:request_id]


### PR DESCRIPTION
In light of https://github.com/alphagov/content-performance-manager/pull/829 this reduces the log level from debug