### PR TITLE
Enforce double quotes and trailing commas

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -17,3 +17,13 @@ Style/FrozenStringLiteralComment:
   Enabled: true
   Exclude:
     - config/**/*
+
+Style/StringLiterals:
+  Enabled: true
+
+Style/TrailingCommaInLiteral:
+  Enabled: true
+
+Style/TrailingCommaInArguments:
+  Enabled: true
+  EnforcedStyleForMultiline: comma

--- a/Rakefile
+++ b/Rakefile
@@ -3,7 +3,7 @@
 # Add your own tasks in files placed in lib/tasks ending in .rake,
 # for example lib/tasks/capistrano.rake, and they will automatically be available to Rake.
 
-require_relative 'config/application'
+require_relative "config/application"
 
 Rails.application.load_tasks
 task default: %i(spec lint brakeman)

--- a/app/controllers/document_associations_controller.rb
+++ b/app/controllers/document_associations_controller.rb
@@ -3,7 +3,7 @@
 class DocumentAssociationsController < ApplicationController
   rescue_from GdsApi::BaseError do |e|
     Rails.logger.error(e)
-    render 'edit_api_down', status: 503
+    render "edit_api_down", status: 503
   end
 
   def edit

--- a/app/controllers/documents_controller.rb
+++ b/app/controllers/documents_controller.rb
@@ -3,7 +3,7 @@
 class DocumentsController < ApplicationController
   rescue_from GdsApi::BaseError do |e|
     Rails.logger.error(e)
-    render 'show_api_down', status: 503
+    render "show_api_down", status: 503
   end
 
   def index

--- a/app/services/document_publishing_service.rb
+++ b/app/services/document_publishing_service.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-require 'gds_api/publishing_api_v2'
+require "gds_api/publishing_api_v2"
 
 class DocumentPublishingService
   def publish_draft(document)
@@ -19,9 +19,9 @@ private
 
   def publishing_api
     GdsApi::PublishingApiV2.new(
-      Plek.new.find('publishing-api'),
+      Plek.new.find("publishing-api"),
       disable_cache: true,
-      bearer_token: ENV['PUBLISHING_API_BEARER_TOKEN'] || 'example',
+      bearer_token: ENV["PUBLISHING_API_BEARER_TOKEN"] || "example",
     )
   end
 end

--- a/app/services/document_type_schema.rb
+++ b/app/services/document_type_schema.rb
@@ -34,7 +34,7 @@ class DocumentTypeSchema
   end
 
   def managed_elsewhere_url
-    Plek.find(managed_elsewhere.fetch('hostname')) + managed_elsewhere.fetch('path')
+    Plek.find(managed_elsewhere.fetch("hostname")) + managed_elsewhere.fetch("path")
   end
 
   def guidance_for(id)

--- a/app/services/document_url.rb
+++ b/app/services/document_url.rb
@@ -12,13 +12,13 @@ class DocumentUrl
 
   def preview_url
     return unless document.base_path
-    Plek.new.external_url_for('draft-origin') + document.base_path
+    Plek.new.external_url_for("draft-origin") + document.base_path
   end
 
   def secret_preview_url
     return unless document.base_path
     params = { token: secret_token_for_preview_url }.to_query
-    preview_url + '?' + params
+    preview_url + "?" + params
   end
 
   # Return a "auth_bypass_id" to send to the publishing-api. This token will
@@ -41,9 +41,9 @@ private
 
   def secret_token_for_preview_url
     JWT.encode(
-      { 'sub' => auth_bypass_id },
+      { "sub" => auth_bypass_id },
       Rails.application.secrets.jwt_auth_secret,
-      'HS256'
+      "HS256",
     )
   end
 
@@ -53,7 +53,7 @@ private
   #
   # See: http://ruby-doc.org/stdlib-1.9.3/libdoc/securerandom/rdoc/SecureRandom.html#uuid-method
   def generate_uuid_for_string(string)
-    ary = Digest::SHA256.hexdigest(string).unpack('NnnnnN')
+    ary = Digest::SHA256.hexdigest(string).unpack("NnnnnN")
     ary[2] = (ary[2] & 0x0fff) | 0x4000
     ary[3] = (ary[3] & 0x3fff) | 0x8000
     "%08x-%04x-%04x-%04x-%04x%08x" % ary

