### PR TITLE
Set type button for toggle preview

### DIFF
--- a/app/views/components/_markdown-editor.html.erb
+++ b/app/views/components/_markdown-editor.html.erb
@@ -9,8 +9,8 @@
       html_for: textarea[:id]
   } %>
   <div class="app-c-markdown-editor__preview-toggle js-markdown-toggle-bar">
-    <button class="app-c-markdown-editor__button app-c-markdown-editor__button--edit js-markdown-edit-button"><%= edit_button_text %></button>
-    <button class="app-c-markdown-editor__button app-c-markdown-editor__button--preview js-markdown-preview-button"><%= preview_button_text %></button>
+    <button type="button" class="app-c-markdown-editor__button app-c-markdown-editor__button--edit js-markdown-edit-button"><%= edit_button_text %></button>
+    <button type="button" class="app-c-markdown-editor__button app-c-markdown-editor__button--preview js-markdown-preview-button"><%= preview_button_text %></button>
   </div>
   <div class="app-c-markdown-editor__input js-markdown-editor-input">
     <%= render "govuk_publishing_components/components/textarea", textarea %>


### PR DESCRIPTION
Explicitly sets types for secondary buttons in forms.

@tijmenb found a bug when hitting enter on an input field would trigger the first button on the form (in our case the preview button) instead of the "Save" button. Setting these buttons explicitly to `type="button"` will avoid having this issue when the component is used in any form.