### PR TITLE
Extend markdown toolbar

### DIFF
--- a/app/assets/javascripts/components/markdown-editor.js
+++ b/app/assets/javascripts/components/markdown-editor.js
@@ -22,6 +22,9 @@ MarkdownEditor.prototype.init = function () {
   // Handle events
   this.$previewButton.addEventListener('click', $module.boundPreviewButtonClick)
   this.$editButton.addEventListener('click', $module.boundEditButtonClick)
+
+  // Prevent toolbar item reveals to overlap with footer
+  this.setContextualGuidancePosition()
 }
 
 MarkdownEditor.prototype.handlePreviewButton = function (event) {
@@ -33,16 +36,26 @@ MarkdownEditor.prototype.handlePreviewButton = function (event) {
   // Mirror textarea's height
   $preview.style.height = this.$input.offsetHeight + 'px'
 
-  // Render markdown
-  window.marked(text, function (err, content) {
-    if (err) {
-      $preview.innerHTML = 'Error previewing content'
-      throw err
-    } else {
-      $preview.innerHTML = content
-    }
-  })
-
+  if (text) {
+    // Render markdown
+    window.marked(
+      text,
+      {
+        gfm: true,
+        breaks: true,
+        tables: true,
+        sanitize: true
+      },
+      function (err, content) {
+        if (err) {
+          $preview.innerHTML = 'Error previewing content'
+          throw err
+        } else {
+          $preview.innerHTML = content
+        }
+      }
+    )
+  }
   this.toggleElements()
 }
 
@@ -65,6 +78,16 @@ MarkdownEditor.prototype.toggle = function (element) {
     element.style.display = 'block'
   } else {
     element.style.display = 'none'
+  }
+}
+
+MarkdownEditor.prototype.setContextualGuidancePosition = function () {
+  var guidanceId = this.$input.getAttribute('data-contextual-guidance')
+  if (guidanceId) {
+    var $guidance = document.querySelector('#' + guidanceId + ' .app-c-contextual-guidance')
+    if ($guidance) {
+      $guidance.style.position = 'relative'
+    }
   }
 }
 

--- a/app/assets/javascripts/components/markdown-editor.js
+++ b/app/assets/javascripts/components/markdown-editor.js
@@ -22,9 +22,6 @@ MarkdownEditor.prototype.init = function () {
   // Handle events
   this.$previewButton.addEventListener('click', $module.boundPreviewButtonClick)
   this.$editButton.addEventListener('click', $module.boundEditButtonClick)
-
-  // Prevent toolbar item reveals to overlap with footer
-  this.setContextualGuidancePosition()
 }
 
 MarkdownEditor.prototype.handlePreviewButton = function (event) {
@@ -72,16 +69,6 @@ MarkdownEditor.prototype.toggle = function (element) {
     element.style.display = 'block'
   } else {
     element.style.display = 'none'
-  }
-}
-
-MarkdownEditor.prototype.setContextualGuidancePosition = function () {
-  var guidanceId = this.$input.getAttribute('data-contextual-guidance')
-  if (guidanceId) {
-    var $guidance = document.querySelector('#' + guidanceId + ' .app-c-contextual-guidance')
-    if ($guidance) {
-      $guidance.style.position = 'relative'
-    }
   }
 }
 

