### PR TITLE
Implement change note and update type feature

### DIFF
--- a/app/controllers/documents_controller.rb
+++ b/app/controllers/documents_controller.rb
@@ -43,7 +43,7 @@ private
     contents_params = document.document_type_schema.contents.map(&:id)
     base_path = PathGeneratorService.new.path(document, params[:document][:title])
 
-    params.require(:document).permit(:title, :summary, contents: contents_params)
+    params.require(:document).permit(:title, :summary, :update_type, :change_note, contents: contents_params)
       .merge(base_path: base_path, publication_state: "changes_not_sent_to_draft", review_state: "unreviewed")
   end
 end

--- a/app/controllers/new_document_controller.rb
+++ b/app/controllers/new_document_controller.rb
@@ -46,6 +46,8 @@ class NewDocumentController < ApplicationController
       review_state: "unreviewed",
       tags: default_tags,
       creator_id: current_user.id,
+      update_type: "major",
+      change_note: "First published.",
     )
 
     redirect_to edit_document_path(document)

--- a/app/models/document.rb
+++ b/app/models/document.rb
@@ -23,6 +23,7 @@ class Document < ApplicationRecord
 
   validates_inclusion_of :publication_state, in: PUBLICATION_STATES
   validates_inclusion_of :review_state, in: REVIEW_STATES
+  validates_inclusion_of :update_type, in: %w[major minor], allow_nil: true
 
   def document_type_schema
     DocumentTypeSchema.find(document_type)

--- a/app/services/document_publishing_service.rb
+++ b/app/services/document_publishing_service.rb
@@ -11,8 +11,8 @@ class DocumentPublishingService
 
   def publish(document, review_state)
     document.update!(publication_state: "sending_to_live", review_state: review_state)
-    publishing_api.publish(document.content_id, "major", locale: document.locale)
-    document.update!(publication_state: "sent_to_live")
+    publishing_api.publish(document.content_id, nil, locale: document.locale)
+    document.update!(publication_state: "sent_to_live", change_note: nil, update_type: "major", has_live_version_on_govuk: true)
   end
 
 private

--- a/app/services/publishing_api_payload.rb
+++ b/app/services/publishing_api_payload.rb
@@ -21,6 +21,8 @@ class PublishingApiPayload
       "document_type" => document.document_type,
       "publishing_app" => PUBLISHING_APP,
       "rendering_app" => publishing_metadata.rendering_app,
+      "update_type" => document.update_type,
+      "change_note" => document.change_note,
       "details" => details,
       "routes" => [
         { "path" => document.base_path, "type" => "exact" },

--- a/app/views/documents/edit.html.erb
+++ b/app/views/documents/edit.html.erb
@@ -76,6 +76,10 @@
     <%= render "documents/fields/#{schema.type}_input", schema: schema, document: @document %>
   <% end %>
 
+  <% if @document.has_live_version_on_govuk %>
+    <%= render "documents/edit/change_notes" %>
+  <% end %>
+
   <%= render "govuk_publishing_components/components/button", {
     text: "Save", margin_bottom: true
   } %>

--- a/app/views/documents/edit/_change_notes.html.erb
+++ b/app/views/documents/edit/_change_notes.html.erb
@@ -1,0 +1,41 @@
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-two-thirds">
+    <%= render "govuk_publishing_components/components/textarea", {
+      label: {
+        text: t("documents.edit.change_note.title"),
+        bold: true,
+      },
+      hint: t("documents.edit.change_note.hint"),
+      name: "document[change_note]",
+      value: @document.change_note,
+      rows: 4
+    } %>
+
+    <%= render "govuk_publishing_components/components/govspeak" do %>
+      <%= govspeak_to_html t("documents.edit.change_note.guidance") %>
+    <% end %>
+
+    <% legend_text = tag.p(t("documents.edit.update_type.title"), class: "govuk-!-margin-bottom-3") %>
+
+    <%= render "govuk_publishing_components/components/fieldset", legend_text: legend_text do %>
+      <%= render "govuk_publishing_components/components/radio", {
+        name: "document[update_type]",
+        id: "update-type",
+        items: [
+          {
+            value: "minor",
+            text: t("documents.edit.update_type.minor_name"),
+            conditional: tag.p(t("documents.edit.update_type.minor_hint"), class: "govuk-body"),
+            checked: @document.update_type == "minor",
+          },
+          {
+            value: "major",
+            text: t("documents.edit.update_type.major_name"),
+            conditional: tag.p(t("documents.edit.update_type.major_hint"), class: "govuk-body"),
+            checked: @document.update_type == "major",
+          }
+        ]
+      } %>
+    <% end %>
+  </div>
+</div>

--- a/app/views/documents/show/_contents.html.erb
+++ b/app/views/documents/show/_contents.html.erb
@@ -11,6 +11,22 @@
   }
 } %>
 
