### PR TITLE
Update markdown editor component

### DIFF
--- a/app/assets/javascripts/components/markdown-editor.js
+++ b/app/assets/javascripts/components/markdown-editor.js
@@ -4,12 +4,13 @@
 
 function MarkdownEditor ($module) {
   this.$module = $module
+  this.$toggleBar = $module.querySelector('.js-markdown-toggle-bar')
   this.$input = $module.querySelector('textarea')
-  this.$preview = $module.querySelector('.js-preview-body .govuk-textarea')
-  this.$previewButton = $module.querySelector('.js-preview-button')
-  this.$editButton = $module.querySelector('.js-edit-button')
-  this.$editorInput = $module.querySelector('.js-editor-input')
-  this.$previewBody = $module.querySelector('.js-preview-body')
+  this.$preview = $module.querySelector('.js-markdown-preview-body .govuk-textarea')
+  this.$previewButton = $module.querySelector('.js-markdown-preview-button')
+  this.$editButton = $module.querySelector('.js-markdown-edit-button')
+  this.$editorInput = $module.querySelector('.js-markdown-editor-input')
+  this.$previewBody = $module.querySelector('.js-markdown-preview-body')
 }
 
 MarkdownEditor.prototype.init = function () {
@@ -18,6 +19,9 @@ MarkdownEditor.prototype.init = function () {
   // Save bounded functions to use when removing event listeners during teardown
   $module.boundPreviewButtonClick = this.handlePreviewButton.bind(this)
   $module.boundEditButtonClick = this.handleEditButton.bind(this)
+
+  // Enable toggle bar
+  this.$toggleBar.style.display = 'block'
 
   // Handle events
   this.$previewButton.addEventListener('click', $module.boundPreviewButtonClick)
@@ -46,6 +50,8 @@ MarkdownEditor.prototype.handlePreviewButton = function (event) {
         }
       }
     )
+  } else {
+    $preview.innerHTML = 'Nothing to preview'
   }
   this.toggleElements()
 }

--- a/app/assets/stylesheets/components/_markdown-editor.scss
+++ b/app/assets/stylesheets/components/_markdown-editor.scss
@@ -1,6 +1,7 @@
 .app-c-markdown-editor__preview-toggle {
   @include govuk-font($size: 19);
 
+  display: none;
   margin-bottom: -$govuk-border-width-form-element;
   padding: govuk-spacing(1);
   border: $govuk-border-width-form-element solid $govuk-input-border-colour;

--- a/app/views/components/_markdown-editor.html.erb
+++ b/app/views/components/_markdown-editor.html.erb
@@ -1,17 +1,23 @@
+<%
+  textarea ||= {}
+  edit_button_text ||= 'Edit'
+  preview_button_text ||= 'Preview'
+%>
 <div class="app-c-markdown-editor" data-module="markdown-editor">
   <%= render "govuk_publishing_components/components/label", {
-      text: textarea[:label][:text],
+      text: label[:text],
       html_for: textarea[:id]
   } %>
-  <% textarea[:label] = nil %>
-  <div class="app-c-markdown-editor__preview-toggle">
-    <button class="app-c-markdown-editor__button app-c-markdown-editor__button--edit js-edit-button">Edit markdown</button>
-    <button class="app-c-markdown-editor__button app-c-markdown-editor__button--preview js-preview-button">Preview markdown</button>
+  <div class="app-c-markdown-editor__preview-toggle js-markdown-toggle-bar">
+    <button class="app-c-markdown-editor__button app-c-markdown-editor__button--edit js-markdown-edit-button"><%= edit_button_text %></button>
+    <button class="app-c-markdown-editor__button app-c-markdown-editor__button--preview js-markdown-preview-button"><%= preview_button_text %></button>
   </div>
-  <div class="app-c-markdown-editor__input js-editor-input">
+  <div class="app-c-markdown-editor__input js-markdown-editor-input">
     <%= render "govuk_publishing_components/components/textarea", textarea %>
   </div>
-  <div class="app-c-markdown-editor__preview js-preview-body">
-    <div class="govuk-textarea">Nothing to preview</div>
+  <div class="app-c-markdown-editor__preview js-markdown-preview-body">
+  <%= render "govuk_publishing_components/components/govspeak", { } do %>
+    <div class="govuk-textarea"></div>
+  <% end %>
   </div>
 </div>

--- a/app/views/components/docs/markdown-editor.yml
+++ b/app/views/components/docs/markdown-editor.yml
@@ -1,7 +1,11 @@
 name: Markdown editor
 description: Allows editing and previewing markdown
 body: |
-  Optional markdown providing further detail about the component
+  If JavaScript is disabled this component falls back to a textarea component
+  without the preview functionality
+part_of_admin_layout: true
+shared_accessibility_criteria:
+  - link
 accessibility_criteria: |
   The component must:
 
@@ -12,4 +16,11 @@ accessibility_criteria: |
   - indicate when they have focus
   - have correctly associated labels
 examples:
-  default: {}
+  default:
+    data:
+      label:
+        text: Body
+      textarea:
+        name: markdown-editor
+        id: markdown-editor
+

--- a/app/views/documents/fields/_govspeak_input.html.erb
+++ b/app/views/documents/fields/_govspeak_input.html.erb
@@ -1,10 +1,10 @@
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
     <%= render "components/markdown-editor", {
+      label: {
+        text: schema.label
+      },
       textarea: {
-        label: {
-          text: schema.label
-        },
         data: {
           "contextual-guidance": "document-contents-guidance"
         },


### PR DESCRIPTION
This PR:
 - makes the preview bar hidden by default (when JavaScript is disabled the preview bar will not be shown) and enable it via JavaScript
 - moves the "Nothing to preview" message from markup to JavaScript to be consistent with "Error previewing content" - it won't be shown/used anyway without having JavaScript enabled.
 - adds a `js-markdown` prefix for element queries to prevent clashes with other components
 - adds a default example for the markdown editor component

### JavaScript enabled
<img width="644" alt="screen shot 2018-08-13 at 14 34 11" src="https://user-images.githubusercontent.com/788096/44034889-218bfdc0-9f06-11e8-8630-4ba4ea005f51.png">

### JavaScript disabled
<img width="647" alt="screen shot 2018-08-13 at 14 33 52" src="https://user-images.githubusercontent.com/788096/44034897-24d4e74e-9f06-11e8-9472-296c4325a55b.png">