--- a/app/services/path_generator_service.rb
+++ b/app/services/path_generator_service.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-require 'gds_api/publishing_api_v2'
+require "gds_api/publishing_api_v2"
 
 class PathGeneratorService
   class ErrorGeneratingPath < RuntimeError

--- a/app/services/publishing_api_payload.rb
+++ b/app/services/publishing_api_payload.rb
@@ -28,7 +28,7 @@ class PublishingApiPayload
       "links" => links,
       "access_limited" => {
         "auth_bypass_ids" => [DocumentUrl.new(document).auth_bypass_id],
-      }
+      },
     }
   end
 
@@ -53,15 +53,15 @@ private
   def temporary_defaults_in_details
     {
       "government" => {
-        "title" => "Hey", "slug" => "what", "current" => true,
+        "title" => "Hey", "slug" => "what", "current" => true
       },
       "change_history" => [
         {
           "public_timestamp" => Time.now.iso8601,
-          "note" => "To support email alerts"
-        }
+          "note" => "To support email alerts",
+        },
       ],
-      "political" => false
+      "political" => false,
     }
   end
 

--- a/config/application.rb
+++ b/config/application.rb
@@ -1,4 +1,4 @@
-require_relative 'boot'
+require_relative "boot"
 
 require "rails"
 # Pick the frameworks you want:

--- a/config/boot.rb
+++ b/config/boot.rb
@@ -1,4 +1,4 @@
-ENV['BUNDLE_GEMFILE'] ||= File.expand_path('../Gemfile', __dir__)
+ENV["BUNDLE_GEMFILE"] ||= File.expand_path("../Gemfile", __dir__)
 
-require 'bundler/setup' # Set up gems listed in the Gemfile.
-require 'bootsnap/setup' # Speed up boot time by caching expensive operations.
+require "bundler/setup" # Set up gems listed in the Gemfile.
+require "bootsnap/setup" # Speed up boot time by caching expensive operations.

--- a/config/environment.rb
+++ b/config/environment.rb
@@ -1,5 +1,5 @@
 # Load the Rails application.
-require_relative 'application'
+require_relative "application"
 
 # Initialize the Rails application.
 Rails.application.initialize!

--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -13,16 +13,16 @@ Rails.application.configure do
   config.eager_load = false
 
   # Show full error reports.
-  config.consider_all_requests_local = true
+  config.consider_all_requests_local = false
 
   # Enable/disable caching. By default caching is disabled.
   # Run rails dev:cache to toggle caching.
-  if Rails.root.join('tmp', 'caching-dev.txt').exist?
+  if Rails.root.join("tmp", "caching-dev.txt").exist?
     config.action_controller.perform_caching = true
 
     config.cache_store = :memory_store
     config.public_file_server.headers = {
-      'Cache-Control' => "public, max-age=#{2.days.to_i}"
+      "Cache-Control" => "public, max-age=#{2.days.to_i}",
     }
   else
     config.action_controller.perform_caching = false

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -22,7 +22,7 @@ Rails.application.configure do
 
   # Disable serving static files from the `/public` folder by default since
   # Apache or NGINX already handles this.
-  config.public_file_server.enabled = ENV['RAILS_SERVE_STATIC_FILES'].present?
+  config.public_file_server.enabled = ENV["RAILS_SERVE_STATIC_FILES"].present?
 
   # Compress JavaScripts and CSS.
   config.assets.js_compressor = :uglifier

--- a/config/environments/test.rb
+++ b/config/environments/test.rb
@@ -15,7 +15,7 @@ Rails.application.configure do
   # Configure public file server for tests with Cache-Control for performance.
   config.public_file_server.enabled = true
   config.public_file_server.headers = {
-    'Cache-Control' => "public, max-age=#{1.hour.to_i}"
+    "Cache-Control" => "public, max-age=#{1.hour.to_i}",
   }
 
   # Show full error reports and disable caching.

--- a/config/initializers/assets.rb
+++ b/config/initializers/assets.rb
@@ -1,12 +1,12 @@
 # Be sure to restart your server when you modify this file.
 
 # Version of your assets, change this if you want to expire all your assets.