+
+<% update_types = if @document.update_type
+  [
+    {
+      field: t("documents.show.contents.items.update_type"),
+      value: t("documents.edit.update_type.#{@document.update_type}_name"),
+    },
+    {
+      field: t("documents.show.contents.items.change_note"),
+      value: @document.change_note,
+    }
+  ]
+else
+  []
+end %>
+
 <%= render "components/summary", {
   title: {
     text: t("documents.show.contents.title"),
@@ -29,5 +45,5 @@
       field: t("documents.show.contents.items.summary"),
       value: @document.summary
     }
-  ] + contents
+  ] + contents + update_types
 } %>

--- a/config/locales/en/documents/edit.yml
+++ b/config/locales/en/documents/edit.yml
@@ -13,3 +13,13 @@ en:
         available: Page address
         no_title: You haven't entered a title yet.
         error: Unable to preview address, please edit title and try again.
+      change_note:
+        title: Change note
+        hint: Describe the change. Include any new or updated information where possible, or summarise and refer to specific sections if it cannot be included.
+        guidance: "[Full guidance on change notes](https://www.gov.uk/guidance/content-design/writing-for-gov-uk#change-notes)"
+      update_type:
+        title: "Is the change significant to users?"
+        minor_name: There’s no change to the published information. For example, spelling corrections.
+        minor_hint: "The ‘last updated’ date will not change, the change note will not be public, and subscribers will not be emailed."
+        major_name: There’s a change to the published information.
+        major_hint: "The ‘last updated’ date will change, the change note will be published on the page and emailed to subscribers."

--- a/config/locales/en/documents/show.yml
+++ b/config/locales/en/documents/show.yml
@@ -16,6 +16,8 @@ en:
           title: Title
           base_path: Base path
           summary: Summary
+          update_type: Update type
+          change_note: Change note
       metadata:
         status: Status
         updated_at: Last updated

--- a/db/migrate/20180906154457_add_has_live_version_on_govuk_to_documents.rb
+++ b/db/migrate/20180906154457_add_has_live_version_on_govuk_to_documents.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+class AddHasLiveVersionOnGovukToDocuments < ActiveRecord::Migration[5.2]
+  def change
+    add_column :documents, :has_live_version_on_govuk, :boolean, default: false, null: false
+  end
+end

--- a/db/migrate/20180906155513_add_change_notes_to_documents.rb
+++ b/db/migrate/20180906155513_add_change_notes_to_documents.rb
@@ -1,0 +1,10 @@
+# frozen_string_literal: true
+
+class AddChangeNotesToDocuments < ActiveRecord::Migration[5.2]
+  def change
+    change_table :documents, bulk: true do |t|
+      t.column :change_note, :text
+      t.column :update_type, :string
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2018_09_05_134625) do
+ActiveRecord::Schema.define(version: 2018_09_07_121447) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -50,6 +50,9 @@ ActiveRecord::Schema.define(version: 2018_09_05_134625) do
     t.string "publication_state", null: false
     t.bigint "creator_id"
     t.string "review_state", null: false
+    t.text "change_note"
+    t.string "update_type"
+    t.boolean "has_live_version_on_govuk", default: false, null: false
     t.index ["base_path"], name: "index_documents_on_base_path", unique: true
     t.index ["content_id", "locale"], name: "index_documents_on_content_id_and_locale", unique: true
     t.index ["creator_id"], name: "index_documents_on_creator_id"

--- a/spec/features/change_notes_spec.rb
+++ b/spec/features/change_notes_spec.rb
@@ -1,0 +1,69 @@
+# frozen_string_literal: true
+
+RSpec.feature "Change notes" do
+  scenario "User updates change notes and update type" do
+    given_there_is_a_previously_published_document
+    when_i_go_to_edit_the_document
+    and_i_fill_in_the_change_note_and_update_type
+
+    then_the_summary_page_displays_change_note_and_update_type
+    and_the_form_displays_the_change_note_and_update_type
+    and_the_publishing_api_should_know_the_update_type_and_change_note
+
+    when_i_publish_the_document
+    then_the_change_note_and_update_type_should_be_cleared_for_the_next_edition
+  end
+
+  def given_there_is_a_previously_published_document
+    @document = create(:document, has_live_version_on_govuk: true)
+  end
+
+  def when_i_go_to_edit_the_document
+    visit edit_document_path(@document)
+  end
+
+  def and_i_fill_in_the_change_note_and_update_type
+    @update_request = stub_any_publishing_api_put_content
+
+    fill_in "document[change_note]", with: "Updated banana pricing"
+    choose I18n.t("documents.edit.update_type.minor_name")
+
+    click_on "Save"
+  end
+
+  def then_the_summary_page_displays_change_note_and_update_type
+    expect(page).to have_content "Updated banana pricing"
+  end
+
+  def and_the_form_displays_the_change_note_and_update_type
+    visit edit_document_path(@document)
+    expect(find("textarea[name='document[change_note]']")).to have_text "Updated banana pricing"
+    expect(find("input[name='document[update_type]'][value='minor']")).to be_checked
+  end
+
+  def and_the_publishing_api_should_know_the_update_type_and_change_note
+    expect(
+      @update_request.with { |req|
+        expect(JSON.parse(req.body)["update_type"]).to eq("minor")
+        expect(JSON.parse(req.body)["change_note"]).to eq("Updated banana pricing")
+      },
+    ).to have_been_requested
+  end
+
+  def when_i_publish_the_document
+    visit publish_document_path(@document)
+
+    # We don't care about what kind of request is done here, this is tested in
+    # the document editing feature test.
+    stub_any_publishing_api_publish
+
+    click_on "Confirm publish"
+  end
+
+  def then_the_change_note_and_update_type_should_be_cleared_for_the_next_edition
+    visit edit_document_path(@document)
+
+    expect(page.find("textarea[name='document[change_note]']").text).to be_empty
+    expect(page).to have_selector("input[name='document[update_type]'][checked='checked'][value='major']")
+  end
+end

