### PR TITLE
Fix URLs on integration

### DIFF
--- a/app/services/document_type_schema.rb
+++ b/app/services/document_type_schema.rb
@@ -36,7 +36,7 @@ class DocumentTypeSchema
   end
 
   def managed_elsewhere_url
-    Plek.find(managed_elsewhere.fetch("hostname")) + managed_elsewhere.fetch("path")
+    Plek.new.external_url_for(managed_elsewhere.fetch("hostname")) + managed_elsewhere.fetch("path")
   end
 
   def guidance_for(id)

--- a/app/services/supertype_schema.rb
+++ b/app/services/supertype_schema.rb
@@ -26,7 +26,7 @@ class SupertypeSchema
 
   def managed_elsewhere_url
     if managed_elsewhere["hostname"]
-      Plek.find(managed_elsewhere.fetch("hostname")) + managed_elsewhere.fetch("path")
+      Plek.new.external_url_for(managed_elsewhere.fetch("hostname")) + managed_elsewhere.fetch("path")
     else
       managed_elsewhere["path"]
     end


### PR DESCRIPTION
The redirect URLs aren't working on integration because we're using the internal hostname
(`whitehall-admin.integration.govuk-internal.digital`) instead of the external (`whitehall-admin.publishing.service.gov.uk`).

https://trello.com/c/5GSUif0g