-Rails.application.config.assets.version = '1.0'
+Rails.application.config.assets.version = "1.0"
 
 # Add additional assets to the asset load path.
 # Rails.application.config.assets.paths << Emoji.images_path
 # Add Yarn node_modules folder to the asset load path.
-Rails.application.config.assets.paths << Rails.root.join('node_modules')
+Rails.application.config.assets.paths << Rails.root.join("node_modules")
 
 # Precompile additional assets.
 # application.js, application.css, and all non-JS/CSS in the app/assets

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,28 +1,28 @@
 # frozen_string_literal: true
 
 Rails.application.routes.draw do
-  root to: redirect('/documents')
+  root to: redirect("/documents")
 
-  get '/documents/publishing-guidance' => 'new_document#guidance', as: :guidance
-  get '/documents/new' => 'new_document#choose_supertype', as: :new_document
-  get '/documents/choose-document-type' => 'new_document#choose_document_type', as: :choose_document_type
-  post '/documents/create' => 'new_document#create', as: :create_document
+  get "/documents/publishing-guidance" => "new_document#guidance", as: :guidance
+  get "/documents/new" => "new_document#choose_supertype", as: :new_document
+  get "/documents/choose-document-type" => "new_document#choose_document_type", as: :choose_document_type
+  post "/documents/create" => "new_document#create", as: :create_document
 
-  get '/documents/:id/publish' => 'publish_document#confirmation', as: :publish_document
-  post '/documents/:id/publish' => 'publish_document#publish'
+  get "/documents/:id/publish" => "publish_document#confirmation", as: :publish_document
+  post "/documents/:id/publish" => "publish_document#publish"
 
-  get '/documents' => 'documents#index'
-  get '/documents/:id/edit' => 'documents#edit', as: :edit_document
-  patch '/documents/:id' => 'documents#update', as: :document
-  get '/documents/:id' => 'documents#show'
-  get '/documents/:id/generate-path' => 'documents#generate_path', as: :generate_path
+  get "/documents" => "documents#index"
+  get "/documents/:id/edit" => "documents#edit", as: :edit_document
+  patch "/documents/:id" => "documents#update", as: :document
+  get "/documents/:id" => "documents#show"
+  get "/documents/:id/generate-path" => "documents#generate_path", as: :generate_path
 
-  get '/documents/:id/associations' => 'document_associations#edit', as: :document_associations
-  post '/documents/:id/associations' => 'document_associations#update'
+  get "/documents/:id/associations" => "document_associations#edit", as: :document_associations
+  post "/documents/:id/associations" => "document_associations#update"
 
   get "/healthcheck", to: proc { [200, {}, ["OK"]] }
 
-  get '/documentation' => 'documentation#index'
+  get "/documentation" => "documentation#index"
 
   mount GovukPublishingComponents::Engine, at: "/component-guide"
 

--- a/db/migrate/20180723183132_add_contents_to_documents.rb
+++ b/db/migrate/20180723183132_add_contents_to_documents.rb
@@ -2,6 +2,6 @@
 
 class AddContentsToDocuments < ActiveRecord::Migration[5.2]
   def change
-    add_column :documents, :contents, :json, default: '{}'
+    add_column :documents, :contents, :json, default: "{}"
   end
 end

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -1,3 +1,3 @@
 # frozen_string_literal: true
 
-User.find_or_create_by name: 'publisher'
+User.find_or_create_by name: "publisher"

--- a/lib/tasks/whitehall_news_importer.rb
+++ b/lib/tasks/whitehall_news_importer.rb
@@ -29,7 +29,7 @@ module Tasks
         base_path: "/government/news/#{document['slug']}",
         content_id: document["content_id"],
         contents: {
-          body: translation["body"]
+          body: translation["body"],
         },
         document_type: edition["news_article_type"]["key"],
         locale: translation["locale"],

--- a/spec/features/choose_a_format_spec.rb
+++ b/spec/features/choose_a_format_spec.rb
@@ -1,7 +1,5 @@
 # frozen_string_literal: true
 
