### PR TITLE
Fix documents not showing due to nil base_path

### DIFF
--- a/db/migrate/20180817153619_default_document_text_fields_to_empty_strings.rb
+++ b/db/migrate/20180817153619_default_document_text_fields_to_empty_strings.rb
@@ -1,0 +1,27 @@
+# frozen_string_literal: true
+
+class DefaultDocumentTextFieldsToEmptyStrings < ActiveRecord::Migration[5.2]
+  def up
+    change_column_default :documents, :base_path, ""
+    change_column_default :documents, :title, ""
+    change_column_default :documents, :summary, ""
+
+    change_column_null :documents, :base_path, false
+    change_column_null :documents, :title, false
+    change_column_null :documents, :summary, false
+    change_column_null :documents, :associations, false
+    change_column_null :documents, :contents, false
+  end
+
+  def down
+    change_column_default :documents, :base_path, nil
+    change_column_default :documents, :title, nil
+    change_column_default :documents, :summary, nil
+
+    change_column_null :documents, :base_path, true
+    change_column_null :documents, :title, true
+    change_column_null :documents, :summary, true
+    change_column_null :documents, :associations, true
+    change_column_null :documents, :contents, true
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2018_08_14_134709) do
+ActiveRecord::Schema.define(version: 2018_08_17_153619) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -19,13 +19,13 @@ ActiveRecord::Schema.define(version: 2018_08_14_134709) do
     t.string "content_id", null: false
     t.string "locale", null: false
     t.string "document_type"
-    t.string "title"
+    t.string "title", default: "", null: false
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
-    t.json "contents", default: {}
-    t.string "base_path"
-    t.text "summary"
-    t.json "associations", default: {}
+    t.json "contents", default: {}, null: false
+    t.string "base_path", default: "", null: false
+    t.text "summary", default: "", null: false
+    t.json "associations", default: {}, null: false
     t.string "publication_state", null: false
     t.index ["base_path"], name: "index_documents_on_base_path", unique: true
     t.index ["content_id", "locale"], name: "index_documents_on_content_id_and_locale", unique: true


### PR DESCRIPTION
If the user aborts creating a document on the edit form, the document
will exist but with a nil base_path. Having a migration to ensure the
column has a realistic value will prevent this. It also makes sense to
default the other textual columns to a textual value.