### PR TITLE
Allow streaming documents from Whitehall export

### DIFF
--- a/lib/tasks/import.rake
+++ b/lib/tasks/import.rake
@@ -3,9 +3,18 @@
 require "tasks/whitehall_news_importer"
 
 namespace :import do
-  task :whitehall_news, [:path] => :environment do |_t, args|
-    to_import = JSON.parse(File.read(args[:path]))
-    done = Tasks::WhitehallNewsImporter.new(to_import).import
-    puts "Imported #{done} Whitehall news documents"
+  desc "Import news documents from JSON e.g. import:whitehall_news INPUT=export_file"
+  task whitehall_news: :environment do
+    importer = Tasks::WhitehallNewsImporter.new
+    imported = 0
+
+    input = ENV["INPUT"] ? File.open(ENV["INPUT"]) : STDIN
+
+    input.each_line do |line|
+      importer.import(JSON.parse(line))
+      imported += 1
+    end
+
+    puts "Imported #{imported} Whitehall news documents"
   end
 end

--- a/lib/tasks/whitehall_news_importer.rb
+++ b/lib/tasks/whitehall_news_importer.rb
@@ -2,20 +2,12 @@
 
 module Tasks
   class WhitehallNewsImporter
-    def initialize(to_import)
-      @to_import = to_import
-    end
+    def import(document)
+      edition = most_recent_edition(document)
 
-    def import
-      to_import.each do |document|
-        edition = most_recent_edition(document)
-
-        edition["translations"].each do |translation|
-          create_or_update_document(translation, edition, document)
-        end
+      edition["translations"].each do |translation|
+        create_or_update_document(translation, edition, document)
       end
-
-      to_import.count
     end
 
   private

--- a/spec/tasks/whitehall_news_importer_spec.rb
+++ b/spec/tasks/whitehall_news_importer_spec.rb
@@ -4,28 +4,28 @@ require "tasks/whitehall_news_importer"
 
 RSpec.describe Tasks::WhitehallNewsImporter do
   it "can import JSON data from Whitehall" do
-    import_json = [
-      {
-        content_id: SecureRandom.uuid,
-        editions: [
-          {
-            created_at: Time.zone.now,
-            news_article_type: { key: "news_story" },
-            translations: [
-              {
-                locale: "en",
-                title: "Title",
-                summary: "Summary",
-                body: "Body",
-                base_path: "/government/news/title",
-              },
-            ],
-          },
-        ],
-      },
-    ].to_json
+    import_json = {
+      content_id: SecureRandom.uuid,
+      editions: [
+        {
+          created_at: Time.zone.now,
+          news_article_type: { key: "news_story" },
+          translations: [
+            {
+              locale: "en",
+              title: "Title",
+              summary: "Summary",
+              body: "Body",
+              base_path: "/government/news/title",
+            },
+          ],
+        },
+      ],
+    }.to_json
 
-    expect { Tasks::WhitehallNewsImporter.new(JSON.parse(import_json)).import }
+    importer = Tasks::WhitehallNewsImporter.new
+
+    expect { importer.import(JSON.parse(import_json)) }
       .to change { Document.count }.by(1)
   end
 end


### PR DESCRIPTION
https://trello.com/c/ORACsrIh/172-create-a-jenkins-job-to-update-integration-content-publisher-with-whitehall-content

This will allow us to stream documents into the app without having to
copy the export file onto the machine.