### PR TITLE
Set bold labels for edit pages

### DIFF
--- a/app/views/components/_autocomplete.html.erb
+++ b/app/views/components/_autocomplete.html.erb
@@ -9,9 +9,9 @@
 
 <div class="app-c-autocomplete govuk-form-group">
   <%= render "govuk_publishing_components/components/label", {
-    text: label,
+    text: label[:text],
     html_for: id
-  } %>
+  }.merge(label) %>
 
   <% if options.any? %>
     <% if multiple %>

--- a/app/views/components/_autocomplete.html.erb
+++ b/app/views/components/_autocomplete.html.erb
@@ -9,7 +9,6 @@
 
 <div class="app-c-autocomplete govuk-form-group">
   <%= render "govuk_publishing_components/components/label", {
-    text: label[:text],
     html_for: id
   }.merge(label) %>
 

--- a/app/views/components/_markdown_editor.html.erb
+++ b/app/views/components/_markdown_editor.html.erb
@@ -7,7 +7,7 @@
   <%= render "govuk_publishing_components/components/label", {
       text: label[:text],
       html_for: textarea[:id]
-  } %>
+  }.merge(label) %>
   <div class="app-c-markdown-editor__container">
     <div class="app-c-markdown-editor__head js-markdown-editor__head">
       <div class="app-c-markdown-editor__preview-toggle">

--- a/app/views/components/_markdown_editor.html.erb
+++ b/app/views/components/_markdown_editor.html.erb
@@ -5,7 +5,6 @@
 %>
 <div class="app-c-markdown-editor" data-module="markdown-editor" data-govspeak-path="<%= govspeak_preview_path %>">
   <%= render "govuk_publishing_components/components/label", {
-      text: label[:text],
       html_for: textarea[:id]
   }.merge(label) %>
   <div class="app-c-markdown-editor__container">

--- a/app/views/document_tags/tags/_multi_tag_input.html.erb
+++ b/app/views/document_tags/tags/_multi_tag_input.html.erb
@@ -1,7 +1,10 @@
 <%= render "components/autocomplete", {
   id: schema.id,
   name: "tags[#{schema.id}][]",
-  label: schema.label,
+  label: {
+    text: schema.label,
+    bold: true
+  },
   options: LinkablesService.new(schema.document_type).select_options,
   selected_options: tags[schema.id],
   multiple: true,

--- a/app/views/document_tags/tags/_single_tag_input.html.erb
+++ b/app/views/document_tags/tags/_single_tag_input.html.erb
@@ -1,7 +1,10 @@
 <%= render "components/autocomplete", {
   id: schema.id,
   name: "tags[#{schema.id}][]",
-  label: schema.label,
+  label: {
+    text: schema.label,
+    bold: true
+  },
   options: LinkablesService.new(schema.document_type).select_options,
   selected_options: tags[schema.id],
   data: {

--- a/app/views/documents/edit.html.erb
+++ b/app/views/documents/edit.html.erb
@@ -4,13 +4,15 @@
   <%= form_for(@document, html: {'autocomplete': 'off'}, data: {'module': 'edit-document-form', 'generate-path-path': generate_path_path}) do |f| %>
   <div class="govuk-grid-row">
     <div class="govuk-grid-column-two-thirds">
-      <%= render "govuk_publishing_components/components/input", {
+      <%= render "govuk_publishing_components/components/textarea", {
         label: {
-          text: t("documents.edit.form_labels.title")
+          text: t("documents.edit.form_labels.title"),
+          bold: true
         },
         id: "document-title-id",
         name: "document[title]",
         value: @document.title,
+        rows: 2,
         data: {
           "contextual-guidance": "document-title-guidance"
         }
@@ -49,7 +51,8 @@
     <div class="govuk-grid-column-two-thirds">
       <%= render "govuk_publishing_components/components/textarea", {
         label: {
-          text: t("documents.edit.form_labels.summary")
+          text: t("documents.edit.form_labels.summary"),
+          bold: true
         },
         name: "document[summary]",
         value: @document.summary,

--- a/app/views/documents/fields/_govspeak_input.html.erb
+++ b/app/views/documents/fields/_govspeak_input.html.erb
@@ -2,7 +2,8 @@
   <div class="govuk-grid-column-two-thirds">
     <%= render "components/markdown_editor", {
       label: {
-        text: schema.label
+        text: schema.label,
+        bold: true
       },
       textarea: {
         data: {


### PR DESCRIPTION
This PR:
 - sets bold labels for textarea fileds on edit document page
 - sets bold labels for autocomplete fileds on edit tags page

### Before
<img width="671" alt="screen shot 2018-09-10 at 10 13 20" src="https://user-images.githubusercontent.com/788096/45288273-320b2580-b4e2-11e8-8615-f1a8121fd1ae.png">

### After
<img width="665" alt="screen shot 2018-09-10 at 10 12 57" src="https://user-images.githubusercontent.com/788096/45288281-36374300-b4e2-11e8-84ab-4ad3387a1852.png">
