### PR TITLE
Replace hard-coded text with translations in specs

### DIFF
--- a/app/services/content_validator.rb
+++ b/app/services/content_validator.rb
@@ -19,13 +19,11 @@ private
 
   def perform_validations_that_apply_to_all_formats(messages)
     if document.title.to_s.size < 10
-      # TODO: extract string into locale file
-      messages << "The title needs to be at least 10 characters long"
+      messages << I18n.t("validations.title", min_length: 10)
     end
 
     if document.summary.to_s.size < 10
-      # TODO: extract string into locale file
-      messages << "The summary needs to be at least 10 characters long"
+      messages << I18n.t("validations.summary", min_length: 10)
     end
   end
 
@@ -42,8 +40,7 @@ private
         case validation_name
         when "min_length"
           if document.contents[field.id].to_s.size < value
-            # TODO: extract string into locale file
-            messages << "#{field.label} needs to be at least #{value} characters long"
+            messages << I18n.t("validations.min_length", field: field.label, min_length: value)
           end
         end
       end

--- a/app/views/document_associations/edit.html.erb
+++ b/app/views/document_associations/edit.html.erb
@@ -15,7 +15,7 @@
       <br/>
 
       <%= render "govuk_publishing_components/components/button", {
-        text: t("document_associations.edit.actions.save")
+        text: "Save"
       } %>
     <% end %>
   </div>

--- a/app/views/documentation/index.html.erb
+++ b/app/views/documentation/index.html.erb
@@ -47,8 +47,8 @@
   <body class='govuk-table__body'>
     <% Document::PUBLICATION_STATES.each do |state| %>
       <tr class='govuk-table__row'>
-        <td class='govuk-table__header'><%= t "documents.show.publication_state.#{state}.name" %></td>
-        <td class='govuk-table__cell'><%= t "documents.show.publication_state.#{state}.description" %></td>
+        <td class='govuk-table__header'><%= t "publication_states.#{state}.name" %></td>
+        <td class='govuk-table__cell'><%= t "publication_states.#{state}.description" %></td>
       </tr>
     <% end %>
   </body>

--- a/app/views/documents/edit.html.erb
+++ b/app/views/documents/edit.html.erb
@@ -77,6 +77,6 @@
   <% end %>
 
   <%= render "govuk_publishing_components/components/button", {
-    text: t("documents.edit.actions.save"), margin_bottom: true
+    text: "Save", margin_bottom: true
   } %>
 <% end %>

--- a/app/views/documents/index.html.erb
+++ b/app/views/documents/index.html.erb
@@ -3,7 +3,7 @@
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
     <%= render "govuk_publishing_components/components/button", {
-      text: t("documents.index.actions.new"), href: new_document_path, margin_bottom: true
+      text: "New document", href: new_document_path, margin_bottom: true
     } %>
 
     <%= render "govuk_publishing_components/components/document_list", {

--- a/app/views/documents/show/_actions.html.erb
+++ b/app/views/documents/show/_actions.html.erb
@@ -19,6 +19,6 @@
   </li>
 </ul>
 
-<div class='govuk-tag' title="<%= t("documents.show.publication_state.#{@document.publication_state}.description") %>">
-  <%= t("documents.show.publication_state.#{@document.publication_state}.name") %>
+<div class='govuk-tag' title="<%= t("publication_states.#{@document.publication_state}.description") %>">
+  <%= t("publication_states.#{@document.publication_state}.name") %>
 </div>

--- a/app/views/documents/show/_actions.html.erb
+++ b/app/views/documents/show/_actions.html.erb
@@ -1,21 +1,21 @@
 <ul class="govuk-list">
   <li>
-    <%= link_to t("documents.show.actions.publish"), publish_document_path(@document), class: "govuk-link" %>
+    <%= link_to "Publish", publish_document_path(@document), class: "govuk-link" %>
   </li>
   <li>
-    <%= link_to t("documents.show.actions.edit"), edit_document_path(@document), class: "govuk-link" %>
+    <%= link_to "Edit document", edit_document_path(@document), class: "govuk-link" %>
   </li>
   <li>
-    <%= link_to t("documents.show.actions.edit_associations"), document_associations_path(@document), class: "govuk-link" %>
+    <%= link_to "Edit associations", document_associations_path(@document), class: "govuk-link" %>
   </li>
   <li>
-    <%= link_to t("documents.show.actions.view_live"), DocumentUrl.new(@document).public_url, class: "govuk-link" %>
+    <%= link_to "View on GOV.UK", DocumentUrl.new(@document).public_url, class: "govuk-link" %>
   </li>
   <li>
-    <%= link_to t("documents.show.actions.view_draft"), DocumentUrl.new(@document).preview_url, class: "govuk-link" %>
+    <%= link_to "Preview", DocumentUrl.new(@document).preview_url, class: "govuk-link" %>
   </li>
   <li>
-    <%= link_to t("documents.show.actions.share_draft"), DocumentUrl.new(@document).secret_preview_url, class: "govuk-link" %>
+    <%= link_to "Shareable preview", DocumentUrl.new(@document).secret_preview_url, class: "govuk-link" %>
   </li>
 </ul>
 

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -12,7 +12,7 @@
     environment: Rails.application.config.govuk_environment,
     navigation_items: [
       { text: current_user.name, href: Plek.new.external_url_for("signon") },
-      { text: t("layouts.application.actions.log_out"), href: gds_sign_out_path }
+      { text: "Log out", href: gds_sign_out_path }
     ]
   }%>
 

--- a/app/views/new_document/choose_document_type.html.erb
+++ b/app/views/new_document/choose_document_type.html.erb
@@ -15,7 +15,7 @@
       } %>
 
       <%= hidden_field(nil, :supertype, value: @supertype_schema.id) %>
-      <%= render "govuk_publishing_components/components/button", text: t("new_document.choose_document_type.actions.continue"), margin_bottom: true %>
+      <%= render "govuk_publishing_components/components/button", text: "Continue", margin_bottom: true %>
     <% end %>
   </div>
 </div>

--- a/app/views/new_document/choose_supertype.html.erb
+++ b/app/views/new_document/choose_supertype.html.erb
@@ -16,7 +16,7 @@
         end
       } %>
 
-      <%= render "govuk_publishing_components/components/button", text: t("new_document.choose_supertype.actions.continue"), margin_bottom: true %>
+      <%= render "govuk_publishing_components/components/button", text: "Continue", margin_bottom: true %>
     <% end %>
   </div>
 </div>

--- a/app/views/publish_document/confirmation.html.erb
+++ b/app/views/publish_document/confirmation.html.erb
@@ -3,6 +3,6 @@
 
 <%= form_tag publish_document_path(@document) do %>
   <%= render "govuk_publishing_components/components/button", {
-    text: t("publish_document.confirmation.actions.confirm")
+    text: "Confirm publish"
   } %>
 <% end %>

--- a/config/locales/en/document_associations/edit.yml
+++ b/config/locales/en/document_associations/edit.yml
@@ -3,5 +3,3 @@ en:
     edit:
       title: Document associations
       api_down: This content can't be edited right now. We're having trouble getting the data we need for you to make changes on this page.
-      actions:
-        save: Save

--- a/config/locales/en/documents/edit.yml
+++ b/config/locales/en/documents/edit.yml
@@ -2,8 +2,6 @@ en:
   documents:
     edit:
       title: Untitled
-      actions:
-        save: Save
       fields:
         govspeak:
           title: Markdown

--- a/config/locales/en/documents/index.yml
+++ b/config/locales/en/documents/index.yml
@@ -2,7 +2,5 @@ en:
   documents:
     index:
       title: Documents
-      actions:
-        new: New document
       search_results:
         untitled: No title

