### PR TITLE
Fix tests failing locally due to missing user

### DIFF
--- a/spec/factories/user_factory.rb
+++ b/spec/factories/user_factory.rb
@@ -1,0 +1,8 @@
+# frozen_string_literal: true
+
+FactoryBot.define do
+  factory :user do
+    name { SecureRandom.alphanumeric(8) }
+    organisation_content_id { SecureRandom.uuid }
+  end
+end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -33,8 +33,15 @@ RSpec.configure do |config|
   config.include GdsApi::TestHelpers::PublishingApiV2
   config.include GovukSchemas::RSpecMatchers
 
+  config.before :each do
+    create :user
+  end
+
   config.before :each, format: true do
-    publishing_api_has_linkables([{ "content_id" => User.first.organisation_content_id, "internal_name" => "Linkable" }], document_type: 'organisation')
+    publishing_api_has_linkables(
+      [{ "content_id" => User.first.organisation_content_id, "internal_name" => "Linkable" }],
+      document_type: 'organisation'
+    )
   end
 
   config.after :each, type: :feature, js: true do


### PR DESCRIPTION
The tests assume a user exists in order to run, but we never explicitly
create one - this commit fixes that using a new factory.