### PR TITLE
Add preview & shareable preview links

### DIFF
--- a/app.json
+++ b/app.json
@@ -9,6 +9,9 @@
     },
     "GOVUK_APP_DOMAIN": {
       "required": true
+    },
+    "JWT_AUTH_SECRET": {
+      "generator": "secret"
     }
   },
   "addons": [

--- a/app/services/document_url.rb
+++ b/app/services/document_url.rb
@@ -1,0 +1,54 @@
+# frozen_string_literal: true
+
+class DocumentUrl
+  def initialize(document)
+    @document = document
+  end
+
+  def public_url
+    Plek.new.website_root + document.base_path
+  end
+
+  def preview_url
+    Plek.new.external_url_for('draft-origin') + document.base_path
+  end
+
+  def secret_preview_url
+    params = { token: secret_token_for_preview_url }.to_query
+    preview_url + '?' + params
+  end
+
+  # Return a "auth_bypass_id" to send to the publishing-api. This token will
+  # be used to give one-time access to a piece of draft content.
+  #
+  # The token is first sent to the publishing-api in the payload. It is persisted
+  # in the content store. Users will then be allowed to visit the draft stack
+  # with a token in the URL. This JWT token is generated using the same `auth_bypass_id`,
+  # which means the the draft stack can determine if the token allows access to
+  # a specific piece of content.
+  #
+  # For more info, see https://docs.publishing.service.gov.uk/manual/content-preview.html#authentication
+  def auth_bypass_id
+    @_auth_bypass_id ||= generate_uuid_for_string(document.content_id)
+  end
+
+private
+
+  attr_reader :document
+
+  def secret_token_for_preview_url
+    JWT.encode({ 'sub' => auth_bypass_id }, ENV.fetch('JWT_AUTH_SECRET'), 'HS256')
+  end
+
+  # Generate a deterministic UUID from a string.
+  #
+  # The code to create the token has been borrowed from SecureRandom.uuid.
+  #
+  # See: http://ruby-doc.org/stdlib-1.9.3/libdoc/securerandom/rdoc/SecureRandom.html#uuid-method
+  def generate_uuid_for_string(string)
+    ary = Digest::SHA256.hexdigest(string).unpack('NnnnnN')
+    ary[2] = (ary[2] & 0x0fff) | 0x4000
+    ary[3] = (ary[3] & 0x3fff) | 0x8000
+    "%08x-%04x-%04x-%04x-%04x%08x" % ary
+  end
+end

--- a/app/services/publishing_api_payload.rb
+++ b/app/services/publishing_api_payload.rb
@@ -26,6 +26,9 @@ class PublishingApiPayload
         { path: document.base_path, type: "exact" },
       ],
       links: document.associations,
+      access_limited: {
+        auth_bypass_ids: [DocumentUrl.new(document).auth_bypass_id],
+      }
     }
   end
 

--- a/app/views/documents/show/_actions.html.erb
+++ b/app/views/documents/show/_actions.html.erb
@@ -8,4 +8,13 @@
   <li>
     <%= link_to "Edit associations", document_associations_path(@document), class: "govuk-link" %>
   </li>
+  <li>
+    <%= link_to "View on GOV.UK", DocumentUrl.new(@document).public_url, class: "govuk-link" %>
+  </li>
+  <li>
+    <%= link_to "Preview", DocumentUrl.new(@document).preview_url, class: "govuk-link" %>
+  </li>
+  <li>
+    <%= link_to "Shareable preview", DocumentUrl.new(@document).secret_preview_url, class: "govuk-link" %>
+  </li>
 </ul>

--- a/spec/services/document_url_spec.rb
+++ b/spec/services/document_url_spec.rb
@@ -1,0 +1,31 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+
+RSpec.describe DocumentUrl do
+  let(:document) { build(:document, base_path: "/foo", content_id: "d2547c42-8ed3-49f5-baeb-6112f98c2bf9") }
+
+  describe "#public_url" do
+    it "returns the URL" do
+      url = DocumentUrl.new(document).public_url
+
+      expect(url).to eql("https://www.test.gov.uk/foo")
+    end
+  end
+
+  describe "#preview_url" do
+    it "returns the URL" do
+      url = DocumentUrl.new(document).preview_url
+
+      expect(url).to eql("https://draft-origin.test.gov.uk/foo")
+    end
+  end
+
+  describe "#preview_url" do
+    it "returns the URL" do
+      url = DocumentUrl.new(document).secret_preview_url
+
+      expect(url).to eql("https://draft-origin.test.gov.uk/foo?token=eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9.eyJzdWIiOiIzMzMxMzEzMS0zMzY1LTQ4MzgtYjk2My0zNDM3MzYzNTMxNjYifQ.5TMX_QV1BGCrG0smlMRfu0TgkBc57u1gb_UUAAW8cnY")
+    end
+  end
+end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -2,6 +2,7 @@
 
 ENV["RAILS_ENV"] ||= "test"
 ENV["GOVUK_APP_DOMAIN"] = "test.gov.uk"
+ENV["JWT_AUTH_SECRET"] = "SUPER_SECRET"
 
 require File.expand_path("../../config/environment", __FILE__)
 require "rspec/rails"


### PR DESCRIPTION
This temporarily adds 3 links to the action menu:

- View on GOV.UK - for the live version of the page
- Preview - the draft page on the draft stack, Signon required
- Shareable preview - the draft page with secret token to bypass Signon

I'm assuming we'll redesign the placing of these links, so I haven't added integration tests for this. This PR is just to add the logic of the links.

The "bypass" code is mostly taken from mainstream publisher and collections-publisher (who introduced the same feature recently - https://github.com/alphagov/collections-publisher/pull/428). It's a complicated system, and I hope I've explained it a bit in the comments.

For this to work on production, we'll need to make `JWT_AUTH_SECRET` available to content publisher: https://github.com/alphagov/govuk-puppet/pull/7968.

https://trello.com/c/ECYqAHfX