### PR TITLE
Fix links to error.css

### DIFF
--- a/public/404.html
+++ b/public/404.html
@@ -3,7 +3,7 @@
 <head>
   <meta charset="utf-8" />
   <title>Page not found – GOV.UK</title>
-  <link rel="stylesheet" media="all" href="errors.css" />
+  <link rel="stylesheet" media="all" href="/errors.css" />
 </head>
 
 <body class='govuk-template__body'>

--- a/public/500.html
+++ b/public/500.html
@@ -3,7 +3,7 @@
 <head>
   <meta charset="utf-8" />
   <title>Sorry, an error occured – GOV.UK</title>
-  <link rel="stylesheet" media="all" href="errors.css" />
+  <link rel="stylesheet" media="all" href="/errors.css" />
 </head>
 
 <body class='govuk-template__body'>


### PR DESCRIPTION
These were created with a relative path and thus fail if you get an
error or 404 on a page that is not at a root path. E.g. we'd fail to
load the stylesheet on a page like /documents/id as it would try load
the stylesheet at documents/error.css