### PR TITLE
Add search engine snippet preview

### DIFF
--- a/app/assets/stylesheets/components/_page_preview.scss
+++ b/app/assets/stylesheets/components/_page_preview.scss
@@ -1,3 +1,7 @@
+$google-link-colour: #1a0dab;
+$google-url-colour: #006621;
+$google-description-colour: #545454;
+
 .app-c-preview__mobile {
   background-image: image-url("components/preview-mobile.svg");
   background-repeat: no-repeat;
@@ -19,4 +23,32 @@
   width: 100%;
   height: 1000px;
   border: 0;
+}
+
+.app-c-preview__google {
+  width: 600px;
+  -webkit-font-smoothing: auto;
+}
+
+.app-c-preview__google-title {
+  font-family: arial,sans-serif;
+  color: $google-link-colour;
+  text-decoration: none;
+  font-size: 18px;
+}
+
+.app-c-preview__google-url {
+  font-family: arial,sans-serif;
+  color: $google-url-colour;
+  font-size: 14px;
+  font-weight: 400;
+  line-height: 16px;
+}
+
+.app-c-preview__google-description {
+  font-family: arial,sans-serif;
+  line-height: 1.4;
+  font-size: 13px;
+  word-wrap: break-word;
+  color: $google-description-colour;
 }

--- a/app/views/components/_page_preview.html.erb
+++ b/app/views/components/_page_preview.html.erb
@@ -15,6 +15,14 @@
     <%= tag.iframe class: "app-c-preview__desktop-preview", src: url, title: "Preview of the page on desktop or tablet" %>
   <% end %>
 
+  <% snippet_preview = capture do %>
+    <%= tag.div class: "app-c-preview__google" do %>
+      <%= link_to "#{title} - GOV.UK", base_path, class: "app-c-preview__google-title" %>
+      <%= tag.div "https://www.gov.uk#{base_path}", class: "app-c-preview__google-url" %>
+      <%= tag.div truncate(description, length: 280), class: "app-c-preview__google-description" %>
+    <% end %>
+  <% end %>
+
   <%= render "govuk_publishing_components/components/tabs", {
     tabs: [
       {
@@ -30,7 +38,7 @@
       {
         id: "search-engine",
         label: "Search engine snippet",
-        content: "Search engine preview coming soon",
+        content: snippet_preview,
       },
     ]
   } %>

--- a/app/views/components/docs/page_preview.yml
+++ b/app/views/components/docs/page_preview.yml
@@ -1,8 +1,12 @@
 name: Page preview
 description: Preview a page on mobile, desktop and Google
+part_of_admin_layout: true
 examples:
   default:
     data:
-      url: "https://draft-origin.publishing.service.gov.uk/bank-holidays"
+      title: "A carrot cake has been baked"
+      base_path: "/news/cake-baked"
+      description: A carrot cake was baked for the publishing workflow team's fika, the government announced today.
+      url: "https://www.gov.uk/browse"
 accessibility_criteria: |
   * Iframes must have a title

--- a/app/views/preview/show.html.erb
+++ b/app/views/preview/show.html.erb
@@ -1,4 +1,9 @@
 <%= content_for :back_link, document_path(@document) %>
 <%= content_for :title, "Preview #{@document.title.inspect}" %>
 
-<%= render "components/page_preview", url: DocumentUrl.new(@document).secret_preview_url %>
+<%= render "components/page_preview",
+  title: @document.title,
+  base_path: @document.base_path,
+  description: @document.summary,
+  url: DocumentUrl.new(@document).secret_preview_url
+%>

--- a/spec/components/page_preview_spec.rb
+++ b/spec/components/page_preview_spec.rb
@@ -6,9 +6,25 @@ RSpec.describe "Page preview", type: :view do
   it "renders an iframe for desktop" do
     render_component(
       url: "http://example.com/iframe-foo",
+      title: "Foo",
+      base_path: "/bar",
+      description: "Baz",
     )
 
     assert_select "iframe", src: "http://example.com/iframe-foo"
+  end
+
+  it "renders a search snippet" do
+    render_component(
+      url: "http://example.com/iframe-foo",
+      title: "Foo",
+      base_path: "/bar",
+      description: "Baz",
+    )
+
+    assert_select "a.app-c-preview__google-title", text: "Foo - GOV.UK"
+    assert_select "div.app-c-preview__google-url", text: "https://www.gov.uk/bar"
+    assert_select "div.app-c-preview__google-description", text: "Baz"
   end
 
   def render_component(locals)


### PR DESCRIPTION
This adds a search engine snippet preview to the preview page.

<img width="1004" alt="screen shot 2018-09-03 at 10 12 21" src="https://user-images.githubusercontent.com/233676/44978246-25c31d80-af62-11e8-8ec0-cc2d7aef0eea.png">

https://trello.com/c/i2Fi5qNQ