### PR TITLE
Use differnt Plek method to avoid errors

### DIFF
--- a/app/services/document_url.rb
+++ b/app/services/document_url.rb
@@ -6,7 +6,7 @@ class DocumentUrl
   end
 
   def public_url
-    Plek.new.website_root + document.base_path
+    Plek.new.find('www') + document.base_path
   end
 
   def preview_url


### PR DESCRIPTION
    The preview use of website_root would require us to configure
    another Heroku environment variable. Using the external_url_for
    method seems to achieve the same thing and on Heroku falls back
    to the GOVUK_APP_DOMAIN (which is incorrect, but we don't care).