### PR TITLE
Fix issue with a slight reposition of conditional content

### DIFF
--- a/app/views/new_document/choose_document_type.html.erb
+++ b/app/views/new_document/choose_document_type.html.erb
@@ -11,7 +11,7 @@
             value: document_type.id,
             text: document_type.label,
             hint_text: document_type.description,
-            conditional: tag.div(govspeak_to_html(document_type.hint), class: "govuk-body"),
+            conditional: document_type.hint ? tag.div(govspeak_to_html(document_type.hint), class: "govuk-body") : nil,
             bold: true,
           }
         }

--- a/app/views/new_document/choose_supertype.html.erb
+++ b/app/views/new_document/choose_supertype.html.erb
@@ -12,7 +12,7 @@
             text: supertype.label,
             hint_text: supertype.description,
             bold: true,
-            conditional: tag.p(supertype.hint, class: "govuk-body"),
+            conditional: supertype.hint ? tag.p(supertype.hint, class: "govuk-body") : nil,
           }
         end
       } %>


### PR DESCRIPTION
This fixes a slight reposition of the radio items when there is no conditionally revealed content. It was caused by the empty paragraph generated by the govspeak converter.

https://trello.com/c/5GSUif0g