### PR TITLE
Add at least one format for the policy supertype

### DIFF
--- a/app/formats/document_types.yml
+++ b/app/formats/document_types.yml
@@ -75,6 +75,13 @@
       validations:
         min_length: 10
 
+- id: policy_paper
+  name: Policy paper
+  supertype: policy
+  managed_elsewhere:
+    hostname: whitehall-admin
+    path: /government/admin/publications/new
+
 - id: detailed_guide
   name: Detailed guide
   supertype: guidance


### PR DESCRIPTION
The lack of any format for the policy supertype is leading to Sentry
errors where the user click 'Continue' but no format is selected.

We should separately also validate the supertype form and the format
form to check that an option has been selected.