### PR TITLE
Fix textarea resize

### DIFF
--- a/app/assets/stylesheets/components/_markdown-editor.scss
+++ b/app/assets/stylesheets/components/_markdown-editor.scss
@@ -7,6 +7,7 @@
 .app-c-markdown-editor {
   .govuk-textarea {
     padding-top: govuk-spacing(8);
+    resize: vertical;
   }
 }
 

--- a/app/assets/stylesheets/utilities/_overwrites.scss
+++ b/app/assets/stylesheets/utilities/_overwrites.scss
@@ -1,3 +1,7 @@
 .gem-c-success-alert__message {
   margin: 0;
 }
+
+.gem-c-textarea {
+  max-width: 100%;
+}


### PR DESCRIPTION
This PR: 
- Prevent textarea component to be resized beyond the bounds of its container
- Disallow horizontal resize for the markdown editor's textarea

### Before
Textarea resized beyond the bounds of its container
<img width="985" alt="screen shot 2018-08-29 at 10 48 16" src="https://user-images.githubusercontent.com/788096/44780195-46adfc00-ab79-11e8-8b22-ef42e760061f.png">

Markdown editor resized horizontally
<img width="981" alt="screen shot 2018-08-29 at 10 49 12" src="https://user-images.githubusercontent.com/788096/44780226-5e858000-ab79-11e8-9015-24eaf5c43271.png">

### After
<img width="977" alt="screen shot 2018-08-29 at 10 49 34" src="https://user-images.githubusercontent.com/788096/44780283-7fe66c00-ab79-11e8-94ed-709269aea882.png">
<img width="983" alt="screen shot 2018-08-29 at 10 51 20" src="https://user-images.githubusercontent.com/788096/44780288-8248c600-ab79-11e8-9f5d-4b80b4b98d26.png">

