### PR TITLE
Set anchors in the preview container to open in a new tab

### DIFF
--- a/app/javascript/components/markdown-editor.js
+++ b/app/javascript/components/markdown-editor.js
@@ -56,6 +56,8 @@ MarkdownEditor.prototype.handlePreviewButton = function (event) {
         }
       }
     )
+    // Open preview links in a new tab
+    this.setTargetBlank(this.$preview)
   } else {
     $preview.innerHTML = 'Nothing to preview'
   }
@@ -89,6 +91,16 @@ MarkdownEditor.prototype.toggle = function (element) {
     element.style.display = 'block'
   } else {
     element.style.display = 'none'
+  }
+}
+
+// Set target="_blank" to anchors inside the container
+MarkdownEditor.prototype.setTargetBlank = function (container) {
+  if (container) {
+    var anchors = container.querySelectorAll('a')
+    anchors.forEach(function (anchor) {
+      anchor.setAttribute('target', '_blank')
+    })
   }
 }
 


### PR DESCRIPTION
This PR adds target blank to anchors generated in the preview container so the user doesn't loose the current page when clicking them.

### Context
<img width="986" alt="screen shot 2018-08-29 at 12 24 46" src="https://user-images.githubusercontent.com/788096/44784755-9a731200-ab86-11e8-8674-bab61e240a96.png">