-require "spec_helper"
-
 RSpec.feature "Choosing a format" do
   scenario "User forgets to choose a format" do
     when_i_dont_choose_a_supertype

--- a/spec/features/create_a_document_api_down_spec.rb
+++ b/spec/features/create_a_document_api_down_spec.rb
@@ -1,7 +1,5 @@
 # frozen_string_literal: true
 
-require "spec_helper"
-
 RSpec.feature "Create a document when the API is down" do
   scenario "User creates a document without API" do
     given_i_start_to_create_a_document

--- a/spec/features/documentation_spec.rb
+++ b/spec/features/documentation_spec.rb
@@ -1,7 +1,5 @@
 # frozen_string_literal: true
 
-require "spec_helper"
-
 RSpec.feature "Documentation" do
   scenario "GDS staff visits the docs page" do
     when_i_visit_the_documentation_page

--- a/spec/features/edit_a_document_spec.rb
+++ b/spec/features/edit_a_document_spec.rb
@@ -1,7 +1,5 @@
 # frozen_string_literal: true
 
-require "spec_helper"
-
 RSpec.feature "Edit a document" do
   scenario "User edits a document" do
     given_there_is_a_document

--- a/spec/features/edit_document_associations_api_down_spec.rb
+++ b/spec/features/edit_document_associations_api_down_spec.rb
@@ -1,7 +1,5 @@
 # frozen_string_literal: true
 
-require "spec_helper"
-
 RSpec.feature "Edit document associations when the API is down" do
   scenario "User tries to edit associations without API" do
     given_there_is_a_document

--- a/spec/features/edit_document_associations_spec.rb
+++ b/spec/features/edit_document_associations_spec.rb
@@ -1,7 +1,5 @@
 # frozen_string_literal: true
 
-require "spec_helper"
-
 RSpec.feature "Edit document associations" do
   let(:initial_association) { { "content_id" => SecureRandom.uuid, "internal_name" => "Initial association" } }
   let(:association_to_select_1) { { "content_id" => SecureRandom.uuid, "internal_name" => "Association to select 1" } }
@@ -74,7 +72,7 @@ RSpec.feature "Edit document associations" do
   def edition_links
     {
       "multi_association_id" => [association_to_select_1["content_id"], association_to_select_2["content_id"]],
-      "single_association_id" => [association_to_select_1["content_id"]]
+      "single_association_id" => [association_to_select_1["content_id"]],
     }
   end
 end

--- a/spec/features/previews_a_url_when_editing_title_spec.rb
+++ b/spec/features/previews_a_url_when_editing_title_spec.rb
@@ -1,7 +1,5 @@
 # frozen_string_literal: true
 
-require "spec_helper"
-
 RSpec.feature "Shows a preview of the URL", js: true do
   scenario "when a user edits the title of a document" do
     given_there_is_a_document

--- a/spec/features/publish_a_document_api_down_spec.rb
+++ b/spec/features/publish_a_document_api_down_spec.rb
@@ -1,7 +1,5 @@
 # frozen_string_literal: true
 
-require "spec_helper"
-
 RSpec.feature "Publishing a document when the API is down" do
   scenario "User publishes a document" do
     given_there_is_a_document

--- a/spec/features/publish_a_document_spec.rb
+++ b/spec/features/publish_a_document_spec.rb
@@ -1,7 +1,5 @@
 # frozen_string_literal: true
 
-require "spec_helper"
-
 RSpec.feature "Publishing a document" do
   scenario "User publishes a document" do
     given_there_is_a_document

--- a/spec/features/publishing_validations_spec.rb
+++ b/spec/features/publishing_validations_spec.rb
@@ -1,7 +1,5 @@
 # frozen_string_literal: true
 
-require "spec_helper"
-
 RSpec.feature "Publish validations" do
   scenario "A document is validated" do
     given_there_is_an_invalid_document

--- a/spec/features/show_a_document_api_down_spec.rb
+++ b/spec/features/show_a_document_api_down_spec.rb
@@ -1,7 +1,5 @@
 # frozen_string_literal: true
 
-require "spec_helper"
-
 RSpec.feature "Showing a document when the API is down" do
   scenario "User views a document without API" do
     given_there_is_a_document_with_associations

