### PR TITLE
Update image endpoint for cropping

### DIFF
--- a/app/models/image.rb
+++ b/app/models/image.rb
@@ -1,11 +1,26 @@
 # frozen_string_literal: true
 
 class Image < ApplicationRecord
+  WIDTH = 960
+  HEIGHT = 640
+
   belongs_to :document
   belongs_to :blob, class_name: "ActiveStorage::Blob"
 
-  WIDTH = 960
-  HEIGHT = 640
+  validates :width,
+            numericality: { only_integer: true, greater_than_or_equal_to: WIDTH }
+  validates :height,
+            numericality: { only_integer: true, greater_than_or_equal_to: HEIGHT }
+  validates :crop_x,
+            numericality: { only_integer: true, greater_than_or_equal_to: 0 }
+  validates :crop_y,
+            numericality: { only_integer: true, greater_than_or_equal_to: 0 }
+  validates :crop_width,
+            numericality: { only_integer: true, greater_than_or_equal_to: WIDTH }
+  validates :crop_height,
+            numericality: { only_integer: true, greater_than_or_equal_to: HEIGHT }
+
+  validates_with ImageAspectRatioValidator
 
   def crop_variant
     crop = "#{crop_width}x#{crop_height}+#{crop_x}+#{crop_y}"

--- a/app/validators/image_aspect_ratio_validator.rb
+++ b/app/validators/image_aspect_ratio_validator.rb
@@ -1,0 +1,53 @@
+# frozen_string_literal: true
+
+class ImageAspectRatioValidator < ActiveModel::Validator
+  def validate(record)
+    return unless sane_input(record.crop_width, record.crop_height)
+
+    unless valid_aspect_ratio?(record.crop_width.to_i, record.crop_height.to_i)
+      record.errors[:base] << error_message
+    end
+  end
+
+private
+
+  def sane_input(width, height)
+    width.to_i.to_s == width.to_s && height.to_i.to_s == height.to_s
+  end
+
+  def valid_aspect_ratio?(width, height)
+    valid_width, valid_height = valid_dimensions
+    aspect_ratio = valid_width.to_f / valid_height
+
+    allowed_dimensions(width, height, aspect_ratio).include?([width, height])
+  end
+
+  def allowed_dimensions(actual_width, actual_height, aspect_ratio)
+    allowed_height = actual_width / aspect_ratio
+    allowed_width = actual_height * aspect_ratio
+
+    # We're being forgiving here to accept both whole numbers if aspect ratio
+    # creates a fraction
+    [
+      [actual_width, allowed_height.ceil],
+      [actual_width, allowed_height.floor],
+      [allowed_width.ceil, actual_height],
+      [allowed_width.floor, actual_height],
+    ].uniq
+  end
+
+  def error_message
+    # This is used to get simplest ratio for dimensions.
+    # E.g. Rational(1920, 1080) => (16/9)
+    ratio = Rational(*valid_dimensions)
+
+    I18n.t(
+      "validations.images.aspect_ratio",
+      aspect_ratio: "#{ratio.numerator}:#{ratio.denominator}",
+    )
+  end
+
+  def valid_dimensions
+    [Image::WIDTH, Image::HEIGHT]
+  end
+end

--- a/config/locales/en/validations.yml
+++ b/config/locales/en/validations.yml
@@ -7,3 +7,4 @@ en:
       invalid_format: "Expected a jpg, png or gif image"
       max_size: "Image uploads must be less than %{max_size} in filesize"
       min_dimensions: "Images must have dimensions of at least %{width} x %{height} pixels"
+      aspect_ratio:  "dimensions are not in the expected %{aspect_ratio} aspect ratio"

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -23,6 +23,7 @@ Rails.application.routes.draw do
   get "/documents/:id/preview" => "preview#show", as: :preview_document
 
   post "/documents/:document_id/images" => "document_images#create", as: :create_document_image
