### PR TITLE
Redesign guidance for change notes

### DIFF
--- a/app/views/documents/edit/_change_notes.html.erb
+++ b/app/views/documents/edit/_change_notes.html.erb
@@ -3,17 +3,14 @@
     <%= render "govuk_publishing_components/components/textarea", {
       label: {
         text: t("documents.edit.change_note.title"),
-        bold: true,
       },
-      hint: t("documents.edit.change_note.hint"),
       name: "document[change_note]",
       value: @document.change_note,
-      rows: 4
+      rows: 4,
+      data: {
+        "contextual-guidance": "change-note-guidance"
+      }
     } %>
-
-    <%= render "govuk_publishing_components/components/govspeak" do %>
-      <%= govspeak_to_html t("documents.edit.change_note.guidance") %>
-    <% end %>
 
     <% legend_text = tag.p(t("documents.edit.update_type.title"), class: "govuk-!-margin-bottom-3") %>
 
@@ -36,6 +33,17 @@
           }
         ]
       } %>
+    <% end %>
+  </div>
+
+  <div class="govuk-grid-column-one-third">
+    <%= render "components/contextual_guidance", {
+      id: "change-note-guidance",
+      title: t("documents.edit.change_note.guidance_title"),
+    } do %>
+      <%= render "govuk_publishing_components/components/govspeak" do %>
+        <%= govspeak_to_html t("documents.edit.change_note.guidance") %>
+      <% end %>
     <% end %>
   </div>
 </div>

--- a/config/locales/en/documents/edit.yml
+++ b/config/locales/en/documents/edit.yml
@@ -15,8 +15,11 @@ en:
         error: Unable to preview address, please edit title and try again.
       change_note:
         title: Change note
-        hint: Describe the change. Include any new or updated information where possible, or summarise and refer to specific sections if it cannot be included.
-        guidance: "[Full guidance on change notes](https://www.gov.uk/guidance/content-design/writing-for-gov-uk#change-notes)"
+        guidance_title: Writing change notes
+        guidance: |
+          Describe the change. Include any new or updated information where possible, or summarise and refer to specific sections if it cannot be included.
+
+          [Full guidance on change notes](https://www.gov.uk/guidance/content-design/writing-for-gov-uk#change-notes)
       update_type:
         title: "Is the change significant to users?"
         minor_name: There’s no change to the published information. For example, spelling corrections.


### PR DESCRIPTION
This replaces the hint and guidance for change notes with right-hand contextual guidance. This makes the page less busy and is more consistent with the other fields.

## Before

<img width="982" alt="screen shot 2018-09-10 at 10 05 53" src="https://user-images.githubusercontent.com/233676/45287819-1b180380-b4e1-11e8-8ea5-bb6b20e35fd3.png">

## After

<img width="982" alt="screen shot 2018-09-10 at 10 05 06" src="https://user-images.githubusercontent.com/233676/45287830-21a67b00-b4e1-11e8-8b69-ee22b9a0287c.png">


https://trello.com/c/NEQWHpoU