--- a/spec/features/show_a_document_spec.rb
+++ b/spec/features/show_a_document_spec.rb
@@ -1,7 +1,5 @@
 # frozen_string_literal: true
 
-require "spec_helper"
-
 RSpec.feature "Showing a document summary" do
   scenario "User view a document" do
     given_there_is_a_document

--- a/spec/formats/configuration_spec.rb
+++ b/spec/formats/configuration_spec.rb
@@ -1,7 +1,5 @@
 # frozen_string_literal: true
 
-require "spec_helper"
-
 RSpec.describe "Format configuration", format: true do
   SupertypeSchema.all.each do |schema|
     describe "Supertype #{schema.id}" do

--- a/spec/formats/consultation_spec.rb
+++ b/spec/formats/consultation_spec.rb
@@ -1,7 +1,5 @@
 # frozen_string_literal: true
 
-require "spec_helper"
-
 RSpec.feature "Create a detailed guide", format: true do
   scenario "User creates a detailed guide" do
     when_i_choose_this_document_type

--- a/spec/formats/detailed_guide_spec.rb
+++ b/spec/formats/detailed_guide_spec.rb
@@ -1,7 +1,5 @@
 # frozen_string_literal: true
 
-require "spec_helper"
-
 RSpec.feature "Create a detailed guide", format: true do
   scenario "User creates a detailed guide" do
     when_i_choose_this_document_type

--- a/spec/formats/news_story_spec.rb
+++ b/spec/formats/news_story_spec.rb
@@ -1,7 +1,5 @@
 # frozen_string_literal: true
 
-require "spec_helper"
-
 RSpec.feature "Create a news story", format: true do
   scenario "User creates news story" do
     when_i_choose_this_document_type

--- a/spec/formats/not_sure_spec.rb
+++ b/spec/formats/not_sure_spec.rb
@@ -1,7 +1,5 @@
 # frozen_string_literal: true
 
-require "spec_helper"
-
 RSpec.feature "User is not sure about the supertype", format: true do
   scenario "User selects the not sure option" do
     when_i_click_on_create_a_document

--- a/spec/formats/policy_paper_spec.rb
+++ b/spec/formats/policy_paper_spec.rb
@@ -1,7 +1,5 @@
 # frozen_string_literal: true
 
-require "spec_helper"
-
 RSpec.feature "Create a policy paper", format: true do
   scenario "User creates a policy paper" do
     when_i_choose_this_document_type

--- a/spec/formats/press_release_spec.rb
+++ b/spec/formats/press_release_spec.rb
@@ -1,7 +1,5 @@
 # frozen_string_literal: true
 
-require "spec_helper"
-
 RSpec.feature "Create a press release", format: true do
   scenario "User creates press release" do
     when_i_choose_this_document_type

--- a/spec/formats/statistical_data_set_spec.rb
+++ b/spec/formats/statistical_data_set_spec.rb
@@ -1,7 +1,5 @@
 # frozen_string_literal: true
 
-require "spec_helper"
-
 RSpec.feature "Create a statistical data set", format: true do
   scenario "User creates statistical data set" do
     when_i_choose_this_document_type

--- a/spec/models/document_spec.rb
+++ b/spec/models/document_spec.rb
@@ -1,7 +1,5 @@
 # frozen_string_literal: true
 
-require 'spec_helper'
-
 RSpec.describe Document do
   describe "PUBLICATION_STATES" do
     it "has correct translations for each state" do

--- a/spec/services/content_validator_spec.rb
+++ b/spec/services/content_validator_spec.rb
@@ -1,65 +1,63 @@
 # frozen_string_literal: true
 
-require 'spec_helper'
-
 RSpec.describe ContentValidator do
-  describe 'title validation' do
-    it 'raises issue if the title is not set' do
+  describe "title validation" do
+    it "raises issue if the title is not set" do
       document = build(:document, title: nil)
       messages = ContentValidator.new(document).validation_messages
       expect(messages).to include(I18n.t("validations.title", min_length: 10))
     end
 
