### PR TITLE
Remember if the document was ever live on GOV.UK

### DIFF
--- a/app/services/document_publishing_service.rb
+++ b/app/services/document_publishing_service.rb
@@ -12,7 +12,7 @@ class DocumentPublishingService
   def publish(document, review_state)
     document.update!(publication_state: "sending_to_live", review_state: review_state)
     publishing_api.publish(document.content_id, "major", locale: document.locale)
-    document.update!(publication_state: "sent_to_live")
+    document.update!(publication_state: "sent_to_live", has_live_version_on_govuk: true)
   end
 
 private

--- a/db/migrate/20180906154457_add_has_live_version_on_govuk_to_documents.rb
+++ b/db/migrate/20180906154457_add_has_live_version_on_govuk_to_documents.rb
@@ -1,0 +1,5 @@
+class AddHasLiveVersionOnGovukToDocuments < ActiveRecord::Migration[5.2]
+  def change
+    add_column :documents, :has_live_version_on_govuk, :boolean, default: false, null: false
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2018_09_05_134625) do
+ActiveRecord::Schema.define(version: 2018_09_06_154457) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -50,6 +50,7 @@ ActiveRecord::Schema.define(version: 2018_09_05_134625) do
     t.string "publication_state", null: false
     t.bigint "creator_id"
     t.string "review_state", null: false
+    t.boolean "has_live_version_on_govuk", default: false, null: false
     t.index ["base_path"], name: "index_documents_on_base_path", unique: true
     t.index ["content_id", "locale"], name: "index_documents_on_content_id_and_locale", unique: true
     t.index ["creator_id"], name: "index_documents_on_creator_id"


### PR DESCRIPTION
This is important because:

- We'll be able to discard the entire document if it's never been published
- We'll be able to show a link to live GOV.UK if it's ever been published
- We need to make send the "major" update type when a document has never been published (https://github.com/alphagov/content-publisher/pull/236#pullrequestreview-153325299)

https://trello.com/c/NEQWHpoU