### PR TITLE
Fix typos for 'Transparency' content

### DIFF
--- a/app/formats/document_types.yml
+++ b/app/formats/document_types.yml
@@ -27,7 +27,7 @@
 
 - id: statistical_data_set
   name: Statistical data set
-  supertype: transparancy
+  supertype: transparency
   publishing_metadata:
     schema_name: statistical_data_set
     rendering_app: government-frontend

--- a/app/formats/supertypes.yml
+++ b/app/formats/supertypes.yml
@@ -3,8 +3,8 @@
   label: News
   description: To tell users about something that government has done or will do.
 
-- id: transparancy
-  label: Transparancy
+- id: transparency
+  label: Transparency
   description: To provide information that helps users hold government to account.
 
 - id: guidance


### PR DESCRIPTION
Fix typos for 'Transparency' in a couple of places.