### PR TITLE
Make sure the tests fail on Javascript errors

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -25,6 +25,7 @@ end
 
 group :development, :test do
   gem "byebug", "~> 10"
+  gem "capybara-chromedriver-logger"
   gem "factory_bot_rails", "~> 4"
   gem "govuk-lint", "~> 3"
   gem "govuk_schemas", "~> 3.2"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -60,11 +60,15 @@ GEM
       rack (>= 1.6.0)
       rack-test (>= 0.6.3)
       xpath (~> 3.1)
+    capybara-chromedriver-logger (0.2.1)
+      capybara
+      colorize
     childprocess (0.9.0)
       ffi (~> 1.0, >= 1.0.11)
     chromedriver-helper (1.2.0)
       archive-zip (~> 0.10)
       nokogiri (~> 1.8)
+    colorize (0.8.1)
     commander (4.4.5)
       highline (~> 1.7.2)
     concurrent-ruby (1.0.5)
@@ -369,6 +373,7 @@ PLATFORMS
 DEPENDENCIES
   bootsnap (~> 1)
   byebug (~> 10)
+  capybara-chromedriver-logger
   factory_bot_rails (~> 4)
   gds-api-adapters (~> 52)
   gds-sso (~> 13)

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -17,6 +17,7 @@ SimpleCov.start
 GovukTest.configure
 WebMock.disable_net_connect!(allow_localhost: true)
 Capybara.automatic_label_click = true
+Capybara::Chromedriver::Logger.raise_js_errors = true
 
 RSpec.configure do |config|
   config.expose_dsl_globally = false
@@ -28,5 +29,9 @@ RSpec.configure do |config|
 
   config.before(:suite) do
     User.create!(permissions: ["signin"])
+  end
+
+  config.after :each, type: :feature, js: true do
+    Capybara::Chromedriver::Logger::TestHooks.after_example!
   end
 end


### PR DESCRIPTION
This adds a gem & config to make sure that when a Javascript error occurs, the tests fail. 

Looks like this:

<img width="1550" alt="screen shot 2018-08-01 at 17 25 23" src="https://user-images.githubusercontent.com/233676/43534847-405dea42-95b0-11e8-920b-14a31f3861fe.png">

If this works in the app we'll push this up to govuk_test.