### PR TITLE
Update Whitehall import script

### DIFF
--- a/lib/tasks/whitehall_news_importer.rb
+++ b/lib/tasks/whitehall_news_importer.rb
@@ -43,6 +43,7 @@ module Tasks
       associations["organisations"] = organisations(edition)
       associations["worldwide_organisations"] = edition["worldwide_organisations"]
       associations["topical_events"] = edition["topical_events"]
+      associations["world_locations"] = edition["world_locations"]
       associations
     end
 

--- a/lib/tasks/whitehall_news_importer.rb
+++ b/lib/tasks/whitehall_news_importer.rb
@@ -41,6 +41,7 @@ module Tasks
       associations = {}
       associations["primary_publishing_organisation"] = primary_publishing_organisation(edition)
       associations["organisations"] = organisations(edition)
+      associations["worldwide_organisations"] = edition["worldwide_organisations"]
       associations
     end
 

--- a/lib/tasks/whitehall_news_importer.rb
+++ b/lib/tasks/whitehall_news_importer.rb
@@ -42,6 +42,7 @@ module Tasks
       associations["primary_publishing_organisation"] = primary_publishing_organisation(edition)
       associations["organisations"] = organisations(edition)
       associations["worldwide_organisations"] = edition["worldwide_organisations"]
+      associations["topical_events"] = edition["topical_events"]
       associations
     end
 

--- a/lib/tasks/whitehall_news_importer.rb
+++ b/lib/tasks/whitehall_news_importer.rb
@@ -39,15 +39,23 @@ module Tasks
 
     def associations(edition)
       associations = {}
-      associations["primary_publishing_organisation"] = [edition["lead_organisations"].shift]
+      associations["primary_publishing_organisation"] = primary_publishing_organisation(edition)
       associations["organisations"] = organisations(edition)
       associations
     end
 
+    def primary_publishing_organisation(edition)
+      [lead_organisations(edition).shift]
+    end
+
     def organisations(edition)
       organisations = edition["supporting_organisations"]
-      organisations += edition["lead_organisations"] if edition["lead_organisations"].any?
+      organisations += lead_organisations(edition) if lead_organisations(edition).any?
       organisations
+    end
+
+    def lead_organisations(edition)
+      @lead_organisations ||= edition["lead_organisations"]
     end
   end
 end

--- a/lib/tasks/whitehall_news_importer.rb
+++ b/lib/tasks/whitehall_news_importer.rb
@@ -40,7 +40,14 @@ module Tasks
     def associations(edition)
       associations = {}
       associations["primary_publishing_organisation"] = [edition["lead_organisations"].shift]
+      associations["organisations"] = organisations(edition)
       associations
+    end
+
+    def organisations(edition)
+      organisations = edition["supporting_organisations"]
+      organisations += edition["lead_organisations"] if edition["lead_organisations"].any?
+      organisations
     end
   end
 end

--- a/lib/tasks/whitehall_news_importer.rb
+++ b/lib/tasks/whitehall_news_importer.rb
@@ -30,6 +30,7 @@ module Tasks
         document_type: edition["news_article_type"]["key"],
         title: translation["title"],
         publication_state: "changes_not_sent_to_draft",
+        summary: translation["summary"],
       )
 
       doc.save!

--- a/lib/tasks/whitehall_news_importer.rb
+++ b/lib/tasks/whitehall_news_importer.rb
@@ -31,9 +31,16 @@ module Tasks
         title: translation["title"],
         publication_state: "changes_not_sent_to_draft",
         summary: translation["summary"],
+        associations: associations(edition),
       )
 
       doc.save!
+    end
+
+    def associations(edition)
+      associations = {}
+      associations["primary_publishing_organisation"] = [edition["lead_organisations"].shift]
+      associations
     end
   end
 end

--- a/spec/tasks/whitehall_news_importer_spec.rb
+++ b/spec/tasks/whitehall_news_importer_spec.rb
@@ -23,6 +23,7 @@ RSpec.describe Tasks::WhitehallNewsImporter do
           supporting_organisations: [SecureRandom.uuid, SecureRandom.uuid],
           worldwide_organisations: [SecureRandom.uuid, SecureRandom.uuid],
           topical_events: [SecureRandom.uuid, SecureRandom.uuid],
