### PR TITLE
Add separate preview page

### DIFF
--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -12,6 +12,7 @@ $govuk-global-styles: true;
 @import "components/markdown-toolbar";
 @import "components/metadata";
 @import "components/summary";
+@import "components/page_preview";
 
 @import "utilities/display";
 @import "utilities/overwrites";

--- a/app/assets/stylesheets/components/_page_preview.scss
+++ b/app/assets/stylesheets/components/_page_preview.scss
@@ -1,0 +1,5 @@
+.app-c-preview__desktop-preview {
+  width: 100%;
+  height: 1000px;
+  border: 0;
+}

--- a/app/controllers/preview_controller.rb
+++ b/app/controllers/preview_controller.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+class PreviewController < ApplicationController
+  def show
+    @document = Document.find(params[:id])
+  end
+end

--- a/app/views/components/_page_preview.html.erb
+++ b/app/views/components/_page_preview.html.erb
@@ -1,0 +1,31 @@
+<%= render "govuk_publishing_components/components/details", title: "Share" do %>
+  <p>Copy and send this link to someone and they’ll be able to preview your draft on GOV.UK.</p>
+
+  <%= link_to url, url %>
+<% end %>
+
+<div class="app-c-preview">
+  <% desktop_and_tablet = capture do %>
+    <%= tag.iframe class: "app-c-preview__desktop-preview", src: url, title: "Preview of the page on desktop or tablet" %>
+  <% end %>
+
+  <%= render "govuk_publishing_components/components/tabs", {
+    tabs: [
+      {
+        id: "desktop",
+        label: "Desktop and tablet",
+        content: desktop_and_tablet,
+      },
+      {
+        id: "mobile",
+        label: "Mobile",
+        content: "Mobile preview coming soon",
+      },
+      {
+        id: "search-engine",
+        label: "Search engine snippet",
+        content: "Search engine preview coming soon",
+      },
+    ]
+  } %>
+</div>

--- a/app/views/components/docs/page_preview.yml
+++ b/app/views/components/docs/page_preview.yml
@@ -1,0 +1,8 @@
+name: Page preview
+description: Preview a page on mobile, desktop and Google
+examples:
+  default:
+    data:
+      url: "https://draft-origin.publishing.service.gov.uk/bank-holidays"
+accessibility_criteria: |
+  * Iframes must have a title

--- a/app/views/preview/show.html.erb
+++ b/app/views/preview/show.html.erb
@@ -1,0 +1,4 @@
+<%= content_for :back_link, document_path(@document) %>
+<%= content_for :title, "Preview #{@document.title.inspect}" %>
+
+<%= render "components/page_preview", url: DocumentUrl.new(@document).secret_preview_url %>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -20,6 +20,8 @@ Rails.application.routes.draw do
   get "/documents/:id/associations" => "document_associations#edit", as: :document_associations
   post "/documents/:id/associations" => "document_associations#update"
 
+  get "/documents/:id/preview" => "preview#show", as: :preview_document
+
   post "/documents/:id/images" => "document_images#create", as: :create_document_image
 
   get "/healthcheck", to: proc { [200, {}, %w[OK]] }

--- a/spec/components/page_preview_spec.rb
+++ b/spec/components/page_preview_spec.rb
@@ -1,0 +1,17 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+
+RSpec.describe "Page preview", type: :view do
+  it "renders an iframe for desktop" do
+    render_component(
+      url: "http://example.com/iframe-foo",
+    )
+
+    assert_select "iframe", src: "http://example.com/iframe-foo"
+  end
+
+  def render_component(locals)
+    render "components/page_preview", locals
+  end
+end

--- a/spec/features/preview_document_spec.rb
+++ b/spec/features/preview_document_spec.rb
@@ -1,0 +1,26 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+
+RSpec.feature "Preview a document" do
+  scenario "User previews a document" do
+    given_there_is_a_document_in_draft
+    when_i_visit_the_preview_page
+    then_i_see_the_previews
+  end
+
+  def given_there_is_a_document_in_draft
+    @document = create(:document, base_path: "/foo/foo", content_id: "d2547c42-8ed3-49f5-baeb-6112f98c2bf9")
+  end
+
+  def when_i_visit_the_preview_page
+    visit preview_document_path(@document)
+  end
+
+  def then_i_see_the_previews
+    # Core functionality of the preview should be tested in the component view test
+    expect(page).to have_content "Mobile"
+    expect(page).to have_content "Desktop and tablet"
+    expect(page).to have_content "Search engine snippet"
+  end
+end


### PR DESCRIPTION
This adds the first bit of the [preview page](https://trello.com/c/KO7s5XJG/152-design-the-preview-page-s). 

It only implements the desktop view (see other todo's on the Trello ticket).

https://trello.com/c/i2Fi5qNQ