### PR TITLE
Update summary

### DIFF
--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -2,62 +2,14 @@ $govuk-image-url-function: "image-url";
 $govuk-font-url-function: "font-url";
 $govuk-global-styles: true;
 
+@import "core/link";
+
+@import "objects/side";
+
 @import "components/contextual-guidance";
 @import "components/markdown-editor";
 @import "components/markdown-toolbar";
 @import "components/summary";
+@import "components/metadata";
 
-.app-hidden {
-  display: none;
-}
-
-.app-side {
-  @include govuk-responsive-margin(6, "bottom");
-  @include govuk-clearfix;
-
-  padding: govuk-spacing(3);
-  background: govuk-colour("grey-4");
-
-  .gem-c-button {
-    width: 100%;
-    margin-bottom: govuk-spacing(3);
-  }
-
-  .govuk-tag {
-    margin-bottom: govuk-spacing(3);
-  }
-}
-
-.app-side__actions {
-  @include govuk-responsive-margin(3, "bottom");
-}
-
-.app-metadata {
-  margin: 0;
-}
-
-.app-metadata__title {
-  @include govuk-font(19);
-  font-weight: bold;
-}
-
-.app-metadata__description {
-  margin: 0;
-  margin-bottom: govuk-spacing(3);
-
-  &:last-child {
-    margin: 0;
-  }
-}
-
-.app-c-link--destructive {
-  color: $govuk-error-colour;
-
-  &:hover {
-    color: govuk-colour("bright-red");
-  }
-}
-
-.app-c-link--right {
-  float: right;
-}
+@import "utilities/display";

--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -2,8 +2,6 @@ $govuk-image-url-function: "image-url";
 $govuk-font-url-function: "font-url";
 $govuk-global-styles: true;
 
-@import "../../../node_modules/govuk-frontend/all";
-
 @import "components/contextual-guidance";
 @import "components/markdown-editor";
 @import "components/markdown-toolbar";

--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -12,3 +12,52 @@ $govuk-global-styles: true;
 .app-hidden {
   display: none;
 }
+
+.app-title__context {
+  @include govuk-font(24);
+  margin: 0;
+  color: $govuk-secondary-text-colour;
+}
+
+.app-side {
+  @include govuk-responsive-margin(6, "bottom");
+  @include govuk-clearfix;
+
+  padding: govuk-spacing(3);
+  background: govuk-colour("grey-4");
+
+  .gem-c-button {
+    width: 100%;
+    margin-bottom: govuk-spacing(3);
+  }
+}
+
+.app-side__actions {
+  @include govuk-responsive-margin(3, "bottom");
+}
+
+.app-metadata {
+  margin: govuk-spacing(3);
+}
+
+.app-metadata__title {
+  @include govuk-font(19);
+  font-weight: bold;
+}
+
+.app-metadata__description {
+  margin: 0;
+  margin-bottom: govuk-spacing(3);
+}
+
+.app-c-link--destructive {
+  color: $govuk-error-colour;
+
+  &:hover {
+    color: govuk-colour("bright-red");
+  }
+}
+
+.app-c-link--right {
+  float: right;
+}

--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -11,12 +11,6 @@ $govuk-global-styles: true;
   display: none;
 }
 
-.app-title__context {
-  @include govuk-font(24);
-  margin: 0;
-  color: $govuk-secondary-text-colour;
-}
-
 .app-side {
   @include govuk-responsive-margin(6, "bottom");
   @include govuk-clearfix;
@@ -28,6 +22,10 @@ $govuk-global-styles: true;
     width: 100%;
     margin-bottom: govuk-spacing(3);
   }