--- a/app/assets/javascripts/components/markdown-editor.js
+++ b/app/assets/javascripts/components/markdown-editor.js
@@ -40,12 +40,6 @@ MarkdownEditor.prototype.handlePreviewButton = function (event) {
     // Render markdown
     window.marked(
       text,
-      {
-        gfm: true,
-        breaks: true,
-        tables: true,
-        sanitize: true
-      },
       function (err, content) {
         if (err) {
           $preview.innerHTML = 'Error previewing content'

--- a/app/assets/javascripts/vendor/@github/markdown-toolbar-element/dist/index.umd.js
+++ b/app/assets/javascripts/vendor/@github/markdown-toolbar-element/dist/index.umd.js
@@ -158,17 +158,77 @@
     window.customElements.define('md-header', MarkdownHeaderButtonElement);
   }
 
-  var MarkdownBoldButtonElement = function (_MarkdownButtonElemen2) {
-    _inherits(MarkdownBoldButtonElement, _MarkdownButtonElemen2);
+  var MarkdownHeading2ButtonElement = function (_MarkdownButtonElemen2) {
+    _inherits(MarkdownHeading2ButtonElement, _MarkdownButtonElemen2);
+
+    function MarkdownHeading2ButtonElement() {
+      _classCallCheck(this, MarkdownHeading2ButtonElement);
+
+      var _this3 = _possibleConstructorReturn(this, (MarkdownHeading2ButtonElement.__proto__ || Object.getPrototypeOf(MarkdownHeading2ButtonElement)).call(this));
+
+      styles.set(_this3, { prefix: '## ', surroundWithNewlines: true });
+      return _this3;
+    }
+
+    return MarkdownHeading2ButtonElement;
+  }(MarkdownButtonElement);
+
+  if (!window.customElements.get('md-header-2')) {
+    window.MarkdownHeading2ButtonElement = MarkdownHeading2ButtonElement;
+    window.customElements.define('md-header-2', MarkdownHeading2ButtonElement);
+  }
+
+  var MarkdownHeading3ButtonElement = function (_MarkdownButtonElemen3) {
+    _inherits(MarkdownHeading3ButtonElement, _MarkdownButtonElemen3);
+
+    function MarkdownHeading3ButtonElement() {
+      _classCallCheck(this, MarkdownHeading3ButtonElement);
+
+      var _this4 = _possibleConstructorReturn(this, (MarkdownHeading3ButtonElement.__proto__ || Object.getPrototypeOf(MarkdownHeading3ButtonElement)).call(this));
+
+      styles.set(_this4, { prefix: '### ', surroundWithNewlines: true });
+      return _this4;
+    }
+
+    return MarkdownHeading3ButtonElement;
+  }(MarkdownButtonElement);
+
+  if (!window.customElements.get('md-header-3')) {
+    window.MarkdownHeading3ButtonElement = MarkdownHeading3ButtonElement;
+    window.customElements.define('md-header-3', MarkdownHeading3ButtonElement);
+  }
+
+  var MarkdownHeading4ButtonElement = function (_MarkdownButtonElemen4) {
+    _inherits(MarkdownHeading4ButtonElement, _MarkdownButtonElemen4);
+
+    function MarkdownHeading4ButtonElement() {
+      _classCallCheck(this, MarkdownHeading4ButtonElement);
+
+      var _this5 = _possibleConstructorReturn(this, (MarkdownHeading4ButtonElement.__proto__ || Object.getPrototypeOf(MarkdownHeading4ButtonElement)).call(this));
+
+      styles.set(_this5, { prefix: '#### ', surroundWithNewlines: true });
+      return _this5;
+    }
+
+    return MarkdownHeading4ButtonElement;
+  }(MarkdownButtonElement);
+
+  if (!window.customElements.get('md-header-4')) {
+    window.MarkdownHeading4ButtonElement = MarkdownHeading4ButtonElement;
+    window.customElements.define('md-header-4', MarkdownHeading4ButtonElement);
+  }
+
+  var MarkdownBoldButtonElement = function (_MarkdownButtonElemen5) {
+    _inherits(MarkdownBoldButtonElement, _MarkdownButtonElemen5);
 
     function MarkdownBoldButtonElement() {
       _classCallCheck(this, MarkdownBoldButtonElement);
 
-      var _this3 = _possibleConstructorReturn(this, (MarkdownBoldButtonElement.__proto__ || Object.getPrototypeOf(MarkdownBoldButtonElement)).call(this));
+      var _this6 = _possibleConstructorReturn(this, (MarkdownBoldButtonElement.__proto__ || Object.getPrototypeOf(MarkdownBoldButtonElement)).call(this));
 
-      _this3.setAttribute('hotkey', 'b');
-      styles.set(_this3, { prefix: '**', suffix: '**', trimFirst: true });
-      return _this3;
+      _this6.setAttribute('hotkey', 'b');
+      styles.set(_this6, { prefix: '**', suffix: '**', trimFirst: true });
+      return _this6;
     }
 
     return MarkdownBoldButtonElement;
@@ -179,17 +239,17 @@
     window.customElements.define('md-bold', MarkdownBoldButtonElement);
   }
 
-  var MarkdownItalicButtonElement = function (_MarkdownButtonElemen3) {
-    _inherits(MarkdownItalicButtonElement, _MarkdownButtonElemen3);
+  var MarkdownItalicButtonElement = function (_MarkdownButtonElemen6) {
+    _inherits(MarkdownItalicButtonElement, _MarkdownButtonElemen6);
 
     function MarkdownItalicButtonElement() {
       _classCallCheck(this, MarkdownItalicButtonElement);
 
-      var _this4 = _possibleConstructorReturn(this, (MarkdownItalicButtonElement.__proto__ || Object.getPrototypeOf(MarkdownItalicButtonElement)).call(this));
+      var _this7 = _possibleConstructorReturn(this, (MarkdownItalicButtonElement.__proto__ || Object.getPrototypeOf(MarkdownItalicButtonElement)).call(this));
 
-      _this4.setAttribute('hotkey', 'i');
-      styles.set(_this4, { prefix: '_', suffix: '_', trimFirst: true });
-      return _this4;
+      _this7.setAttribute('hotkey', 'i');
+      styles.set(_this7, { prefix: '_', suffix: '_', trimFirst: true });
+      return _this7;
     }
 
     return MarkdownItalicButtonElement;
@@ -200,16 +260,16 @@
     window.customElements.define('md-italic', MarkdownItalicButtonElement);
   }
 
-  var MarkdownQuoteButtonElement = function (_MarkdownButtonElemen4) {
-    _inherits(MarkdownQuoteButtonElement, _MarkdownButtonElemen4);
+  var MarkdownQuoteButtonElement = function (_MarkdownButtonElemen7) {
+    _inherits(MarkdownQuoteButtonElement, _MarkdownButtonElemen7);
 
     function MarkdownQuoteButtonElement() {
       _classCallCheck(this, MarkdownQuoteButtonElement);
 
-      var _this5 = _possibleConstructorReturn(this, (MarkdownQuoteButtonElement.__proto__ || Object.getPrototypeOf(MarkdownQuoteButtonElement)).call(this));
+      var _this8 = _possibleConstructorReturn(this, (MarkdownQuoteButtonElement.__proto__ || Object.getPrototypeOf(MarkdownQuoteButtonElement)).call(this));
 
-      styles.set(_this5, { prefix: '> ', multiline: true, surroundWithNewlines: true });
-      return _this5;
+      styles.set(_this8, { prefix: '> ', multiline: true, surroundWithNewlines: true });
+      return _this8;
     }
 
     return MarkdownQuoteButtonElement;
@@ -220,16 +280,16 @@
     window.customElements.define('md-quote', MarkdownQuoteButtonElement);
   }
 
-  var MarkdownCodeButtonElement = function (_MarkdownButtonElemen5) {
-    _inherits(MarkdownCodeButtonElement, _MarkdownButtonElemen5);
+  var MarkdownCodeButtonElement = function (_MarkdownButtonElemen8) {
+    _inherits(MarkdownCodeButtonElement, _MarkdownButtonElemen8);
 
     function MarkdownCodeButtonElement() {
       _classCallCheck(this, MarkdownCodeButtonElement);
 
-      var _this6 = _possibleConstructorReturn(this, (MarkdownCodeButtonElement.__proto__ || Object.getPrototypeOf(MarkdownCodeButtonElement)).call(this));
+      var _this9 = _possibleConstructorReturn(this, (MarkdownCodeButtonElement.__proto__ || Object.getPrototypeOf(MarkdownCodeButtonElement)).call(this));
 
-      styles.set(_this6, { prefix: '`', suffix: '`', blockPrefix: '```', blockSuffix: '```' });
-      return _this6;
+      styles.set(_this9, { prefix: '`', suffix: '`', blockPrefix: '```', blockSuffix: '```' });
+      return _this9;
     }
 
     return MarkdownCodeButtonElement;
@@ -240,17 +300,17 @@
     window.customElements.define('md-code', MarkdownCodeButtonElement);
   }
 
-  var MarkdownLinkButtonElement = function (_MarkdownButtonElemen6) {
-    _inherits(MarkdownLinkButtonElement, _MarkdownButtonElemen6);
+  var MarkdownLinkButtonElement = function (_MarkdownButtonElemen9) {
+    _inherits(MarkdownLinkButtonElement, _MarkdownButtonElemen9);
 
     function MarkdownLinkButtonElement() {
       _classCallCheck(this, MarkdownLinkButtonElement);
 
-      var _this7 = _possibleConstructorReturn(this, (MarkdownLinkButtonElement.__proto__ || Object.getPrototypeOf(MarkdownLinkButtonElement)).call(this));
+      var _this10 = _possibleConstructorReturn(this, (MarkdownLinkButtonElement.__proto__ || Object.getPrototypeOf(MarkdownLinkButtonElement)).call(this));
 
-      _this7.setAttribute('hotkey', 'k');
-      styles.set(_this7, { prefix: '[', suffix: '](url)', replaceNext: 'url', scanFor: 'https?://' });
-      return _this7;
+      _this10.setAttribute('hotkey', 'k');
+      styles.set(_this10, { prefix: '[', suffix: '](url)', replaceNext: 'url', scanFor: 'https?://' });
+      return _this10;
     }
 
     return MarkdownLinkButtonElement;
@@ -261,16 +321,62 @@
     window.customElements.define('md-link', MarkdownLinkButtonElement);
   }
 
-  var MarkdownUnorderedListButtonElement = function (_MarkdownButtonElemen7) {
-    _inherits(MarkdownUnorderedListButtonElement, _MarkdownButtonElemen7);
+  var MarkdownCallToActionButtonElement = function (_MarkdownButtonElemen10) {
+    _inherits(MarkdownCallToActionButtonElement, _MarkdownButtonElemen10);
+
+    function MarkdownCallToActionButtonElement() {
+      _classCallCheck(this, MarkdownCallToActionButtonElement);
+
+      var _this11 = _possibleConstructorReturn(this, (MarkdownCallToActionButtonElement.__proto__ || Object.getPrototypeOf(MarkdownCallToActionButtonElement)).call(this));
+
+      styles.set(_this11, {
+        prefix: '$CTA [',
+        suffix: '](url) $CTA',
+        replaceNext: 'url',
+        scanFor: 'https?://',
+        surroundWithNewlines: true
+      });
+      return _this11;
+    }
+
+    return MarkdownCallToActionButtonElement;
+  }(MarkdownButtonElement);
+
+  if (!window.customElements.get('md-link-cta')) {
+    window.MarkdownCallToActionButtonElement = MarkdownCallToActionButtonElement;
+    window.customElements.define('md-link-cta', MarkdownCallToActionButtonElement);
+  }
+
+  var MarkdownEmailLinkButtonElement = function (_MarkdownButtonElemen11) {
+    _inherits(MarkdownEmailLinkButtonElement, _MarkdownButtonElemen11);
+
+    function MarkdownEmailLinkButtonElement() {
+      _classCallCheck(this, MarkdownEmailLinkButtonElement);
+
+      var _this12 = _possibleConstructorReturn(this, (MarkdownEmailLinkButtonElement.__proto__ || Object.getPrototypeOf(MarkdownEmailLinkButtonElement)).call(this));
+
+      styles.set(_this12, { prefix: '<', suffix: '>' });
+      return _this12;
+    }
+
+    return MarkdownEmailLinkButtonElement;
+  }(MarkdownButtonElement);
+
+  if (!window.customElements.get('md-link-email')) {
+    window.MarkdownEmailLinkButtonElement = MarkdownEmailLinkButtonElement;
+    window.customElements.define('md-link-email', MarkdownEmailLinkButtonElement);
+  }
+
+  var MarkdownUnorderedListButtonElement = function (_MarkdownButtonElemen12) {
+    _inherits(MarkdownUnorderedListButtonElement, _MarkdownButtonElemen12);
 
     function MarkdownUnorderedListButtonElement() {
       _classCallCheck(this, MarkdownUnorderedListButtonElement);
 
-      var _this8 = _possibleConstructorReturn(this, (MarkdownUnorderedListButtonElement.__proto__ || Object.getPrototypeOf(MarkdownUnorderedListButtonElement)).call(this));
+      var _this13 = _possibleConstructorReturn(this, (MarkdownUnorderedListButtonElement.__proto__ || Object.getPrototypeOf(MarkdownUnorderedListButtonElement)).call(this));
 
-      styles.set(_this8, { prefix: '- ', multiline: true, surroundWithNewlines: true });
-      return _this8;
+      styles.set(_this13, { prefix: '- ', multiline: true, surroundWithNewlines: true });
+      return _this13;
     }
 
     return MarkdownUnorderedListButtonElement;
@@ -281,16 +387,16 @@
     window.customElements.define('md-unordered-list', MarkdownUnorderedListButtonElement);
   }
 
-  var MarkdownOrderedListButtonElement = function (_MarkdownButtonElemen8) {
-    _inherits(MarkdownOrderedListButtonElement, _MarkdownButtonElemen8);
+  var MarkdownOrderedListButtonElement = function (_MarkdownButtonElemen13) {
+    _inherits(MarkdownOrderedListButtonElement, _MarkdownButtonElemen13);
 
     function MarkdownOrderedListButtonElement() {
       _classCallCheck(this, MarkdownOrderedListButtonElement);
 
-      var _this9 = _possibleConstructorReturn(this, (MarkdownOrderedListButtonElement.__proto__ || Object.getPrototypeOf(MarkdownOrderedListButtonElement)).call(this));
+      var _this14 = _possibleConstructorReturn(this, (MarkdownOrderedListButtonElement.__proto__ || Object.getPrototypeOf(MarkdownOrderedListButtonElement)).call(this));
 
-      styles.set(_this9, { prefix: '1. ', multiline: true, orderedList: true });
-      return _this9;
+      styles.set(_this14, { prefix: '1. ', multiline: true, orderedList: true });
+      return _this14;
     }
 
     return MarkdownOrderedListButtonElement;
@@ -301,17 +407,17 @@
     window.customElements.define('md-ordered-list', MarkdownOrderedListButtonElement);
   }
 
-  var MarkdownTaskListButtonElement = function (_MarkdownButtonElemen9) {
-    _inherits(MarkdownTaskListButtonElement, _MarkdownButtonElemen9);
+  var MarkdownTaskListButtonElement = function (_MarkdownButtonElemen14) {
+    _inherits(MarkdownTaskListButtonElement, _MarkdownButtonElemen14);
 
     function MarkdownTaskListButtonElement() {
       _classCallCheck(this, MarkdownTaskListButtonElement);
 
-      var _this10 = _possibleConstructorReturn(this, (MarkdownTaskListButtonElement.__proto__ || Object.getPrototypeOf(MarkdownTaskListButtonElement)).call(this));
+      var _this15 = _possibleConstructorReturn(this, (MarkdownTaskListButtonElement.__proto__ || Object.getPrototypeOf(MarkdownTaskListButtonElement)).call(this));
 
-      _this10.setAttribute('hotkey', 'L');
-      styles.set(_this10, { prefix: '- [ ] ', multiline: true, surroundWithNewlines: true });
-      return _this10;
+      _this15.setAttribute('hotkey', 'L');
+      styles.set(_this15, { prefix: '- [ ] ', multiline: true, surroundWithNewlines: true });
+      return _this15;
     }
 
     return MarkdownTaskListButtonElement;
@@ -322,16 +428,16 @@
     window.customElements.define('md-task-list', MarkdownTaskListButtonElement);
   }
 
-  var MarkdownMentionButtonElement = function (_MarkdownButtonElemen10) {
-    _inherits(MarkdownMentionButtonElement, _MarkdownButtonElemen10);
+  var MarkdownMentionButtonElement = function (_MarkdownButtonElemen15) {
+    _inherits(MarkdownMentionButtonElement, _MarkdownButtonElemen15);
 
     function MarkdownMentionButtonElement() {
       _classCallCheck(this, MarkdownMentionButtonElement);
 
-      var _this11 = _possibleConstructorReturn(this, (MarkdownMentionButtonElement.__proto__ || Object.getPrototypeOf(MarkdownMentionButtonElement)).call(this));
+      var _this16 = _possibleConstructorReturn(this, (MarkdownMentionButtonElement.__proto__ || Object.getPrototypeOf(MarkdownMentionButtonElement)).call(this));
 
-      styles.set(_this11, { prefix: '@', prefixSpace: true });
-      return _this11;
+      styles.set(_this16, { prefix: '@', prefixSpace: true });
+      return _this16;
     }
 
     return MarkdownMentionButtonElement;
@@ -342,16 +448,16 @@
     window.customElements.define('md-mention', MarkdownMentionButtonElement);
   }
 
-  var MarkdownRefButtonElement = function (_MarkdownButtonElemen11) {
-    _inherits(MarkdownRefButtonElement, _MarkdownButtonElemen11);
+  var MarkdownRefButtonElement = function (_MarkdownButtonElemen16) {
+    _inherits(MarkdownRefButtonElement, _MarkdownButtonElemen16);
 
     function MarkdownRefButtonElement() {
       _classCallCheck(this, MarkdownRefButtonElement);
 
-      var _this12 = _possibleConstructorReturn(this, (MarkdownRefButtonElement.__proto__ || Object.getPrototypeOf(MarkdownRefButtonElement)).call(this));
+      var _this17 = _possibleConstructorReturn(this, (MarkdownRefButtonElement.__proto__ || Object.getPrototypeOf(MarkdownRefButtonElement)).call(this));
 
-      styles.set(_this12, { prefix: '#', prefixSpace: true });
-      return _this12;
+      styles.set(_this17, { prefix: '#', prefixSpace: true });
+      return _this17;
     }
 
     return MarkdownRefButtonElement;
@@ -360,6 +466,26 @@
   if (!window.customElements.get('md-ref')) {
     window.MarkdownRefButtonElement = MarkdownRefButtonElement;
     window.customElements.define('md-ref', MarkdownRefButtonElement);
+  }
+
+  var MarkdownAddressButtonElement = function (_MarkdownButtonElemen17) {
+    _inherits(MarkdownAddressButtonElement, _MarkdownButtonElemen17);
+
+    function MarkdownAddressButtonElement() {
+      _classCallCheck(this, MarkdownAddressButtonElement);
+
+      var _this18 = _possibleConstructorReturn(this, (MarkdownAddressButtonElement.__proto__ || Object.getPrototypeOf(MarkdownAddressButtonElement)).call(this));
+
+      styles.set(_this18, { prefix: '$A\n', suffix: '\n$A', multiline: true, surroundWithNewlines: true });
+      return _this18;
+    }
+
+    return MarkdownAddressButtonElement;
+  }(MarkdownButtonElement);
+
+  if (!window.customElements.get('md-address')) {
+    window.MarkdownAddressButtonElement = MarkdownAddressButtonElement;
+    window.customElements.define('md-address', MarkdownAddressButtonElement);
   }
 
   var modifierKey = navigator.userAgent.match(/Macintosh/) ? 'Meta' : 'Control';

--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -6,6 +6,7 @@ $govuk-global-styles: true;
 
 @import "components/contextual-guidance";
 @import "components/markdown-editor";
+@import "components/markdown-toolbar";
 
 .app-hidden {
   display: none;

--- a/app/assets/stylesheets/components/_contextual-guidance.scss
+++ b/app/assets/stylesheets/components/_contextual-guidance.scss
@@ -1,6 +1,4 @@
 .app-c-contextual-guidance-wrapper {
-  position: relative;
-
   @include govuk-responsive-margin(6, "bottom");
 
   @include govuk-media-query($from: tablet) {
@@ -9,10 +7,6 @@
 }
 
 .app-c-contextual-guidance {
-  @include govuk-media-query($from: desktop) {
-    position: absolute;
-  }
-
   padding-top: govuk-spacing(5);
   border-top: 5px solid $govuk-focus-colour;
   background: govuk-colour("white");

--- a/app/assets/stylesheets/components/_contextual-guidance.scss
+++ b/app/assets/stylesheets/components/_contextual-guidance.scss
@@ -1,10 +1,18 @@
 .app-c-contextual-guidance-wrapper {
   position: relative;
-  padding-top: govuk-spacing(6);
+
+  @include govuk-responsive-margin(6, "bottom");
+
+  @include govuk-media-query($from: tablet) {
+    padding-top: govuk-spacing(6);
+  }
 }
 
 .app-c-contextual-guidance {
-  position: absolute;
+  @include govuk-media-query($from: desktop) {
+    position: absolute;
+  }
+
   padding-top: govuk-spacing(5);
   border-top: 5px solid $govuk-focus-colour;
   background: govuk-colour("white");

--- a/app/assets/stylesheets/components/_markdown-editor.scss
+++ b/app/assets/stylesheets/components/_markdown-editor.scss
@@ -34,31 +34,7 @@
   display: none;
   margin-top: 0;
 
-  p {
-    margin: 0;
-  }
-}
-
-markdown-toolbar {
-  @extend %govuk-list;
-
-  .govuk-link {
-    display: block;
-    color: $govuk-link-colour;
-    text-decoration: underline;
-    cursor: pointer;
-
-    &:hover {
-      color: $govuk-link-hover-colour;
-    }
-
-    &:active {
-      color: $govuk-link-active-colour;
-    }
-
-    @include govuk-media-query($from: tablet) {
-      margin-bottom: govuk-spacing(1);
-    }
-
+  .govuk-textarea {
+    overflow: scroll;
   }
 }

--- a/app/assets/stylesheets/components/_markdown-toolbar.scss
+++ b/app/assets/stylesheets/components/_markdown-toolbar.scss
@@ -1,0 +1,48 @@
+.app-c-markdown-toolbar {
+  .govuk-details {
+    margin: 0;
+    padding-top: govuk-spacing(2);
+    padding-bottom: govuk-spacing(1);
+    border-top: 1px solid $govuk-border-colour;
+
+    &:last-child {
+      border-bottom: 1px solid $govuk-border-colour;
+    }
+  }
+
+  .govuk-details__summary {
+    display: block;
+    font-weight: bold;
+
+    .govuk-details__summary-text {
+      text-decoration: none;
+    }
+  }
+
+  .govuk-details__text {
+    padding-right: 0;
+    padding-left: 0;
+    border-color: transparent;
+  }
+}
+
+.app-c-markdown-toolbar__list {
+  @extend %govuk-list;
+}
+
+.app-c-markdown-toolbar__item {
+  list-style: none;
+
+  &:before {
+    content: "+";
+  }
+
+  @include govuk-media-query($from: tablet) {
+    margin-bottom: govuk-spacing(1);
+  }
+}
+
+.app-c-markdown-toolbar__button {
+  text-decoration: underline;
+  cursor: pointer;
+}

--- a/app/views/components/_markdown-toolbar.html.erb
+++ b/app/views/components/_markdown-toolbar.html.erb
@@ -1,0 +1,71 @@
+<markdown-toolbar class="app-c-markdown-toolbar" for="<%= html_for %>">
+  <%= render "govuk_publishing_components/components/details", {
+      title: "Headings and sub-headings"
+  } do %>
+  <ul class="app-c-markdown-toolbar__list">
+    <li class="app-c-markdown-toolbar__item">
+      <md-header-2 class="app-c-markdown-toolbar__button">Heading 2</md-header-2>
+    </li>
+    <li class="app-c-markdown-toolbar__item">
+      <md-header-3 class="app-c-markdown-toolbar__button">Heading 3</md-header-3>
+    </li>
+    <li class="app-c-markdown-toolbar__item">
+      <md-header-4 class="app-c-markdown-toolbar__button">Heading 4</md-header-4>
+    </li>
+  </ul>
+  <a href="https://www.gov.uk/guidance/how-to-publish-on-gov-uk/markdown#headings-and-sub-headings" class="govuk-link" target="_blank"> Guidance on headings</a>
+  <% end %>
+
+  <%= render "govuk_publishing_components/components/details", {
+      title: "Links"
+  } do %>
+  <ul class="app-c-markdown-toolbar__list">
+    <li class="app-c-markdown-toolbar__item">
+      <md-link class="app-c-markdown-toolbar__button">Link</md-link>
+    </li>
+    <li class="app-c-markdown-toolbar__item">
+      <md-link-email class="app-c-markdown-toolbar__button">Email link</md-link-email>
+    </li>
+    <li class="app-c-markdown-toolbar__item">
+      <md-link-cta class="app-c-markdown-toolbar__button">Call to action</md-link-cta>
+    </li>
+  </ul>
+  <a href="https://www.gov.uk/guidance/how-to-publish-on-gov-uk/markdown#links" class="govuk-link" target="_blank"> Guidance on links</a>
+  <% end %>
+
+  <%= render "govuk_publishing_components/components/details", {
+      title: "Bullets"
+  } do %>
+  <ul class="app-c-markdown-toolbar__list">
+    <li class="app-c-markdown-toolbar__item">
+      <md-unordered-list class="app-c-markdown-toolbar__button">Bullets</md-unordered-list>
+    </li>
+    <li class="app-c-markdown-toolbar__item">
+      <md-ordered-list class="app-c-markdown-toolbar__button">Numbered list</md-ordered-list>
+    </li>
+  </ul>
+  <a href="https://www.gov.uk/guidance/how-to-publish-on-gov-uk/markdown#bullets" class="govuk-link" target="_blank"> Guidance on bullets</a>
+  <% end %>
+
+  <%= render "govuk_publishing_components/components/details", {
+      title: "Blockquotes"
+  } do %>
+  <ul class="app-c-markdown-toolbar__list">
+    <li class="app-c-markdown-toolbar__item">
+      <md-quote class="app-c-markdown-toolbar__button">Blockquotes</md-quote>
+    </li>
+  </ul>
+  <a href="https://www.gov.uk/guidance/how-to-publish-on-gov-uk/markdown#blockquotes" class="govuk-link" target="_blank"> Guidance on blockquotes</a>
+  <% end %>
+
+  <%= render "govuk_publishing_components/components/details", {
+      title: "Addresses"
+  } do %>
+  <ul class="app-c-markdown-toolbar__list">
+    <li class="app-c-markdown-toolbar__item">
+      <md-address class="app-c-markdown-toolbar__button">Addresses</md-address>
+    </li>
+  </ul>
+  <a href="https://www.gov.uk/guidance/how-to-publish-on-gov-uk/markdown#markdown-addresses" class="govuk-link" target="_blank"> Guidance on addresses</a>
+  <% end %>
+</markdown-toolbar>

--- a/app/views/components/_markdown-toolbar.html.erb
+++ b/app/views/components/_markdown-toolbar.html.erb
@@ -26,9 +26,6 @@
     <li class="app-c-markdown-toolbar__item">
       <md-link-email class="app-c-markdown-toolbar__button">Email link</md-link-email>
     </li>
-    <li class="app-c-markdown-toolbar__item">
-      <md-link-cta class="app-c-markdown-toolbar__button">Call to action</md-link-cta>
-    </li>
   </ul>
   <a href="https://www.gov.uk/guidance/how-to-publish-on-gov-uk/markdown#links" class="govuk-link" target="_blank"> Guidance on links</a>
   <% end %>
@@ -56,16 +53,5 @@
     </li>
   </ul>
   <a href="https://www.gov.uk/guidance/how-to-publish-on-gov-uk/markdown#blockquotes" class="govuk-link" target="_blank"> Guidance on blockquotes</a>
-  <% end %>
-
-  <%= render "govuk_publishing_components/components/details", {
-      title: "Addresses"
-  } do %>
-  <ul class="app-c-markdown-toolbar__list">
-    <li class="app-c-markdown-toolbar__item">
-      <md-address class="app-c-markdown-toolbar__button">Addresses</md-address>
-    </li>
-  </ul>
-  <a href="https://www.gov.uk/guidance/how-to-publish-on-gov-uk/markdown#markdown-addresses" class="govuk-link" target="_blank"> Guidance on addresses</a>
   <% end %>
 </markdown-toolbar>

--- a/app/views/components/docs/markdown-toolbar.yml
+++ b/app/views/components/docs/markdown-toolbar.yml
@@ -1,0 +1,10 @@
+name: Markdown toolbar
+description: Allow injecting markdown syntax
+body: |
+  Optional markdown providing further detail about the component
+accessibility_criteria: |
+  The links must:
+
+  * be keyboard focusable
+examples:
+  default: {}

--- a/app/views/documents/fields/_govspeak_input.html.erb
+++ b/app/views/documents/fields/_govspeak_input.html.erb
@@ -11,7 +11,7 @@
         id: "govspeak-editor",
         name: "document[contents][#{schema.id}]",
         value: document.contents[schema.id],
-        rows: 30,
+        rows: 25,
         spellcheck: "false"
       }
     } %>
@@ -27,13 +27,10 @@
       <p class="govuk-body">
           <a href="https://www.gov.uk/guidance/how-to-publish-on-gov-uk/markdown" class="govuk-link">Full Markdown guidance</a>
       </p>
-      <markdown-toolbar for="govspeak-editor">
-        <md-header class="govuk-link">Heading</md-header>
-        <md-link class="govuk-link">Link</md-link>
-        <md-unordered-list class="govuk-link">Bullets</md-unordered-list>
-        <md-ordered-list class="govuk-link">Numbered list</md-ordered-list>
-        <md-quote class="govuk-link">Blockquote</md-quote>
-      </markdown-toolbar>
+
+      <%= render "components/markdown-toolbar", {
+        html_for: "govspeak-editor"
+      } %>
     <% end %>
   </div>
 </div>


### PR DESCRIPTION
This PR:
- moves markdown-toolbar in a component
- groups toolbar items in sections using the `details` component and add links to the relevant guidance (the content of these sections will be reviewed with a content designer and potentially read from a separate file)
- ~prevents markdown contextual guidance to overlap footer or other components on small screens~
- extends markdown-toolbar with the following snippets:
  - heading 2 (`##`), heading 3 (`###`), heading 4 (`####`)
  - ~call to action~ (`$CTA [Start](url) %CTA`)
  - link email (`<john.doe@mail.tld>`)
  - ~address~ (`$A 10 Whitechapel $A`)
- ~configures marked renderer to~
  - support line breaks
  - render tables
  - sanitise user input
- removes the absolute position of contextual guidance


[Trello card](https://trello.com/c/yKPf7Kd6)