### PR TITLE
Replace supertype thing as a first-class supertype

### DIFF
--- a/app/controllers/new_document_controller.rb
+++ b/app/controllers/new_document_controller.rb
@@ -2,16 +2,17 @@
 
 class NewDocumentController < ApplicationController
   def choose_supertype
-    @supertype_radio_options = SupertypeThing.new.options
+    @supertypes = SupertypeSchema.all
   end
 
   def choose_document_type
-    if params[:supertype] == SupertypeThing::NOT_SURE_OPTION.fetch(:value)
-      redirect_to guidance_path
+    supertype_schema = SupertypeSchema.find(params[:supertype])
+
+    if supertype_schema.managed_elsewhere
+      redirect_to supertype_schema.managed_elsewhere_url
       return
     end
 
-    supertype_schema = SupertypeSchema.find(params[:supertype])
     @document_types = supertype_schema.document_types
   end
 
@@ -30,33 +31,5 @@ class NewDocumentController < ApplicationController
     )
 
     redirect_to edit_document_path(document)
-  end
-
-  # TODO: This class has an intentionally silly name, because we don't know if there
-  # will be classes like this and how to organise these.
-  class SupertypeThing
-    NOT_SURE_OPTION = {
-      value: "not-sure",
-      text: "I'm not sure this should be on GOV.UK",
-      hint_text: "View this guide to what should go on GOV.UK and where else we can publish content.",
-      bold: true
-    }.freeze
-
-    def options
-      supertype_options + [NOT_SURE_OPTION]
-    end
-
-  private
-
-    def supertype_options
-      SupertypeSchema.all.map do |supertype|
-        {
-          value: supertype.id,
-          text: supertype.label,
-          hint_text: supertype.description,
-          bold: true,
-        }
-      end
-    end
   end
 end

--- a/app/formats/supertypes.yml
+++ b/app/formats/supertypes.yml
@@ -17,5 +17,10 @@
 
 - id: consultations
   label: Consultations
-  description: To request users views or evidence on an issue and to build collective
-    agreement.
+  description: To request users views or evidence on an issue and to build collective agreement.
+
+- id: not-sure
+  label: I'm not sure this should be on GOV.UK
+  description: View this guide to see what should go on GOV.UK and where else you can publish content.
+  managed_elsewhere:
+    path: /documents/publishing-guidance

--- a/app/services/supertype_schema.rb
+++ b/app/services/supertype_schema.rb
@@ -1,12 +1,13 @@
 # frozen_string_literal: true
 
 class SupertypeSchema
-  attr_reader :id, :label, :description
+  attr_reader :id, :label, :description, :managed_elsewhere
 
   def initialize(params = {})
     @id = params["id"]
     @label = params["label"]
     @description = params["description"]
+    @managed_elsewhere = params["managed_elsewhere"]
   end
 
   def self.all
@@ -19,6 +20,10 @@ class SupertypeSchema
   def self.find(schema_id)
     item = all.find { |schema| schema.id == schema_id }
     item || (raise RuntimeError, "Supertype #{schema_id} not found")
+  end
+
+  def managed_elsewhere_url
+    managed_elsewhere["path"]
   end
 
   def document_types

--- a/app/views/new_document/choose_supertype.html.erb
+++ b/app/views/new_document/choose_supertype.html.erb
@@ -4,7 +4,14 @@
 <%= form_tag do %>
   <%= render "govuk_publishing_components/components/radio", {
     name: "supertype",
-    items: @supertype_radio_options
+    items: @supertypes.map do |supertype|
+      {
+        value: supertype.id,
+        text: supertype.label,
+        hint_text: supertype.description,
+        bold: true,
+      }
+    end
   } %>
   <br/>
   <br/>

--- a/spec/formats/configuration_spec.rb
+++ b/spec/formats/configuration_spec.rb
@@ -3,29 +3,41 @@
 require 'spec_helper'
 
 RSpec.describe "Format configuration" do
-  SupertypeSchema.all.each do |supertype_schema|
-    describe "Supertype #{supertype_schema.id}" do
-      it "has the required attributes for #{supertype_schema.id}" do
-        expect(supertype_schema.id).to_not be_blank
-        expect(supertype_schema.label).to_not be_blank
-        expect(supertype_schema.description).to_not be_blank
+  SupertypeSchema.all.each do |schema|
+    describe "Supertype #{schema.id}" do
+      it "has the required attributes for #{schema.id}" do
+        expect(schema.id).to_not be_blank
+        expect(schema.label).to_not be_blank
+        expect(schema.description).to_not be_blank
       end
     end
   end
 
-  DocumentTypeSchema.all.each do |document_type_schema|
-    describe "Document type #{document_type_schema.id}" do
+  DocumentTypeSchema.all.each do |schema|
+    describe "Document type #{schema.id}" do
       it "has the required attributes" do
-        expect(document_type_schema.id).to_not be_blank
-        expect(document_type_schema.name).to_not be_blank
+        expect(schema.id).to_not be_blank
+        expect(schema.name).to_not be_blank
+      end
+
+      if schema.managed_elsewhere
+        it "has the required attributes for managed_elsewhere" do
+          expect(schema.managed_elsewhere.keys).to contain_exactly("hostname", "path")
+        end
+      else
+        it "has the required attributes for publishing_metadata" do
+          expect(schema.publishing_metadata.rendering_app).to_not be_blank
+          expect(schema.publishing_metadata.schema_name).to_not be_blank
+        end
       end
 
       it "has a valid supertype" do
-        expect(document_type_schema.supertype).to be_a(SupertypeSchema)
+        expect(schema.supertype).to be_a(SupertypeSchema)
+        expect(schema.supertype.managed_elsewhere).to be_falsey
       end
 
       it "has a valid document type" do
-        expect(document_type_schema.id).to be_in(GovukSchemas::DocumentTypes.valid_document_types)
+        expect(schema.id).to be_in(GovukSchemas::DocumentTypes.valid_document_types)
       end
     end
   end


### PR DESCRIPTION
Previously a static not-sure supertype was defined in the new documents
controller, which required a proxy SupertypeThing class to handle the
generation and processing of options. My original intention was simply
to move this class into /services to highlight its existance, but
instead this PR is an attempt to remove it altogether by adding a 'path'
option to supertypes, behaving similarly to managed_elsewhere for docs.

I also added a few more configuration_specs after the required spec to check
a document_type has not been associated with the new "not-sure" supertype.