+
+  .govuk-tag {
+    margin-bottom: govuk-spacing(3);
+  }
 }
 
 .app-side__actions {
@@ -35,7 +33,7 @@ $govuk-global-styles: true;
 }
 
 .app-metadata {
-  margin: govuk-spacing(3);
+  margin: 0;
 }
 
 .app-metadata__title {
@@ -46,6 +44,10 @@ $govuk-global-styles: true;
 .app-metadata__description {
   margin: 0;
   margin-bottom: govuk-spacing(3);
+
+  &:last-child {
+    margin: 0;
+  }
 }
 
 .app-c-link--destructive {

--- a/app/assets/stylesheets/components/_contextual-guidance.scss
+++ b/app/assets/stylesheets/components/_contextual-guidance.scss
@@ -1,3 +1,6 @@
+@import "../../../node_modules/govuk-frontend/settings/all";
+@import "../../../node_modules/govuk-frontend/helpers/all";
+
 .app-c-contextual-guidance-wrapper {
   @include govuk-font(19);
 

--- a/app/assets/stylesheets/components/_markdown-editor.scss
+++ b/app/assets/stylesheets/components/_markdown-editor.scss
@@ -1,5 +1,9 @@
+@import "../../../node_modules/govuk-frontend/helpers/all";
+@import "../../../node_modules/govuk-frontend/settings/all";
+@import "../../../node_modules/govuk-frontend/tools/all";
+
 .app-c-markdown-editor__preview-toggle {
-  @include govuk-font($size: 19);
+  @include govuk-font(19);
 
   display: none;
   margin-bottom: -$govuk-border-width-form-element;
@@ -10,6 +14,7 @@
 }
 
 .app-c-markdown-editor__button {
+  @include govuk-font(19);
   padding: 0;
   border: 0;
   color: $govuk-link-colour;

--- a/app/assets/stylesheets/components/_markdown-editor.scss
+++ b/app/assets/stylesheets/components/_markdown-editor.scss
@@ -1,6 +1,7 @@
 @import "../../../node_modules/govuk-frontend/helpers/all";
 @import "../../../node_modules/govuk-frontend/settings/all";
 @import "../../../node_modules/govuk-frontend/tools/all";
+@import "../../../node_modules/govuk-frontend/core/links";
 
 .app-c-markdown-editor__preview-toggle {
   @include govuk-font(19);
@@ -14,6 +15,7 @@
 }
 
 .app-c-markdown-editor__button {
+  @include govuk-link-common;
   @include govuk-font(19);
   padding: 0;
   border: 0;

--- a/app/assets/stylesheets/components/_markdown-toolbar.scss
+++ b/app/assets/stylesheets/components/_markdown-toolbar.scss
@@ -1,4 +1,11 @@
+@import "../../../node_modules/govuk-frontend/helpers/all";
+@import "../../../node_modules/govuk-frontend/settings/all";
+@import "../../../node_modules/govuk-frontend/tools/all";
+@import "../../../node_modules/govuk-frontend/core/lists";
+
 .app-c-markdown-toolbar {
+  @include govuk-font(19);
+
   .govuk-details {
     margin: 0;
     padding-top: govuk-spacing(2);

--- a/app/assets/stylesheets/components/_metadata.scss
+++ b/app/assets/stylesheets/components/_metadata.scss
@@ -1,0 +1,24 @@
+@import "../../../node_modules/govuk-frontend/helpers/all";
+@import "../../../node_modules/govuk-frontend/settings/all";
+@import "../../../node_modules/govuk-frontend/tools/all";
+
+.app-c-metadata {
+  @include govuk-font(19);
+}
+
+.app-c-metadata__list {
+  margin: 0;
+}
+
+.app-c-metadata__title {
+  @include govuk-font($size: 19, $weight: bold);
+}
+
+.app-c-metadata__description {
+  margin: 0;
+  margin-bottom: govuk-spacing(3);
+
+  &:last-child {
+    margin: 0;
+  }
+}

--- a/app/assets/stylesheets/components/_summary.scss
+++ b/app/assets/stylesheets/components/_summary.scss
@@ -4,13 +4,20 @@
 @import "../../../node_modules/govuk-frontend/helpers/all";
 @import "../../../node_modules/govuk-frontend/settings/all";
 @import "../../../node_modules/govuk-frontend/tools/all";
+@import "../../../node_modules/govuk-frontend/core/links";
 
 .app-c-summary {
   @include govuk-font(19);
   position: relative;
 }
 
-.app-c-summary__edit {
+.app-c-summary__change-link {
+  @extend %govuk-link;
+}
+
+.app-c-summary__change-section-link {
+  @extend %govuk-link;
+
   position: absolute;
   top: 0;
   right: 0;

--- a/app/assets/stylesheets/components/_summary.scss
+++ b/app/assets/stylesheets/components/_summary.scss
@@ -1,6 +1,10 @@
 // Recommended styles from the check your answers pattern
 // https://design-system.service.gov.uk/patterns/check-answers/
 
+@import "../../../node_modules/govuk-frontend/helpers/all";
+@import "../../../node_modules/govuk-frontend/settings/all";
+@import "../../../node_modules/govuk-frontend/tools/all";
+
 .app-c-summary {
   @include govuk-font(19);
   position: relative;

--- a/app/assets/stylesheets/core/_link.scss
+++ b/app/assets/stylesheets/core/_link.scss
@@ -1,0 +1,17 @@
+@import "../../../node_modules/govuk-frontend/helpers/all";
+@import "../../../node_modules/govuk-frontend/settings/all";
+@import "../../../node_modules/govuk-frontend/tools/all";
+@import "../../../node_modules/govuk-frontend/core/links";
+
+.app-link--destructive {
+  @include govuk-link-common;
+  color: $govuk-error-colour;
+
+  &:hover {
+    color: govuk-colour("bright-red");
+  }
+}
+
+.app-link--right {
+  float: right;
+}

--- a/app/assets/stylesheets/objects/_side.scss
+++ b/app/assets/stylesheets/objects/_side.scss
@@ -1,0 +1,20 @@
+@import "../../../node_modules/govuk-frontend/helpers/all";
+@import "../../../node_modules/govuk-frontend/settings/all";
+@import "../../../node_modules/govuk-frontend/tools/all";
+
+.app-side {
+  @include govuk-responsive-margin(6, "bottom");
+  @include govuk-clearfix;
+
+  padding: govuk-spacing(3);
+  background: govuk-colour("grey-4");
+}
+
+.app-side__actions {
+  @include govuk-responsive-margin(3, "bottom");
+
+  .govuk-button {
+    width: 100%;
+    margin-bottom: govuk-spacing(3);
+  }
+}

--- a/app/assets/stylesheets/utilities/_display.scss
+++ b/app/assets/stylesheets/utilities/_display.scss
@@ -1,0 +1,3 @@
+.app-hidden {
+  display: none;
+}

--- a/app/views/components/_metadata.html.erb
+++ b/app/views/components/_metadata.html.erb
@@ -1,0 +1,15 @@
+<%
+  items||= []
+%>
+<div class="app-c-metadata">
+
+  <% if items.any? %>
+  <dl class="app-c-metadata__list">
+    <% items.each do |item| %>
+      <dt class="app-c-metadata__title"><%= item[:field] %>:</dt>
+      <dd class="app-c-metadata__description"><%= item[:value] %></dd>
+    <% end %>
+  </dl>
+  <% end %>
+
+</div>

--- a/app/views/components/_summary.html.erb
+++ b/app/views/components/_summary.html.erb
@@ -10,7 +10,7 @@
     <%= title[:text] %>
   </h2>
   <% if title[:change_url] %>
-  <a class="app-c-summary__change-section-link" href="<%= title[:change_url] %>">
+  <a class="app-c-summary__change-section-link" href="<%= title[:change_url] %>" title="Change <%= title[:text] %>">
     Change<span class="govuk-visually-hidden"> <%= title[:text] %></span>
   </a>
   <% end %>

--- a/app/views/components/_summary.html.erb
+++ b/app/views/components/_summary.html.erb
@@ -10,7 +10,7 @@
     <%= title[:text] %>
   </h2>
   <% if title[:change_url] %>
-  <a class="app-c-summary__edit" href="<%= title[:change_url] %>">
+  <a class="app-c-summary__change-section-link" href="<%= title[:change_url] %>">
     Change<span class="govuk-visually-hidden"> <%= title[:text] %></span>
   </a>
   <% end %>
@@ -28,7 +28,7 @@
       </dd>
       <% if item[:change_url] %>
       <dd class="app-c-summary__change">
-        <a href="<%= item[:change_url] %>">
+        <a class="app-c-summary__change-link" href="<%= item[:change_url] %>">
           Change<span class="govuk-visually-hidden"> <%= item[:field] %></span>
         </a>
       </dd>

--- a/app/views/components/docs/metadata.yml
+++ b/app/views/components/docs/metadata.yml
@@ -1,0 +1,18 @@
+name: Metadata
+description: To display relevant metadata about a document
+accessibility_criteria: |
+  If metadata contains links, they must:
+
+  * be keyboard focusable
+examples:
+  default:
+    data:
+      items:
+      - field: "Status"
+        value: "Saved as draft"
+      - field: "Last updated"
+        value: "12:58pm on 17 August 2018"
+      - field: "Created"
+        value: "11:02pm on 10 August 2018"
+      - field: "First published on GOV.UK"
+        value: "12:00pm on 10 August 2018"

--- a/app/views/documents/show.html.erb
+++ b/app/views/documents/show.html.erb
@@ -1,15 +1,11 @@
 <% content_for :back_link, documents_path %>
 <% content_for :title, @document.title || t("documents.show.title_default") %>
+<% content_for :context, @document.document_type_schema.label %>
+
+<% @edit_document_content = capture do %>
 
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
-    <p>
-      Created at: <%= @document.created_at.strftime("%d %b %Y %H:%M") %>
-    </p>
-
-    <p>
-      Updated at: <%= @document.updated_at.strftime("%d %b %Y %H:%M") %>
-    </p>
 
     <%= render "documents/show/contents" %>
 
@@ -35,3 +31,22 @@
     <%= render "documents/show/actions" %>
   </div>
 </div>
+
+<% end %>
+
+<%= render "govuk_publishing_components/components/tabs", {
+  panel_border: false,
+  tabs: [
+    {
+      id: "edit-document",
+      label: "Edit document",
+      content: @edit_document_content
+    },
+    {
+      id: "document-history",
+      label: "Document history",
+      content: "Document history is not available right now"
+    }
+  ]
+} %>
+

--- a/app/views/documents/show/_actions.html.erb
+++ b/app/views/documents/show/_actions.html.erb
@@ -4,10 +4,10 @@ view_live_button = { text: t("documents.show.actions.view_live"), href: Document
 share_draft_button = { text: t("documents.show.actions.share_draft"), href: DocumentUrl.new(@document).secret_preview_url }
 preview_button = { text: t("documents.show.actions.view_draft"), href: DocumentUrl.new(@document).preview_url }
 create_draft_button = { text: t("documents.show.actions.create_draft"), href: edit_document_path(@document) }
-submit_2i_button = { text: t("documents.show.actions.submit_2i"), href: "submit_2i" }
-delete_draft_button = { text: t("documents.show.actions.delete_draft"), href: "delete" }
-withdraw_button = { text: t("documents.show.actions.withdraw"), href: "withdraw" }
-unpublish_button = { text: t("documents.show.actions.unpublish"), href: "unpublish" }
+submit_2i_button = { text: t("documents.show.actions.submit_2i"), href: "#" }
+delete_draft_button = { text: t("documents.show.actions.delete_draft"), href: "#" }
+withdraw_button = { text: t("documents.show.actions.withdraw"), href: "#" }
+unpublish_button = { text: t("documents.show.actions.unpublish"), href: "#" }
 
 case @document.publication_state
 when "sent_to_draft" || "sending_to_live" || "error_sending_to_live" # Draft

--- a/app/views/documents/show/_actions.html.erb
+++ b/app/views/documents/show/_actions.html.erb
@@ -1,24 +1,71 @@
-<ul class="govuk-list">
-  <li>
-    <%= link_to "Publish", publish_document_path(@document), class: "govuk-link" %>
-  </li>
-  <li>
-    <%= link_to "Edit document", edit_document_path(@document), class: "govuk-link" %>
-  </li>
-  <li>
-    <%= link_to "Edit associations", document_associations_path(@document), class: "govuk-link" %>
-  </li>
-  <li>
-    <%= link_to "View on GOV.UK", DocumentUrl.new(@document).public_url, class: "govuk-link" %>
-  </li>
-  <li>
-    <%= link_to "Preview", DocumentUrl.new(@document).preview_url, class: "govuk-link" %>
-  </li>
-  <li>
-    <%= link_to "Shareable preview", DocumentUrl.new(@document).secret_preview_url, class: "govuk-link" %>
-  </li>
-</ul>
+<%
+publish_button = { text: t("documents.show.actions.publish"), href: publish_document_path(@document) }
+view_live_button = { text: t("documents.show.actions.view_live"), href: DocumentUrl.new(@document).public_url }
+share_draft_button = { text: t("documents.show.actions.share_draft"), href: DocumentUrl.new(@document).secret_preview_url }
+preview_button = { text: t("documents.show.actions.view_draft"), href: DocumentUrl.new(@document).preview_url }
+create_draft_button = { text: t("documents.show.actions.create_draft"), href: edit_document_path(@document) }
+submit_2i_button = { text: t("documents.show.actions.submit_2i"), href: "submit_2i" }
+delete_draft_button = { text: t("documents.show.actions.delete_draft"), href: "delete" }
+withdraw_button = { text: t("documents.show.actions.withdraw"), href: "withdraw" }
+unpublish_button = { text: t("documents.show.actions.unpublish"), href: "unpublish" }
 
-<div class='govuk-tag' title="<%= t("publication_states.#{@document.publication_state}.description") %>">
-  <%= t("publication_states.#{@document.publication_state}.name") %>
+case @document.publication_state
+when "sent_to_draft" || "sending_to_live" || "error_sending_to_live" # Draft
+  primary_button = submit_2i_button
+  secondary_button = preview_button
+  ternary_button = publish_button
+  destructive_button = delete_draft_button
+when "sent_to_review" # Ready for review
+  primary_button = publish_button
+  secondary_button = preview_button
+  destructive_button = delete_draft_button
+when "sent_to_live" # Published
+  primary_button = create_draft_button
+  secondary_button = withdraw_button
+  ternary_button = view_live_button
+  destructive_button = unpublish_button
+end
+%>
+
+<% if primary_button || secondary_button %>
+<div class="app-side">
+  <div class="app-side__actions">
+    <% if primary_button %>
+      <%= render "govuk_publishing_components/components/button", primary_button %>
+    <% end %>
+
+    <% if secondary_button %>
+      <% secondary_button[:secondary] = true %>
+      <% secondary_button[:rel] = 'external' %>
+      <%= render "govuk_publishing_components/components/button", secondary_button %>
+    <% end %>
+  </div>
+
+  <% if ternary_button %>
+    <%= link_to ternary_button[:text], ternary_button[:href], class: "govuk-link" %>
+  <% end %>
+
+  <% if destructive_button %>
+    <%= link_to destructive_button[:text], destructive_button[:href], class: "app-link--destructive app-link--right" %>
+  <% end %>
+</div>
+<% end %>
+
+<div class="app-side">
+  <%= render "components/metadata", {
+    items: [
+      {
+        field: t("documents.show.metadata.status"),
+        value: t("publication_states.#{@document.publication_state}.name")
+      },
+      {
+        field: t("documents.show.metadata.updated_at"),
+        value: @document.updated_at.strftime("%l:%M%P on %d %B %Y")
+      },
+      {
+        field: t("documents.show.metadata.created_at"),
+        value: @document.created_at.strftime("%l:%M%P on %d %B %Y")
+      },
+    ]
+  } %>
 </div>

--- a/app/views/documents/show/_actions.html.erb
+++ b/app/views/documents/show/_actions.html.erb
@@ -15,15 +15,21 @@ when "sent_to_draft" || "sending_to_live" || "error_sending_to_live" # Draft
   secondary_button = preview_button
   ternary_button = publish_button
   destructive_button = delete_draft_button
-when "sent_to_review" # Ready for review
-  primary_button = publish_button
-  secondary_button = preview_button
-  destructive_button = delete_draft_button
+
+# NOTE:
+# This state doesn't exist yet. The following lines should be uncommented when review states are defined
+#
+# when "sent_to_review" # Ready for review
+#  primary_button = publish_button
+#  secondary_button = preview_button
+#  destructive_button = delete_draft_button
+
 when "sent_to_live" # Published
   primary_button = create_draft_button
   secondary_button = withdraw_button
   ternary_button = view_live_button
   destructive_button = unpublish_button
+
 end
 %>
 

--- a/app/views/documents/show/_contents.html.erb
+++ b/app/views/documents/show/_contents.html.erb
@@ -4,18 +4,6 @@
   <% end %>
 </ul>
 
-<%= render "components/summary", {
-  title: {
-    text: t("documents.show.format.title")
-  },
-  items: [
-    {
-      field: t("documents.show.format.items.document_type"),
-      value: @document.document_type_schema.label
-    }
-  ]
-} %>
-
 <% contents = @document.document_type_schema.contents.map { |schema|
   {
     field: schema.label,

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -34,6 +34,7 @@
     <% end %>
 
     <main class="govuk-main-wrapper<%= " govuk-main-wrapper--l" if yield(:back_link).blank?%>" id="main-content" role="main">
+      <p class="app-title__context"><%= yield(:context) %></p>
       <h1 class="govuk-heading-xl"><%= yield(:title) %></h1>
       <%= yield %>
     </main>

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -34,8 +34,12 @@
     <% end %>
 
     <main class="govuk-main-wrapper<%= " govuk-main-wrapper--l" if yield(:back_link).blank?%>" id="main-content" role="main">
-      <p class="app-title__context"><%= yield(:context) %></p>
-      <h1 class="govuk-heading-xl"><%= yield(:title) %></h1>
+      <div class="govuk-grid-row">
+        <div class="govuk-grid-column-two-thirds">
+          <span class="govuk-caption-l"><%= yield(:context) %></span>
+          <h1 class="govuk-heading-l"><%= yield(:title) %></h1>
+        </div>
+      </div>
       <%= yield %>
     </main>
   </div>

--- a/config/locales/en/documents/show.yml
+++ b/config/locales/en/documents/show.yml
@@ -7,15 +7,31 @@ en:
         items:
           document_type: Document type
       associations:
-        title: Associations
+        title: Tags
         api_down: This content isn't available right now. We're having trouble getting the data we need to show you this content.
         none: None
       contents:
-        title: Title, summary and body
+        title: Content
         items:
           title: Title
           base_path: Base path
           summary: Summary
+      actions:
+        publish: Publish
+        edit_associations: Edit associations
+        edit: Edit document
+        view_live: View on GOV.UK
+        view_draft: Preview
+        share_draft: Shareable preview
+        create_draft: Create draft
+        submit_2i: Submit for 2i review
+        delete_draft: Delete draft
+        withdraw: Withdraw
+        unpublish: Unpublish
+      metadata:
+        status: Status
+        updated_at: Last updated
+        created_at: Created
       flashes:
         draft_success: Preview creation successful
         draft_error: Error creating preview

--- a/spec/features/edit_a_document_spec.rb
+++ b/spec/features/edit_a_document_spec.rb
@@ -21,7 +21,7 @@ RSpec.feature "Edit a document" do
   def when_i_go_to_edit_the_document
     visit document_path(Document.last)
     expect(page).to have_content("Existing body")
-    click_on "Edit document"
+    click_on "Change Content"
   end
 
   def and_i_fill_in_the_content_fields

--- a/spec/features/edit_document_associations_api_down_spec.rb
+++ b/spec/features/edit_document_associations_api_down_spec.rb
@@ -27,7 +27,7 @@ RSpec.feature "Edit document associations when the API is down" do
   end
 
   def and_i_click_on_edit_associations
-    click_on "Edit associations"
+    click_on "Change Tags"
   end
 
   def then_i_should_see_an_error_message

--- a/spec/features/edit_document_associations_spec.rb
+++ b/spec/features/edit_document_associations_spec.rb
@@ -36,7 +36,7 @@ RSpec.feature "Edit document associations" do
   end
 
   def and_i_click_on_edit_associations
-    click_on "Edit associations"
+    click_on "Change Tags"
   end
 
   def then_i_can_see_the_current_selections

--- a/spec/features/previews_a_url_when_editing_title_spec.rb
+++ b/spec/features/previews_a_url_when_editing_title_spec.rb
@@ -27,7 +27,7 @@ RSpec.feature "Shows a preview of the URL", js: true do
 
   def when_i_go_to_edit_the_document
     visit document_path(@document)
-    click_on "Edit document"
+    click_on "Change Content"
   end
 
   def and_i_interact_with_the_title_but_leave_it_unedited

--- a/spec/features/publish_a_document_api_down_spec.rb
+++ b/spec/features/publish_a_document_api_down_spec.rb
@@ -11,7 +11,7 @@ RSpec.feature "Publishing a document when the API is down" do
   end
 
   def given_there_is_a_document
-    @document = create(:document)
+    @document = create(:document, publication_state: "sent_to_draft")
   end
 
   def and_the_publishing_api_is_down

--- a/spec/features/publish_a_document_spec.rb
+++ b/spec/features/publish_a_document_spec.rb
@@ -12,7 +12,7 @@ RSpec.feature "Publishing a document" do
   end
 
   def given_there_is_a_document
-    @document = create(:document)
+    @document = create(:document, publication_state: "sent_to_draft")
   end
 
   def when_i_visit_the_document_page

--- a/spec/features/publishing_validations_spec.rb
+++ b/spec/features/publishing_validations_spec.rb
@@ -31,7 +31,7 @@ RSpec.feature "Publish validations" do
     stub_any_publishing_api_put_content
     base_path = "#{@document.document_type_schema.path_prefix}/a-nice-title-of-considerable-length"
     publishing_api_has_lookups(base_path => nil)
-    click_on "Edit document"
+    click_on "Change Content"
     fill_in "document[title]", with: "A nice title of considerable length"
     fill_in "document[summary]", with: "A nice summary of considerable length"
     fill_in "document[contents][body]", with: "A very long body text."

--- a/spec/features/show_a_document_spec.rb
+++ b/spec/features/show_a_document_spec.rb
@@ -20,7 +20,7 @@ RSpec.feature "Showing a document summary" do
   def then_i_see_the_document_summary
     expect(page).to have_content(@document.title)
     expect(page).to have_content(@document.summary)
-    expect(page).to have_content(@document.created_at.strftime("%d %b %Y %H:%M"))
-    expect(page).to have_content(@document.updated_at.strftime("%d %b %Y %H:%M"))
+    expect(page).to have_content(@document.created_at.strftime("%l:%M%P on %d %B %Y"))
+    expect(page).to have_content(@document.updated_at.strftime("%l:%M%P on %d %B %Y"))
   end
 end

--- a/spec/formats/news_story_spec.rb
+++ b/spec/formats/news_story_spec.rb
@@ -35,7 +35,7 @@ RSpec.feature "Create a news story", format: true do
     publishing_api_has_linkables([linkable], document_type: "world_location")
     publishing_api_has_linkables([linkable], document_type: "organisation")
 
-    click_on "Edit associations"
+    click_on "Change Tags"
 
     select linkable["internal_name"], from: "associations[topical_events][]"
     select linkable["internal_name"], from: "associations[worldwide_organisations][]"

--- a/spec/formats/press_release_spec.rb
+++ b/spec/formats/press_release_spec.rb
@@ -35,7 +35,7 @@ RSpec.feature "Create a press release", format: true do
     publishing_api_has_linkables([linkable], document_type: "world_location")
     publishing_api_has_linkables([linkable], document_type: "organisation")
 
-    click_on "Edit associations"
+    click_on "Change Tags"
 
     select linkable["internal_name"], from: "associations[topical_events][]"
     select linkable["internal_name"], from: "associations[worldwide_organisations][]"

--- a/spec/formats/statistical_data_set_spec.rb
+++ b/spec/formats/statistical_data_set_spec.rb
@@ -32,7 +32,7 @@ RSpec.feature "Create a statistical data set", format: true do
     expect(Document.last.document_type_schema.associations.count).to eq(2)
     publishing_api_has_linkables([linkable], document_type: "organisation")
 
-    click_on "Edit associations"
+    click_on "Change Tags"
 
     select linkable["internal_name"], from: "associations[organisations][]"
 


### PR DESCRIPTION
This PR updates the summary page as per design and content
   - Adds possible actions in a side box
   - Adds document metadata component
   - Updates main heading to match gov.uk style (for summary page: document format and document title)

Contains CSS refactor:
   - Import only the needed bits in each SCSS file
   - Structure CSS following ITCSS

Updates tests to use updated content and states.

### Before
![government estate strategy 2018 - gov uk 1](https://user-images.githubusercontent.com/788096/44398107-99186880-a53a-11e8-8f16-96eaded35610.png)

### After
![government estate strategy 2018 - gov uk](https://user-images.githubusercontent.com/788096/44398037-52c30980-a53a-11e8-92c4-42ce11dcc541.png)
