### PR TITLE
Implement flash messages after 2i submit

### DIFF
--- a/app/controllers/review_controller.rb
+++ b/app/controllers/review_controller.rb
@@ -4,7 +4,8 @@ class ReviewController < ApplicationController
   def submit_for_2i
     document = Document.find_by_param(params[:id])
     document.update!(review_state: "submitted_for_review")
-    redirect_to document, notice: "Content has been submitted for 2i review"
+    flash[:submitted_for_review] = true
+    redirect_to document
   end
 
   def approve

--- a/app/controllers/review_controller.rb
+++ b/app/controllers/review_controller.rb
@@ -10,6 +10,6 @@ class ReviewController < ApplicationController
   def approve
     document = Document.find_by_param(params[:id])
     document.update!(review_state: "reviewed")
-    redirect_to document, notice: "Content has been reviewed and approved"
+    redirect_to document, notice: t("documents.show.flashes.approved")
   end
 end

--- a/app/views/documents/show/_submitted_for_review.html.erb
+++ b/app/views/documents/show/_submitted_for_review.html.erb
@@ -1,0 +1,10 @@
+<% copy_to_clipboard = render(
+  "govuk_publishing_components/components/copy_to_clipboard",
+    label: t("documents.show.flashes.submitted_for_review.label"),
+    copyable_content: DocumentUrl.new(@document).public_url,
+    button_text: "Copy link"
+) %>
+
+<%= render "govuk_publishing_components/components/success_alert",
+  message: t("documents.show.flashes.submitted_for_review.title"),
+  description: copy_to_clipboard %>

--- a/app/views/documents/show/_summary_tab.html.erb
+++ b/app/views/documents/show/_summary_tab.html.erb
@@ -1,5 +1,8 @@
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
+    <% if flash[:submitted_for_review] %>
+      <%= render "documents/show/submitted_for_review" %>
+    <% end %>
 
     <%= render "documents/show/contents" %>
 

--- a/config/locales/en/documents/show.yml
+++ b/config/locales/en/documents/show.yml
@@ -27,3 +27,6 @@ en:
         draft_error: Error creating preview
         publish_error: Error publishing
         approved: Content has been reviewed and approved
+        submitted_for_review:
+          title: Content has been submitted for 2i review
+          label: Send this document to another publisher for them to review. When content is ready you or they can publish it.

--- a/config/locales/en/documents/show.yml
+++ b/config/locales/en/documents/show.yml
@@ -26,3 +26,4 @@ en:
         draft_success: Preview creation successful
         draft_error: Error creating preview
         publish_error: Error publishing
+        approved: Content has been reviewed and approved

--- a/spec/features/force_publishing_spec.rb
+++ b/spec/features/force_publishing_spec.rb
@@ -47,6 +47,6 @@ RSpec.feature "Force publishing" do
   end
 
   def then_i_see_that_its_reviewed
-    expect(page).to have_content "Content has been reviewed and approved"
+    expect(page).to have_content I18n.t("documents.show.flashes.approved")
   end
 end


### PR DESCRIPTION
This is the flash message that occurs when the user has submitted the
content for review.

![screen shot 2018-09-05 at 17 56 18](https://user-images.githubusercontent.com/233676/45108677-2fe94580-b135-11e8-8f87-cae3845a829c.png)

https://trello.com/c/9szY348f