+  patch "/documents/:document_id/images/:id" => "document_images#update", as: :update_document_image
 
   get "/healthcheck", to: proc { [200, {}, %w[OK]] }
 

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -22,7 +22,7 @@ Rails.application.routes.draw do
 
   get "/documents/:id/preview" => "preview#show", as: :preview_document
 
-  post "/documents/:id/images" => "document_images#create", as: :create_document_image
+  post "/documents/:document_id/images" => "document_images#create", as: :create_document_image
 
   get "/healthcheck", to: proc { [200, {}, %w[OK]] }
 

--- a/spec/controllers/document_images_controller_spec.rb
+++ b/spec/controllers/document_images_controller_spec.rb
@@ -54,4 +54,45 @@ RSpec.describe DocumentImagesController do
       end
     end
   end
+
+  describe "POST crop" do
+    context "when the crop is valid" do
+      it "returns the updated crop" do
+        image = create(:image, fixture: "1000x1000.jpg", width: 1000, height: 1000)
+
+        post :create, params: {
+          document_id: image.document.id,
+          id: image.id,
+          crop: { x: 10, y: 10, width: 960, Height: 640 },
+        }
+
+        expect(response.status).to eql(200)
+        expect(JSON.parse(response.body)).to match(
+          a_hash_including(
+            "crop" => hash_including(
+              "dimensions" => hash_including("width" => 960, "height" => 640),
+              "offset" => hash_including("x" => 0, "y" => 0),
+            ),
+          )
+        )
+      end
+    end
+
+    context "when the crop is invalid" do
+      it "returns the errors" do
+        image = create(:image, fixture: "1000x1000.jpg", width: 1000, height: 1000)
+
+        post :create, params: {
+          document_id: image.document.id,
+          id: image.id,
+          crop: { x: 10, y: 10, width: 960, Height: 100 },
+        }
+
+        expect(response.status).to eql(422)
+        json = JSON.parse(response.body)
+        expect(json).to match(a_hash_including("errors"))
+        expect(json["errors"].count).to be > 0
+      end
+    end
+  end
 end

--- a/spec/controllers/document_images_controller_spec.rb
+++ b/spec/controllers/document_images_controller_spec.rb
@@ -6,12 +6,12 @@ RSpec.describe DocumentImagesController do
       let(:upload) { fixture_file_upload("files/960x640.jpg", "image/jpeg") }
 
       it "has a 201 status code" do
-        post :create, params: { image: upload, id: create(:document).to_param }
+        post :create, params: { image: upload, document_id: create(:document).to_param }
         expect(response.status).to eql(201)
       end
 
       it "returns a JSON representation" do
