### PR TITLE
Ensure user chooses supertype / document type

### DIFF
--- a/app/controllers/new_document_controller.rb
+++ b/app/controllers/new_document_controller.rb
@@ -6,17 +6,29 @@ class NewDocumentController < ApplicationController
   end
 
   def choose_document_type
-    supertype_schema = SupertypeSchema.find(params[:supertype])
-
-    if supertype_schema.managed_elsewhere
-      redirect_to supertype_schema.managed_elsewhere_url
+    unless params[:supertype]
+      redirect_to new_document_path, alert: "Please choose a supertype"
       return
     end
 
-    @document_types = supertype_schema.document_types
+    @supertype_schema = SupertypeSchema.find(params[:supertype])
+
+    if @supertype_schema.managed_elsewhere
+      redirect_to @supertype_schema.managed_elsewhere_url
+      return
+    end
+
+    @document_types = @supertype_schema.document_types
   end
 
   def create
+    unless params[:document_type]
+      redirect_to choose_document_type_path(supertype: params[:supertype]),
+        alert: "Please choose a document type"
+
+      return
+    end
+
     document_type_schema = DocumentTypeSchema.find(params[:document_type])
 
     if document_type_schema.managed_elsewhere

--- a/app/views/new_document/choose_document_type.html.erb
+++ b/app/views/new_document/choose_document_type.html.erb
@@ -14,6 +14,7 @@
         }
       } %>
 
+      <%= hidden_field(nil, :supertype, value: @supertype_schema.id) %>
       <%= render "govuk_publishing_components/components/button", text: "Continue", margin_bottom: true %>
     <% end %>
   </div>

--- a/app/views/new_document/choose_supertype.html.erb
+++ b/app/views/new_document/choose_supertype.html.erb
@@ -3,7 +3,7 @@
 
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
-    <%= form_tag do %>
+    <%= form_tag(choose_document_type_path, method: :get, enforce_utf8: false) do %>
       <%= render "govuk_publishing_components/components/radio", {
         name: "supertype",
         items: @supertypes.map do |supertype|
@@ -15,6 +15,7 @@
           }
         end
       } %>
+
       <%= render "govuk_publishing_components/components/button", text: "Continue", margin_bottom: true %>
     <% end %>
   </div>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -6,7 +6,7 @@ Rails.application.routes.draw do
 
   get '/documents/publishing-guidance' => 'new_document#guidance', as: :guidance
   get '/documents/new' => 'new_document#choose_supertype', as: :new_document
-  post '/documents/new' => 'new_document#choose_document_type'
+  get '/documents/choose-document-type' => 'new_document#choose_document_type', as: :choose_document_type
   post '/documents/create' => 'new_document#create', as: :create_document
 
   get '/documents/:id/publish' => 'publish_document#confirmation', as: :publish_document

--- a/spec/features/choose_a_format_spec.rb
+++ b/spec/features/choose_a_format_spec.rb
@@ -1,0 +1,36 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+
+RSpec.feature "Choosing a format" do
+  scenario "User forgets to choose a format" do
+    when_i_dont_choose_a_supertype
+    then_i_see_a_supertype_error
+    when_i_choose_a_supertype
+    and_i_dont_choose_a_document_type
+    then_i_see_a_document_type_error
+  end
+
+  def when_i_dont_choose_a_supertype
+    visit "/"
+    click_on "New document"
+    click_on "Continue"
+  end
+
+  def then_i_see_a_supertype_error
+    expect(page).to have_content "Please choose a supertype"
+  end
+
+  def when_i_choose_a_supertype
+    choose SupertypeSchema.all.reject(&:managed_elsewhere).map(&:label).sample
+    click_on "Continue"
+  end
+
+  def and_i_dont_choose_a_document_type
+    click_on "Continue"
+  end
+
+  def then_i_see_a_document_type_error
+    expect(page).to have_content "Please choose a document type"
+  end
+end


### PR DESCRIPTION
https://trello.com/c/EDDD2DYl/128-handle-when-the-user-doesnt-select-a-supertype-or-document-type

This prevents the user reaching an error page in the case where they
forget to choose a supertype or a document type, and then click the
'Continue' button when creating a document.

The page to choose a document type was previously a POST route, which
made it awkward to re-visit the page if the user doesn't select a
document type and clicks 'Continue'. To support re-visiting the page,
the route is now a GET route and the form_tag for choosing a supertype
now has the explicit route to get to it, turning off the UTF8 character
set param to keep the resulting URL query params clean.

Note that there's still a spurious 'button' query param, which is added by the 
form submit button. There's a separate PR to fix this: https://github.com/alphagov/govuk_publishing_components/pull/479.