### PR TITLE
Import document from custom translation base path

### DIFF
--- a/spec/tasks/whitehall_news_importer_spec.rb
+++ b/spec/tasks/whitehall_news_importer_spec.rb
@@ -7,13 +7,18 @@ RSpec.describe Tasks::WhitehallNewsImporter do
     import_json = [
       {
         content_id: SecureRandom.uuid,
-        slug: "test-page",
         editions: [
           {
             created_at: Time.zone.now,
             news_article_type: { key: "news_story" },
             translations: [
-              { locale: "en", title: "Title", summary: "Summary", body: "Body" },
+              {
+                locale: "en",
+                title: "Title",
+                summary: "Summary",
+                body: "Body",
+                base_path: "/government/news/title",
+              },
             ],
           },
         ],


### PR DESCRIPTION
https://trello.com/c/ORACsrIh/172-create-a-jenkins-job-to-update-integration-content-publisher-with-whitehall-content

The Whitehall export of news articles now includes the locale-specific
base_path as part of each translation. Previously we were using the
document-level slug, which caused conflicts for documents with multiple
locales.