### PR TITLE
Upgrade govuk-publishing-components

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -129,7 +129,7 @@ GEM
     govuk_frontend_toolkit (7.6.0)
       railties (>= 3.1.0)
       sass (>= 3.2.0)
-    govuk_publishing_components (9.12.1)
+    govuk_publishing_components (9.12.2)
       govspeak (>= 5.0.3)
       govuk_app_config
       govuk_frontend_toolkit


### PR DESCRIPTION
This removes the spurious button query param when creating a new document.