-    it 'raises issue if the title is too short' do
+    it "raises issue if the title is too short" do
       document = build(:document, title: "Too short")
       messages = ContentValidator.new(document).validation_messages
       expect(messages).to include(I18n.t("validations.title", min_length: 10))
     end
 
-    it 'does not raise an issue if the title is fine' do
+    it "does not raise an issue if the title is fine" do
       document = build(:document, title: "Just long enough to validate.")
       messages = ContentValidator.new(document).validation_messages
       expect(messages).to_not include(I18n.t("validations.title", min_length: 10))
     end
   end
 
-  describe 'summary validation' do
-    it 'raises issue if the summary is not set' do
+  describe "summary validation" do
+    it "raises issue if the summary is not set" do
       document = build(:document, summary: nil)
       messages = ContentValidator.new(document).validation_messages
       expect(messages).to include(I18n.t("validations.summary", min_length: 10))
     end
 
-    it 'raises issue if the summary is too short' do
+    it "raises issue if the summary is too short" do
       document = build(:document, summary: "Too short")
       messages = ContentValidator.new(document).validation_messages
       expect(messages).to include(I18n.t("validations.summary", min_length: 10))
     end
 
-    it 'does not raise an issue if the summary is fine' do
+    it "does not raise an issue if the summary is fine" do
       document = build(:document, summary: "Just long enough to validate.")
       messages = ContentValidator.new(document).validation_messages
       expect(messages).to_not include(I18n.t("validations.summary", min_length: 10))
     end
   end
 
-  describe 'min_length validation' do
+  describe "min_length validation" do
     let(:body_field_schema) { build(:field_schema, id: "body", label: "Body", validations: { "min_length" => 10 }) }
     let(:document_type_schema) { build(:document_type_schema, contents: [body_field_schema]) }
 
-    it 'raises issue if the field is not set' do
+    it "raises issue if the field is not set" do
       document = build(:document, document_type: document_type_schema.id)
       messages = ContentValidator.new(document).validation_messages
       expect(messages).to include(I18n.t("validations.min_length", field: "Body", min_length: 10))
     end
 
-    it 'raises issue if the field is too short' do
+    it "raises issue if the field is too short" do
       document = build(:document, document_type: document_type_schema.id, contents: { body: "Too short" })
       messages = ContentValidator.new(document).validation_messages
       expect(messages).to include(I18n.t("validations.min_length", field: "Body", min_length: 10))
     end
 
-    it 'does not raise an issue if the field is fine' do
+    it "does not raise an issue if the field is fine" do
       document = build(:document, document_type: document_type_schema.id, contents: { body: "Just long enough to validate." })
       messages = ContentValidator.new(document).validation_messages
       expect(messages).to_not include(I18n.t("validations.min_length", field: "Body", min_length: 10))

--- a/spec/services/document_publishing_service_spec.rb
+++ b/spec/services/document_publishing_service_spec.rb
@@ -1,9 +1,9 @@
 # frozen_string_literal: true
 
-require 'spec_helper'
+require "spec_helper"
 
 RSpec.describe DocumentPublishingService do
-  describe '#publish_draft' do
+  describe "#publish_draft" do
     it "keeps track of the publication state" do
       stub_any_publishing_api_put_content
       document = create(:document)
@@ -16,7 +16,7 @@ RSpec.describe DocumentPublishingService do
     end
   end
 
-  describe '#publish' do
+  describe "#publish" do
     it "keeps track of the publication state" do
       stub_any_publishing_api_publish
       document = create(:document)

--- a/spec/services/document_type_schema_spec.rb
+++ b/spec/services/document_type_schema_spec.rb
@@ -1,7 +1,5 @@
 # frozen_string_literal: true
 
-require 'spec_helper'
-
 RSpec.describe DocumentTypeSchema do
   describe ".find" do
     it "returns a DocumentTypeSchema when it's a known document_type" do
@@ -14,8 +12,8 @@ RSpec.describe DocumentTypeSchema do
     end
   end
 
-  describe '#managed_elsewhere_url' do
-    it 'returns a full URL' do
+  describe "#managed_elsewhere_url" do
+    it "returns a full URL" do
       schema = DocumentTypeSchema.find("consultation")
       path = "https://whitehall-admin.test.gov.uk/government/admin/consultations/new"
       expect(schema.managed_elsewhere_url).to eq(path)

