### PR TITLE
Add state class as selector to avoid flaky test

### DIFF
--- a/app/assets/javascripts/components/markdown-editor.js
+++ b/app/assets/javascripts/components/markdown-editor.js
@@ -41,6 +41,7 @@ MarkdownEditor.prototype.handlePreviewButton = function (event) {
 
   // Clear previous preview
   this.$preview.innerHTML = ''
+  this.$preview.classList.remove('app-c-markdown-editor__govspeak--rendered')
 
   if (!this.$input.value) {
     this.$preview.innerHTML = 'Nothing to preview'
@@ -56,6 +57,9 @@ MarkdownEditor.prototype.handlePreviewButton = function (event) {
     })
     .catch(function () {
       $preview.innerHTML = 'Error previewing content'
+    })
+    .finally(function () {
+      $preview.classList.add('app-c-markdown-editor__govspeak--rendered')
     })
 
   this.setTargetBlank(this.$preview)

--- a/spec/features/previews_govspeak_when_editing_spec.rb
+++ b/spec/features/previews_govspeak_when_editing_spec.rb
@@ -29,6 +29,7 @@ RSpec.feature "Shows a preview of Govspeak", js: true do
   end
 
   def then_i_see_the_rendered_govspeak
-    expect(find(".govuk-govspeak")["innerHTML"]).to include('<div class="contact">')
+    expect(find(".app-c-markdown-editor__govspeak--rendered")["innerHTML"])
+      .to include('<div class="contact">')
   end
 end


### PR DESCRIPTION
I got caught by this test failing a number of times for me locally which
seems to be related to a timing issue. The hypothesis is that if the
fetch request doesn't return rendered govspeak before capybara looks up
the rendered govspeak then the test will fail.

This can be confirmed by adding a sleep(1) to the render govspeak
controller.

This resolves this issue by adding a class when govspeak is rendered -
this means the capybara finder will keep trying until the class exists.