### PR TITLE
Revert "Turn on rails linting (and fix offences)"

### DIFF
--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-class User < ApplicationRecord
+class User < ActiveRecord::Base
   include GDS::SSO::User
 
   serialize :permissions, Array

--- a/db/migrate/20180725084729_fix_document_contents_default.rb
+++ b/db/migrate/20180725084729_fix_document_contents_default.rb
@@ -1,11 +1,7 @@
 # frozen_string_literal: true
 
 class FixDocumentContentsDefault < ActiveRecord::Migration[5.2]
-  def up
+  def change
     change_column_default :documents, :contents, {}
-  end
-
-  def down
-    change_column_default :documents, :contents, "{}"
   end
 end

--- a/lib/tasks/lint.rake
+++ b/lib/tasks/lint.rake
@@ -2,7 +2,7 @@
 
 desc "Run govuk-lint on all files"
 task "lint" do
-  sh "govuk-lint-ruby --format clang --rails"
+  sh "govuk-lint-ruby --format clang"
   sh "govuk-lint-sass app/assets/stylesheets"
   sh "npm run lint --silent"
 end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -12,7 +12,7 @@ require "simplecov"
 require "webmock/rspec"
 require "gds_api/test_helpers/publishing_api_v2"
 
-Dir[Rails.root.join("spec", "support", "**", "*.rb")].each { |f| require f }
+Dir[Rails.root.join("spec/support/**/*.rb")].each { |f| require f }
 SimpleCov.start
 GovukTest.configure
 WebMock.disable_net_connect!(allow_localhost: true)


### PR DESCRIPTION
Reverts alphagov/content-publisher#97

This seems to have broken the build as the standard linter appears to be unavailable when running the default rake task.