### PR TITLE
Set app time zone to London

### DIFF
--- a/config/application.rb
+++ b/config/application.rb
@@ -47,6 +47,8 @@ module ContentPublisher
     config.i18n.load_path += Dir[Rails.root.join("config", "locales", "**", "*.yml")]
     config.action_view.raise_on_missing_translations = true
 
+    config.time_zone = "London"
+
     unless Rails.application.secrets.jwt_auth_secret
       raise "JWT auth secret is not configured. See config/secrets.yml"
     end


### PR DESCRIPTION
We store dates in the database in UTC, which means that when we're displaying
dates and times in the views they're an hour out of date during daylight saving
time. This sets the app's time zone to 'London' so that ActiveRecord
automatically converts dates and times to the UK's current time zone, whether
it's GMT or BST.