### PR TITLE
Integrate application with raven-js

### DIFF
--- a/app/javascript/packs/application.js
+++ b/app/javascript/packs/application.js
@@ -11,6 +11,17 @@ import restrict from '../restrict'
 import editDocumentForm from '../documents/edit'
 import MarkdownEditor from '../components/markdown-editor'
 import ContextualGuidance from '../components/contextual-guidance'
+import Raven from 'raven-js'
+
+var $sentryDsn = document.querySelector('meta[name=sentry-dsn]')
+var $sentryCurrentEnv = document.querySelector('meta[name=sentry-current-env]')
+
+if ($sentryDsn && $sentryCurrentEnv) {
+  // set as global variable for console usage
+  window.Raven = Raven.config($sentryDsn.getAttribute('content'), {
+    environment: $sentryCurrentEnv.getAttribute('content')
+  }).install()
+}
 
 restrict('edit-document-form', editDocumentForm)
 restrict('markdown-editor', ($el) => new MarkdownEditor($el).init())

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -1,5 +1,9 @@
 <% content_for :head do %>
-<%= stylesheet_link_tag "application" %>
+  <%= stylesheet_link_tag "application" %>
+  <% if ENV["SENTRY_DSN"] && ENV["SENTRY_CURRENT_ENV"] %>
+    <meta name="sentry-dsn" content="<%= ENV["SENTRY_DSN"] %>">
+    <meta name="sentry-current-env" content="<%= ENV["SENTRY_CURRENT_ENV"] %>">
+  <% end %>
 <% end %>
 
 <%= render 'govuk_publishing_components/components/layout_for_admin',

--- a/config/webpack/production.js
+++ b/config/webpack/production.js
@@ -2,4 +2,7 @@ process.env.NODE_ENV = process.env.NODE_ENV || 'production'
 
 const environment = require('./environment')
 
-module.exports = environment.toWebpackConfig()
+const config = environment.toWebpackConfig()
+config.devtool = 'sourcemap'
+
+module.exports = config

--- a/package.json
+++ b/package.json
@@ -13,7 +13,8 @@
     "@rails/webpacker": "3.5",
     "@webcomponents/webcomponentsjs": "^2.0.4",
     "marked": "^0.4.0",
-    "nodelist-foreach-polyfill": "^1.2.0"
+    "nodelist-foreach-polyfill": "^1.2.0",
+    "raven-js": "^3.26.4"
   },
   "standard": {
     "ignore": [

--- a/yarn.lock
+++ b/yarn.lock
@@ -5001,6 +5001,10 @@ range-parser@^1.0.3, range-parser@~1.2.0:
   version "1.2.0"
   resolved "https://registry.yarnpkg.com/range-parser/-/range-parser-1.2.0.tgz#f49be6b487894ddc40dcc94a322f611092e00d5e"
 
+raven-js@^3.26.4:
+  version "3.26.4"
+  resolved "https://registry.yarnpkg.com/raven-js/-/raven-js-3.26.4.tgz#32aae3a63a9314467a453c94c89a364ea43707be"
+
 raw-body@2.3.2:
   version "2.3.2"
   resolved "https://registry.yarnpkg.com/raw-body/-/raw-body-2.3.2.tgz#bcd60c77d3eb93cde0050295c3f379389bc88f89"


### PR DESCRIPTION
Trello: https://trello.com/c/0pzXlC9R/144-track-javascript-errors-s

Raven-js is a JS module that is used to send errors to sentry.io. To
enable us to do this we expose our SENTRY_DSN and SENTRY_CURRENT_ENV
environment variables to HTML meta tags. We then read those attributes
in as part of our Javascript initialisation and install Sentry.

The code for the application is then wrapped in a Raven.context function
as recommended by: https://docs.sentry.io/clients/javascript/#configuring-the-client

Finally we set Raven as a global variable on window so that it can be
available in the console for testing purposes.

I've configured sentry to just accept errors from *.publishing.service.gov.uk hosts, ~I'm going to expand this to include heroku too.~ - actually I can't do that since we don't have a sentry dsn set up for heroku currently.