### PR TITLE
Add Google Tag Manager script

### DIFF
--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -4,6 +4,14 @@
     <meta name="sentry-dsn" content="<%= ENV["SENTRY_DSN"] %>">
     <meta name="sentry-current-env" content="<%= ENV["SENTRY_CURRENT_ENV"] %>">
   <% end %>
+
+  <% if ENV["GOOGLE_TAG_MANAGER_ID"] %>
+    <%= render "govuk_publishing_components/components/google_tag_manager_script", {
+      gtm_id: ENV["GOOGLE_TAG_MANAGER_ID"],
+      gtm_auth: ENV["GOOGLE_TAG_MANAGER_AUTH"],
+      gtm_preview: ENV["GOOGLE_TAG_MANAGER_PREVIEW"]
+    } %>
+  <% end %>
 <% end %>
 
 <%= render 'govuk_publishing_components/components/layout_for_admin',


### PR DESCRIPTION
This PR adds the Google Tag Manager component and it needs [Add Google Tag Manager env vars for Content Publisher](https://github.com/alphagov/govuk-puppet/pull/8041) to get merged in order to render the component. Raised this PR to have it ready.

[Trello card](https://trello.com/c/wh7K3ul2)