### PR TITLE
Associate document with user who created it

### DIFF
--- a/app/controllers/new_document_controller.rb
+++ b/app/controllers/new_document_controller.rb
@@ -44,6 +44,7 @@ class NewDocumentController < ApplicationController
       document_type: params[:document_type],
       publication_state: "changes_not_sent_to_draft",
       associations: default_associations,
+      creator_id: current_user.id,
     )
 
     redirect_to edit_document_path(document)

--- a/app/models/document.rb
+++ b/app/models/document.rb
@@ -2,6 +2,7 @@
 
 class Document < ApplicationRecord
   has_many :images, dependent: :destroy
+  belongs_to :creator, class_name: "User", optional: true, foreign_key: :creator_id, inverse_of: :documents
 
   PUBLICATION_STATES = %w[
     changes_not_sent_to_draft

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -2,6 +2,6 @@
 
 class User < ApplicationRecord
   include GDS::SSO::User
-
+  has_many :documents, foreign_key: :creator_id, inverse_of: :creator, dependent: :restrict_with_exception
   serialize :permissions, Array
 end

--- a/app/views/documents/show/_actions.html.erb
+++ b/app/views/documents/show/_actions.html.erb
@@ -72,6 +72,10 @@ end
         field: t("documents.show.metadata.created_at"),
         value: @document.created_at.strftime("%l:%M%P on %d %B %Y")
       },
+      {
+        field: t("documents.show.metadata.created_by"),
+        value: @document.creator.name
+      },
     ]
   } %>
 </div>

--- a/app/views/documents/show/_actions.html.erb
+++ b/app/views/documents/show/_actions.html.erb
@@ -74,7 +74,7 @@ end
       },
       {
         field: t("documents.show.metadata.created_by"),
-        value: @document.creator.name
+        value: @document.creator&.name || I18n.t("documents.show.metadata.unknown_data")
       },
     ]
   } %>

--- a/config/locales/en/documents/show.yml
+++ b/config/locales/en/documents/show.yml
@@ -32,6 +32,7 @@ en:
         status: Status
         updated_at: Last updated
         created_at: Created
+        created_by: Document created by
       flashes:
         draft_success: Preview creation successful
         draft_error: Error creating preview

--- a/config/locales/en/documents/show.yml
+++ b/config/locales/en/documents/show.yml
@@ -33,6 +33,7 @@ en:
         updated_at: Last updated
         created_at: Created
         created_by: Document created by
+        unknown_data: Unknown
       flashes:
         draft_success: Preview creation successful
         draft_error: Error creating preview

--- a/db/migrate/20180831100426_add_creator_to_documents.rb
+++ b/db/migrate/20180831100426_add_creator_to_documents.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+class AddCreatorToDocuments < ActiveRecord::Migration[5.2]
+  def change
+    add_reference :documents, :creator, foreign_key: { to_table: :users }
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2018_08_23_143905) do
+ActiveRecord::Schema.define(version: 2018_08_31_100426) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -48,8 +48,10 @@ ActiveRecord::Schema.define(version: 2018_08_23_143905) do
     t.text "summary"
     t.json "associations", default: {}
     t.string "publication_state", null: false
+    t.bigint "creator_id"
     t.index ["base_path"], name: "index_documents_on_base_path", unique: true
     t.index ["content_id", "locale"], name: "index_documents_on_content_id_and_locale", unique: true
+    t.index ["creator_id"], name: "index_documents_on_creator_id"
   end
 
   create_table "images", force: :cascade do |t|
@@ -82,6 +84,7 @@ ActiveRecord::Schema.define(version: 2018_08_23_143905) do
     t.datetime "updated_at", null: false
   end
 
+  add_foreign_key "documents", "users", column: "creator_id"
   add_foreign_key "images", "active_storage_blobs", column: "blob_id", on_delete: :cascade
   add_foreign_key "images", "documents", on_delete: :cascade
 end

--- a/spec/factories/document_factory.rb
+++ b/spec/factories/document_factory.rb
@@ -8,5 +8,6 @@ FactoryBot.define do
     base_path { title ? "/prefix/#{title.parameterize}" : nil }
     document_type { build(:document_type_schema, path_prefix: "/prefix").id }
     publication_state { "changes_not_sent_to_draft" }
+    creator_id { User.last.id }
   end
 end

--- a/spec/features/show_a_document_spec.rb
+++ b/spec/features/show_a_document_spec.rb
@@ -18,7 +18,11 @@ RSpec.feature "Showing a document summary" do
   def then_i_see_the_document_summary
     expect(page).to have_content(@document.title)
     expect(page).to have_content(@document.summary)
-    expect(page).to have_content(@document.created_at.strftime("%l:%M%P on %d %B %Y"))
-    expect(page).to have_content(@document.updated_at.strftime("%l:%M%P on %d %B %Y"))
+
+    within("div.app-c-metadata") do
+      expect(page).to have_content(@document.created_at.strftime("%l:%M%P on %d %B %Y"))
+      expect(page).to have_content(@document.updated_at.strftime("%l:%M%P on %d %B %Y"))
+      expect(page).to have_content(@document.creator.name)
+    end
   end
 end

--- a/spec/features/show_a_document_with_no_creator_spec.rb
+++ b/spec/features/show_a_document_with_no_creator_spec.rb
@@ -1,0 +1,24 @@
+# frozen_string_literal: true
+
+RSpec.feature "Showing a document summary" do
+  scenario "User views a document that has no creator" do
+    given_there_is_a_document_with_no_creator
+    when_i_visit_the_document_page
+    the_document_creator_is_shown_as_unknown
+  end
+
+  def given_there_is_a_document_with_no_creator
+    @document = create(:document, creator_id: nil)
+  end
+
+  def when_i_visit_the_document_page
+    visit document_path(@document)
+  end
+
+  def the_document_creator_is_shown_as_unknown
+    within("div.app-c-metadata") do
+      expect(page).to have_content(I18n.t("documents.show.metadata.created_by") +
+        ": " + I18n.t("documents.show.metadata.unknown_data"))
+    end
+  end
+end


### PR DESCRIPTION
For https://trello.com/c/Th0t8cUb/165-associate-a-document-with-the-user-who-created-it

In this PR we associate a document with a creator so we're able to look up who created it.  This allows us to display information about the person who created the document; for now it will just be the creator's name on the document summary page, but in future could include their organisation for example.

<img width="370" alt="screen shot 2018-08-30 at 14 13 36" src="https://user-images.githubusercontent.com/13434452/44856763-227c1900-ac66-11e8-9b16-aa5b4e13e387.png">

We also handle instances where a document has no creator by displaying it as "Unknown".