### PR TITLE
Additional content changes

### DIFF
--- a/app/formats/document_types.yml
+++ b/app/formats/document_types.yml
@@ -23,14 +23,10 @@
       validations:
         min_length: 10
   associations:
-    - id: topical_events
-      label: Topical events
-      type: multi_association
-      document_type: topical_event
-    - id: world_locations
-      label: World locations
-      type: multi_association
-      document_type: world_location
+    - id: primary_publishing_organisation
+      label: Primary organisation
+      type: single_association
+      document_type: organisation
     - id: organisations
       label: Organisations
       type: multi_association
@@ -39,10 +35,14 @@
       label: Worldwide organisations
       type: multi_association
       document_type: worldwide_organisation
-    - id: primary_publishing_organisation
-      label: Primary organisation
-      type: single_association
-      document_type: organisation
+    - id: topical_events
+      label: Topical events
+      type: multi_association
+      document_type: topical_event
+    - id: world_locations
+      label: World locations
+      type: multi_association
+      document_type: world_location
 
 - id: news_story
   label: News story
@@ -68,14 +68,10 @@
       validations:
         min_length: 10
   associations:
-    - id: topical_events
-      label: Topical events
-      type: multi_association
-      document_type: topical_event
-    - id: world_locations
-      label: World locations
-      type: multi_association
-      document_type: world_location
+    - id: primary_publishing_organisation
+      label: Primary organisation
+      type: single_association
+      document_type: organisation
     - id: organisations
       label: Organisations
       type: multi_association
@@ -84,10 +80,14 @@
       label: Worldwide organisations
       type: multi_association
       document_type: worldwide_organisation
-    - id: primary_publishing_organisation
-      label: Primary organisation
-      type: single_association
-      document_type: organisation
+    - id: topical_events
+      label: Topical events
+      type: multi_association
+      document_type: topical_event
+    - id: world_locations
+      label: World locations
+      type: multi_association
+      document_type: world_location
 
 - id: statistical_data_set
   label: Statistical data set
@@ -113,13 +113,13 @@
       validations:
         min_length: 10
   associations:
-    - id: organisations
-      label: Organisations
-      type: multi_association
-      document_type: organisation
     - id: primary_publishing_organisation
       label: Primary organisation
       type: single_association
+      document_type: organisation
+    - id: organisations
+      label: Organisations
+      type: multi_association
       document_type: organisation
 
 - id: policy_paper

--- a/app/models/document.rb
+++ b/app/models/document.rb
@@ -18,4 +18,8 @@ class Document < ApplicationRecord
   def document_type_schema
     DocumentTypeSchema.find(document_type)
   end
+
+  def newly_created?
+    self.created_at == self.updated_at
+  end
 end

--- a/app/views/documents/edit.html.erb
+++ b/app/views/documents/edit.html.erb
@@ -1,5 +1,5 @@
 <%= content_for :back_link, document_path(@document) %>
-<% content_for :title, @document.title || t("documents.edit.title") %>
+<% content_for :title, "#{@document.newly_created? ? 'Create' : 'Edit'} #{@document.document_type_schema.label.downcase}" %>
 
   <%= form_for(@document, html: {'autocomplete': 'off'}, data: {'module': 'edit-document-form', 'generate-path-path': generate_path_path}) do |f| %>
   <div class="govuk-grid-row">


### PR DESCRIPTION
For https://trello.com/c/Gm1BOO1O/151-review-pages-with-updated-content-in-content-publisher-s

### 1. Edit document page: display "Create" or "Edit" + document_type

#### Before - display the document title
<img width="676" alt="edit-title-before" src="https://user-images.githubusercontent.com/13434452/44529699-a1aca280-a6e4-11e8-922d-92ade9aaa3b0.png">

#### After - display "Create" + document_type when the document is new
<img width="657" alt="new-create-press-release-after" src="https://user-images.githubusercontent.com/13434452/44534435-af1b5a00-a6ef-11e8-84bb-1538f8539635.png">

#### After - display "Edit" + document_type when editing an existing document
<img width="676" alt="screen shot 2018-08-23 at 16 18 23" src="https://user-images.githubusercontent.com/13434452/44534650-323cb000-a6f0-11e8-8346-ab6649d26bb6.png">

### 2. Summary page: reorder associations

#### Before
<img width="681" alt="tags-before" src="https://user-images.githubusercontent.com/13434452/44529854-ff40ef00-a6e4-11e8-9046-a7e05c843b8e.png">

#### After
_Note:_ It's unclear where Worldwide Organisations should go. I've tagged Ben H in the Google doc to check; in the meantime it seems logical to place it near to Organisations.

<img width="669" alt="tags-after" src="https://user-images.githubusercontent.com/13434452/44529858-0405a300-a6e5-11e8-8819-d4d504791476.png">
