### PR TITLE
Reorganise document types to improve readability

### DIFF
--- a/app/controllers/documents_controller.rb
+++ b/app/controllers/documents_controller.rb
@@ -26,7 +26,7 @@ class DocumentsController < ApplicationController
 private
 
   def document_update_params(document)
-    contents_params = document.document_type_schema.fields.map(&:id)
+    contents_params = document.document_type_schema.contents.map(&:id)
     params.require(:document).permit(:title, :summary, :base_path, contents: contents_params)
   end
 end

--- a/app/controllers/new_document_controller.rb
+++ b/app/controllers/new_document_controller.rb
@@ -18,7 +18,7 @@ class NewDocumentController < ApplicationController
   def create
     document_type_schema = DocumentTypeSchema.find(params[:document_type])
 
-    if document_type_schema.managed_elsewhere?
+    if document_type_schema.managed_elsewhere
       redirect_to document_type_schema.managed_elsewhere_url
       return
     end

--- a/app/formats/document_types.yml
+++ b/app/formats/document_types.yml
@@ -1,51 +1,52 @@
 ---
-- document_type: press_release
-  schema_name: news_article
-  rendering_app: government-frontend
+- id: press_release
   name: Press release
   supertype: news
-  fields:
+  publishing_metadata:
+    schema_name: news_article
+    rendering_app: government-frontend
+  contents:
     - id: body
       label: Body
       type: govspeak
       validations:
         min_length: 10
 
-- document_type: news_story
-  schema_name: news_article
-  rendering_app: government-frontend
+- id: news_story
   name: News story
   supertype: news
-  fields:
+  publishing_metadata:
+    schema_name: news_article
+    rendering_app: government-frontend
+  contents:
     - id: body
       label: Body
       type: govspeak
       validations:
         min_length: 10
 
-- document_type: statistical_data_set
-  schema_name: statistical_data_set
-  rendering_app: government-frontend
+- id: statistical_data_set
   name: Statistical data set
   supertype: transparancy
-  fields:
+  publishing_metadata:
+    schema_name: statistical_data_set
+    rendering_app: government-frontend
+  contents:
     - id: body
       label: Body
       type: govspeak
       validations:
         min_length: 10
 
-- document_type: detailed_guide
-  schema_name: detailed_guide
-  rendering_app: government-frontend
-  name: Detailed guides
+- id: detailed_guide
+  name: Detailed guide
   supertype: guidance
   managed_elsewhere:
     hostname: whitehall-admin
     path: /government/admin/detailed-guides/new
 
-- document_type: consultation
-  name: Consultation (managed elsewhere)
+- id: consultation
+  name: Consultation
   supertype: consultations
   managed_elsewhere:
     hostname: whitehall-admin

--- a/app/services/content_validator.rb
+++ b/app/services/content_validator.rb
@@ -32,7 +32,7 @@ private
   def perform_format_specific_validations(messages)
     schema = document.document_type_schema
 
-    schema.fields.each do |field|
+    schema.contents.each do |field|
       # Validations come in pairs, like `min_length: 10`. They should use
       # a underscored version of JSON Schema's validation system. For example,
       # `max_length`, `one_of`.

--- a/app/services/document_type_schema.rb
+++ b/app/services/document_type_schema.rb
@@ -1,21 +1,20 @@
 # frozen_string_literal: true
 
 class DocumentTypeSchema
-  attr_reader :fields, :document_type, :name, :supertype, :managed_elsewhere, :schema_name, :rendering_app
+  attr_reader :contents, :id, :name, :supertype, :managed_elsewhere, :publishing_metadata
 
   def initialize(params = {})
-    @document_type = params["document_type"]
+    @id = params["id"]
     @name = params["name"]
-    @supertype = params["supertype"]
+    @supertype = SupertypeSchema.find(params["supertype"])
     @managed_elsewhere = params["managed_elsewhere"]
