### PR TITLE
Catch more API errors and display them well

### DIFF
--- a/app/controllers/documents_controller.rb
+++ b/app/controllers/documents_controller.rb
@@ -18,7 +18,7 @@ class DocumentsController < ApplicationController
     document.update(document_update_params(document))
     DocumentPublishingService.new.publish_draft(document)
     redirect_to document, notice: "Preview creation successful"
-  rescue GdsApi::HTTPErrorResponse, SocketError => e
+  rescue GdsApi::BaseError => e
     Rails.logger.error(e)
     redirect_to document, alert: "Error creating preview"
   end

--- a/app/controllers/publish_document_controller.rb
+++ b/app/controllers/publish_document_controller.rb
@@ -9,7 +9,7 @@ class PublishDocumentController < ApplicationController
     document = Document.find(params[:id])
     DocumentPublishingService.new.publish(document)
     redirect_to document, notice: "Publish successful"
-  rescue GdsApi::HTTPErrorResponse, SocketError => e
+  rescue GdsApi::BaseError => e
     Rails.logger.error(e)
     redirect_to document, alert: "Error publishing"
   end


### PR DESCRIPTION
https://trello.com/c/4sTwhdPN/87-make-associations-available-to-select-when-creating-a-document-l

In particular, we should handling GdsApi::TimedOutException explicitly.