+          world_locations: [SecureRandom.uuid, SecureRandom.uuid],
         },
       ],
     }.to_json
@@ -51,5 +52,7 @@ RSpec.describe Tasks::WhitehallNewsImporter do
       .to eq(imported_edition["worldwide_organisations"])
     expect(document_associations["topical_events"])
       .to eq(imported_edition["topical_events"])
+    expect(document_associations["world_locations"])
+      .to eq(imported_edition["world_locations"])
   end
 end

--- a/spec/tasks/whitehall_news_importer_spec.rb
+++ b/spec/tasks/whitehall_news_importer_spec.rb
@@ -27,5 +27,8 @@ RSpec.describe Tasks::WhitehallNewsImporter do
 
     expect { importer.import(JSON.parse(import_json)) }
       .to change { Document.count }.by(1)
+    expect(Document.last.summary).to eq(
+      JSON.parse(import_json)["editions"][0]["translations"][0]["summary"]
+    )
   end
 end

--- a/spec/tasks/whitehall_news_importer_spec.rb
+++ b/spec/tasks/whitehall_news_importer_spec.rb
@@ -19,16 +19,19 @@ RSpec.describe Tasks::WhitehallNewsImporter do
               base_path: "/government/news/title",
             },
           ],
+          lead_organisations: [SecureRandom.uuid, SecureRandom.uuid],
         },
       ],
     }.to_json
 
     importer = Tasks::WhitehallNewsImporter.new
+    parsed_json = JSON.parse(import_json)
 
-    expect { importer.import(JSON.parse(import_json)) }
-      .to change { Document.count }.by(1)
+    expect { importer.import(parsed_json) }.to change { Document.count }.by(1)
     expect(Document.last.summary).to eq(
-      JSON.parse(import_json)["editions"][0]["translations"][0]["summary"]
+      parsed_json["editions"][0]["translations"][0]["summary"]
     )
+    expect(Document.last.associations["primary_publishing_organisation"][0])
+      .to eq(parsed_json["editions"][0]["lead_organisations"][0])
   end
 end

--- a/spec/tasks/whitehall_news_importer_spec.rb
+++ b/spec/tasks/whitehall_news_importer_spec.rb
@@ -22,6 +22,7 @@ RSpec.describe Tasks::WhitehallNewsImporter do
           lead_organisations: [SecureRandom.uuid, SecureRandom.uuid],
           supporting_organisations: [SecureRandom.uuid, SecureRandom.uuid],
           worldwide_organisations: [SecureRandom.uuid, SecureRandom.uuid],
+          topical_events: [SecureRandom.uuid, SecureRandom.uuid],
         },
       ],
     }.to_json
@@ -48,5 +49,7 @@ RSpec.describe Tasks::WhitehallNewsImporter do
     )
     expect(document_associations["worldwide_organisations"])
       .to eq(imported_edition["worldwide_organisations"])
+    expect(document_associations["topical_events"])
+      .to eq(imported_edition["topical_events"])
   end
 end

--- a/spec/tasks/whitehall_news_importer_spec.rb
+++ b/spec/tasks/whitehall_news_importer_spec.rb
@@ -21,6 +21,7 @@ RSpec.describe Tasks::WhitehallNewsImporter do
           ],
           lead_organisations: [SecureRandom.uuid, SecureRandom.uuid],
           supporting_organisations: [SecureRandom.uuid, SecureRandom.uuid],
+          worldwide_organisations: [SecureRandom.uuid, SecureRandom.uuid],
         },
       ],
     }.to_json
@@ -45,5 +46,7 @@ RSpec.describe Tasks::WhitehallNewsImporter do
     expect(document_associations["organisations"]).not_to include(
       imported_edition["lead_organisations"][0],
     )
+    expect(document_associations["worldwide_organisations"])
+      .to eq(imported_edition["worldwide_organisations"])
   end
 end


### PR DESCRIPTION
For https://trello.com/c/LVpjWa42/173-update-whitehall-import-script-to-support-organisations

This updates the Whitehall import script to handle a document summary and its various associations.