### PR TITLE
Show raw markdown on the summary page

### DIFF
--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -8,6 +8,7 @@ $govuk-global-styles: true;
 
 @import "components/contextual-guidance";
 @import "components/error-alert";
+@import "components/formatted-text";
 @import "components/markdown-editor";
 @import "components/markdown-toolbar";
 @import "components/metadata";

--- a/app/assets/stylesheets/components/_formatted-text.scss
+++ b/app/assets/stylesheets/components/_formatted-text.scss
@@ -1,0 +1,6 @@
+.app-c-formatted-text {
+  @include govuk-font(19);
+
+  margin: 0;
+  white-space: pre-wrap;
+}

--- a/app/views/components/_formatted_text.html.erb
+++ b/app/views/components/_formatted_text.html.erb
@@ -1,0 +1,3 @@
+<pre class="app-c-formatted-text">
+<%= text.lines[0..lines].join.strip %> <% if text.lines.count > lines %>…<% end %>
+</pre>

--- a/app/views/components/docs/markdown_raw.yml
+++ b/app/views/components/docs/markdown_raw.yml
@@ -1,0 +1,9 @@
+name: Markdown raw
+description: Shows truncated markdown in raw form
+examples:
+  default:
+    text: |
+      \# Some
+
+      Markdown
+    lines: 3

--- a/app/views/documents/fields/_govspeak.html.erb
+++ b/app/views/documents/fields/_govspeak.html.erb
@@ -1,3 +1,4 @@
-<%= render "govuk_publishing_components/components/govspeak", {} do %>
-  <%= raw Govspeak::Document.new(@document.contents[schema.id]).to_html %>
-<% end %>
+<%= render "components/formatted_text", {
+  text: @document.contents[schema.id].to_s,
+  lines: 3
+} %>


### PR DESCRIPTION
https://trello.com/c/tOx0eK0R/176-show-raw-markdown-and-truncate-output-on-summary-page

We think users will find it confusing to see styled markdown content
next to static page content (e.g. titles), so this commit changes the
preview to show the raw markdown using a new 'markdown_raw' component.

The component truncates the raw markdown by lines, for which 3 lines
seems to give a reasonable preview (two paragraphs, or title and a
paragraph).