### PR TITLE
Make factory traits about schemas more clear

### DIFF
--- a/spec/factories/document_factory.rb
+++ b/spec/factories/document_factory.rb
@@ -7,7 +7,7 @@ FactoryBot.define do
     base_path { "/#{SecureRandom.alphanumeric(8)}" }
     document_type { DocumentTypeSchema.all.reject(&:managed_elsewhere).sample.id }
 
-    trait :with_body do
+    trait :with_body_in_schema do
       document_type do
         DocumentTypeSchema.all.select { |schema| schema.contents.any? { |field| field.id == "body" } }.sample.id
       end

--- a/spec/features/publishing_validations_spec.rb
+++ b/spec/features/publishing_validations_spec.rb
@@ -12,7 +12,7 @@ RSpec.feature "Publish validations" do
   end
 
   def given_there_is_a_document_with_not_enough_info
-    @document = create(:document, :with_body)
+    @document = create(:document, :with_body_in_schema)
   end
 
   def when_i_visit_the_document_page

--- a/spec/services/content_validator_spec.rb
+++ b/spec/services/content_validator_spec.rb
@@ -57,7 +57,7 @@ RSpec.describe ContentValidator do
 
   describe 'custom validation' do
     it 'raises issue if the summary is not set' do
-      document = build(:document, :with_body, contents: { body: "Too short" })
+      document = build(:document, :with_body_in_schema, contents: { body: "Too short" })
 
       messages = ContentValidator.new(document).validation_messages
 

--- a/spec/services/publishing_api_payload_spec.rb
+++ b/spec/services/publishing_api_payload_spec.rb
@@ -5,7 +5,7 @@ require 'spec_helper'
 RSpec.describe PublishingApiPayload do
   describe "#payload" do
     it "transforms Govspeak before sending it to the publishing-api" do
-      document = build(:document, :with_body, contents: { body: "Hey **buddy**!" })
+      document = build(:document, :with_body_in_schema, contents: { body: "Hey **buddy**!" })
 
       payload = PublishingApiPayload.new(document).payload
 


### PR DESCRIPTION
https://trello.com/c/4sTwhdPN/87-make-associations-available-to-select-when-creating-a-document-l

The previous document trait of :with_body implied the resulting document
would have a populated body. Since the trait is actually effecting the
document_type, it makes more sense to say it as :with_body_in_schema.