### PR TITLE
Update views

### DIFF
--- a/app/views/documents/edit.html.erb
+++ b/app/views/documents/edit.html.erb
@@ -1,5 +1,5 @@
 <%= content_for :back_link, document_path(@document) %>
-<% content_for :title, @document.title || "Untitled document" %>
+<% content_for :title, @document.title || "Create " + @document.document_type_schema.name %>
 
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
@@ -12,27 +12,26 @@
         value: @document.title
       } %>
 
-      <%= render "govuk_publishing_components/components/input", {
+      <%= render "govuk_publishing_components/components/inset_text", {
+        text: '<p class="govuk-heading-s">The web address for this content will look like:</p>
+        <span class="govuk-body">You haven’t entered a title yet.</span>'.html_safe
+      } %>
+
+      <%= render "govuk_publishing_components/components/textarea", {
         label: {
-          text: "Base path"
+          text: "Summary"
         },
-        name: "document[base_path]",
-        value: @document.base_path
+        name: "document[summary]",
+        value: @document.summary,
+        rows: 4
       } %>
-
-      <%= render "govuk_publishing_components/components/label", {
-        text: "Summary",
-        html_for: "document[summary]"
-      } %>
-
-      <%= tag.textarea @document.summary, rows: 4, class: "govuk-textarea", name: "document[summary]" %>
 
       <% @document.document_type_schema.contents.each do |field| %>
         <%= render "documents/fields/#{field.type}_input", name: field.id, label: field.label, document: @document %>
       <% end %>
 
       <%= render "govuk_publishing_components/components/button", {
-        text: "Save"
+        text: "Save", margin_bottom: true
       } %>
     <% end %>
   </div>

--- a/app/views/documents/index.html.erb
+++ b/app/views/documents/index.html.erb
@@ -3,7 +3,7 @@
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
     <%= render "govuk_publishing_components/components/button", {
-      text: "New document", href: new_document_path
+      text: "New document", href: new_document_path, margin_bottom: true
     } %>
 
     <%= render "govuk_publishing_components/components/document_list", {
@@ -17,7 +17,7 @@
           },
           metadata: {
             public_updated_at: document.updated_at,
-            document_type: document.document_type
+            document_type: document.document_type_schema.name
           }
         }
       end

--- a/app/views/documents/show.html.erb
+++ b/app/views/documents/show.html.erb
@@ -28,4 +28,4 @@
   href: publish_document_path(@document),
 } %>
 
-<%= link_to "Edit document", edit_document_path(@document) %>
+<%= link_to "Edit document", edit_document_path(@document), class: "govuk-link" %>

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -29,8 +29,8 @@
       </p>
     <% end %>
 
-    <main class="govuk-main-wrapper " id="main-content" role="main">
-      <%= render "govuk_publishing_components/components/title", title: yield(:title) %>
+    <main class="govuk-main-wrapper<%= " govuk-main-wrapper--l" if yield(:back_link).blank?%>" id="main-content" role="main">
+      <h1 class="govuk-heading-xl"><%= yield(:title) %></h1>
       <%= yield %>
     </main>
   </div>

--- a/app/views/new_document/choose_document_type.html.erb
+++ b/app/views/new_document/choose_document_type.html.erb
@@ -1,17 +1,20 @@
 <% content_for :back_link, new_document_path %>
 <% content_for :title, "Document type" %>
 
-<%= form_tag create_document_path do %>
-  <%= render "govuk_publishing_components/components/radio", {
-    name: "document_type",
-    items: @document_types.map { |document_type|
-      {
-        value: document_type.id,
-        text: document_type.name,
-      }
-    }
-  } %>
-  <br/>
-  <br/>
-  <%= render "govuk_publishing_components/components/button", text: "Continue" %>
-<% end %>
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-two-thirds">
+    <%= form_tag create_document_path do %>
+      <%= render "govuk_publishing_components/components/radio", {
+        name: "document_type",
+        items: @document_types.map { |document_type|
+          {
+            value: document_type.id,
+            text: document_type.name,
+          }
+        }
+      } %>
+
+      <%= render "govuk_publishing_components/components/button", text: "Continue", margin_bottom: true %>
+    <% end %>
+  </div>
+</div>

--- a/app/views/new_document/choose_supertype.html.erb
+++ b/app/views/new_document/choose_supertype.html.erb
@@ -1,19 +1,21 @@
 <% content_for :back_link, root_path %>
 <% content_for :title, "Content type" %>
 
-<%= form_tag do %>
-  <%= render "govuk_publishing_components/components/radio", {
-    name: "supertype",
-    items: @supertypes.map do |supertype|
-      {
-        value: supertype.id,
-        text: supertype.label,
-        hint_text: supertype.description,
-        bold: true,
-      }
-    end
-  } %>
-  <br/>
-  <br/>
-  <%= render "govuk_publishing_components/components/button", text: "Continue" %>
-<% end %>
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-two-thirds">
+    <%= form_tag do %>
+      <%= render "govuk_publishing_components/components/radio", {
+        name: "supertype",
+        items: @supertypes.map do |supertype|
+          {
+            value: supertype.id,
+            text: supertype.label,
+            hint_text: supertype.description,
+            bold: true,
+          }
+        end
+      } %>
+      <%= render "govuk_publishing_components/components/button", text: "Continue", margin_bottom: true %>
+    <% end %>
+  </div>
+</div>

--- a/app/views/new_document/guidance.html.erb
+++ b/app/views/new_document/guidance.html.erb
@@ -1,6 +1,10 @@
 <% content_for :back_link, new_document_path %>
 <% content_for :title, "What to publish on GOV.UK" %>
 
-<%= render "govuk_publishing_components/components/govspeak" do %>
-  <%= raw Govspeak::Document.new(File.read("app/views/new_document/guidance.govspeak.md")).to_html %>
-<% end %>
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-two-thirds">
+    <%= render "govuk_publishing_components/components/govspeak" do %>
+      <%= raw Govspeak::Document.new(File.read("app/views/new_document/guidance.govspeak.md")).to_html %>
+    <% end %>
+  </div>
+</div>


### PR DESCRIPTION
This PR:
- updates layouts to use 2/3 layout
- updates the edit document page to use publishing components

Note: `inset_text` component should be updated to act as a wrapper and use `yield` for rendering content instead of text attribute.