--- a/config/locales/en/documents/show.yml
+++ b/config/locales/en/documents/show.yml
@@ -6,28 +6,6 @@ en:
         title: Document type
         items:
           document_type: Document type
-      publication_state:
-        changes_not_sent_to_draft:
-          name: Unsaved changes
-          description: You have made changes that haven't been sent to our publishing platform in draft.
-        sending_to_draft:
-          name: Saving draft
-          description: We're publishing your draft so that you can preview the document.
-        sent_to_draft:
-          name: Saved as draft
-          description: The page is now visible in draft.
-        error_sending_to_draft:
-          name: Error sending to draft
-          description: We've encountered a problem making your preview available.
-        sending_to_live:
-          name: Publishing
-          description: We're currently publishing a new edition to GOV.UK.
-        sent_to_live:
-          name: Published
-          description: Your content has been published on GOV.UK.
-        error_sending_to_live:
-          name: Error publishing
-          description: We've encountered a problem during the publishing.
       associations:
         title: Associations
         api_down: This content isn't available right now. We're having trouble getting the data we need to show you this content.

--- a/config/locales/en/documents/show.yml
+++ b/config/locales/en/documents/show.yml
@@ -37,13 +37,6 @@ en:
           title: Title
           base_path: Base path
           summary: summary
-      actions:
-        publish: Publish
-        edit_associations: Edit associations
-        edit: Edit document
-        view_live: View on GOV.UK
-        view_draft: Preview
-        share_draft: Shareable preview
       flashes:
         draft_success: Preview creation successful
         draft_error: Error creating preview

--- a/config/locales/en/layouts/application.yml
+++ b/config/locales/en/layouts/application.yml
@@ -1,5 +1,0 @@
-en:
-  layouts:
-    application:
-      actions:
-        log_out: Log out

--- a/config/locales/en/new_document/choose_document_type.yml
+++ b/config/locales/en/new_document/choose_document_type.yml
@@ -2,7 +2,5 @@ en:
   new_document:
     choose_document_type:
       title: Document type
-      actions:
-        continue: Continue
       flashes:
         choose_error: Please choose a document type

--- a/config/locales/en/new_document/choose_supertype.yml
+++ b/config/locales/en/new_document/choose_supertype.yml
@@ -2,7 +2,5 @@ en:
   new_document:
     choose_supertype:
       title: Content type
-      actions:
-        continue: Continue
       flashes:
         choose_error: Please choose a supertype

--- a/config/locales/en/publication_states.yml
+++ b/config/locales/en/publication_states.yml
@@ -1,0 +1,23 @@
+en:
+  publication_states:
+    changes_not_sent_to_draft:
+      name: Unsaved changes
+      description: You have made changes that haven't been sent to our publishing platform in draft.
+    sending_to_draft:
+      name: Saving draft
+      description: We're publishing your draft so that you can preview the document.
+    sent_to_draft:
+      name: Saved as draft
+      description: The page is now visible in draft.
+    error_sending_to_draft:
+      name: Error sending to draft
+      description: We've encountered a problem making your preview available.
+    sending_to_live:
+      name: Publishing
+      description: We're currently publishing a new edition to GOV.UK.
+    sent_to_live:
+      name: Published
+      description: Your content has been published on GOV.UK.
+    error_sending_to_live:
+      name: Error publishing
+      description: We've encountered a problem during the publishing.

--- a/config/locales/en/publish_document/confirmation.yml
+++ b/config/locales/en/publish_document/confirmation.yml
@@ -2,5 +2,3 @@ en:
   publish_document:
     confirmation:
       title: Do you really want to publish?
-      actions:
-        confirm: Confirm publish

--- a/config/locales/en/validations.yml
+++ b/config/locales/en/validations.yml
@@ -1,0 +1,5 @@
+en:
+  validations:
+    title: "The title should be at least %{min_length} characters long"
+    summary: "The summary should be at least %{min_length} characters long"
+    min_length: "%{field} should be at least %{min_length} characters long"

--- a/spec/factories/document_type_schema_factory.rb
+++ b/spec/factories/document_type_schema_factory.rb
@@ -4,6 +4,7 @@ FactoryBot.define do
   factory :document_type_schema do
     supertype { "not-sure" }
     id { SecureRandom.hex(4) }
+    label { SecureRandom.alphanumeric(8) }
     document_type { SecureRandom.alphanumeric(8) }
     initialize_with { DocumentTypeSchema.create(attributes.stringify_keys) }
   end

--- a/spec/features/choose_a_format_spec.rb
+++ b/spec/features/choose_a_format_spec.rb
@@ -13,24 +13,24 @@ RSpec.feature "Choosing a format" do
 
   def when_i_dont_choose_a_supertype
     visit "/"
-    click_on "New document"
-    click_on "Continue"
+    click_on I18n.t("documents.index.actions.new")
+    click_on I18n.t("new_document.choose_supertype.actions.continue")
   end
 
   def then_i_see_a_supertype_error
-    expect(page).to have_content "Please choose a supertype"
+    expect(page).to have_content(I18n.t("new_document.choose_supertype.flashes.choose_error"))
   end
 
   def when_i_choose_a_supertype
-    choose "News"
-    click_on "Continue"
+    choose SupertypeSchema.all.first.label
+    click_on I18n.t("new_document.choose_supertype.actions.continue")
   end
 
   def and_i_dont_choose_a_document_type
-    click_on "Continue"
+    click_on I18n.t("new_document.choose_document_type.actions.continue")
   end
 
   def then_i_see_a_document_type_error
-    expect(page).to have_content "Please choose a document type"
+    expect(page).to have_content(I18n.t("new_document.choose_document_type.flashes.choose_error"))
   end
 end

--- a/spec/features/choose_a_format_spec.rb
+++ b/spec/features/choose_a_format_spec.rb
@@ -13,8 +13,8 @@ RSpec.feature "Choosing a format" do
 
   def when_i_dont_choose_a_supertype
     visit "/"
-    click_on I18n.t("documents.index.actions.new")
-    click_on I18n.t("new_document.choose_supertype.actions.continue")
+    click_on "New document"
+    click_on "Continue"
   end
 
   def then_i_see_a_supertype_error
@@ -23,11 +23,11 @@ RSpec.feature "Choosing a format" do
 
   def when_i_choose_a_supertype
     choose SupertypeSchema.all.first.label
-    click_on I18n.t("new_document.choose_supertype.actions.continue")
+    click_on "Continue"
   end
 
   def and_i_dont_choose_a_document_type
-    click_on I18n.t("new_document.choose_document_type.actions.continue")
+    click_on "Continue"
   end
 
   def then_i_see_a_document_type_error

--- a/spec/features/create_a_document_api_down_spec.rb
+++ b/spec/features/create_a_document_api_down_spec.rb
@@ -12,36 +12,35 @@ RSpec.feature "Create a document when the API is down" do
   end
 
   def given_i_start_to_create_a_document
+    @schema = build(:document_type_schema, supertype: "news")
     visit "/"
-    click_on "New document"
-
-    choose "News"
-    click_on "Continue"
-
-    choose "Press release"
-    click_on "Continue"
+    click_on I18n.t("documents.index.actions.new")
+    choose @schema.supertype.label
+    click_on I18n.t("new_document.choose_supertype.actions.continue")
+    choose @schema.label
+    click_on I18n.t("new_document.choose_document_type.actions.continue")
   end
 
   def and_the_publishing_api_is_down
     @request = stub_publishing_api_put_content(Document.last.content_id,
-                                                           hash_including(title: "A great title"))
+                                               hash_including(title: "A great title"))
     publishing_api_isnt_available
   end
 
   def when_i_submit_the_form
     fill_in "document[title]", with: "A great title"
-    click_on "Save"
+    click_on I18n.t("documents.edit.actions.save")
   end
 
   def then_i_see_the_document_exists
