### PR TITLE
Scopes methods for user facing state

### DIFF
--- a/app/services/user_facing_state.rb
+++ b/app/services/user_facing_state.rb
@@ -1,8 +1,30 @@
 # frozen_string_literal: true
 
 class UserFacingState
+  STATES = %w[draft submitted_for_review published_but_needs_2i published].freeze
+
   attr_reader :document
   delegate :review_state, :publication_state, to: :document
+
+  def self.scope(query, state)
+    case state.to_sym
+    when :draft
+      query
+        .where(publication_state: %w[changes_not_sent_to_draft sent_to_draft sending_to_draft error_sending_to_draft])
+        .where.not(review_state: "submitted_for_review")
+    when :submitted_for_review
+      query.where(review_state: "submitted_for_review")
+    when :published_but_needs_2i
+      query.where(review_state: "published_without_review")
+    when :published
+      # Note this includes published_but_needs_2i as this is expected to be
+      # included when traversing published documents, this is a Whitehall
+      # quirk we've inherited.
+      query.where(publication_state: %w[sending_to_live sent_to_live error_sending_to_live])
+    else
+      raise "Unknown user_facing_state: #{state}"
+    end
+  end
 
   def initialize(document)
     @document = document


### PR DESCRIPTION
Trello: https://trello.com/c/l8MAts3s/205-build-the-index-page-with-filtering

This ties into the index page PR: https://github.com/alphagov/content-publisher/pull/244as that's still in flight I've extracted this aspect of it out, since it could be controversial. 

This creates scope methods for each of the current known user facing
states.

The intention is to use these as part of the document index where there
is a Whitehall quirk that is intended to be kept as a feature. This is
that for when a filter is applied to published documents this returns
results all published items whether they need a review or not.