-        post :create, params: { image: upload, id: create(:document).to_param }
+        post :create, params: { image: upload, document_id: create(:document).to_param }
         json = JSON.parse(response.body)
         expect(json).to match(
           a_hash_including(
@@ -32,7 +32,7 @@ RSpec.describe DocumentImagesController do
 
       it "creates an image" do
         create = -> do
-          post :create, params: { image: upload, id: create(:document).to_param }
+          post :create, params: { image: upload, document_id: create(:document).to_param }
         end
         expect(create).to change { Image.count }.by(1)
       end
@@ -42,12 +42,12 @@ RSpec.describe DocumentImagesController do
       let(:upload) { fixture_file_upload("files/text-file.txt", "text/plain") }
 
       it "has a 422 status code" do
-        post :create, params: { image: upload, id: create(:document).to_param }
+        post :create, params: { image: upload, document_id: create(:document).to_param }
         expect(response.status).to eql(422)
       end
 
       it "returns errors" do
-        post :create, params: { image: upload, id: create(:document).to_param }
+        post :create, params: { image: upload, document_id: create(:document).to_param }
         json = JSON.parse(response.body)
         expect(json).to match(a_hash_including("errors"))
         expect(json["errors"].count).to be > 0
@@ -55,15 +55,15 @@ RSpec.describe DocumentImagesController do
     end
   end
 
-  describe "POST crop" do
-    context "when the crop is valid" do
-      it "returns the updated crop" do
+  describe "PATCH update" do
+    context "when the image is valid" do
+      it "returns the image" do
         image = create(:image, fixture: "1000x1000.jpg", width: 1000, height: 1000)
 
-        post :create, params: {
-          document_id: image.document.id,
+        patch :update, params: {
+          document_id: image.document.to_param,
           id: image.id,
-          crop: { x: 10, y: 10, width: 960, Height: 640 },
+          image: { crop_x: 10, crop_y: 10, crop_width: 960, crop_height: 640 },
         }
 
         expect(response.status).to eql(200)
@@ -71,27 +71,45 @@ RSpec.describe DocumentImagesController do
           a_hash_including(
             "crop" => hash_including(
               "dimensions" => hash_including("width" => 960, "height" => 640),
-              "offset" => hash_including("x" => 0, "y" => 0),
+              "offset" => hash_including("x" => 10, "y" => 10),
             ),
-          )
+          ),
         )
+      end
+
+      it "updates the image" do
+        image = create(:image, fixture: "1000x1000.jpg", width: 1000, height: 1000)
+
+        update = -> do
+          patch :update, params: {
+            document_id: image.document.to_param,
+            id: image.id,
+            image: { crop_x: 10, crop_y: 10, crop_width: 960, crop_height: 640 },
+          }
+        end
+
+        expect(update).to change { image.reload.crop_x }.to(10)
       end
     end
 
-    context "when the crop is invalid" do
+    context "when the input is invalid" do
       it "returns the errors" do
         image = create(:image, fixture: "1000x1000.jpg", width: 1000, height: 1000)
 
-        post :create, params: {
-          document_id: image.document.id,
+        patch :update, params: {
+          document_id: image.document.to_param,
           id: image.id,
-          crop: { x: 10, y: 10, width: 960, Height: 100 },
+          image: { crop_x: 10, crop_y: -10, crop_width: 960, crop_height: 640 },
         }
 
         expect(response.status).to eql(422)
+
         json = JSON.parse(response.body)
-        expect(json).to match(a_hash_including("errors"))
-        expect(json["errors"].count).to be > 0
+        expect(json).to match(
+          a_hash_including(
+            "errors" => hash_including("crop_y"),
+          ),
+        )
       end
     end
   end

--- a/spec/factories/image_factory.rb
+++ b/spec/factories/image_factory.rb
@@ -1,0 +1,27 @@
+# frozen_string_literal: true
+
+FactoryBot.define do
+  factory :image do
+    document
+    filename { "my-image.jpg" }
+    width { 1000 }
+    height { 1000 }
+    crop_x { 0 }
+    crop_y { 166 }
+    crop_width { 1000 }
+    crop_height { 667 }
+
+    transient do
+      fixture { "1000x1000.jpg" }
+    end
+
+    after(:build) do |image, evaluator|
+      fixture_path = Rails.root.join("spec/fixtures/files/#{evaluator.fixture}")
+
+      image.blob = ActiveStorage::Blob.build_after_upload(
+        io: File.new(fixture_path),
+        filename: image.filename,
+      )
+    end
+  end
+end

--- a/spec/models/image_spec.rb
+++ b/spec/models/image_spec.rb
@@ -1,0 +1,49 @@
+# frozen_string_literal: true
+
+RSpec.describe Image do
+  describe "validations" do
+    it "is valid for the default factory" do
+      expect(build(:image)).to be_valid
+    end
+
+    it "requires width to be an integer greater than or equal to 960" do
+      expect(build(:image, width: "a")).to be_invalid
+      expect(build(:image, width: -1)).to be_invalid
+      expect(build(:image, width: 1000)).to be_valid
+    end
+
+    it "requires height to be an integer greater than or equal to 640" do
+      expect(build(:image, height: "a")).to be_invalid
+      expect(build(:image, height: -1)).to be_invalid
+      expect(build(:image, height: 700)).to be_valid
+    end
+
+    it "requires crop_x to be an integer greater than or equal to 0" do
+      expect(build(:image, crop_x: "a")).to be_invalid
+      expect(build(:image, crop_x: -1)).to be_invalid
+      expect(build(:image, crop_x: 10)).to be_valid
+    end
+
+    it "requires crop_y to be an integer greater than or equal to 0" do
+      expect(build(:image, crop_y: "a")).to be_invalid
+      expect(build(:image, crop_y: -1)).to be_invalid
+      expect(build(:image, crop_y: 10)).to be_valid
+    end
+
+    it "requires crop_width to be an integer" do
+      expect(build(:image, crop_width: "a")).to be_invalid
+      expect(build(:image, crop_width: -1)).to be_invalid
+    end
+
+    it "requires crop_height to be an integer" do
+      expect(build(:image, crop_height: "a")).to be_invalid
+      expect(build(:image, crop_height: -1)).to be_invalid
+    end
+
+    it "requires crop_width and crop_width to be atleast 960x640px and 3:2 aspect ratio" do
+      expect(build(:image, crop_width: 3000, crop_height: 1000)).to be_invalid
+      expect(build(:image, crop_width: 3000, crop_height: 2000)).to be_valid
+      expect(build(:image, crop_width: 300, crop_height: 200)).to be_invalid
+    end
+  end
+end

--- a/spec/validators/image_aspect_ratio_validator_spec.rb
+++ b/spec/validators/image_aspect_ratio_validator_spec.rb
@@ -1,0 +1,50 @@
+# frozen_string_literal: true
+
+RSpec.describe ImageAspectRatioValidator do
+  subject(:instance) do
+    anon_class = Class.new do
+      include ActiveModel::Validations
+      attr_accessor :crop_width, :crop_height
+      validates_with ImageAspectRatioValidator
+    end
+    anon_class.new
+  end
+
+  it "is valid for a 3:2 aspect ratio" do
+    instance.crop_width = 3000
+    instance.crop_height = 2000
+    expect(instance).to be_valid
+  end
+
+  it "is valid when rounding makes the aspect ratio slightly off" do
+    # 664 wide at 3:2 equates to 442.666666
+    # 443 height at 3:2 equates to 664.5
+    instance.crop_width = 664
+    instance.crop_height = 443
+    expect(instance).to be_valid
+
+    instance.crop_width = 664
+    instance.crop_height = 442
+    expect(instance).to be_valid
+
+    instance.crop_height = 443
+    instance.crop_width = 665
+    expect(instance).to be_valid
+  end
+
+  it "is valid when the input isn't appropriate" do
+    instance.crop_width = 1.12321312
+    instance.crop_height = "a string"
+    expect(instance).to be_valid
+  end
+
+  it "is invalid for an incorrect aspect ratio" do
+    instance.crop_width = 900
+    instance.crop_height = 100
+    expect(instance).to be_invalid
+
+    expect(instance.errors[:base]).to match(
+      [I18n.t("validations.images.aspect_ratio", aspect_ratio: "3:2")],
+    )
+  end
+end


### PR DESCRIPTION
Trello: https://trello.com/c/jY14RKov/182-create-endpoint-for-cropping-image-via-javascript

This is a refactor of https://github.com/alphagov/content-publisher/pull/188 based on feedback. 

This switches the validations to be done on model layer and then, since we're doing that, sets up an update image endpoint rather than a crop endpoint.

Because we're updating the image directly we then need to accept the parameters in the form of the db structure (or we have to do some mapping and swapping). 

Having put this together I'm feeling that this is potentially the worse of the routes, it may be way more consistent with how Rails does things in a RESTful context but since we don't really seem to be operating in this manner for the rest of the app it feels like an exception. It also fears like it forces us to have a generic REST update endpoint rather than anything specialist and that we should update presentation to match db so format so that's consistent with input

Not sure if there's any sort of half way approach that might be nicer? 