### PR TITLE
Build models rather than creating

### DIFF
--- a/spec/integration/edit_a_document_spec.rb
+++ b/spec/integration/edit_a_document_spec.rb
@@ -17,7 +17,7 @@ RSpec.describe "Edit a document", type: :feature do
     end
 
     def given_there_is_a_document
-      create :document, document_type: @schema.document_type
+      create(:document, document_type: @schema.document_type)
     end
 
     def when_i_go_to_edit_the_document

--- a/spec/integration/publish_a_document_api_down_spec.rb
+++ b/spec/integration/publish_a_document_api_down_spec.rb
@@ -11,7 +11,7 @@ RSpec.describe "Publishing a document when the API is down", type: :feature do
   end
 
   def given_there_is_a_document
-    @document = create :document
+    @document = create(:document)
   end
 
   def and_the_publishing_api_is_down

--- a/spec/integration/publish_a_document_spec.rb
+++ b/spec/integration/publish_a_document_spec.rb
@@ -12,7 +12,7 @@ RSpec.describe "Publishing a document", type: :feature do
   end
 
   def given_there_is_a_document
-    @document = create :document
+    @document = create(:document)
   end
 
   def when_i_visit_the_document_page

--- a/spec/integration/publishing_validations_spec.rb
+++ b/spec/integration/publishing_validations_spec.rb
@@ -12,7 +12,7 @@ RSpec.describe "Publish validations", type: :feature do
   end
 
   def given_there_is_a_document_with_not_enough_info
-    @document = create :document, :with_body
+    @document = create(:document, :with_body)
   end
 
   def when_i_visit_the_document_page

--- a/spec/integration/show_a_document_spec.rb
+++ b/spec/integration/show_a_document_spec.rb
@@ -10,7 +10,7 @@ RSpec.describe "Showing a document summary", type: :feature do
   end
 
   def given_there_is_a_document
-    @document = create :document, title: "Title"
+    @document = create(:document, title: "Title")
   end
 
   def when_i_visit_the_document_page

--- a/spec/services/content_validator_spec.rb
+++ b/spec/services/content_validator_spec.rb
@@ -5,7 +5,7 @@ require 'spec_helper'
 RSpec.describe ContentValidator do
   describe 'title validation' do
     it 'raises issue if the title is not set' do
-      document = create(:document, title: nil)
+      document = build(:document, title: nil)
 
       messages = ContentValidator.new(document).validation_messages
 
@@ -13,7 +13,7 @@ RSpec.describe ContentValidator do
     end
 
     it 'raises issue if the title is too short' do
-      document = create(:document, title: "Too short")
+      document = build(:document, title: "Too short")
 
       messages = ContentValidator.new(document).validation_messages
 
@@ -21,7 +21,7 @@ RSpec.describe ContentValidator do
     end
 
     it 'does not raise an issue if the title is fine' do
-      document = create(:document, title: "Just long enough to validate.")
+      document = build(:document, title: "Just long enough to validate.")
 
       messages = ContentValidator.new(document).validation_messages
 
@@ -31,7 +31,7 @@ RSpec.describe ContentValidator do
 
   describe 'summary validation' do
     it 'raises issue if the summary is not set' do
-      document = create(:document, summary: nil)
+      document = build(:document, summary: nil)
 
       messages = ContentValidator.new(document).validation_messages
 
@@ -39,7 +39,7 @@ RSpec.describe ContentValidator do
     end
 
     it 'raises issue if the summary is too short' do
-      document = create(:document, summary: "Too short")
+      document = build(:document, summary: "Too short")
 
       messages = ContentValidator.new(document).validation_messages
 
@@ -47,7 +47,7 @@ RSpec.describe ContentValidator do
     end
 
     it 'does not raise an issue if the summary is fine' do
-      document = create(:document, summary: "Just long enough to validate.")
+      document = build(:document, summary: "Just long enough to validate.")
 
       messages = ContentValidator.new(document).validation_messages
 
@@ -57,7 +57,7 @@ RSpec.describe ContentValidator do
 
   describe 'custom validation' do
     it 'raises issue if the summary is not set' do
-      document = create(:document, :with_body, contents: { body: "Too short" })
+      document = build(:document, :with_body, contents: { body: "Too short" })
 
       messages = ContentValidator.new(document).validation_messages
 

--- a/spec/services/publishing_api_payload_spec.rb
+++ b/spec/services/publishing_api_payload_spec.rb
@@ -5,7 +5,7 @@ require 'spec_helper'
 RSpec.describe PublishingApiPayload do
   describe "#payload" do
     it "transforms Govspeak before sending it to the publishing-api" do
-      document = create(:document, :with_body, contents: { body: "Hey **buddy**!" })
+      document = build(:document, :with_body, contents: { body: "Hey **buddy**!" })
 
       payload = PublishingApiPayload.new(document).payload
 


### PR DESCRIPTION
In most cases in unit tests we need an object of a particular model and it's not required to be persisted.

Using `build` doesn't save the record to the database and makes the tests run faster.