### PR TITLE
Update mobile preview

### DIFF
--- a/app/assets/stylesheets/components/_page_preview.scss
+++ b/app/assets/stylesheets/components/_page_preview.scss
@@ -1,25 +1,29 @@
 $google-link-colour: #1a0dab;
 $google-url-colour: #006621;
 $google-description-colour: #545454;
+$mobile-frame-width: 320px;
+$mobile-frame-height: 585px;
+$mobile-border-width: 17px;
+$mobile-border-bottom-width: 68px;
 
 .app-c-preview__mobile {
+  display: block;
+  width: $mobile-frame-width + 2 * $mobile-border-width;
+  height: $mobile-frame-height + $mobile-border-width + $mobile-border-bottom-width;
   background-image: image-url("components/preview-mobile.svg");
   background-repeat: no-repeat;
-  height: 674px;
-
-  // 356px width causes the screen portion of the SGV to match the
-  // iPhone's 320px logical screen width
-  width: 356px;
 }
 
 .app-c-preview__mobile-iframe {
-  margin: 18px;
+  width: $mobile-frame-width;
+  height: $mobile-frame-height;
+  margin: $mobile-border-width;
+  margin-bottom: $mobile-border-bottom-width;
   border: 0;
-  width: 320px;
-  height: 587px;
 }
 
 .app-c-preview__desktop-preview {
+  display: block;
   width: 100%;
   height: 1000px;
   border: 0;
@@ -31,24 +35,24 @@ $google-description-colour: #545454;
 }
 
 .app-c-preview__google-title {
-  font-family: arial,sans-serif;
   color: $google-link-colour;
-  text-decoration: none;
+  font-family: arial, sans-serif;
   font-size: 18px;
+  text-decoration: none;
 }
 
 .app-c-preview__google-url {
-  font-family: arial,sans-serif;
   color: $google-url-colour;
+  font-family: arial, sans-serif;
   font-size: 14px;
   font-weight: 400;
   line-height: 16px;
 }
 
 .app-c-preview__google-description {
-  font-family: arial,sans-serif;
-  line-height: 1.4;
-  font-size: 13px;
-  word-wrap: break-word;
   color: $google-description-colour;
+  font-family: arial, sans-serif;
+  font-size: 13px;
+  line-height: 1.4;
+  word-wrap: break-word;
 }

--- a/app/assets/stylesheets/components/_page_preview.scss
+++ b/app/assets/stylesheets/components/_page_preview.scss
@@ -30,7 +30,7 @@ $mobile-border-bottom-width: 68px;
 }
 
 .app-c-preview__google {
-  width: 600px;
+  max-width: 600px;
   -webkit-font-smoothing: auto;
 }
 

--- a/app/views/components/_page_preview.html.erb
+++ b/app/views/components/_page_preview.html.erb
@@ -1,11 +1,13 @@
-<%= render "govuk_publishing_components/components/details", title: "Share" do %>
-  <%= render "govuk_publishing_components/components/copy_to_clipboard",
-    label: "Copy and send this link to someone and they’ll be able to preview your draft on GOV.UK.",
-    copyable_content: url,
-    button_text: "Copy link" %>
-
-  <%= link_to url, url %>
-<% end %>
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-two-thirds">
+    <%= render "govuk_publishing_components/components/details", title: "Share" do %>
+      <%= render "govuk_publishing_components/components/copy_to_clipboard",
+        label: "Copy and send this link to someone and they’ll be able to preview your draft on GOV.UK.",
+        copyable_content: url,
+        button_text: "Copy link" %>
+    <% end %>
+  </div>
+</div>
 
 <div class="app-c-preview">
   <% mobile_preview = capture do %>


### PR DESCRIPTION
This PR updates the page preview component to:
- restrict the share component width to two thirds
- refactors the SCSS and calculate the mobile frame width and height
- make the search engine snippet preview responsive (setting `max-width`)

[Trello card](https://trello.com/c/i2Fi5qNQ)

### Preview
<img width="394" alt="screen shot 2018-09-07 at 10 53 19" src="https://user-images.githubusercontent.com/788096/45212242-4f46b680-b28c-11e8-87df-b29f74839f92.png">
