### PR TITLE
Update action link styles to reflect design

### DIFF
--- a/app/views/documents/show/_actions.html.erb
+++ b/app/views/documents/show/_actions.html.erb
@@ -8,17 +8,17 @@
       <%= render "govuk_publishing_components/components/button", text: "Create new edition", href: edit_document_path(@document), secondary: true %>
 
       <%= link_to "Retire", "#", class: "govuk-link" %>
-      <%= link_to "Remove", "#", class: "govuk-link app-link--right" %>
+      <%= link_to "Remove", "#", class: "app-link--destructive app-link--right" %>
     <% elsif @document.user_facing_state == "published" %>
       <%= render "govuk_publishing_components/components/button", text: "Create new edition", href: edit_document_path(@document) %>
 
       <%= link_to "Retire", "#", class: "govuk-link" %>
-      <%= link_to "Remove", "#", class: "govuk-link app-link--right" %>
+      <%= link_to "Remove", "#", class: "app-link--destructive app-link--right" %>
     <% elsif @document.user_facing_state == "submitted_for_review" %>
       <%= render "govuk_publishing_components/components/button", text: "Publish", href: publish_document_path(@document) %>
       <%= render "govuk_publishing_components/components/button", text: "Preview", href: preview_document_path(@document), secondary: true, target: "_blank" %>
 
-      <%= link_to "Delete draft", '#' %>
+      <%= link_to "Delete draft", '#', class: "app-link--destructive app-link--right" %>
     <% elsif @document.user_facing_state == "draft" %>
       <%= form_tag submit_document_for_2i_path(@document) do %>
         <%= render "govuk_publishing_components/components/button", text: "Submit for 2i review" %>
@@ -26,8 +26,8 @@
 
       <%= render "govuk_publishing_components/components/button", text: "Preview", href: preview_document_path(@document), secondary: true, target: "_blank" %>
 
-      <%= link_to "Publish", publish_document_path(@document) %>
-      <%= link_to "Delete draft", "#", class: "govuk-link app-link--right" %>
+      <%= link_to "Publish", publish_document_path(@document), class: "govuk-link" %>
+      <%= link_to "Delete draft", "#", class: "app-link--destructive app-link--right" %>
     <% end %>
   </div>
 </div>


### PR DESCRIPTION
This PR updates the styles used for action links to reflect the design.

### Before
<img width="300" alt="screen shot 2018-09-10 at 09 45 06" src="https://user-images.githubusercontent.com/788096/45286735-814f5700-b4de-11e8-834c-0ffa23d35118.png">

### After
<img width="301" alt="screen shot 2018-09-10 at 09 45 36" src="https://user-images.githubusercontent.com/788096/45286740-83b1b100-b4de-11e8-872f-d9b2bc97a0d6.png">
