### PR TITLE
Consistently handle transitional states

### DIFF
--- a/app/services/user_facing_state.rb
+++ b/app/services/user_facing_state.rb
@@ -11,11 +11,11 @@ class UserFacingState
   def to_s
     if review_state == "submitted_for_review"
       "submitted_for_review"
-    elsif publication_state.in?(%w[changes_not_sent_to_draft sent_to_draft sending_to_draft error_sending_to_draft sending_to_live])
+    elsif publication_state.in?(%w[changes_not_sent_to_draft sent_to_draft sending_to_draft error_sending_to_draft])
       "draft"
     elsif review_state == "published_without_review"
       "published_but_needs_2i"
-    elsif publication_state.in?(%w[sent_to_live error_sending_to_live])
+    elsif publication_state.in?(%w[sent_to_live sending_to_live error_sending_to_live])
       "published"
     else
       raise "Encountered an unknown user facing state. review_state: #{review_state}, publication_state: #{publication_state}"

--- a/spec/services/user_facing_state_spec.rb
+++ b/spec/services/user_facing_state_spec.rb
@@ -44,14 +44,6 @@ RSpec.describe UserFacingState do
       expect(state).to eql("draft")
     end
 
-    it "is draft if it has unpublished changes when sending to live" do
-      document = build(:document, publication_state: "sending_to_live")
-
-      state = UserFacingState.new(document).to_s
-
-      expect(state).to eql("draft")
-    end
-
     it "is published_but_needs_2i if it has unreviewed changes sent to live" do
       document = build(:document, publication_state: "sent_to_live", review_state: "published_without_review")
 
@@ -62,6 +54,14 @@ RSpec.describe UserFacingState do
 
     it "is published if it has reviewed changes sent to live" do
       document = build(:document, publication_state: "sent_to_live", review_state: "reviewed")
+
+      state = UserFacingState.new(document).to_s
+
+      expect(state).to eql("published")
+    end
+
+    it "is published if it has reviewed changes sending to live" do
+      document = build(:document, publication_state: "sending_to_live", review_state: "reviewed")
 
       state = UserFacingState.new(document).to_s
 


### PR DESCRIPTION
This makes sure that we handle the transitional states `sending_to_draft` and `sending_to_live` consistently. As discussed in https://trello.com/c/VkVrVGeB, users don't need to see these states. We'll consider something `sending_to_draft` to be the same as `sent_to_draft`, and `sending_to_live` the same as `sent_to_live`.

https://trello.com/c/VkVrVGeB