-    expect(page).to have_content "A great title"
-    expect(page).to have_content "Press release"
-    expect(Document.last.title).to eq "A great title"
+    expect(page).to have_content("A great title")
+    expect(page).to have_content(@schema.label)
+    expect(Document.last.title).to eq("A great title")
   end
 
   def and_the_preview_creation_failed
     expect(@request).to have_been_requested
-    expect(page).to have_content "Error creating preview"
-    expect(Document.last.publication_state).to eq "error_sending_to_draft"
+    expect(page).to have_content(I18n.t("documents.show.flashes.draft_error"))
+    expect(Document.last.publication_state).to eq("error_sending_to_draft")
   end
 end

--- a/spec/features/create_a_document_api_down_spec.rb
+++ b/spec/features/create_a_document_api_down_spec.rb
@@ -14,11 +14,11 @@ RSpec.feature "Create a document when the API is down" do
   def given_i_start_to_create_a_document
     @schema = build(:document_type_schema, supertype: "news")
     visit "/"
-    click_on I18n.t("documents.index.actions.new")
+    click_on "New document"
     choose @schema.supertype.label
-    click_on I18n.t("new_document.choose_supertype.actions.continue")
+    click_on "Continue"
     choose @schema.label
-    click_on I18n.t("new_document.choose_document_type.actions.continue")
+    click_on "Continue"
   end
 
   def and_the_publishing_api_is_down
@@ -29,7 +29,7 @@ RSpec.feature "Create a document when the API is down" do
 
   def when_i_submit_the_form
     fill_in "document[title]", with: "A great title"
-    click_on I18n.t("documents.edit.actions.save")
+    click_on "Save"
   end
 
   def then_i_see_the_document_exists

--- a/spec/features/documentation_spec.rb
+++ b/spec/features/documentation_spec.rb
@@ -13,6 +13,6 @@ RSpec.feature "Documentation" do
   end
 
   def then_i_see_the_documentation_page
-    expect(page).to have_content "App documentation"
+    expect(page).to have_content(I18n.t("documentation.index.title"))
   end
 end

--- a/spec/features/edit_a_document_spec.rb
+++ b/spec/features/edit_a_document_spec.rb
@@ -20,28 +20,28 @@ RSpec.feature "Edit a document" do
 
   def when_i_go_to_edit_the_document
     visit document_path(Document.last)
-    click_on "Edit document"
     expect(page).to have_content("Existing body")
+    click_on I18n.t("documents.show.actions.edit")
   end
 
   def and_i_fill_in_the_content_fields
     fill_in "document[contents][body]", with: "Edited body."
     @request = stub_publishing_api_put_content(Document.last.content_id, {})
-    click_on "Save"
+    click_on I18n.t("documents.edit.actions.save")
   end
 
   def then_i_see_the_document_is_saved
-    expect(page).to have_content "Edited body."
+    expect(page).to have_content("Edited body.")
   end
 
   def and_the_preview_creation_succeeded
     expect(@request).to have_been_requested
-    expect(page).to have_content "Preview creation successful"
+    expect(page).to have_content(I18n.t("documents.show.flashes.draft_success"))
 
     expect(a_request(:put, /content/).with { |req|
-      expect(JSON.parse(req.body)["details"]["body"]).to eq "<p>Edited body.</p>\n"
+      expect(JSON.parse(req.body)["details"]["body"]).to eq("<p>Edited body.</p>\n")
     }).to have_been_requested
 
-    expect(Document.last.publication_state).to eql("sent_to_draft")
+    expect(Document.last.publication_state).to eq("sent_to_draft")
   end
 end

--- a/spec/features/edit_a_document_spec.rb
+++ b/spec/features/edit_a_document_spec.rb
@@ -21,13 +21,13 @@ RSpec.feature "Edit a document" do
   def when_i_go_to_edit_the_document
     visit document_path(Document.last)
     expect(page).to have_content("Existing body")
-    click_on I18n.t("documents.show.actions.edit")
+    click_on "Edit document"
   end
 
   def and_i_fill_in_the_content_fields
     fill_in "document[contents][body]", with: "Edited body."
     @request = stub_publishing_api_put_content(Document.last.content_id, {})
-    click_on I18n.t("documents.edit.actions.save")
+    click_on "Save"
   end
 
   def then_i_see_the_document_is_saved

--- a/spec/features/edit_document_associations_api_down_spec.rb
+++ b/spec/features/edit_document_associations_api_down_spec.rb
@@ -27,10 +27,10 @@ RSpec.feature "Edit document associations when the API is down" do
   end
 
   def and_i_click_on_edit_associations
-    click_on "Edit associations"
+    click_on I18n.t("documents.show.actions.edit_associations")
   end
 
   def then_i_should_see_an_error_message
-    expect(page).to have_content("This content can't be edited right now.")
+    expect(page).to have_content(I18n.t("document_associations.edit.api_down"))
   end
 end

--- a/spec/features/edit_document_associations_api_down_spec.rb
+++ b/spec/features/edit_document_associations_api_down_spec.rb
@@ -27,7 +27,7 @@ RSpec.feature "Edit document associations when the API is down" do
   end
 
   def and_i_click_on_edit_associations
-    click_on I18n.t("documents.show.actions.edit_associations")
+    click_on "Edit associations"
   end
 
   def then_i_should_see_an_error_message

--- a/spec/features/edit_document_associations_spec.rb
+++ b/spec/features/edit_document_associations_spec.rb
@@ -31,7 +31,7 @@ RSpec.feature "Edit document associations" do
   end
 
   def and_i_click_on_edit_associations
-    click_on "Edit associations"
+    click_on I18n.t("documents.show.actions.edit_associations")
   end
 
   def then_i_can_see_the_current_selections
@@ -45,18 +45,18 @@ RSpec.feature "Edit document associations" do
     select "Association to select 2", from: "associations[association_id][]"
     unselect "Initial association", from: "associations[association_id][]"
 
-    click_on "Save"
+    click_on I18n.t("document_associations.edit.actions.save")
   end
 
   def then_i_can_view_the_associations
-    expect(page).to have_content "Association to select 1"
-    expect(page).to have_content "Association to select 2"
-    expect(page).not_to have_content "Initial association"
+    expect(page).to have_content("Association to select 1")
+    expect(page).to have_content("Association to select 2")
+    expect(page).not_to have_content("Initial association")
   end
 
   def and_the_preview_creation_succeeded
     expect(@request).to have_been_requested
