### PR TITLE
Remove redundant spec for document_type_schema

### DIFF
--- a/spec/services/document_type_schema_spec.rb
+++ b/spec/services/document_type_schema_spec.rb
@@ -14,16 +14,6 @@ RSpec.describe DocumentTypeSchema do
     end
   end
 
-  describe '#contents' do
-    it "returns an array of content fields" do
-      expect(DocumentTypeSchema.find("press_release").contents.first).to be_a(DocumentTypeSchema::Field)
-    end
-
-    it 'is an empty array if there are not contents' do
-      expect(DocumentTypeSchema.find("consultation").contents).to be_empty
-    end
-  end
-
   describe '#managed_elsewhere_url' do
     it 'returns a full URL' do
       schema = DocumentTypeSchema.find("consultation")


### PR DESCRIPTION
https://trello.com/c/4sTwhdPN/87-make-associations-available-to-select-when-creating-a-document-l

This spec was originally written to ensure we were doing a to_a on the
fields param, but it's very much covered by the feature tests - all of
them fail if it's removed. Rather than copy/paste this for the upcoming
'associations' param, it seems better to remove it but keep the coverage.