### PR TITLE
Make API down rescue mechanism generic

### DIFF
--- a/app/controllers/document_tags_controller.rb
+++ b/app/controllers/document_tags_controller.rb
@@ -3,7 +3,7 @@
 class DocumentTagsController < ApplicationController
   rescue_from GdsApi::BaseError do |e|
     Rails.logger.error(e)
-    render "edit_api_down", status: :service_unavailable
+    render "#{action_name}_api_down", status: :service_unavailable
   end
 
   def edit

--- a/app/controllers/documents_controller.rb
+++ b/app/controllers/documents_controller.rb
@@ -3,7 +3,7 @@
 class DocumentsController < ApplicationController
   rescue_from GdsApi::BaseError do |e|
     Rails.logger.error(e)
-    render "show_api_down", status: :service_unavailable
+    render "#{action_name}_api_down", status: :service_unavailable
   end
 
   def index


### PR DESCRIPTION
This allows us to have multiple views containing GdsApi code and still
handle the API down case gracefully via a dedicated view.