### PR TITLE
Link to the separate preview page

### DIFF
--- a/app/views/documents/show/_actions.html.erb
+++ b/app/views/documents/show/_actions.html.erb
@@ -2,7 +2,7 @@
 publish_button = { text: t("documents.show.actions.publish"), href: publish_document_path(@document) }
 view_live_button = { text: t("documents.show.actions.view_live"), href: DocumentUrl.new(@document).public_url }
 share_draft_button = { text: t("documents.show.actions.share_draft"), href: DocumentUrl.new(@document).secret_preview_url }
-preview_button = { text: t("documents.show.actions.view_draft"), href: DocumentUrl.new(@document).preview_url }
+preview_button = { text: t("documents.show.actions.view_draft"), href: preview_document_path(@document) }
 create_draft_button = { text: t("documents.show.actions.create_draft"), href: edit_document_path(@document) }
 submit_2i_button = { text: t("documents.show.actions.submit_2i"), href: "#" }
 delete_draft_button = { text: t("documents.show.actions.delete_draft"), href: "#" }

--- a/app/views/documents/show/_actions.html.erb
+++ b/app/views/documents/show/_actions.html.erb
@@ -1,7 +1,6 @@
 <%
 publish_button = { text: t("documents.show.actions.publish"), href: publish_document_path(@document) }
 view_live_button = { text: t("documents.show.actions.view_live"), href: DocumentUrl.new(@document).public_url }
-share_draft_button = { text: t("documents.show.actions.share_draft"), href: DocumentUrl.new(@document).secret_preview_url }
 preview_button = { text: t("documents.show.actions.view_draft"), href: preview_document_path(@document) }
 create_draft_button = { text: t("documents.show.actions.create_draft"), href: edit_document_path(@document) }
 submit_2i_button = { text: t("documents.show.actions.submit_2i"), href: "#" }

--- a/spec/features/preview_document_spec.rb
+++ b/spec/features/preview_document_spec.rb
@@ -15,7 +15,7 @@ RSpec.feature "Preview a document" do
 
   def when_i_visit_the_preview_page
     visit document_path(@document)
-    click_on I18n.t("documents.show.actions.view_draft")
+    click_on "Preview"
   end
 
   def then_i_see_the_previews

--- a/spec/features/preview_document_spec.rb
+++ b/spec/features/preview_document_spec.rb
@@ -10,11 +10,12 @@ RSpec.feature "Preview a document" do
   end
 
   def given_there_is_a_document_in_draft
-    @document = create(:document, base_path: "/foo/foo", content_id: "d2547c42-8ed3-49f5-baeb-6112f98c2bf9")
+    @document = create(:document, publication_state: "sent_to_draft", base_path: "/foo/foo", content_id: "d2547c42-8ed3-49f5-baeb-6112f98c2bf9")
   end
 
   def when_i_visit_the_preview_page
-    visit preview_document_path(@document)
+    visit document_path(@document)
+    click_on I18n.t("documents.show.actions.view_draft")
   end
 
   def then_i_see_the_previews


### PR DESCRIPTION
This changes the action link to go to the new separate preview page, so the user can see the preview on mobile, desktop and Google.

https://trello.com/c/i2Fi5qNQ