-    @fields = params["fields"].to_a.map { |field| Field.new(field) }
-    @schema_name = params["schema_name"]
-    @rendering_app = params["rendering_app"]
+    @contents = params["contents"].to_a.map { |field| Field.new(field) }
+    @publishing_metadata = PublishingMetadata.new(params["publishing_metadata"])
   end
 
-  def self.find(document_type)
-    item = all.find { |schema| schema.document_type == document_type }
-    item || (raise RuntimeError, "Document type #{document_type} not found")
+  def self.find(document_type_id)
+    item = all.find { |schema| schema.id == document_type_id }
+    item || (raise RuntimeError, "Document type #{document_type_id} not found")
   end
 
   def self.all
@@ -25,12 +24,13 @@ class DocumentTypeSchema
     end
   end
 
-  def managed_elsewhere?
-    managed_elsewhere
-  end
-
   def managed_elsewhere_url
     Plek.find(managed_elsewhere.fetch('hostname')) + managed_elsewhere.fetch('path')
+  end
+
+  class PublishingMetadata
+    include ActiveModel::Model
+    attr_accessor :schema_name, :rendering_app
   end
 
   class Field

--- a/app/services/publishing_api_payload.rb
+++ b/app/services/publishing_api_payload.rb
@@ -3,8 +3,12 @@
 class PublishingApiPayload
   PUBLISHING_APP = "content-publisher"
 
+  attr_reader :document, :document_type_schema, :publishing_metadata
+
   def initialize(document)
     @document = document
+    @document_type_schema = document.document_type_schema
+    @publishing_metadata = document_type_schema.publishing_metadata
   end
 
   def payload
@@ -13,10 +17,10 @@ class PublishingApiPayload
       title: document.title,
       locale: document.locale,
       description: document.summary,
-      schema_name: document.document_type_schema.schema_name,
+      schema_name: publishing_metadata.schema_name,
       document_type: document.document_type,
       publishing_app: PUBLISHING_APP,
