### PR TITLE
Fix url preview errors when base_path is nil

### DIFF
--- a/app/services/document_url.rb
+++ b/app/services/document_url.rb
@@ -6,14 +6,17 @@ class DocumentUrl
   end
 
   def public_url
+    return unless document.base_path
     Plek.new.website_root + document.base_path
   end
 
   def preview_url
+    return unless document.base_path
     Plek.new.external_url_for('draft-origin') + document.base_path
   end
 
   def secret_preview_url
+    return unless document.base_path
     params = { token: secret_token_for_preview_url }.to_query
     preview_url + '?' + params
   end

--- a/spec/services/document_url_spec.rb
+++ b/spec/services/document_url_spec.rb
@@ -8,16 +8,26 @@ RSpec.describe DocumentUrl do
   describe "#public_url" do
     it "returns the URL" do
       url = DocumentUrl.new(document).public_url
-
       expect(url).to eq("https://www.test.gov.uk/foo")
+    end
+
+    it "returns nil without a base_path" do
+      document.update(base_path: nil)
+      url = DocumentUrl.new(document).public_url
+      expect(url).to be_nil
     end
   end
 
   describe "#preview_url" do
     it "returns the URL" do
       url = DocumentUrl.new(document).preview_url
-
       expect(url).to eq("https://draft-origin.test.gov.uk/foo")
+    end
+
+    it "returns nil without a base_path" do
+      document.update(base_path: nil)
+      url = DocumentUrl.new(document).preview_url
+      expect(url).to be_nil
     end
   end
 
@@ -25,6 +35,12 @@ RSpec.describe DocumentUrl do
     it "returns the URL" do
       url = DocumentUrl.new(document).secret_preview_url
       expect(url).to eq("https://draft-origin.test.gov.uk/foo?token=eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9.eyJzdWIiOiIzMzMxMzEzMS0zMzY1LTQ4MzgtYjk2My0zNDM3MzYzNTMxNjYifQ.nsYQ81gx2DKs2XQanFQIZzgkq_Ofw4C3Jys9II2RFoQ")
+    end
+
+    it "returns nil without a base_path" do
+      document.update(base_path: nil)
+      url = DocumentUrl.new(document).secret_preview_url
+      expect(url).to be_nil
     end
   end
 end


### PR DESCRIPTION
This happens when a user aborts the document creation process (never
clicks save on the edit form) before we can assign (even a blank)
base_path. We can't set a default in the DB, as this would violate the
uniqueness constraint when multiple users start creating documents.