### PR TITLE
Run full rake on CI so we match dev

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -11,11 +11,6 @@ node {
       }
     },
     rubyLintDiff: false,
-    rubyLintRails: true,
-    overrideTestTask: {
-      stage("Run tests") {
-        sh("bundle exec rake spec")
-      }
-    }
+    rubyLintRails: true
   )
 }

--- a/db/migrate/20180814134709_add_publication_state_to_documents.rb
+++ b/db/migrate/20180814134709_add_publication_state_to_documents.rb
@@ -1,6 +1,10 @@
+# frozen_string_literal: true
+
 class AddPublicationStateToDocuments < ActiveRecord::Migration[5.2]
-  def change
+  def up
     execute "TRUNCATE documents"
-    add_column :documents, :publication_state, :string, null: false
+    add_column :documents, :publication_state, :string, null: false # rubocop:disable Rails/NotNullColumn
   end
+
+  def down; end
 end


### PR DESCRIPTION
Running the CI pipeline currently has a different result than running
rake locally, as the default rake task has more strict checks than those
on CI. Rather than trying to sync the two, which would affect other
apps, we can go back to running both and benefit from their combination.