-    expect(page).to have_content "Preview creation successful"
+    expect(page).to have_content(I18n.t("documents.show.flashes.draft_success"))
 
     expect(a_request(:put, /content/).with { |req|
       expect(JSON.parse(req.body)["links"]).to eq(edition_links)

--- a/spec/features/edit_document_associations_spec.rb
+++ b/spec/features/edit_document_associations_spec.rb
@@ -31,7 +31,7 @@ RSpec.feature "Edit document associations" do
   end
 
   def and_i_click_on_edit_associations
-    click_on I18n.t("documents.show.actions.edit_associations")
+    click_on "Edit associations"
   end
 
   def then_i_can_see_the_current_selections
@@ -45,7 +45,7 @@ RSpec.feature "Edit document associations" do
     select "Association to select 2", from: "associations[association_id][]"
     unselect "Initial association", from: "associations[association_id][]"
 
-    click_on I18n.t("document_associations.edit.actions.save")
+    click_on "Save"
   end
 
   def then_i_can_view_the_associations

--- a/spec/features/previews_a_url_when_editing_title_spec.rb
+++ b/spec/features/previews_a_url_when_editing_title_spec.rb
@@ -27,7 +27,7 @@ RSpec.feature "Shows a preview of the URL", js: true do
 
   def when_i_go_to_edit_the_document
     visit document_path(@document)
-    click_on I18n.t("documents.show.actions.edit")
+    click_on "Edit document"
   end
 
   def and_i_interact_with_the_title_but_leave_it_unedited

--- a/spec/features/previews_a_url_when_editing_title_spec.rb
+++ b/spec/features/previews_a_url_when_editing_title_spec.rb
@@ -27,7 +27,7 @@ RSpec.feature "Shows a preview of the URL", js: true do
 
   def when_i_go_to_edit_the_document
     visit document_path(@document)
-    click_on "Edit document"
+    click_on I18n.t("documents.show.actions.edit")
   end
 
   def and_i_interact_with_the_title_but_leave_it_unedited
@@ -41,7 +41,7 @@ RSpec.feature "Shows a preview of the URL", js: true do
   end
 
   def then_i_see_a_prompt_to_enter_a_title
-    expect(page).to have_content "You haven't entered a title yet."
+    expect(page).to have_content(I18n.t("documents.edit.url_preview.no_title"))
   end
 
   def and_i_fill_in_the_title
@@ -50,11 +50,11 @@ RSpec.feature "Shows a preview of the URL", js: true do
   end
 
   def then_i_see_a_preview_of_the_url_on_govuk
-    expect(page).to have_content "www.test.gov.uk#{@document_path_prefix}/a-great-title"
+    expect(page).to have_content("www.test.gov.uk#{@document_path_prefix}/a-great-title")
   end
 
   def then_i_see_the_path_preview_unchanged
-    expect(page).to have_content "www.test.gov.uk#{@document_base_path}"
-    expect(page).to_not have_content "www.test.gov.uk#{@document_base_path}-1"
+    expect(page).to have_content("www.test.gov.uk#{@document_base_path}")
+    expect(page).to_not have_content("www.test.gov.uk#{@document_base_path}-1")
   end
 end

--- a/spec/features/publish_a_document_api_down_spec.rb
+++ b/spec/features/publish_a_document_api_down_spec.rb
@@ -21,8 +21,8 @@ RSpec.feature "Publishing a document when the API is down" do
 
   def when_i_try_to_publish_the_document
     visit document_path(@document)
-    click_on I18n.t("documents.show.actions.publish")
-    click_on I18n.t("publish_document.confirmation.actions.confirm")
+    click_on "Publish"
+    click_on "Confirm publish"
   end
 
   def then_i_see_the_publish_failed

--- a/spec/features/publish_a_document_api_down_spec.rb
+++ b/spec/features/publish_a_document_api_down_spec.rb
@@ -21,13 +21,13 @@ RSpec.feature "Publishing a document when the API is down" do
 
   def when_i_try_to_publish_the_document
     visit document_path(@document)
-    click_on "Publish"
-    click_on "Confirm publish"
+    click_on I18n.t("documents.show.actions.publish")
+    click_on I18n.t("publish_document.confirmation.actions.confirm")
   end
 
   def then_i_see_the_publish_failed
     expect(@request).to have_been_requested
-    expect(page).to have_content "Error publishing"
-    expect(@document.reload.publication_state).to eql("error_sending_to_live")
+    expect(page).to have_content(I18n.t("documents.show.flashes.publish_error"))
+    expect(@document.reload.publication_state).to eq("error_sending_to_live")
   end
 end

--- a/spec/features/publish_a_document_spec.rb
+++ b/spec/features/publish_a_document_spec.rb
@@ -20,12 +20,12 @@ RSpec.feature "Publishing a document" do
   end
 
   def and_i_click_on_the_publish_button
-    click_on I18n.t("documents.show.actions.publish")
+    click_on "Publish"
   end
 
   def and_i_confirm_the_publishing
     @request = stub_publishing_api_publish(@document.content_id, update_type: "major", locale: @document.locale)
-    click_on I18n.t("publish_document.confirmation.actions.confirm")
+    click_on "Confirm publish"
   end
 
   def then_i_see_the_publish_succeeded

--- a/spec/features/publish_a_document_spec.rb
+++ b/spec/features/publish_a_document_spec.rb
@@ -20,17 +20,17 @@ RSpec.feature "Publishing a document" do
   end
 
   def and_i_click_on_the_publish_button
-    click_on "Publish"
+    click_on I18n.t("documents.show.actions.publish")
   end
 
   def and_i_confirm_the_publishing
     @request = stub_publishing_api_publish(@document.content_id, update_type: "major", locale: @document.locale)
-    click_on "Confirm publish"
+    click_on I18n.t("publish_document.confirmation.actions.confirm")
   end
 
   def then_i_see_the_publish_succeeded
     expect(@request).to have_been_requested
-    expect(page).to have_content "Publish successful"
-    expect(@document.reload.publication_state).to eql("sent_to_live")
+    expect(page).to have_content(I18n.t("documents.show.flashes.publish_success"))
+    expect(@document.reload.publication_state).to eq("sent_to_live")
   end
 end

--- a/spec/features/publishing_validations_spec.rb
+++ b/spec/features/publishing_validations_spec.rb
@@ -31,10 +31,10 @@ RSpec.feature "Publish validations" do
     stub_any_publishing_api_put_content
     base_path = "#{@document.document_type_schema.path_prefix}/a-nice-title-of-considerable-length"
     publishing_api_has_lookups(base_path => nil)
-    click_on I18n.t("documents.show.actions.edit")
+    click_on "Edit document"
     fill_in "document[title]", with: "A nice title of considerable length"
     fill_in "document[contents][body]", with: "A very long body text."
-    click_on I18n.t("documents.edit.actions.save")
+    click_on "Save"
   end
 
   def then_i_see_fewer_warnings

--- a/spec/features/publishing_validations_spec.rb
+++ b/spec/features/publishing_validations_spec.rb
@@ -4,14 +4,14 @@ require "spec_helper"
 
 RSpec.feature "Publish validations" do
   scenario "A document is validated" do
-    given_there_is_a_document_with_not_enough_info
+    given_there_is_an_invalid_document
     when_i_visit_the_document_page
-    then_i_see_the_warnings
-    when_i_fix_some_warnings
-    then_i_see_fewer_warnings
+    then_i_see_the_validation_warnings
+    when_i_fix_the_validation_warnings
+    then_i_see_no_validation_warnings
   end
 
-  def given_there_is_a_document_with_not_enough_info
+  def given_there_is_an_invalid_document
     body_field_schema = build(:field_schema, id: "body", type: "govspeak", label: "Body", validations: { "min_length" => 10 })
     document_type_schema = build(:document_type_schema, contents: [body_field_schema])
     @document = create(:document, title: "Too small", summary: "Too small", document_type: document_type_schema.id)
@@ -21,25 +21,26 @@ RSpec.feature "Publish validations" do
     visit document_path(@document)
   end
 
-  def then_i_see_the_warnings
-    expect(page).to have_content("The title needs to be at least 10 characters long")
-    expect(page).to have_content("The summary needs to be at least 10 characters long")
-    expect(page).to have_content("Body needs to be at least 10 characters long")
+  def then_i_see_the_validation_warnings
+    expect(page).to have_content(I18n.t("validations.title", min_length: 10))
+    expect(page).to have_content(I18n.t("validations.summary", min_length: 10))
+    expect(page).to have_content(I18n.t("validations.min_length", field: "Body", min_length: 10))
   end
 
-  def when_i_fix_some_warnings
+  def when_i_fix_the_validation_warnings
     stub_any_publishing_api_put_content
     base_path = "#{@document.document_type_schema.path_prefix}/a-nice-title-of-considerable-length"
     publishing_api_has_lookups(base_path => nil)
     click_on "Edit document"
     fill_in "document[title]", with: "A nice title of considerable length"
+    fill_in "document[summary]", with: "A nice summary of considerable length"
     fill_in "document[contents][body]", with: "A very long body text."
     click_on "Save"
   end
 
-  def then_i_see_fewer_warnings
-    expect(page).not_to have_content("The title needs to be at least 10 characters long")
-    expect(page).not_to have_content("Body needs to be at least 10 characters long")
-    expect(page).to have_content("The summary needs to be at least 10 characters long")
+  def then_i_see_no_validation_warnings
+    expect(page).to_not have_content(I18n.t("validations.title", min_length: 10))
+    expect(page).to_not have_content(I18n.t("validations.summary", min_length: 10))
+    expect(page).to_not have_content(I18n.t("validations.min_length", field: "Body", min_length: 10))
   end
 end

--- a/spec/features/publishing_validations_spec.rb
+++ b/spec/features/publishing_validations_spec.rb
@@ -22,25 +22,24 @@ RSpec.feature "Publish validations" do
   end
 
   def then_i_see_the_warnings
-    expect(page).to have_content "The title needs to be at least 10 characters long"
-    expect(page).to have_content "The summary needs to be at least 10 characters long"
-    expect(page).to have_content "Body needs to be at least 10 characters long"
+    expect(page).to have_content("The title needs to be at least 10 characters long")
+    expect(page).to have_content("The summary needs to be at least 10 characters long")
+    expect(page).to have_content("Body needs to be at least 10 characters long")
   end
 
   def when_i_fix_some_warnings
     stub_any_publishing_api_put_content
     base_path = "#{@document.document_type_schema.path_prefix}/a-nice-title-of-considerable-length"
     publishing_api_has_lookups(base_path => nil)
-    click_on "Edit document"
+    click_on I18n.t("documents.show.actions.edit")
     fill_in "document[title]", with: "A nice title of considerable length"
     fill_in "document[contents][body]", with: "A very long body text."
-    click_on "Save"
+    click_on I18n.t("documents.edit.actions.save")
   end
 
   def then_i_see_fewer_warnings
-    expect(page).not_to have_content "The title needs to be at least 10 characters long"
-    expect(page).not_to have_content "Body needs to be at least 10 characters long"
-
-    expect(page).to have_content "The summary needs to be at least 10 characters long"
+    expect(page).not_to have_content("The title needs to be at least 10 characters long")
+    expect(page).not_to have_content("Body needs to be at least 10 characters long")
+    expect(page).to have_content("The summary needs to be at least 10 characters long")
   end
 end

--- a/spec/features/save_document_associations_api_down_spec.rb
+++ b/spec/features/save_document_associations_api_down_spec.rb
@@ -30,15 +30,15 @@ RSpec.feature "Save document associations when the API is down" do
   end
 
   def when_i_finish_editing_the_associations
-    click_on "Save"
+    click_on I18n.t("document_associations.edit.actions.save")
   end
 
   def then_i_see_the_document_page
-    expect(page).to have_content @document.title
+    expect(page).to have_content(@document.title)
   end
 
   def and_the_preview_creation_failed
     expect(@request).to have_been_requested
-    expect(page).to have_content "Error creating preview"
+    expect(page).to have_content(I18n.t("documents.show.flashes.draft_error"))
   end
 end

--- a/spec/features/save_document_associations_api_down_spec.rb
+++ b/spec/features/save_document_associations_api_down_spec.rb
@@ -30,7 +30,7 @@ RSpec.feature "Save document associations when the API is down" do
   end
 
   def when_i_finish_editing_the_associations
-    click_on I18n.t("document_associations.edit.actions.save")
+    click_on "Save"
   end
 
   def then_i_see_the_document_page

--- a/spec/features/show_a_document_api_down_spec.rb
+++ b/spec/features/show_a_document_api_down_spec.rb
@@ -26,6 +26,6 @@ RSpec.feature "Showing a document when the API is down" do
   end
 
   def then_i_should_see_an_error_message
-    expect(page).to have_content("This content isn't available right now.")
+    expect(page).to have_content(I18n.t("documents.show.associations.api_down"))
   end
 end

--- a/spec/formats/configuration_spec.rb
+++ b/spec/formats/configuration_spec.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-require 'spec_helper'
+require "spec_helper"
 
 RSpec.describe "Format configuration" do
   SupertypeSchema.all.each do |schema|

--- a/spec/formats/consultation_spec.rb
+++ b/spec/formats/consultation_spec.rb
@@ -10,13 +10,11 @@ RSpec.feature "Create a detailed guide" do
 
   def when_i_choose_this_document_type
     visit "/"
-    click_on I18n.t("documents.index.actions.new")
-
+    click_on "New document"
     choose SupertypeSchema.find("consultations").label
-    click_on I18n.t("new_document.choose_supertype.actions.continue")
-
+    click_on "Continue"
     choose DocumentTypeSchema.find("consultation").label
-    click_on I18n.t("new_document.choose_document_type.actions.continue")
+    click_on "Continue"
   end
 
   def then_i_am_redirected_to_another_app

--- a/spec/formats/consultation_spec.rb
+++ b/spec/formats/consultation_spec.rb
@@ -10,17 +10,17 @@ RSpec.feature "Create a detailed guide" do
 
   def when_i_choose_this_document_type
     visit "/"
-    click_on "New document"
+    click_on I18n.t("documents.index.actions.new")
 
-    choose "Consultations"
-    click_on "Continue"
+    choose SupertypeSchema.find("consultations").label
+    click_on I18n.t("new_document.choose_supertype.actions.continue")
 
-    choose "Consultation"
-    click_on "Continue"
+    choose DocumentTypeSchema.find("consultation").label
+    click_on I18n.t("new_document.choose_document_type.actions.continue")
   end
 
   def then_i_am_redirected_to_another_app
-    expect(page.current_path).to eql '/government/admin/consultations/new'
-    expect(page).to have_content "You've been redirected"
+    expect(page.current_path).to eq("/government/admin/consultations/new")
+    expect(page).to have_content("You've been redirected")
   end
 end

--- a/spec/formats/detailed_guide_spec.rb
+++ b/spec/formats/detailed_guide_spec.rb
@@ -10,13 +10,11 @@ RSpec.feature "Create a detailed guide" do
 
   def when_i_choose_this_document_type
     visit "/"
-    click_on I18n.t("documents.index.actions.new")
-
+    click_on "New document"
     choose SupertypeSchema.find("guidance").label
-    click_on I18n.t("new_document.choose_supertype.actions.continue")
-
+    click_on "Continue"
     choose DocumentTypeSchema.find("detailed_guide").label
-    click_on I18n.t("new_document.choose_document_type.actions.continue")
+    click_on "Continue"
   end
 
   def then_i_am_redirected_to_another_app

--- a/spec/formats/detailed_guide_spec.rb
+++ b/spec/formats/detailed_guide_spec.rb
@@ -10,17 +10,17 @@ RSpec.feature "Create a detailed guide" do
 
   def when_i_choose_this_document_type
     visit "/"
-    click_on "New document"
+    click_on I18n.t("documents.index.actions.new")
 
-    choose "Guidance"
-    click_on "Continue"
+    choose SupertypeSchema.find("guidance").label
+    click_on I18n.t("new_document.choose_supertype.actions.continue")
 
-    choose "Detailed guide"
-    click_on "Continue"
+    choose DocumentTypeSchema.find("detailed_guide").label
+    click_on I18n.t("new_document.choose_document_type.actions.continue")
   end
 
   def then_i_am_redirected_to_another_app
-    expect(page.current_path).to eql '/government/admin/detailed-guides/new'
-    expect(page).to have_content "You've been redirected"
+    expect(page.current_path).to eq("/government/admin/detailed-guides/new")
+    expect(page).to have_content("You've been redirected")
   end
 end

--- a/spec/formats/news_story_spec.rb
+++ b/spec/formats/news_story_spec.rb
@@ -12,18 +12,18 @@ RSpec.feature "Create a news story" do
 
   def when_i_choose_this_document_type
     visit "/"
-    click_on I18n.t("documents.index.actions.new")
+    click_on "New document"
     choose SupertypeSchema.find("news").label
-    click_on I18n.t("new_document.choose_supertype.actions.continue")
+    click_on "Continue"
     choose DocumentTypeSchema.find("news_story").label
-    click_on I18n.t("new_document.choose_document_type.actions.continue")
+    click_on "Continue"
   end
 
   def and_i_fill_in_the_form_fields
     stub_any_publishing_api_put_content
     fill_in "document[title]", with: "A great title"
     fill_in "document[summary]", with: "A great summary"
-    click_on I18n.t("documents.edit.actions.save")
+    click_on "Save"
     WebMock.reset!
   end
 
@@ -35,14 +35,14 @@ RSpec.feature "Create a news story" do
     publishing_api_has_linkables([linkable], document_type: "world_location")
     publishing_api_has_linkables([linkable], document_type: "organisation")
 
-    click_on I18n.t("documents.show.actions.edit_associations")
+    click_on "Edit associations"
 
     select linkable["internal_name"], from: "associations[topical_events][]"
     select linkable["internal_name"], from: "associations[worldwide_organisations][]"
     select linkable["internal_name"], from: "associations[world_locations][]"
     select linkable["internal_name"], from: "associations[organisations][]"
 
-    click_on I18n.t("document_associations.edit.actions.save")
+    click_on "Save"
   end
 
   def then_i_can_publish_the_document

--- a/spec/formats/news_story_spec.rb
+++ b/spec/formats/news_story_spec.rb
@@ -12,37 +12,37 @@ RSpec.feature "Create a news story" do
 
   def when_i_choose_this_document_type
     visit "/"
-    click_on "New document"
-    choose "News"
-    click_on "Continue"
-    choose "News story"
-    click_on "Continue"
+    click_on I18n.t("documents.index.actions.new")
+    choose SupertypeSchema.find("news").label
+    click_on I18n.t("new_document.choose_supertype.actions.continue")
+    choose DocumentTypeSchema.find("news_story").label
+    click_on I18n.t("new_document.choose_document_type.actions.continue")
   end
 
   def and_i_fill_in_the_form_fields
     stub_any_publishing_api_put_content
     fill_in "document[title]", with: "A great title"
     fill_in "document[summary]", with: "A great summary"
-    click_on "Save"
+    click_on I18n.t("documents.edit.actions.save")
     WebMock.reset!
   end
 
   def and_i_add_some_associations
     stub_any_publishing_api_put_content
     expect(Document.last.document_type_schema.associations.count).to eq(4)
-    publishing_api_has_linkables([linkable], document_type: 'topical_event')
-    publishing_api_has_linkables([linkable], document_type: 'worldwide_organisation')
-    publishing_api_has_linkables([linkable], document_type: 'world_location')
-    publishing_api_has_linkables([linkable], document_type: 'organisation')
+    publishing_api_has_linkables([linkable], document_type: "topical_event")
+    publishing_api_has_linkables([linkable], document_type: "worldwide_organisation")
+    publishing_api_has_linkables([linkable], document_type: "world_location")
+    publishing_api_has_linkables([linkable], document_type: "organisation")
 
-    click_on "Edit associations"
+    click_on I18n.t("documents.show.actions.edit_associations")
 
     select linkable["internal_name"], from: "associations[topical_events][]"
     select linkable["internal_name"], from: "associations[worldwide_organisations][]"
     select linkable["internal_name"], from: "associations[world_locations][]"
     select linkable["internal_name"], from: "associations[organisations][]"
 
-    click_on "Save"
+    click_on I18n.t("document_associations.edit.actions.save")
   end
 
   def then_i_can_publish_the_document

--- a/spec/formats/not_sure_spec.rb
+++ b/spec/formats/not_sure_spec.rb
@@ -2,8 +2,8 @@
 
 require "spec_helper"
 
-RSpec.feature "User is not sure if the content belongs on GOV.UK" do
-  scenario "User selects 'I’m not sure this should be on GOV.UK'" do
+RSpec.feature "User is not sure about the supertype" do
+  scenario "User selects the not sure option" do
     when_i_click_on_create_a_document
     and_i_choose_i_am_not_sure_if_it_belongs_on_govuk
     then_i_see_the_guidance
@@ -11,15 +11,16 @@ RSpec.feature "User is not sure if the content belongs on GOV.UK" do
 
   def when_i_click_on_create_a_document
     visit "/"
-    click_on "New document"
+    click_on I18n.t("documents.index.actions.new")
   end
 
   def and_i_choose_i_am_not_sure_if_it_belongs_on_govuk
-    choose "I'm not sure this should be on GOV.UK"
-    click_on "Continue"
+    choose SupertypeSchema.find("not-sure").label
+    click_on I18n.t("new_document.choose_supertype.actions.continue")
   end
 
   def then_i_see_the_guidance
-    expect(page).to have_title "What to publish on GOV.UK"
+    title = I18n.t("new_document.guidance.title")
+    expect(page).to have_title(title)
   end
 end

--- a/spec/formats/not_sure_spec.rb
+++ b/spec/formats/not_sure_spec.rb
@@ -11,16 +11,15 @@ RSpec.feature "User is not sure about the supertype" do
 
   def when_i_click_on_create_a_document
     visit "/"
-    click_on I18n.t("documents.index.actions.new")
+    click_on "New document"
   end
 
   def and_i_choose_i_am_not_sure_if_it_belongs_on_govuk
     choose SupertypeSchema.find("not-sure").label
-    click_on I18n.t("new_document.choose_supertype.actions.continue")
+    click_on "Continue"
   end
 
   def then_i_see_the_guidance
-    title = I18n.t("new_document.guidance.title")
-    expect(page).to have_title(title)
+    expect(page).to have_title(I18n.t("new_document.guidance.title"))
   end
 end

--- a/spec/formats/policy_paper_spec.rb
+++ b/spec/formats/policy_paper_spec.rb
@@ -10,13 +10,11 @@ RSpec.feature "Create a policy paper" do
 
   def when_i_choose_this_document_type
     visit "/"
-    click_on I18n.t("documents.index.actions.new")
-
+    click_on "New document"
     choose SupertypeSchema.find("policy").label
-    click_on I18n.t("new_document.choose_supertype.actions.continue")
-
+    click_on "Continue"
     choose DocumentTypeSchema.find("policy_paper").label
-    click_on I18n.t("new_document.choose_document_type.actions.continue")
+    click_on "Continue"
   end
 
   def then_i_am_redirected_to_another_app

--- a/spec/formats/policy_paper_spec.rb
+++ b/spec/formats/policy_paper_spec.rb
@@ -10,17 +10,17 @@ RSpec.feature "Create a policy paper" do
 
   def when_i_choose_this_document_type
     visit "/"
-    click_on "New document"
+    click_on I18n.t("documents.index.actions.new")
 
-    choose "Policy"
-    click_on "Continue"
+    choose SupertypeSchema.find("policy").label
+    click_on I18n.t("new_document.choose_supertype.actions.continue")
 
-    choose "Policy paper"
-    click_on "Continue"
+    choose DocumentTypeSchema.find("policy_paper").label
+    click_on I18n.t("new_document.choose_document_type.actions.continue")
   end
 
   def then_i_am_redirected_to_another_app
-    expect(page.current_path).to eql '/government/admin/publications/new'
-    expect(page).to have_content "You've been redirected"
+    expect(page.current_path).to eq("/government/admin/publications/new")
+    expect(page).to have_content("You've been redirected")
   end
 end

--- a/spec/formats/press_release_spec.rb
+++ b/spec/formats/press_release_spec.rb
@@ -12,18 +12,18 @@ RSpec.feature "Create a press release" do
 
   def when_i_choose_this_document_type
     visit "/"
-    click_on I18n.t("documents.index.actions.new")
+    click_on "New document"
     choose SupertypeSchema.find("news").label
-    click_on I18n.t("new_document.choose_supertype.actions.continue")
+    click_on "Continue"
     choose DocumentTypeSchema.find("press_release").label
-    click_on I18n.t("new_document.choose_document_type.actions.continue")
+    click_on "Continue"
   end
 
   def and_i_fill_in_the_form_fields
     stub_any_publishing_api_put_content
     fill_in "document[title]", with: "A great title"
     fill_in "document[summary]", with: "A great summary"
-    click_on I18n.t("documents.edit.actions.save")
+    click_on "Save"
     WebMock.reset!
   end
 
@@ -35,14 +35,14 @@ RSpec.feature "Create a press release" do
     publishing_api_has_linkables([linkable], document_type: "world_location")
     publishing_api_has_linkables([linkable], document_type: "organisation")
 
-    click_on I18n.t("documents.show.actions.edit_associations")
+    click_on "Edit associations"
 
     select linkable["internal_name"], from: "associations[topical_events][]"
     select linkable["internal_name"], from: "associations[worldwide_organisations][]"
     select linkable["internal_name"], from: "associations[world_locations][]"
     select linkable["internal_name"], from: "associations[organisations][]"
 
-    click_on I18n.t("document_associations.edit.actions.save")
+    click_on "Save"
   end
 
   def then_i_can_publish_the_document

--- a/spec/formats/press_release_spec.rb
+++ b/spec/formats/press_release_spec.rb
@@ -12,37 +12,37 @@ RSpec.feature "Create a press release" do
 
   def when_i_choose_this_document_type
     visit "/"
-    click_on "New document"
-    choose "News"
-    click_on "Continue"
-    choose "Press release"
-    click_on "Continue"
+    click_on I18n.t("documents.index.actions.new")
+    choose SupertypeSchema.find("news").label
+    click_on I18n.t("new_document.choose_supertype.actions.continue")
+    choose DocumentTypeSchema.find("press_release").label
+    click_on I18n.t("new_document.choose_document_type.actions.continue")
   end
 
   def and_i_fill_in_the_form_fields
     stub_any_publishing_api_put_content
     fill_in "document[title]", with: "A great title"
     fill_in "document[summary]", with: "A great summary"
-    click_on "Save"
+    click_on I18n.t("documents.edit.actions.save")
     WebMock.reset!
   end
 
   def and_i_add_some_associations
     stub_any_publishing_api_put_content
     expect(Document.last.document_type_schema.associations.count).to eq(4)
-    publishing_api_has_linkables([linkable], document_type: 'topical_event')
-    publishing_api_has_linkables([linkable], document_type: 'worldwide_organisation')
-    publishing_api_has_linkables([linkable], document_type: 'world_location')
-    publishing_api_has_linkables([linkable], document_type: 'organisation')
+    publishing_api_has_linkables([linkable], document_type: "topical_event")
+    publishing_api_has_linkables([linkable], document_type: "worldwide_organisation")
+    publishing_api_has_linkables([linkable], document_type: "world_location")
+    publishing_api_has_linkables([linkable], document_type: "organisation")
 
-    click_on "Edit associations"
+    click_on I18n.t("documents.show.actions.edit_associations")
 
     select linkable["internal_name"], from: "associations[topical_events][]"
     select linkable["internal_name"], from: "associations[worldwide_organisations][]"
     select linkable["internal_name"], from: "associations[world_locations][]"
     select linkable["internal_name"], from: "associations[organisations][]"
 
-    click_on "Save"
+    click_on I18n.t("document_associations.edit.actions.save")
   end
 
   def then_i_can_publish_the_document

--- a/spec/formats/statistical_data_set_spec.rb
+++ b/spec/formats/statistical_data_set_spec.rb
@@ -12,31 +12,31 @@ RSpec.feature "Create a statistical data set" do
 
   def when_i_choose_this_document_type
     visit "/"
-    click_on "New document"
-    choose "Transparency"
-    click_on "Continue"
-    choose "Statistical data set"
-    click_on "Continue"
+    click_on I18n.t("documents.index.actions.new")
+    choose SupertypeSchema.find("transparency").label
+    click_on I18n.t("new_document.choose_supertype.actions.continue")
+    choose DocumentTypeSchema.find("statistical_data_set").label
+    click_on I18n.t("new_document.choose_document_type.actions.continue")
   end
 
   def and_i_fill_in_the_form_fields
     stub_any_publishing_api_put_content
     fill_in "document[title]", with: "A great title"
     fill_in "document[summary]", with: "A great summary"
-    click_on "Save"
+    click_on I18n.t("documents.edit.actions.save")
     WebMock.reset!
   end
 
   def and_i_add_some_associations
     stub_any_publishing_api_put_content
     expect(Document.last.document_type_schema.associations.count).to eq(1)
-    publishing_api_has_linkables([linkable], document_type: 'organisation')
+    publishing_api_has_linkables([linkable], document_type: "organisation")
 
-    click_on "Edit associations"
+    click_on I18n.t("documents.show.actions.edit_associations")
 
     select linkable["internal_name"], from: "associations[organisations][]"
 
-    click_on "Save"
+    click_on I18n.t("document_associations.edit.actions.save")
   end
 
   def then_i_can_publish_the_document

--- a/spec/formats/statistical_data_set_spec.rb
+++ b/spec/formats/statistical_data_set_spec.rb
@@ -12,18 +12,18 @@ RSpec.feature "Create a statistical data set" do
 
   def when_i_choose_this_document_type
     visit "/"
-    click_on I18n.t("documents.index.actions.new")
+    click_on "New document"
     choose SupertypeSchema.find("transparency").label
-    click_on I18n.t("new_document.choose_supertype.actions.continue")
+    click_on "Continue"
     choose DocumentTypeSchema.find("statistical_data_set").label
-    click_on I18n.t("new_document.choose_document_type.actions.continue")
+    click_on "Continue"
   end
 
   def and_i_fill_in_the_form_fields
     stub_any_publishing_api_put_content
     fill_in "document[title]", with: "A great title"
     fill_in "document[summary]", with: "A great summary"
-    click_on I18n.t("documents.edit.actions.save")
+    click_on "Save"
     WebMock.reset!
   end
 
@@ -32,11 +32,11 @@ RSpec.feature "Create a statistical data set" do
     expect(Document.last.document_type_schema.associations.count).to eq(1)
     publishing_api_has_linkables([linkable], document_type: "organisation")
 
-    click_on I18n.t("documents.show.actions.edit_associations")
+    click_on "Edit associations"
 
     select linkable["internal_name"], from: "associations[organisations][]"
 
-    click_on I18n.t("document_associations.edit.actions.save")
+    click_on "Save"
   end
 
   def then_i_can_publish_the_document

--- a/spec/models/document_spec.rb
+++ b/spec/models/document_spec.rb
@@ -6,8 +6,8 @@ RSpec.describe Document do
   describe "PUBLICATION_STATES" do
     it "has correct translations for each state" do
       Document::PUBLICATION_STATES.each do |state|
-        I18n.t!("documents.show.publication_state.#{state}.name")
-        I18n.t!("documents.show.publication_state.#{state}.description")
+        I18n.t!("publication_states.#{state}.name")
+        I18n.t!("publication_states.#{state}.description")
       end
     end
   end

--- a/spec/services/content_validator_spec.rb
+++ b/spec/services/content_validator_spec.rb
@@ -6,64 +6,63 @@ RSpec.describe ContentValidator do
   describe 'title validation' do
     it 'raises issue if the title is not set' do
       document = build(:document, title: nil)
-
       messages = ContentValidator.new(document).validation_messages
-
-      expect(messages).to include("The title needs to be at least 10 characters long")
+      expect(messages).to include(I18n.t("validations.title", min_length: 10))
     end
 
     it 'raises issue if the title is too short' do
       document = build(:document, title: "Too short")
-
       messages = ContentValidator.new(document).validation_messages
-
-      expect(messages).to include("The title needs to be at least 10 characters long")
+      expect(messages).to include(I18n.t("validations.title", min_length: 10))
     end
 
     it 'does not raise an issue if the title is fine' do
       document = build(:document, title: "Just long enough to validate.")
-
       messages = ContentValidator.new(document).validation_messages
-
-      expect(messages).not_to include("The title needs to be at least 10 characters long")
+      expect(messages).to_not include(I18n.t("validations.title", min_length: 10))
     end
   end
 
   describe 'summary validation' do
     it 'raises issue if the summary is not set' do
       document = build(:document, summary: nil)
-
       messages = ContentValidator.new(document).validation_messages
-
-      expect(messages).to include("The summary needs to be at least 10 characters long")
+      expect(messages).to include(I18n.t("validations.summary", min_length: 10))
     end
 
     it 'raises issue if the summary is too short' do
       document = build(:document, summary: "Too short")
-
       messages = ContentValidator.new(document).validation_messages
-
-      expect(messages).to include("The summary needs to be at least 10 characters long")
+      expect(messages).to include(I18n.t("validations.summary", min_length: 10))
     end
 
     it 'does not raise an issue if the summary is fine' do
       document = build(:document, summary: "Just long enough to validate.")
-
       messages = ContentValidator.new(document).validation_messages
-
-      expect(messages).not_to include("The summary needs to be at least 10 characters long")
+      expect(messages).to_not include(I18n.t("validations.summary", min_length: 10))
     end
   end
 
-  describe 'custom validation' do
-    it 'raises issue if the summary is not set' do
-      body_field_schema = build(:field_schema, type: "govspeak", label: "Body", validations: { "min_length" => 10 })
-      document_type_schema = build(:document_type_schema, contents: [body_field_schema])
-      document = build(:document, document_type: document_type_schema.id, contents: { body: "Too short" })
+  describe 'min_length validation' do
+    let(:body_field_schema) { build(:field_schema, id: "body", label: "Body", validations: { "min_length" => 10 }) }
+    let(:document_type_schema) { build(:document_type_schema, contents: [body_field_schema]) }
 
+    it 'raises issue if the field is not set' do
+      document = build(:document, document_type: document_type_schema.id)
       messages = ContentValidator.new(document).validation_messages
+      expect(messages).to include(I18n.t("validations.min_length", field: "Body", min_length: 10))
+    end
 
-      expect(messages).to include("Body needs to be at least 10 characters long")
+    it 'raises issue if the field is too short' do
+      document = build(:document, document_type: document_type_schema.id, contents: { body: "Too short" })
+      messages = ContentValidator.new(document).validation_messages
+      expect(messages).to include(I18n.t("validations.min_length", field: "Body", min_length: 10))
+    end
+
+    it 'does not raise an issue if the field is fine' do
+      document = build(:document, document_type: document_type_schema.id, contents: { body: "Just long enough to validate." })
+      messages = ContentValidator.new(document).validation_messages
+      expect(messages).to_not include(I18n.t("validations.min_length", field: "Body", min_length: 10))
     end
   end
 end

--- a/spec/services/document_url_spec.rb
+++ b/spec/services/document_url_spec.rb
@@ -24,7 +24,7 @@ RSpec.describe DocumentUrl do
   describe "#secret_preview_url" do
     it "returns the URL" do
       url = DocumentUrl.new(document).secret_preview_url
-      expect(url).to eq("https://draft-origin.test.gov.uk/foo?token=eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9.eyJzdWIiOiIzMzMxMzEzMS0zMzY1LTQ4MzgtYjk2My0zNDM3MzYzNTMxNjYifQ.5TMX_QV1BGCrG0smlMRfu0TgkBc57u1gb_UUAAW8cnY")
+      expect(url).to eq("https://draft-origin.test.gov.uk/foo?token=eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9.eyJzdWIiOiIzMzMxMzEzMS0zMzY1LTQ4MzgtYjk2My0zNDM3MzYzNTMxNjYifQ.nsYQ81gx2DKs2XQanFQIZzgkq_Ofw4C3Jys9II2RFoQ")
     end
   end
 end

--- a/spec/services/document_url_spec.rb
+++ b/spec/services/document_url_spec.rb
@@ -9,7 +9,7 @@ RSpec.describe DocumentUrl do
     it "returns the URL" do
       url = DocumentUrl.new(document).public_url
 
-      expect(url).to eql("https://www.test.gov.uk/foo")
+      expect(url).to eq("https://www.test.gov.uk/foo")
     end
   end
 
@@ -17,14 +17,14 @@ RSpec.describe DocumentUrl do
     it "returns the URL" do
       url = DocumentUrl.new(document).preview_url
 
-      expect(url).to eql("https://draft-origin.test.gov.uk/foo")
+      expect(url).to eq("https://draft-origin.test.gov.uk/foo")
     end
   end
 
   describe "#secret_preview_url" do
     it "returns the URL" do
       url = DocumentUrl.new(document).secret_preview_url
-      expect(url).to eql("https://draft-origin.test.gov.uk/foo?token=eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9.eyJzdWIiOiIzMzMxMzEzMS0zMzY1LTQ4MzgtYjk2My0zNDM3MzYzNTMxNjYifQ.nsYQ81gx2DKs2XQanFQIZzgkq_Ofw4C3Jys9II2RFoQ")
+      expect(url).to eq("https://draft-origin.test.gov.uk/foo?token=eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9.eyJzdWIiOiIzMzMxMzEzMS0zMzY1LTQ4MzgtYjk2My0zNDM3MzYzNTMxNjYifQ.5TMX_QV1BGCrG0smlMRfu0TgkBc57u1gb_UUAAW8cnY")
     end
   end
 end

--- a/spec/services/linkables_service_spec.rb
+++ b/spec/services/linkables_service_spec.rb
@@ -17,7 +17,7 @@ RSpec.describe LinkablesService do
       linkable = { "content_id" => SecureRandom.uuid, "internal_name" => "Linkable 1" }
       publishing_api_has_linkables([linkable], document_type: "topical_event")
       service = LinkablesService.new("topical_event")
-      expect(service.by_content_id(linkable["content_id"])).to eq linkable
+      expect(service.by_content_id(linkable["content_id"])).to eq(linkable)
       expect(service.by_content_id("something-else")).to be_nil
     end
   end

--- a/spec/services/publishing_api_payload_spec.rb
+++ b/spec/services/publishing_api_payload_spec.rb
@@ -11,7 +11,7 @@ RSpec.describe PublishingApiPayload do
 
       payload = PublishingApiPayload.new(document).payload
 
-      expect(payload[:details]["body"]).to eql("<p>Hey <strong>buddy</strong>!</p>\n")
+      expect(payload[:details]["body"]).to eq("<p>Hey <strong>buddy</strong>!</p>\n")
     end
   end
 end


### PR DESCRIPTION
https://trello.com/c/7XfrouK7/90-allow-content-designers-to-edit-the-application-microcopy-m

This helps to decouple the tests from the exact text being shown to the
user, such that the tests are robust against content-only changes.

This comes at the expense of making the tests a little harder to read
due to the calls to the translation framework. I've chosen to keep the
lookups inline rather than creating variables, as this would distract
from the more important state being created within each test method.