--- a/spec/features/create_a_document_spec.rb
+++ b/spec/features/create_a_document_spec.rb
@@ -1,0 +1,42 @@
+# frozen_string_literal: true
+
+RSpec.feature "Create a document" do
+  scenario "User creates a document" do
+    when_i_choose_a_format
+    then_i_wont_be_able_to_choose_an_update_type_or_change_note
+
+    when_i_visit_the_summary_page
+    then_i_see_the_document_is_in_draft
+    and_the_update_type_is_major
+  end
+
+  def when_i_choose_a_format
+    stub_any_publishing_api_put_content
+
+    schema = DocumentTypeSchema.find("news_story")
+    visit "/"
+    click_on "New document"
+    choose SupertypeSchema.find("news").label
+    click_on "Continue"
+    choose schema.label
+    click_on "Continue"
+  end
+
+  def then_i_wont_be_able_to_choose_an_update_type_or_change_note
+    expect(page).not_to have_selector("textarea[name='document[change_note]']")
+    expect(page).not_to have_selector("input[name='document[update_type]']")
+  end
+
+  def when_i_visit_the_summary_page
+    @document = Document.last
+    visit document_path(@document)
+  end
+
+  def then_i_see_the_document_is_in_draft
+    expect(page).to have_content("Draft")
+  end
+
+  def and_the_update_type_is_major
+    expect(page).to have_content("major")
+  end
+end

--- a/spec/features/publish_a_document_spec.rb
+++ b/spec/features/publish_a_document_spec.rb
@@ -28,7 +28,7 @@ RSpec.feature "Publishing a document" do
   end
 
   def and_i_confirm_the_publishing
-    @request = stub_publishing_api_publish(@document.content_id, update_type: "major", locale: @document.locale)
+    @request = stub_publishing_api_publish(@document.content_id, update_type: nil, locale: @document.locale)
     click_on "Confirm publish"
   end
 

--- a/spec/services/document_publishing_service_spec.rb
+++ b/spec/services/document_publishing_service_spec.rb
@@ -25,7 +25,7 @@ RSpec.describe DocumentPublishingService do
       DocumentPublishingService.new.publish(document, "reviewed")
 
       expect(document).to have_received(:update!).with(publication_state: "sending_to_live", review_state: "reviewed")
-      expect(document).to have_received(:update!).with(publication_state: "sent_to_live")
+      expect(document).to have_received(:update!).with(publication_state: "sent_to_live", has_live_version_on_govuk: true, change_note: nil, update_type: "major")
     end
   end
 end


### PR DESCRIPTION
This implements the change note and update type feature.

- Users can now add a change note and select an update type in the edit screen.
- When a document is first created, it has a "major" update type by default and "First published." as change note. This can't be changed.
- The update type and change note are sent to the publishing-api, so change notes for major updates will be displayed on the site. The update type is no longer part of the `publish` call.
- The change note is displayed on the summary page as well.
- After a document is published, we reset the update type and change note.
- I've added a test for the creation of a document, because there wasn't a feature test that tests all the things that need to be set up when the document is first created.

## Known issues

- The layout of the new form labels will be fixed by @alex-ju and https://github.com/alphagov/govuk_publishing_components/pull/508.
- If users don't select an update type, the publishing-api will reject the update. This needs a new validation rule, which will be part of https://trello.com/c/K52YqwPK. 

## Preview

![sep-07-2018 12-49-16](https://user-images.githubusercontent.com/233676/45217562-79a07000-b29c-11e8-9c23-14ccd56958be.gif)

https://trello.com/c/NEQWHpoU