### PR TITLE
Remove stray translations for clickable items

### DIFF
--- a/app/views/documents/show/_actions.html.erb
+++ b/app/views/documents/show/_actions.html.erb
@@ -1,12 +1,12 @@
 <%
-publish_button = { text: t("documents.show.actions.publish"), href: publish_document_path(@document) }
-view_live_button = { text: t("documents.show.actions.view_live"), href: DocumentUrl.new(@document).public_url }
-preview_button = { text: t("documents.show.actions.view_draft"), href: preview_document_path(@document) }
-create_draft_button = { text: t("documents.show.actions.create_draft"), href: edit_document_path(@document) }
-submit_2i_button = { text: t("documents.show.actions.submit_2i"), href: "#" }
-delete_draft_button = { text: t("documents.show.actions.delete_draft"), href: "#" }
-withdraw_button = { text: t("documents.show.actions.withdraw"), href: "#" }
-unpublish_button = { text: t("documents.show.actions.unpublish"), href: "#" }
+publish_button = { text: "Publish", href: publish_document_path(@document) }
+view_live_button = { text: "View on GOV.UK", href: DocumentUrl.new(@document).public_url }
+preview_button = { text: "Preview", href: preview_document_path(@document) }
+create_draft_button = { text: "Create draft", href: edit_document_path(@document) }
+submit_2i_button = { text: "Submit for 2i review", href: "#" }
+delete_draft_button = { text: "Delete draft", href: "#" }
+withdraw_button = { text: "Withdraw", href: "#" }
+unpublish_button = { text: "Unpublish", href: "#" }
 
 case @document.publication_state
 when "sent_to_draft" || "sending_to_live" || "error_sending_to_live" # Draft

--- a/config/locales/en/documents/show.yml
+++ b/config/locales/en/documents/show.yml
@@ -16,18 +16,6 @@ en:
           title: Title
           base_path: Base path
           summary: Summary
-      actions:
-        publish: Publish
-        edit_associations: Edit associations
-        edit: Edit document
-        view_live: View on GOV.UK
-        view_draft: Preview
-        share_draft: Shareable preview
-        create_draft: Create draft
-        submit_2i: Submit for 2i review
-        delete_draft: Delete draft
-        withdraw: Withdraw
-        unpublish: Unpublish
       metadata:
         status: Status
         updated_at: Last updated


### PR DESCRIPTION
We established a convention that clickable items should not have
translations, as we felt it made the tests too difficult to read. These
ones appear to have been missed when we applied this convention.