--- a/spec/services/document_url_spec.rb
+++ b/spec/services/document_url_spec.rb
@@ -1,7 +1,5 @@
 # frozen_string_literal: true
 
-require 'spec_helper'
-
 RSpec.describe DocumentUrl do
   let(:document) { build(:document, base_path: "/foo", content_id: "d2547c42-8ed3-49f5-baeb-6112f98c2bf9") }
 

--- a/spec/services/linkables_service_spec.rb
+++ b/spec/services/linkables_service_spec.rb
@@ -1,7 +1,5 @@
 # frozen_string_literal: true
 
-require 'spec_helper'
-
 RSpec.describe LinkablesService do
   describe "#select_options" do
     it "returns an array of titles with content_ids" do

--- a/spec/services/path_generator_service_spec.rb
+++ b/spec/services/path_generator_service_spec.rb
@@ -1,9 +1,7 @@
 # frozen_string_literal: true
 
-require 'spec_helper'
-
 RSpec.describe PathGeneratorService do
-  describe '.path' do
+  describe ".path" do
     it "generates a base path which is unique to our database" do
       service = PathGeneratorService.new
       original_document = create(:document)

--- a/spec/services/publishing_api_payload_spec.rb
+++ b/spec/services/publishing_api_payload_spec.rb
@@ -1,7 +1,5 @@
 # frozen_string_literal: true
 
-require 'spec_helper'
-
 RSpec.describe PublishingApiPayload do
   describe "#payload" do
     it "generates a payload for the publishing API" do

--- a/spec/services/supertype_schema_spec.rb
+++ b/spec/services/supertype_schema_spec.rb
@@ -1,7 +1,5 @@
 # frozen_string_literal: true
 
-require 'spec_helper'
-
 RSpec.describe SupertypeSchema do
   describe ".find" do
     it "returns a SupertypeSchema when it's a known supertype" do

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -22,7 +22,7 @@ ActiveRecord::Migration.maintain_test_schema!
 Capybara.server = :puma, { Silent: true }
 Capybara::Chromedriver::Logger.raise_js_errors = true
 Capybara::Chromedriver::Logger.filters = [
-  /the server responded with a status of 409/i
+  /the server responded with a status of 409/i,
 ]
 
 RSpec.configure do |config|
@@ -34,7 +34,7 @@ RSpec.configure do |config|
   config.include GovukSchemas::RSpecMatchers
 
   config.before :each, format: true do
-    publishing_api_has_linkables([{ "content_id" => User.first.organisation_content_id, "internal_name" => "Linkable" }], document_type: 'organisation')
+    publishing_api_has_linkables([{ "content_id" => User.first.organisation_content_id, "internal_name" => "Linkable" }], document_type: "organisation")
   end
 
   config.after :each, type: :feature, js: true do

--- a/spec/tasks/whitehall_news_importer_spec.rb
+++ b/spec/tasks/whitehall_news_importer_spec.rb
@@ -1,6 +1,5 @@
 # frozen_string_literal: true
 
-require "spec_helper"
 require "tasks/whitehall_news_importer"
 
 RSpec.describe Tasks::WhitehallNewsImporter do
@@ -14,11 +13,11 @@ RSpec.describe Tasks::WhitehallNewsImporter do
             created_at: Time.zone.now,
             news_article_type: { key: "news_story" },
             translations: [
-              { locale: "en", title: "Title", summary: "Summary", body: "Body" }
-            ]
-          }
-        ]
-      }
+              { locale: "en", title: "Title", summary: "Summary", body: "Body" },
+            ],
+          },
+        ],
+      },
     ].to_json
 
     expect { Tasks::WhitehallNewsImporter.new(JSON.parse(import_json)).import }


### PR DESCRIPTION
This is brings us closer to the origin GDS style guide and removes the
ambiguity of which quote and list syntax to use, which has been a
persistent pain. Note that the quoting isn't enforced where it would be
semantically invalid (e.g. '"hello"').

https://github.com/alphagov/styleguides/blob/7a9045bf653e6f12d614217b30d70b7798ece5bd/ruby.md