### PR TITLE
Endpoint to update the crop of an image

### DIFF
--- a/app/controllers/document_images_controller.rb
+++ b/app/controllers/document_images_controller.rb
@@ -13,7 +13,23 @@ class DocumentImagesController < ApplicationController
     end
   end
 
+  def crop
+    image = Image.find_by!(id: params[:id], document_id: params[:document_id])
+    crop = UpdateImageCropService.new(image, crop_params)
+
+    if crop.valid?
+      crop.update_image
+      render json: ImageJsonPresenter.new(image).present, status: :ok
+    else
+      render json: { errors: crop.errors }, status: :unprocessable_entity
+    end
+  end
+
 private
+
+  def crop_params
+    params.require(:crop).permit(:x, :y, :width, :height)
+  end
 
   def create_image_from_upload(upload, document)
     blob = ActiveStorage::Blob.create_after_upload!(

--- a/app/controllers/document_images_controller.rb
+++ b/app/controllers/document_images_controller.rb
@@ -2,7 +2,7 @@
 
 class DocumentImagesController < ApplicationController
   def create
-    document = Document.find(params[:id])
+    document = Document.find(params[:document_id])
     upload = UploadedImageService.new(params.require(:image)).process
 
     if upload.valid?

--- a/app/services/update_image_crop_service.rb
+++ b/app/services/update_image_crop_service.rb
@@ -1,0 +1,53 @@
+# frozen_string_literal: true
+
+require "ostruct"
+
+class UpdateImageCropService
+  attr_reader :image, :params
+
+  def initialize(image, params)
+    @image = image
+    @params = params
+  end
+
+  def valid?
+    validator.valid?
+  end
+
+  def errors
+    validator.validate
+    validator.errors
+  end
+
+  def update_image
+    raise RuntimeError, "Invalid crop" unless valid?
+
+    image.update!(
+      crop_x: params[:x],
+      crop_y: params[:y],
+      crop_width: params[:width],
+      crop_height: params[:height],
+    )
+  end
+
+private
+
+  def validator
+    @validator ||= CropValidator.new(params)
+  end
+
+  class CropValidator < OpenStruct
+    include ActiveModel::Validations
+
+    validates :x,
+              numericality: { only_integer: true, greater_than_or_equal_to: 0 }
+    validates :y,
+              numericality: { only_integer: true, greater_than_or_equal_to: 0 }
+    validates :width,
+              numericality: { only_integer: true, greater_than_or_equal_to: Image::WIDTH }
+    validates :height,
+              numericality: { only_integer: true, greater_than_or_equal_to: Image::HEIGHT }
+
+    validates_with ImageAspectRatioValidator
+  end
+end

--- a/app/validators/image_aspect_ratio_validator.rb
+++ b/app/validators/image_aspect_ratio_validator.rb
@@ -1,0 +1,53 @@
+# frozen_string_literal: true
+
+class ImageAspectRatioValidator < ActiveModel::Validator
+  def validate(record)
+    return unless sane_input(record.width, record.height)
+
+    unless valid_aspect_ratio?(record.width.to_i, record.height.to_i)
+      record.errors[:base] << error_message
+    end
+  end
+
+private
+
+  def sane_input(width, height)
+    width.to_i.to_s == width.to_s && height.to_i.to_s == height.to_s
+  end
+
+  def valid_aspect_ratio?(width, height)
+    valid_width, valid_height = valid_dimensions
+    aspect_ratio = valid_width.to_f / valid_height
+
+    allowed_dimensions(width, height, aspect_ratio).include?([width, height])
+  end
+
+  def allowed_dimensions(actual_width, actual_height, aspect_ratio)
+    allowed_height = actual_width / aspect_ratio
+    allowed_width = actual_height * aspect_ratio
+
+    # We're being forgiving here to accept both whole numbers if aspect ratio
+    # creates a fraction
+    [
+      [actual_width, allowed_height.ceil],
+      [actual_width, allowed_height.floor],
+      [allowed_width.ceil, actual_height],
+      [allowed_width.floor, actual_height],
+    ].uniq
+  end
+
+  def error_message
+    # This is used to get simplest ratio for dimensions.
+    # E.g. Rational(1920, 1080) => (16/9)
+    ratio = Rational(*valid_dimensions)
+
+    I18n.t(
+      "validations.images.aspect_ratio",
+      aspect_ratio: "#{ratio.numerator}:#{ratio.denominator}",
+    )
+  end
+
+  def valid_dimensions
+    [Image::WIDTH, Image::HEIGHT]
+  end
+end

--- a/config/locales/en/validations.yml
+++ b/config/locales/en/validations.yml
@@ -7,3 +7,4 @@ en:
       invalid_format: "Expected a jpg, png or gif image"
       max_size: "Image uploads must be less than %{max_size} in filesize"
       min_dimensions: "Images must have dimensions of at least %{width} x %{height} pixels"
+      aspect_ratio:  "dimensions are not in the expected %{aspect_ratio} aspect ratio"

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -20,7 +20,7 @@ Rails.application.routes.draw do
   get "/documents/:id/associations" => "document_associations#edit", as: :document_associations
   post "/documents/:id/associations" => "document_associations#update"
 
-  post "/documents/:id/images" => "document_images#create", as: :create_document_image
+  post "/documents/:document_id/images" => "document_images#create", as: :create_document_image
 
   get "/healthcheck", to: proc { [200, {}, %w[OK]] }
 

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -21,6 +21,7 @@ Rails.application.routes.draw do
   post "/documents/:id/associations" => "document_associations#update"
 
   post "/documents/:document_id/images" => "document_images#create", as: :create_document_image
+  post "/documents/:document_id/images/:id/crop" => "document_images#crop", as: :crop_document_image
 
   get "/healthcheck", to: proc { [200, {}, %w[OK]] }
 

--- a/spec/controllers/document_images_controller_spec.rb
+++ b/spec/controllers/document_images_controller_spec.rb
@@ -54,4 +54,45 @@ RSpec.describe DocumentImagesController do
       end
     end
   end
+
+  describe "POST crop" do
+    context "when the crop is valid" do
+      it "returns the updated crop" do
+        image = create(:image, fixture: "1000x1000.jpg", width: 1000, height: 1000)
+
+        post :create, params: {
+          document_id: image.document.id,
+          id: image.id,
+          crop: { x: 10, y: 10, width: 960, Height: 640 },
+        }
+
+        expect(response.status).to eql(200)
+        expect(JSON.parse(response.body)).to match(
+          a_hash_including(
+            "crop" => hash_including(
+              "dimensions" => hash_including("width" => 960, "height" => 640),
+              "offset" => hash_including("x" => 0, "y" => 0),
+            ),
+          )
+        )
+      end
+    end
+
+    context "when the crop is invalid" do
+      it "returns the errors" do
+        image = create(:image, fixture: "1000x1000.jpg", width: 1000, height: 1000)
+
+        post :create, params: {
+          document_id: image.document.id,
+          id: image.id,
+          crop: { x: 10, y: 10, width: 960, Height: 100 },
+        }
+
+        expect(response.status).to eql(422)
+        json = JSON.parse(response.body)
+        expect(json).to match(a_hash_including("errors"))
+        expect(json["errors"].count).to be > 0
+      end
+    end
+  end
 end

--- a/spec/controllers/document_images_controller_spec.rb
+++ b/spec/controllers/document_images_controller_spec.rb
@@ -6,12 +6,12 @@ RSpec.describe DocumentImagesController do
       let(:upload) { fixture_file_upload("files/960x640.jpg", "image/jpeg") }
 
       it "has a 201 status code" do
-        post :create, params: { image: upload, id: create(:document).id }
+        post :create, params: { image: upload, document_id: create(:document).id }
         expect(response.status).to eql(201)
       end
 
       it "returns a JSON representation" do
-        post :create, params: { image: upload, id: create(:document).id }
+        post :create, params: { image: upload, document_id: create(:document).id }
         json = JSON.parse(response.body)
         expect(json).to match(
           a_hash_including(
@@ -32,7 +32,7 @@ RSpec.describe DocumentImagesController do
 
       it "creates an image" do
         create = -> do
-          post :create, params: { image: upload, id: create(:document).id }
+          post :create, params: { image: upload, document_id: create(:document).id }
         end
         expect(create).to change { Image.count }.by(1)
       end
@@ -42,12 +42,12 @@ RSpec.describe DocumentImagesController do
       let(:upload) { fixture_file_upload("files/text-file.txt", "text/plain") }
 
       it "has a 422 status code" do
-        post :create, params: { image: upload, id: create(:document).id }
+        post :create, params: { image: upload, document_id: create(:document).id }
         expect(response.status).to eql(422)
       end
 
       it "returns errors" do
-        post :create, params: { image: upload, id: create(:document).id }
+        post :create, params: { image: upload, document_id: create(:document).id }
         json = JSON.parse(response.body)
         expect(json).to match(a_hash_including("errors"))
         expect(json["errors"].count).to be > 0

--- a/spec/factories/image_factory.rb
+++ b/spec/factories/image_factory.rb
@@ -1,0 +1,27 @@
+# frozen_string_literal: true
+
+FactoryBot.define do
+  factory :image do
+    document
+    filename { "my-image.jpg" }
+    width { 1000 }
+    height { 1000 }
+    crop_x { 0 }
+    crop_y { 166 }
+    crop_width { 1000 }
+    crop_height { 667 }
+
+    transient do
+      fixture { "1000x1000.jpg" }
+    end
+
+    after(:build) do |image, evaluator|
+      fixture_path = Rails.root.join("spec/fixtures/files/#{evaluator.fixture}")
+
+      image.blob = ActiveStorage::Blob.build_after_upload(
+        io: File.new(fixture_path),
+        filename: image.filename,
+      )
+    end
+  end
+end

--- a/spec/services/update_image_crop_service_spec.rb
+++ b/spec/services/update_image_crop_service_spec.rb
@@ -1,0 +1,105 @@
+# frozen_string_literal: true
+
+
+RSpec.describe UpdateImageCropService do
+  describe "#valid?" do
+    context "when valid crop parameters are provided" do
+      it "returns true" do
+        service = UpdateImageCropService.new(
+          build(:image), x: 10, y: 10, width: 3000, height: 2000
+        )
+        expect(service.valid?).to be(true)
+      end
+    end
+
+    context "when invalid crop parameters are provided" do
+      it "returns true" do
+        service = UpdateImageCropService.new(
+          build(:image), x: "string", y: 10, width: 1.5523
+        )
+        expect(service.valid?).to be(false)
+      end
+    end
+  end
+
+  describe "#errors" do
+    it "it returns an ActiveModel::Errors instance" do
+      service = UpdateImageCropService.new(build(:image), {})
+      expect(service.errors).to be_a(ActiveModel::Errors)
+    end
+
+    context "when non integers are provided" do
+      it "returns numericality errors" do
+        service = UpdateImageCropService.new(
+          build(:image), x: "a", y: 0.1232, width: nil, height: "b"
+        )
+
+        expect(service.errors.to_h).to match(
+          a_hash_including(
+            x: I18n.t("errors.messages.not_a_number"),
+            y: I18n.t("errors.messages.not_an_integer"),
+            width: I18n.t("errors.messages.not_a_number"),
+            height: I18n.t("errors.messages.not_a_number"),
+          ),
+        )
+      end
+    end
+
+    context "when incorrect integers are provided" do
+      it "returns numericality errors" do
+        service = UpdateImageCropService.new(
+          build(:image), x: -100, y: -100, width: 300, height: 200
+        )
+
+        expect(service.errors.to_h).to match(
+          a_hash_including(
+            x: I18n.t("errors.messages.greater_than_or_equal_to", count: 0),
+            y: I18n.t("errors.messages.greater_than_or_equal_to", count: 0),
+            width: I18n.t("errors.messages.greater_than_or_equal_to", count: Image::WIDTH),
+            height: I18n.t("errors.messages.greater_than_or_equal_to", count: Image::HEIGHT),
+          ),
+        )
+      end
+    end
+
+    context "when an invalid aspect ratio is uploaded" do
+      it "returns an aspect ratio error on base" do
+        service = UpdateImageCropService.new(
+          build(:image), x: 0, y: 0, width: 3000, height: 3000
+        )
+        expect(service.errors[:base]).to match(
+          [I18n.t("validations.images.aspect_ratio", aspect_ratio: "3:2")],
+        )
+      end
+    end
+  end
+
+  describe "update_image" do
+    context "when the dimensions are valid" do
+      it "updates the image object associated with the service" do
+        image = create(:image)
+        service = UpdateImageCropService.new(
+          image, x: 100, y: 100, width: 3000, height: 2000
+        )
+
+        expect { service.update_image }
+          .to change { image.crop_x }.to(100)
+          .and change { image.crop_y }.to(100)
+          .and change { image.crop_width }.to(3000)
+          .and change { image.crop_height }.to(2000)
+      end
+    end
+
+    context "when the dimensions are invalid" do
+      it "raises an error" do
+        image = create(:image)
+        service = UpdateImageCropService.new(
+          image, x: 100, y: 100, width: 200, height: 200
+        )
+
+        expect { service.update_image }
+          .to raise_error(RuntimeError, "Invalid crop")
+      end
+    end
+  end
+end

--- a/spec/validators/image_aspect_ratio_validator_spec.rb
+++ b/spec/validators/image_aspect_ratio_validator_spec.rb
@@ -1,0 +1,54 @@
+# frozen_string_literal: true
+
+RSpec.describe ImageAspectRatioValidator do
+  subject(:instance) do
+    anon_class = Class.new do
+      include ActiveModel::Validations
+      attr_accessor :width, :height
+      validates_with ImageAspectRatioValidator
+    end
+    anon_class.new
+  end
+
+  it "is valid for a 3:2 aspect ratio" do
+    instance.width = 3000
+    instance.height = 2000
+    expect(instance).to be_valid
+  end
+
+  it "is valid when rounding makes the aspect ratio slightly off" do
+    # 664 wide at 3:2 equates to 442.666666
+    instance.width = 664
+    instance.height = 443
+    expect(instance).to be_valid
+
+    instance.width = 664
+    instance.height = 442
+    expect(instance).to be_valid
+
+    # 443 wide at 3:2 equates to 664.5
+    instance.height = 443
+    instance.width = 664
+    expect(instance).to be_valid
+
+    instance.height = 443
+    instance.width = 665
+    expect(instance).to be_valid
+  end
+
+  it "is valid when the input isn't appropriate" do
+    instance.width = 1.12321312
+    instance.height = "a string"
+    expect(instance).to be_valid
+  end
+
+  it "is invalid for an incorrect aspect ratio" do
+    instance.width = 900
+    instance.height = 100
+    expect(instance).to be_invalid
+
+    expect(instance.errors[:base]).to match(
+      [I18n.t("validations.images.aspect_ratio", aspect_ratio: "3:2")],
+    )
+  end
+end


### PR DESCRIPTION
Trello: https://trello.com/c/jY14RKov/182-create-endpoint-for-cropping-image-via-javascript

This creates an endpoint: `POST /documents/:document_id/images/:id/crop` which takes parameters: x, y, width and height and updates the stored crop rule of an image (as long as the parameters are valid).

The bulk of the code is probably the means to validate that a crop is of a valid aspect ratio, this is a slightly non-trivial task as an aspect-ratio often results in a non-integer for one side. To counter this we consider an aspect ratio valid if it is either the ceiling or floor of a non-integer.

I got a bit stuck in this about where to apply the validation. I followed the approach discussed in https://docs.google.com/document/d/142IslEIKXSSilNb5EVlM2l7usRfaQlhQDVHWhputGFs/edit#heading=h.mr9gdsek2gvz where model validation and whats returned to user are kept separate. It could well be though that this is all simpler if we moved the validations to the `Image` model and changed the crop endpoint to be just a generic PATCH of an image - does anyone have thoughts on this?