-      rendering_app: document.document_type_schema.rendering_app,
+      rendering_app: publishing_metadata.rendering_app,
       details: details,
       routes: [
         { path: document.base_path, type: "exact" },
@@ -26,12 +30,10 @@ class PublishingApiPayload
 
 private
 
-  attr_reader :document
-
   def details
     details_hash = temporary_defaults_in_details
 
-    document.document_type_schema.fields.each do |field|
+    document_type_schema.contents.each do |field|
       details_hash[field.id] = perform_input_type_specific_transformations(field)
     end
 

--- a/app/services/supertype_schema.rb
+++ b/app/services/supertype_schema.rb
@@ -16,11 +16,12 @@ class SupertypeSchema
     end
   end
 
-  def self.find(type_id)
-    all.find { |schema| schema.id == type_id }
+  def self.find(schema_id)
+    item = all.find { |schema| schema.id == schema_id }
+    item || (raise RuntimeError, "Supertype #{schema_id} not found")
   end
 
   def document_types
-    DocumentTypeSchema.all.select { |schema| schema.supertype == id }
+    DocumentTypeSchema.all.select { |schema| schema.supertype == self }
   end
 end

--- a/app/views/documents/edit.html.erb
+++ b/app/views/documents/edit.html.erb
@@ -27,7 +27,7 @@
 
       <%= tag.textarea @document.summary, rows: 4, class: "govuk-textarea", name: "document[summary]" %>
 
-      <% @document.document_type_schema.fields.each do |field| %>
+      <% @document.document_type_schema.contents.each do |field| %>
         <%= render "documents/fields/#{field.type}_input", name: field.id, label: field.label, document: @document %>
       <% end %>
 

--- a/app/views/documents/show.html.erb
+++ b/app/views/documents/show.html.erb
@@ -19,7 +19,7 @@
 <% end %>
 </ul>
 
-<% @document.document_type_schema.fields.each do |field| %>
+<% @document.document_type_schema.contents.each do |field| %>
   <%= render "documents/fields/#{field.type}", name: field.id, label: field.label, document: @document %>
 <% end %>
 

--- a/app/views/new_document/choose_document_type.html.erb
+++ b/app/views/new_document/choose_document_type.html.erb
@@ -6,7 +6,7 @@
     name: "document_type",
     items: @document_types.map { |document_type|
       {
-        value: document_type.document_type,
+        value: document_type.id,
         text: document_type.name,
       }
     }

--- a/spec/factories/document_factory.rb
+++ b/spec/factories/document_factory.rb
@@ -5,10 +5,12 @@ FactoryBot.define do
     content_id { SecureRandom.uuid }
     locale { I18n.available_locales.sample }
     base_path { "/#{SecureRandom.alphanumeric(8)}" }
-    document_type { DocumentTypeSchema.all.reject(&:managed_elsewhere?).sample.document_type }
+    document_type { DocumentTypeSchema.all.reject(&:managed_elsewhere).sample.id }
 
     trait :with_body do
-      document_type { DocumentTypeSchema.all.select { |schema| schema.fields.any? { |field| field.id == "body" } }.sample.document_type }
+      document_type do
+        DocumentTypeSchema.all.select { |schema| schema.contents.any? { |field| field.id == "body" } }.sample.id
+      end
     end
   end
 end

--- a/spec/formats/configuration_spec.rb
+++ b/spec/formats/configuration_spec.rb
@@ -3,29 +3,29 @@
 require 'spec_helper'
 
 RSpec.describe "Format configuration" do
-  supertypes = YAML.load_file("app/formats/supertypes.yml")
-  document_types = YAML.load_file("app/formats/document_types.yml")
-
-  supertypes.each do |supertype_schema|
-    describe "Supertype #{supertype_schema['id']}" do
-      it "has the required attributes for #{supertype_schema['id']}" do
-        expect(supertype_schema.keys).to include('id', 'label', 'description')
+  SupertypeSchema.all.each do |supertype_schema|
+    describe "Supertype #{supertype_schema.id}" do
+      it "has the required attributes for #{supertype_schema.id}" do
+        expect(supertype_schema.id).to_not be_blank
+        expect(supertype_schema.label).to_not be_blank
+        expect(supertype_schema.description).to_not be_blank
       end
     end
   end
 
-  document_types.each do |document_type_schema|
-    describe "Document type #{document_type_schema['document_type']}" do
+  DocumentTypeSchema.all.each do |document_type_schema|
+    describe "Document type #{document_type_schema.id}" do
       it "has the required attributes" do
-        expect(document_type_schema.keys).to include('document_type', 'name', 'supertype')
+        expect(document_type_schema.id).to_not be_blank
+        expect(document_type_schema.name).to_not be_blank
       end
 
       it "has a valid supertype" do
-        expect(document_type_schema["supertype"]).to be_in(supertypes.pluck("id"))
+        expect(document_type_schema.supertype).to be_a(SupertypeSchema)
       end
 
       it "has a valid document type" do
-        expect(document_type_schema["document_type"]).to be_in(GovukSchemas::DocumentTypes.valid_document_types)
+        expect(document_type_schema.id).to be_in(GovukSchemas::DocumentTypes.valid_document_types)
       end
     end
   end

--- a/spec/integration/create_a_document_elsewhere_spec.rb
+++ b/spec/integration/create_a_document_elsewhere_spec.rb
@@ -3,7 +3,9 @@
 require "spec_helper"
 
 RSpec.describe "Create a document that is managed elsewhere", type: :feature do
-  DocumentTypeSchema.all.select(&:managed_elsewhere?).each do |schema|
+  DocumentTypeSchema.all.each do |schema|
+    next unless schema.managed_elsewhere
+
     scenario "User creates a #{schema.name}" do
       @schema = schema
 
@@ -18,7 +20,7 @@ RSpec.describe "Create a document that is managed elsewhere", type: :feature do
     end
 
     def and_i_choose_a_document_that_is_not_managed_in_this_app
-      choose SupertypeSchema.find(@schema.supertype).label
+      choose @schema.supertype.label
       click_on "Continue"
 
       choose @schema.name

--- a/spec/integration/create_a_document_spec.rb
+++ b/spec/integration/create_a_document_spec.rb
@@ -3,7 +3,9 @@
 require "spec_helper"
 
 RSpec.describe "Create a document", type: :feature do
-  DocumentTypeSchema.all.reject(&:managed_elsewhere?).each do |schema|
+  DocumentTypeSchema.all.each do |schema|
+    next if schema.managed_elsewhere
+
     scenario "User creates #{schema.name}" do
       @schema = schema
 
@@ -20,7 +22,7 @@ RSpec.describe "Create a document", type: :feature do
     end
 
     def and_i_choose_a_supertype
-      choose SupertypeSchema.find(@schema.supertype).label
+      choose @schema.supertype.label
       click_on "Continue"
     end
 
@@ -40,7 +42,7 @@ RSpec.describe "Create a document", type: :feature do
 
     def then_i_see_the_document_exists
       expect(Document.last.title).to eq "A great title"
-      expect(page).to have_content @schema.document_type
+      expect(page).to have_content @schema.id
       expect(page).to have_content "A great title"
     end
   end

--- a/spec/services/document_type_schema_spec.rb
+++ b/spec/services/document_type_schema_spec.rb
@@ -14,24 +14,21 @@ RSpec.describe DocumentTypeSchema do
     end
   end
 
-  describe '#fields' do
-    it 'is an empty array by default' do
-      schema = DocumentTypeSchema.new
+  describe '#contents' do
+    it "returns an array of content fields" do
+      expect(DocumentTypeSchema.find("press_release").contents.first).to be_a(DocumentTypeSchema::Field)
+    end
 
-      expect(schema.fields).to eql([])
+    it 'is an empty array if there are not contents' do
+      expect(DocumentTypeSchema.find("consultation").contents).to be_empty
     end
   end
 
   describe '#managed_elsewhere_url' do
     it 'returns a full URL' do
-      schema = DocumentTypeSchema.new(
-        "managed_elsewhere" => {
-          "hostname" => "whitehall-admin",
-          "path" => "/some/new/document",
-        }
-      )
-
-      expect(schema.managed_elsewhere_url).to eql("https://whitehall-admin.test.gov.uk/some/new/document")
+      schema = DocumentTypeSchema.find("consultation")
+      path = "https://whitehall-admin.test.gov.uk/government/admin/consultations/new"
+      expect(schema.managed_elsewhere_url).to eq(path)
     end
   end
 end

--- a/spec/services/supertype_schema_spec.rb
+++ b/spec/services/supertype_schema_spec.rb
@@ -1,0 +1,16 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+
+RSpec.describe SupertypeSchema do
+  describe ".find" do
+    it "returns a SupertypeSchema when it's a known supertype" do
+      expect(SupertypeSchema.find("news")).to be_a(SupertypeSchema)
+    end
+
+    it "raises a RuntimeError when we don't know the supertype" do
+      expect { SupertypeSchema.find("unknown_supertype") }
+        .to raise_error(RuntimeError, "Supertype unknown_supertype not found")
+    end
+  end
+end


### PR DESCRIPTION
https://trello.com/c/4sTwhdPN/87-make-associations-available-to-select-when-creating-a-document-l

This PR renames 'fields' to 'contents' to support future data keys at
this level, such as the upcoming 'associations' work.

This PR also makes the document types more consistent with fields and
supertype schemas by renaming 'document_type' to 'id', as well as nested
schema_name and rendering_app under a 'publishing_metadata' hash to
reduce the number of top-level keys and thereby improve readability.

To make this change easier, I refactored the configuration_spec to make
use of the schema models, as opposed to accessing the YAML files
directly. I also replaced several instances of SupertypeSchema.find with
document_type.supertype, so the lookup is done automatically.

This PR also contains a few minor changes to make the tests more
consistent and remove a redundant managed_elsewhere? question method.
I can move these into a separate PR if they're not to people's tastes.