### PR TITLE
Update summary page

### DIFF
--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -7,6 +7,7 @@ $govuk-global-styles: true;
 @import "components/contextual-guidance";
 @import "components/markdown-editor";
 @import "components/markdown-toolbar";
+@import "components/summary";
 
 .app-hidden {
   display: none;

--- a/app/assets/stylesheets/components/_summary.scss
+++ b/app/assets/stylesheets/components/_summary.scss
@@ -1,0 +1,102 @@
+// Recommended styles from the check your answers pattern
+// https://design-system.service.gov.uk/patterns/check-answers/
+
+.app-c-summary {
+  @include govuk-font(19);
+  position: relative;
+}
+
+.app-c-summary__edit {
+  position: absolute;
+  top: 0;
+  right: 0;
+}
+
+.app-c-summary__list {
+  @include govuk-font(19);
+
+  margin-top: 0;
+
+  @include govuk-responsive-margin(9, "bottom");
+
+  @include govuk-media-query($from: desktop) {
+    display: table;
+  }
+}
+
+.app-c-summary__list--short {
+  @include govuk-media-query($from: desktop) {
+    // to make group of q&a line up horizontally (unless there is just one group)
+    width: 100%;
+
+    // recommended for mostly short questions
+    .app-c-summary__question {
+      width: 30%;
+    }
+  }
+}
+
+.app-c-summary__list--long {
+  @include govuk-media-query($from: desktop) {
+    // to make group of q&a line up horizontally (unless there is just one group)
+    width: 100%;
+
+    // recommended for mostly long questions
+    .app-c-summary__question {
+      width: 50%;
+    }
+  }
+}
+
+.app-c-summary__contents {
+  position: relative;
+  border-bottom: 1px solid $govuk-border-colour;
+
+  @include govuk-media-query($from: desktop) {
+    display: table-row;
+    border-bottom-width: 0;
+  }
+}
+
+.app-c-summary__contents:first-child .app-c-summary__question,
+.app-c-summary__contents:first-child .app-c-summary__answer,
+.app-c-summary__contents:first-child .app-c-summary__change {
+  @include govuk-media-query($from: desktop) {
+    padding-top: 0;
+  }
+}
+
+.app-c-summary__question,
+.app-c-summary__answer,
+.app-c-summary__change {
+  display: block;
+  margin: 0;
+
+  @include govuk-media-query($from: desktop) {
+    display: table-cell;
+    padding: govuk-em(12, 19) govuk-em(20, 19) govuk-em(9, 19) 0;
+    border-bottom: 1px solid $govuk-border-colour;
+  }
+}
+
+.app-c-summary__question {
+  margin: govuk-em(12, 19) 4em govuk-em(4, 19) 0;
+  font-weight: bold;
+  // using margin instead of padding because of easier absolutely positioning of .app-c-summary__change
+}
+
+.app-c-summary__answer {
+  padding-bottom: govuk-em(9, 19);
+}
+
+.app-c-summary__change {
+  position: absolute;
+  top: 0;
+  right: 0;
+  text-align: right;
+
+  @include govuk-media-query($from: desktop) {
+    position: static;
+    padding-right: 0;
+  }
+}

--- a/app/views/components/_summary.html.erb
+++ b/app/views/components/_summary.html.erb
@@ -1,0 +1,41 @@
+<%
+  title||= nil
+  items||= []
+%>
+
+<div class="app-c-summary">
+
+<% if title %>
+  <h2 class="govuk-heading-m">
+    <%= title[:text] %>
+  </h2>
+  <% if title[:change_url] %>
+  <a class="app-c-summary__edit" href="<%= title[:change_url] %>">
+    Change<span class="govuk-visually-hidden"> <%= title[:text] %></span>
+  </a>
+  <% end %>
+<% end %>
+
+<% if items.any? %>
+  <dl class="app-c-summary__list app-c-summary__list--short">
+    <% items.each do |item| %>
+    <div class="app-c-summary__contents">
+      <dt class="app-c-summary__question">
+        <%= item[:field] %>
+      </dt>
+      <dd class="app-c-summary__answer">
+        <%= item[:value] %>
+      </dd>
+      <% if item[:change_url] %>
+      <dd class="app-c-summary__change">
+        <a href="<%= item[:change_url] %>">
+          Change<span class="govuk-visually-hidden"> <%= item[:field] %></span>
+        </a>
+      </dd>
+      <% end %>
+    </div>
+    <% end %>
+  </dl>
+<% end %>
+
+</div>

--- a/app/views/components/docs/summary.yml
+++ b/app/views/components/docs/summary.yml
@@ -1,0 +1,39 @@
+name: Summary
+description: Let users check their input before proceeding forward
+body: |
+  This component was build based on [Check answers pattern](https://design-system.service.gov.uk/patterns/check-answers/)
+part_of_admin_layout: true
+shared_accessibility_criteria:
+- link
+accessibility_criteria: |
+  The change/edit link must:
+
+  * indicate which item or section refers to (e.g. Change title)
+examples:
+  default:
+    data:
+      title:
+        text: "Title, summary and body"
+        change_url: "#change-title-summary-body"
+      items:
+      - field: "Title"
+        value: "Ethical standards for public service providers"
+      - field: "Summary"
+        value: "Find out more about our reviews on the subject of ethical standards for public service providers, including our 2014 report, 2015 guidance and 2018 follow-up publication."
+      - field: "Body"
+        value: "After the government decided in 2013 to expand the remit of the Committee to include public service providers, the Committee on Standards in Public Life produced our first report on the issue: Ethical Standards for Providers of Public Services in 2014."
+
+  change-item:
+    data:
+      title:
+        text: "Title, summary and body"
+      items:
+      - field: "Title"
+        value: "Ethical standards for public service providers"
+        change_url: "#change-title"
+      - field: "Summary"
+        value: "Find out more about our reviews on the subject of ethical standards for public service providers, including our 2014 report, 2015 guidance and 2018 follow-up publication."
+        change_url: "#change-summary"
+      - field: "Body"
+        value: "After the government decided in 2013 to expand the remit of the Committee to include public service providers, the Committee on Standards in Public Life produced our first report on the issue: Ethical Standards for Providers of Public Services in 2014."
+        change_url: "#change-body"

--- a/app/views/documents/associations/_multi_association.html.erb
+++ b/app/views/documents/associations/_multi_association.html.erb
@@ -1,15 +1,11 @@
-<div id=<%= schema.id %>>
-  <p><%= schema.id %>:</p>
+<% service = LinkablesService.new(schema.document_type) %>
 
-  <% service = LinkablesService.new(schema.document_type) %>
-
-  <% if values&.any? %>
-    <ul>
-      <% values.each do |content_id| %>
-        <li><%= service.by_content_id(content_id)["internal_name"] %></li>
-      <% end %>
-    </ul>
-  <% else %>
-    None
-  <% end %>
-</div>
+<% if values&.any? %>
+  <ul class="govuk-list govuk-list--bullet">
+    <% values.each do |content_id| %>
+      <li><%= content_id %><%= service.by_content_id(content_id)["internal_name"] %></li>
+    <% end %>
+  </ul>
+<% else %>
+  None
+<% end %>

--- a/app/views/documents/fields/_govspeak.html.erb
+++ b/app/views/documents/fields/_govspeak.html.erb
@@ -1,9 +1,3 @@
-<p>
-  <%= render "govuk_publishing_components/components/heading", {
-    text: schema.id
-  } %>
-
-  <%= render "govuk_publishing_components/components/govspeak", {} do %>
-    <%= raw Govspeak::Document.new(@document.contents[schema.id]).to_html %>
-  <% end %>
-</p>
+<%= render "govuk_publishing_components/components/govspeak", {} do %>
+  <%= raw Govspeak::Document.new(@document.contents[schema.id]).to_html %>
+<% end %>

--- a/app/views/documents/show.html.erb
+++ b/app/views/documents/show.html.erb
@@ -1,40 +1,85 @@
 <% content_for :back_link, documents_path %>
 <% content_for :title, @document.title || "No title" %>
 
-<p>
-  Base path: <%= @document.base_path %>
-</p>
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-two-thirds">
 
-<p>
-  Document type: <%= @document.document_type %>
-</p>
+    <ul>
+      <% ContentValidator.new(@document).validation_messages.each do |message| %>
+        <li><%= message %></li>
+      <% end %>
+    </ul>
 
-<p>
-  Summary: <%= @document.summary %>
-</p>
+    <%= render "components/summary", {
+      title: {
+        text: "Document type"
+      },
+      items: [
+        {
+          field: "Document type",
+          value: @document.document_type_schema.name
+        }
+      ]
+    } %>
 
-<ul>
-<% ContentValidator.new(@document).validation_messages.each do |message| %>
-  <li><%= message %></li>
-<% end %>
-</ul>
+    <% contents = @document.document_type_schema.contents.map { |schema|
+      {
+        field: schema.label,
+        value: capture do
+          render "documents/fields/#{schema.type}", schema: schema, document: @document
+        end
+      }
+    } %>
 
-<% @document.document_type_schema.contents.each do |schema| %>
-  <%= render "documents/fields/#{schema.type}", schema: schema, document: @document %>
-<% end %>
+    <%= render "components/summary", {
+      title: {
+        text: "Title, summary and body",
+        change_url: edit_document_path(@document)
+      },
+      items: [
+        {
+          field: "Title",
+          value: @document.title
+        },
+        {
+          field: "Base path",
+          value: @document.base_path
+        },
+        {
+          field: "Summary",
+          value: @document.summary
+        }
+      ] + contents
+    } %>
 
-<h2>Associations</h2>
+    <% associations = @document.document_type_schema.associations.map { |schema|
+      {
+        field: schema.label,
+        value: capture do
+          render "documents/associations/#{schema.type}", schema: schema, values: @document.associations[schema.id]
+        end
+      }
+    } %>
 
-<% @document.document_type_schema.associations.each do |schema| %>
-  <%= render "documents/associations/#{schema.type}",
-    schema: schema,
-    values: @document.associations[schema.id] %>
-<% end %>
+    <%= render "components/summary", {
+      title: {
+        text: "Associations",
+        change_url: document_associations_path(@document)
+      },
+      items: associations
+    } %>
 
-<%= render "govuk_publishing_components/components/button", {
-  text: "Publish",
-  href: publish_document_path(@document),
-} %>
-
-<%= link_to "Edit document", edit_document_path(@document), class: "govuk-link" %>
-<%= link_to "Edit associations", document_associations_path(@document), class: "govuk-link" %>
+  </div>
+  <div class="govuk-grid-column-one-third">
+    <ul class="govuk-list">
+      <li>
+        <%= link_to "Publish", publish_document_path(@document), class: "govuk-link" %>
+      </li>
+      <li>
+        <%= link_to "Edit document", edit_document_path(@document), class: "govuk-link" %>
+      </li>
+      <li>
+        <%= link_to "Edit associations", document_associations_path(@document), class: "govuk-link" %>
+      </li>
+  </div>
+</div>

--- a/spec/features/create_a_document_api_down_spec.rb
+++ b/spec/features/create_a_document_api_down_spec.rb
@@ -35,7 +35,7 @@ RSpec.feature "Create a document when the API is down" do
 
   def then_i_see_the_document_exists
     expect(page).to have_content "A great title"
-    expect(page).to have_content "press_release"
+    expect(page).to have_content "Press release"
     expect(Document.last.title).to eq "A great title"
   end
 


### PR DESCRIPTION
This PR:
- Adds the summary component based on [Check answers pattern](https://design-system.service.gov.uk/patterns/check-answers/)
- Defines two examples for the summary page component
- Updates `show` and `multi_association` views to use the summary component

Note:
The associations section in the summary page spans both `show` view and `multi_association` partial - due to iteration over `document_type_schema.associations`. Would be good to pair with a backend dev and try and refactor this so we can use the component instead of plain markup.

[Trello card](https://trello.com/c/lsCHlZTt)