### PR TITLE
Pass schema through to field partials

### DIFF
--- a/app/views/documents/edit.html.erb
+++ b/app/views/documents/edit.html.erb
@@ -26,8 +26,8 @@
         rows: 4
       } %>
 
-      <% @document.document_type_schema.contents.each do |field| %>
-        <%= render "documents/fields/#{field.type}_input", name: field.id, label: field.label, document: @document %>
+      <% @document.document_type_schema.contents.each do |schema| %>
+        <%= render "documents/fields/#{schema.type}_input", schema: schema, document: @document %>
       <% end %>
 
       <%= render "govuk_publishing_components/components/button", {

--- a/app/views/documents/fields/_govspeak.html.erb
+++ b/app/views/documents/fields/_govspeak.html.erb
@@ -1,9 +1,9 @@
 <p>
   <%= render "govuk_publishing_components/components/heading", {
-    text: name
+    text: schema.id
   } %>
 
   <%= render "govuk_publishing_components/components/govspeak", {} do %>
-    <%= raw Govspeak::Document.new(@document.contents[name]).to_html %>
+    <%= raw Govspeak::Document.new(@document.contents[schema.id]).to_html %>
   <% end %>
 </p>

--- a/app/views/documents/fields/_govspeak_input.html.erb
+++ b/app/views/documents/fields/_govspeak_input.html.erb
@@ -1,8 +1,12 @@
 <p>
-  <%= render "govuk_publishing_components/components/label", {
-    text: label,
-    html_for: "document[contents][#{name}]"
-  } %>
+  <%= render "govuk_publishing_components/components/label",
+    text: schema.label,
+    html_for: "document[contents][#{schema.id}]"
+  %>
 
-  <%= tag.textarea document.contents[name], rows: 15, class: "govuk-textarea", name: "document[contents][#{name}]" %>
+  <%= tag.textarea document.contents[schema.id],
+    rows: 15,
+    class: "govuk-textarea",
+    name: "document[contents][#{schema.id}]"
+  %>
 </p>

--- a/app/views/documents/show.html.erb
+++ b/app/views/documents/show.html.erb
@@ -19,8 +19,8 @@
 <% end %>
 </ul>
 
-<% @document.document_type_schema.contents.each do |field| %>
-  <%= render "documents/fields/#{field.type}", name: field.id, label: field.label, document: @document %>
+<% @document.document_type_schema.contents.each do |schema| %>
+  <%= render "documents/fields/#{schema.type}", schema: schema, document: @document %>
 <% end %>
 
 <%= render "govuk_publishing_components/components/button", {


### PR DESCRIPTION
https://trello.com/c/4sTwhdPN/87-make-associations-available-to-select-when-creating-a-document-l

The separation between the source of the data (the schema) and the use
of that data in a field partial (name, label) making it hard to remember
which value came from where. Passing the schema through to the partial
and explicitly calling it a schema (it's not a field) makes the link
between data and view more visible. In general we should try to be more
consistent in our variable names to differentiate between a schema from
the config file and something that's created to conform to the schema.