### PR TITLE
Fix encoding issue with govspeak preview body

### DIFF
--- a/app/controllers/govspeak_preview_controller.rb
+++ b/app/controllers/govspeak_preview_controller.rb
@@ -4,6 +4,6 @@ class GovspeakPreviewController < ApplicationController
   skip_before_action :verify_authenticity_token
 
   def to_html
-    render plain: GovspeakService.new.to_html(request.raw_post)
+    render plain: GovspeakService.new.to_html(params[:govspeak])
   end
 end

--- a/app/javascript/components/markdown-editor.js
+++ b/app/javascript/components/markdown-editor.js
@@ -60,8 +60,11 @@ MarkdownEditor.prototype.fetchGovspeakPreview = function (text) {
   var path = this.$module.getAttribute('data-govspeak-path')
   var url = new URL(document.location.origin + path)
 
+  var formData = new window.FormData()
+  formData.append('govspeak', text)
+
   var controller = new window.AbortController()
-  var options = { credentials: 'include', signal: controller.signal, method: 'POST', body: text }
+  var options = { credentials: 'include', signal: controller.signal, method: 'POST', body: formData }
   setTimeout(() => controller.abort(), 5000)
 
   return window.fetch(url, options).then((response) => response.text())

--- a/spec/features/previews_govspeak_when_editing_spec.rb
+++ b/spec/features/previews_govspeak_when_editing_spec.rb
@@ -21,7 +21,7 @@ RSpec.feature "Shows a preview of Govspeak", js: true do
   end
 
   def and_i_enter_some_govspeak
-    fill_in "document[contents][body]", with: "$C contact $C"
+    fill_in "document[contents][body]", with: "$C “contact” $C"
   end
 
   def and_i_view_the_govspeak_preview


### PR DESCRIPTION
https://trello.com/c/ORACsrIh/172-create-a-jenkins-job-to-update-integration-content-publisher-with-whitehall-content

It looks like Rack is interpreting the body text as ASCII-8BIT rather
than UTF-8, so we need to force this encoding.