### PR TITLE
Avoid hard-coding label from supertype schema

### DIFF
--- a/spec/features/create_a_document_api_down_spec.rb
+++ b/spec/features/create_a_document_api_down_spec.rb
@@ -13,7 +13,7 @@ RSpec.feature "Create a document when the API is down" do
     @schema = DocumentTypeSchema.find("news_story")
     visit "/"
     click_on "New document"
-    choose "News"
+    choose SupertypeSchema.find("news").label
     click_on "Continue"
     choose @schema.label
     click_on "Continue"


### PR DESCRIPTION
https://trello.com/c/ORACsrIh/172-create-a-jenkins-job-to-update-integration-content-publisher-with-whitehall-content

This keeps us consistent with using the label in the rest of the specs,
which allows this text to be edited without the tests failing.