### PR TITLE
Fix renamed state name in translations

### DIFF
--- a/config/application.rb
+++ b/config/application.rb
@@ -27,6 +27,8 @@ module ContentPublisher
     # -- all .rb files in that directory are automatically loaded after loading
     # the framework and any gems in your application.
 
+    config.action_view.raise_on_missing_translations = true
+
     # The "Slimmer" gem is loaded by the publishing components and will automatically
     # attempt to intercept requests and provide a layout. We don't use that
     # functionality here, so we have to tell slimmer to not do it.

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -45,7 +45,7 @@ en:
     error_sending_to_draft:
       name: Error sending to draft
       description: We've encountered a problem making your preview available.
-    publishing:
+    sending_to_live:
       name: Publishing
       description: We're currently publishing a new edition to GOV.UK.
     sent_to_live:

--- a/spec/models/document_spec.rb
+++ b/spec/models/document_spec.rb
@@ -1,0 +1,14 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+
+RSpec.describe Document do
+  describe "PUBLICATION_STATES" do
+    it "has correct translations for each state" do
+      Document::PUBLICATION_STATES.each do |state|
+        I18n.t!("publication_state.#{state}.name")
+        I18n.t!("publication_state.#{state}.description")
+      end
+    end
+  end
+end


### PR DESCRIPTION
The `publishing` state was renamed to `sending_to_live` at some point. This fixes that and adds tests.

https://trello.com/c/i6C3pY03