### PR TITLE
Start exposing the inner workings of the application

### DIFF
--- a/app/controllers/documentation_controller.rb
+++ b/app/controllers/documentation_controller.rb
@@ -1,0 +1,5 @@
+# frozen_string_literal: true
+
+class DocumentationController < ApplicationController
+  # TODO: restrict to GDS staff.
+end

--- a/app/views/documentation/index.html.erb
+++ b/app/views/documentation/index.html.erb
@@ -1,0 +1,49 @@
+<% content_for :title, "App documentation" %>
+
+<h2 class='govuk-heading-m'>Document types</h2>
+
+<table class='govuk-table'>
+  <thead class='govuk-table__head'>
+    <tr class='govuk-table__row'>
+      <th class='govuk-table__header' scope='col'>Name</th>
+      <th class='govuk-table__header' scope='col'>Type</th>
+      <th class='govuk-table__header' scope='col'>Supertype</th>
+      <th class='govuk-table__header' scope='col'>Non-beta?</th>
+      <th class='govuk-table__header' scope='col'>Link</th>
+    </tr>
+  </thead>
+
+  <body class='govuk-table__body'>
+    <% DocumentTypeSchema.all.each do |schema| %>
+      <tr class='govuk-table__row'>
+        <td class='govuk-table__header'><%= schema.name %></td>
+        <td class='govuk-table__cell'><%= schema.id %></td>
+        <td class='govuk-table__cell'><%= schema.supertype.label %></td>
+        <td class='govuk-table__cell'><%= schema.managed_elsewhere ? link_to('Other app', schema.managed_elsewhere_url) : '' %></td>
+        <td class='govuk-table__cell'><%= link_to 'Tech docs', "https://docs.publishing.service.gov.uk/document-types/#{schema.id}.html" %></td>
+      </tr>
+    <% end %>
+  </body>
+</table>
+
+<h2 class='govuk-heading-m'>Publication states</h2>
+
+<p>Whenever something changes in the document we update the "publication state".</p>
+
+<table class='govuk-table'>
+  <thead class='govuk-table__head'>
+    <tr class='govuk-table__row'>
+      <th class='govuk-table__header' scope='col'>State</th>
+      <th class='govuk-table__header' scope='col'>Description</th>
+    </tr>
+  </thead>
+
+  <body class='govuk-table__body'>
+    <% Document::PUBLICATION_STATES.each do |state| %>
+      <tr class='govuk-table__row'>
+        <td class='govuk-table__header'><%= t "publication_state.#{state}.name" %></td>
+        <td class='govuk-table__cell'><%= t "publication_state.#{state}.description" %></td>
+      </tr>
+    <% end %>
+  </body>
+</table>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -22,6 +22,8 @@ Rails.application.routes.draw do
 
   get "/healthcheck", to: proc { [200, {}, ["OK"]] }
 
+  get '/documentation' => 'documentation#index'
+
   mount GovukPublishingComponents::Engine, at: "/component-guide"
 
   if Rails.env.test?

--- a/spec/features/documentation_spec.rb
+++ b/spec/features/documentation_spec.rb
@@ -1,0 +1,18 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+
+RSpec.feature "Documentation" do
+  scenario "GDS staff visits the docs page" do
+    when_i_visit_the_documentation_page
+    then_i_see_the_documentation_page
+  end
+
+  def when_i_visit_the_documentation_page
+    visit "/documentation"
+  end
+
+  def then_i_see_the_documentation_page
+    expect(page).to have_content "App documentation"
+  end
+end


### PR DESCRIPTION
This is a first stab at a documentation approach for this app. The target of these docs are the people working on it - the PM, DM, user researchers, designers, content designers, and developers.

My dream for documentation is that content publisher will be able to "explain itself", rather than needing developers to explain it. It's mainly inspired by the difficulty we have in understanding the current workings of Whitehall.

This PR adds two things to `/documentation`:

- All the formats. This is to answer the question "What formats are currently available in this application?". Instead of reading the code, or clicking through the entire app, team members have access to a single list.
- All the publication states. This is especially important because some will be rare or transient, so having a central place to show all the states and translations can make it clearer to the team how the app works.

https://content-publisher-revie-pr-135.herokuapp.com/documentation

I expect this section to grow as the app becomes more complicated.