### PR TITLE
Manage JWT_AUTH_SECRET by Rails secrets

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -3,6 +3,9 @@
 library("govuk")
 
 node {
+  // This is required for assets:precompile which runs in rails production
+  govuk.setEnvar("JWT_AUTH_SECRET", "secret")
+
   govuk.buildProject(
     beforeTest: {
       stage("Lint Javascript") {

--- a/app/services/document_url.rb
+++ b/app/services/document_url.rb
@@ -37,7 +37,11 @@ private
   attr_reader :document
 
   def secret_token_for_preview_url
-    JWT.encode({ 'sub' => auth_bypass_id }, ENV.fetch('JWT_AUTH_SECRET'), 'HS256')
+    JWT.encode(
+      { 'sub' => auth_bypass_id },
+      Rails.application.secrets.jwt_auth_secret,
+      'HS256'
+    )
   end
 
   # Generate a deterministic UUID from a string.

--- a/config/application.rb
+++ b/config/application.rb
@@ -46,5 +46,9 @@ module ContentPublisher
 
     config.i18n.load_path += Dir[Rails.root.join("config", "locales", "**", "*.yml")]
     config.action_view.raise_on_missing_translations = true
+
+    unless Rails.application.secrets.jwt_auth_secret
+      raise "JWT auth secret is not configured. See config/secrets.yml"
+    end
   end
 end

--- a/config/secrets.yml
+++ b/config/secrets.yml
@@ -1,8 +1,11 @@
 development:
   secret_key_base: secret
+  jwt_auth_secret: secret
 
 test:
   secret_key_base: secret
+  jwt_auth_secret: secret
 
 production:
   secret_key_base: <%= ENV['SECRET_KEY_BASE'] %>
+  jwt_auth_secret: <%= ENV['JWT_AUTH_SECRET'] %>

--- a/spec/services/document_url_spec.rb
+++ b/spec/services/document_url_spec.rb
@@ -21,11 +21,10 @@ RSpec.describe DocumentUrl do
     end
   end
 
-  describe "#preview_url" do
+  describe "#secret_preview_url" do
     it "returns the URL" do
       url = DocumentUrl.new(document).secret_preview_url
-
-      expect(url).to eql("https://draft-origin.test.gov.uk/foo?token=eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9.eyJzdWIiOiIzMzMxMzEzMS0zMzY1LTQ4MzgtYjk2My0zNDM3MzYzNTMxNjYifQ.5TMX_QV1BGCrG0smlMRfu0TgkBc57u1gb_UUAAW8cnY")
+      expect(url).to eql("https://draft-origin.test.gov.uk/foo?token=eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9.eyJzdWIiOiIzMzMxMzEzMS0zMzY1LTQ4MzgtYjk2My0zNDM3MzYzNTMxNjYifQ.nsYQ81gx2DKs2XQanFQIZzgkq_Ofw4C3Jys9II2RFoQ")
     end
   end
 end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -2,7 +2,6 @@
 
 ENV["RAILS_ENV"] ||= "test"
 ENV["GOVUK_APP_DOMAIN"] = "test.gov.uk"
-ENV["JWT_AUTH_SECRET"] = "SUPER_SECRET"
 
 require File.expand_path("../../config/environment", __FILE__)
 require "rspec/rails"


### PR DESCRIPTION
Trello: https://trello.com/c/ECYqAHfX/98-allow-users-to-preview-the-content-s

This moves the handling of this to be done by inclusion in the secrets
file and a check in application.rb rather than using ENV.fetch.

This was prompted by a number of instances where devs were getting
caught without this ENV var.