### PR TITLE
Make active storage service configurable by env var

### DIFF
--- a/app.json
+++ b/app.json
@@ -4,6 +4,10 @@
     "postdeploy": "rake db:migrate db:seed"
   },
   "env": {
+    "ACTIVE_STORAGE_SERVICE": {
+      "required": true,
+      "value": "local"
+    },
     "GDS_SSO_STRATEGY": {
       "required": true,
       "value": "mock"

--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -30,8 +30,8 @@ Rails.application.configure do
     config.cache_store = :null_store
   end
 
-  # Store uploaded files on the local file system (see config/storage.yml for options)
-  config.active_storage.service = :local
+  # See config/storage.yml for options
+  config.active_storage.service = ENV.fetch("ACTIVE_STORAGE_SERVICE", "local")
 
   # Print deprecation notices to the Rails logger.
   config.active_support.deprecation = :log

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -40,8 +40,8 @@ Rails.application.configure do
   # config.action_dispatch.x_sendfile_header = 'X-Sendfile' # for Apache
   # config.action_dispatch.x_sendfile_header = 'X-Accel-Redirect' # for NGINX
 
-  # Store uploaded files on the local file system (see config/storage.yml for options)
-  config.active_storage.service = :amazon
+  # See config/storage.yml for options
+  config.active_storage.service = ENV.fetch("ACTIVE_STORAGE_SERVICE", "amazon")
 
   # Force all access to the app over SSL, use Strict-Transport-Security, and use secure cookies.
   # config.force_ssl = true


### PR DESCRIPTION
This allows us to configure Heroku to use the local settings for this
rather than hook it up to AWS - Heroku does warn us about using this
since the data wouldn't be available if the dyno is restarted or if we
run multiple dynos. But this seems a pretty low risk scenario for PR
previews.