### PR TITLE
Remove unncessary code from Whitehall News Importer

### DIFF
--- a/lib/tasks/whitehall_news_importer.rb
+++ b/lib/tasks/whitehall_news_importer.rb
@@ -12,8 +12,6 @@ module Tasks
 
   private
 
-    attr_reader :to_import
-
     def most_recent_edition(document)
       document["editions"].max_by { |e| e["created_at"] }
     end
@@ -58,7 +56,7 @@ module Tasks
     end
 
     def lead_organisations(edition)
-      @lead_organisations ||= edition["lead_organisations"]
+      edition["lead_organisations"]
     end
   end
 end


### PR DESCRIPTION
The `lead_organisations` instance variable is only instantiated once when
importing many documents, which meant that it didn't return the correct lead
organisations for each document. We remove this and return the current
edition's lead organisations instead.

We also remove the `to_import` attr_reader as this instance variable is not
used by anything anymore.