### PR TITLE
Fix title bug on show_api_down page

### DIFF
--- a/app/views/documents/show_api_down.html.erb
+++ b/app/views/documents/show_api_down.html.erb
@@ -1,5 +1,5 @@
 <% content_for :back_link, documents_path %>
-<% content_for :title, @document.title || t("documents.show.title") %>
+<% content_for :title, @document.title || t("documents.show.title_default") %>
 
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">


### PR DESCRIPTION
In the translation files `document.show.title` has been renamed
`document.show.title_default`. This is an instance where this hasn't been
updated and is causing the page to break.