### PR TITLE
Add lead image workflow

### DIFF
--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -16,6 +16,7 @@ $govuk-global-styles: true;
 @import "components/page_preview";
 @import "components/autocomplete";
 @import "components/url_preview";
+@import "image_list";
 
 @import "utilities/display";
 @import "utilities/overwrites";

--- a/app/assets/stylesheets/image_list.scss
+++ b/app/assets/stylesheets/image_list.scss
@@ -1,0 +1,36 @@
+.image-list {
+  padding-bottom: govuk-spacing(4);
+  @include govuk-font(19);
+  vertical-align: top;
+}
+
+.image-list__metadata {
+  padding-left: govuk-spacing(4);
+  align: top;
+  padding-top: 0;
+}
+
+.image-list__lead-image-flag {
+  position: absolute;
+  margin-top: govuk-spacing(4);
+}
+
+.image-list__lead-image-label {
+  float: left;
+  margin-right: govuk-spacing(4);
+}
+
+.image-list__remove-button {
+  float: left;
+}
+
+.image-list__edit-image {
+  float: left;
+  margin-bottom: govuk-spacing(2);
+}
+
+.image-list__choose-image {
+  float: left;
+  margin-right: govuk-spacing(4);
+  margin-bottom: govuk-spacing(2);
+}

--- a/app/controllers/document_lead_image_controller.rb
+++ b/app/controllers/document_lead_image_controller.rb
@@ -1,0 +1,13 @@
+# frozen_string_literal: true
+
+class DocumentLeadImageController < ApplicationController
+  def index
+    @document = Document.find_by_param(params[:document_id])
+  end
+
+  def create
+  end
+
+  def edit
+  end
+end

--- a/app/controllers/document_lead_image_controller.rb
+++ b/app/controllers/document_lead_image_controller.rb
@@ -6,8 +6,39 @@ class DocumentLeadImageController < ApplicationController
   end
 
   def create
+    document = Document.find_by_param(params[:document_id])
+    upload = UploadedImageService.new(params.require(:image)).process
+
+    if upload.valid?
+      image = create_image_from_upload(upload, document)
+      redirect_to edit_document_lead_image_path(params[:document_id], image.id)
+    end
   end
 
   def edit
+    @document = Document.find_by_param(params[:document_id])
+    @image = Image.find_by(id: params[:image_id])
+  end
+
+private
+
+  def create_image_from_upload(upload, document)
+    blob = ActiveStorage::Blob.create_after_upload!(
+      io: upload.file,
+      filename: upload.filename,
+      content_type: upload.mime_type,
+    )
+
+    Image.create!(
+      document: document,
+      blob: blob,
+      filename: blob.filename,
+      width: upload.dimensions[:width],
+      height: upload.dimensions[:height],
+      crop_x: upload.crop_dimensions[:x],
+      crop_y: upload.crop_dimensions[:y],
+      crop_width: upload.crop_dimensions[:width],
+      crop_height: upload.crop_dimensions[:height],
+    )
   end
 end

--- a/app/controllers/document_lead_image_controller.rb
+++ b/app/controllers/document_lead_image_controller.rb
@@ -7,6 +7,11 @@ class DocumentLeadImageController < ApplicationController
 
   def create
     document = Document.find_by_param(params[:document_id])
+    unless params[:image]
+      redirect_to document_lead_image_path, alert: t("document_lead_image.index.no_file_selected")
+      return
+    end
+
     upload = UploadedImageService.new(params.require(:image)).process
 
     if upload.valid?

--- a/app/controllers/document_lead_image_controller.rb
+++ b/app/controllers/document_lead_image_controller.rb
@@ -34,6 +34,12 @@ class DocumentLeadImageController < ApplicationController
     redirect_to document_path(document)
   end
 
+  def destroy
+    document = Document.find_by_param(params[:document_id])
+    document.update(lead_image_id: nil)
+    redirect_to document_path(document)
+  end
+
 private
 
   def update_params

--- a/app/controllers/document_lead_image_controller.rb
+++ b/app/controllers/document_lead_image_controller.rb
@@ -20,7 +20,19 @@ class DocumentLeadImageController < ApplicationController
     @image = Image.find_by(id: params[:image_id])
   end
 
+  def update
+    document = Document.find_by_param(params[:document_id])
+    image = Image.find_by(id: params[:image_id])
+    image.update(update_params)
+    document.update(lead_image_id: image.id)
+    redirect_to document_path(document)
+  end
+
 private
+
+  def update_params
+    params.permit(:caption, :alt_text, :credit)
+  end
 
   def create_image_from_upload(upload, document)
     blob = ActiveStorage::Blob.create_after_upload!(

--- a/app/controllers/document_lead_image_controller.rb
+++ b/app/controllers/document_lead_image_controller.rb
@@ -12,6 +12,8 @@ class DocumentLeadImageController < ApplicationController
     if upload.valid?
       image = create_image_from_upload(upload, document)
       redirect_to edit_document_lead_image_path(params[:document_id], image.id)
+    else
+      redirect_to document_lead_image_path, alert: upload.errors
     end
   end
 

--- a/app/controllers/document_lead_image_controller.rb
+++ b/app/controllers/document_lead_image_controller.rb
@@ -27,6 +27,10 @@ class DocumentLeadImageController < ApplicationController
     image = Image.find_by(id: params[:image_id])
     image.update(update_params)
     document.update(lead_image_id: image.id)
+    if params[:next] == "lead-image"
+      redirect_to document_lead_image_path(document)
+      return
+    end
     redirect_to document_path(document)
   end
 

--- a/app/controllers/document_lead_image_controller.rb
+++ b/app/controllers/document_lead_image_controller.rb
@@ -18,7 +18,10 @@ class DocumentLeadImageController < ApplicationController
       image = create_image_from_upload(upload, document)
       redirect_to edit_document_lead_image_path(params[:document_id], image.id)
     else
-      redirect_to document_lead_image_path, alert: upload.errors
+      redirect_to document_lead_image_path, alert: {
+        "alerts" => upload.errors,
+        "title" => t("document_lead_image.index.error_summary_title"),
+      }
     end
   end
 

--- a/app/controllers/document_lead_image_controller.rb
+++ b/app/controllers/document_lead_image_controller.rb
@@ -35,10 +35,16 @@ class DocumentLeadImageController < ApplicationController
     image = Image.find_by(id: params[:image_id])
     image.update(update_params)
     document.update(lead_image_id: image.id)
-    if params[:next] == "lead-image"
+    if params[:next_screen] == "lead-image"
       redirect_to document_lead_image_path(document)
       return
     end
+    redirect_to document_path(document)
+  end
+
+  def choose_image
+    document = Document.find_by_param(params[:document_id])
+    document.update(lead_image_id: params[:image_id])
     redirect_to document_path(document)
   end
 

--- a/app/formats/document_types.yml
+++ b/app/formats/document_types.yml
@@ -6,6 +6,7 @@
     Do not include advice in news stories. Do not use to promote other content.
     Read the full [guidance on news stories](https://www.gov.uk/guidance/content-design/content-types#news-story).
   path_prefix: /news
+  lead_image: true
   publishing_metadata:
     schema_name: news_article
     rendering_app: government-frontend

--- a/app/models/document.rb
+++ b/app/models/document.rb
@@ -46,8 +46,4 @@ class Document < ApplicationRecord
   def user_facing_state
     UserFacingState.new(self).to_s
   end
-
-  def lead_image_thumbnail
-    self.lead_image.blob.variant(resize: "300x195")
-  end
 end

--- a/app/models/document.rb
+++ b/app/models/document.rb
@@ -2,6 +2,7 @@
 
 class Document < ApplicationRecord
   has_many :images, dependent: :destroy
+  belongs_to :lead_image, class_name: "Image", optional: true, foreign_key: :lead_image_id, inverse_of: :document
   belongs_to :creator, class_name: "User", optional: true, foreign_key: :creator_id, inverse_of: :documents
 
   PUBLICATION_STATES = %w[

--- a/app/models/document.rb
+++ b/app/models/document.rb
@@ -46,4 +46,8 @@ class Document < ApplicationRecord
   def user_facing_state
     UserFacingState.new(self).to_s
   end
+
+  def lead_image_thumbnail
+    self.lead_image.blob.variant(resize: "300x195")
+  end
 end

--- a/app/models/image.rb
+++ b/app/models/image.rb
@@ -3,6 +3,8 @@
 class Image < ApplicationRecord
   WIDTH = 960
   HEIGHT = 640
+  THUMBNAIL_WIDTH = 300
+  THUMBNAIL_HEIGHT = 200
 
   belongs_to :document
   belongs_to :blob, class_name: "ActiveStorage::Blob"
@@ -22,11 +24,15 @@ class Image < ApplicationRecord
 
   validates_with ImageAspectRatioValidator
 
-  def crop_variant
+  def thumbnail
+    crop_variant("#{THUMBNAIL_WIDTH}x#{THUMBNAIL_HEIGHT}")
+  end
+
+  def crop_variant(resize = "#{WIDTH}x#{HEIGHT}")
     crop = "#{crop_width}x#{crop_height}+#{crop_x}+#{crop_y}"
     blob.variant(
       crop: crop,
-      resize: "#{WIDTH}x#{HEIGHT}",
+      resize: resize,
     )
   end
 end

--- a/app/services/document_type_schema.rb
+++ b/app/services/document_type_schema.rb
@@ -2,7 +2,7 @@
 
 class DocumentTypeSchema
   attr_reader :contents, :id, :label, :managed_elsewhere, :publishing_metadata,
-    :path_prefix, :tags, :guidance, :description, :hint
+    :path_prefix, :tags, :guidance, :description, :hint, :lead_image
 
   def initialize(params = {})
     @id = params["id"]
@@ -15,6 +15,7 @@ class DocumentTypeSchema
     @guidance = params["guidance"].to_a.map(&Guidance.method(:new))
     @description = params["description"]
     @hint = params["hint"]
+    @lead_image = params["lead_image"]
   end
 
   def self.find(document_type_id)

--- a/app/views/document_lead_image/_image_list.html.erb
+++ b/app/views/document_lead_image/_image_list.html.erb
@@ -1,0 +1,38 @@
+<table>
+  <% @document.images.each_with_index do |image, i| %>
+    <tr>
+      <td class="image-list">
+        <%= image_tag(url_for(image.thumbnail), id: "image-#{i}") %>
+      </td>
+      <td class="image-list" id=<%= "image-#{i}-metadata" %>>
+        <div class="image-list__metadata">
+          <strong><%= t("document_lead_image.index.alt_text") %></strong>: <%= image.alt_text %> <br \>
+          <strong><%= t("document_lead_image.index.caption") %></strong>: <%= image.caption %> <br \>
+          <strong><%= t("document_lead_image.index.credit") %></strong>: <%= image.credit %> <br \>
+          <div class="image-list__lead-image-flag">
+            <% if image == @document.lead_image %>
+              <div class="image-list__lead-image-label">Lead image</div>
+              <div class="image-list__remove-button">
+                <%= form_tag remove_document_lead_image_path(@document), method: :delete do %>
+                <button>Remove</button>
+                <% end %>
+              </div>
+            <% end %>
+          </div>
+        </div>
+      </td>
+    </tr>
+    <tr>
+      <td class="image-list" id=<%= "image-#{i}-choose-action" %>>
+        <div class="image-list__choose-image">
+          <%= form_tag update_document_lead_image_path(@document, image), method: :patch do %>
+            <button>Choose image</button>
+          <% end %>
+        </div>
+        <div class="image-list__edit-image">
+          <%= link_to("Edit details", edit_document_lead_image_path(@document, image, next: "lead-image"), class: "govuk-link") %>
+        </div>
+      </td>
+    </tr>
+  <% end %>
+</table>

--- a/app/views/document_lead_image/_image_list.html.erb
+++ b/app/views/document_lead_image/_image_list.html.erb
@@ -25,12 +25,12 @@
     <tr>
       <td class="image-list" id=<%= "image-#{i}-choose-action" %>>
         <div class="image-list__choose-image">
-          <%= form_tag update_document_lead_image_path(@document, image), method: :patch do %>
+          <%= form_tag choose_document_lead_image_path(@document, image) do %>
             <button>Choose image</button>
           <% end %>
         </div>
         <div class="image-list__edit-image">
-          <%= link_to("Edit details", edit_document_lead_image_path(@document, image, next: "lead-image"), class: "govuk-link") %>
+          <%= link_to("Edit details", edit_document_lead_image_path(@document, image, next_screen: "lead-image"), class: "govuk-link") %>
         </div>
       </td>
     </tr>

--- a/app/views/document_lead_image/edit.html.erb
+++ b/app/views/document_lead_image/edit.html.erb
@@ -1,0 +1,40 @@
+<%= content_for :back_link, document_path(@document) %>
+<% content_for :title, t("document_lead_image.edit.title") %>
+
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-two-thirds">
+    <% if flash[:errors].present? %>
+      <ul>
+        <% flash[:errors].each do |error| %>
+          <li><%= error %></li>
+        <% end %>
+      </ul>
+    <% end %>
+    <%= form_tag(update_document_lead_image_path(@document, @image), method: :patch) do %>
+      <%= render "govuk_publishing_components/components/input", {
+        label: {
+          text: t("document_lead_image.edit.form_labels.caption")
+        },
+        name: "caption",
+        value: @image.caption,
+      } %>
+      <%= render "govuk_publishing_components/components/input", {
+        label: {
+          text: t("document_lead_image.edit.form_labels.alt_text")
+        },
+        name: "alt_text",
+        value: @image.alt_text,
+      } %>
+      <%= render "govuk_publishing_components/components/input", {
+        label: {
+          text: t("document_lead_image.edit.form_labels.credit")
+        },
+        name: "credit",
+        value: @image.credit,
+      } %>
+      <%= render "govuk_publishing_components/components/button", {
+        text: "Save and choose"
+      } %>
+    <% end %>
+  </div>
+</div>

--- a/app/views/document_lead_image/edit.html.erb
+++ b/app/views/document_lead_image/edit.html.erb
@@ -27,7 +27,7 @@
         value: @image.credit,
       } %>
       <%= render "govuk_publishing_components/components/button", {
-        text: "Save image"
+        text: "Save and choose"
       } %>
     <% end %>
   </div>

--- a/app/views/document_lead_image/edit.html.erb
+++ b/app/views/document_lead_image/edit.html.erb
@@ -10,6 +10,7 @@
         <% end %>
       </ul>
     <% end %>
+    <%= image_tag(url_for(@image.blob.variant(resize: "300x195"))) %>
     <%= form_tag(update_document_lead_image_path(@document, @image), method: :patch) do %>
       <%= render "govuk_publishing_components/components/input", {
         label: {

--- a/app/views/document_lead_image/edit.html.erb
+++ b/app/views/document_lead_image/edit.html.erb
@@ -1,4 +1,4 @@
-<%= content_for :back_link, document_path(@document) %>
+<%= content_for :back_link, document_lead_image_path(@document) %>
 <% content_for :title, t("document_lead_image.edit.title") %>
 
 <div class="govuk-grid-row">

--- a/app/views/document_lead_image/edit.html.erb
+++ b/app/views/document_lead_image/edit.html.erb
@@ -4,7 +4,7 @@
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
     <%= image_tag(url_for(@image.thumbnail), id: "selected-image") %>
-    <%= form_tag(update_document_lead_image_path(@document, @image), method: :patch) do %>
+    <%= form_tag(update_document_lead_image_path(@document, @image, next: params[:next]), method: :patch) do %>
       <%= render "govuk_publishing_components/components/input", {
         label: {
           text: t("document_lead_image.edit.form_labels.caption")
@@ -27,7 +27,7 @@
         value: @image.credit,
       } %>
       <%= render "govuk_publishing_components/components/button", {
-        text: "Save and choose"
+        text: "Save image"
       } %>
     <% end %>
   </div>

--- a/app/views/document_lead_image/edit.html.erb
+++ b/app/views/document_lead_image/edit.html.erb
@@ -3,14 +3,7 @@
 
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
-    <% if flash[:errors].present? %>
-      <ul>
-        <% flash[:errors].each do |error| %>
-          <li><%= error %></li>
-        <% end %>
-      </ul>
-    <% end %>
-    <%= image_tag(url_for(@image.blob.variant(resize: "300x195"))) %>
+    <%= image_tag(url_for(@image.blob.variant(resize: "300x195")), id: "selected-image") %>
     <%= form_tag(update_document_lead_image_path(@document, @image), method: :patch) do %>
       <%= render "govuk_publishing_components/components/input", {
         label: {

--- a/app/views/document_lead_image/edit.html.erb
+++ b/app/views/document_lead_image/edit.html.erb
@@ -3,7 +3,7 @@
 
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
-    <%= image_tag(url_for(@image.blob.variant(resize: "300x195")), id: "selected-image") %>
+    <%= image_tag(url_for(@image.thumbnail), id: "selected-image") %>
     <%= form_tag(update_document_lead_image_path(@document, @image), method: :patch) do %>
       <%= render "govuk_publishing_components/components/input", {
         label: {

--- a/app/views/document_lead_image/edit.html.erb
+++ b/app/views/document_lead_image/edit.html.erb
@@ -4,7 +4,7 @@
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
     <%= image_tag(url_for(@image.thumbnail), id: "selected-image") %>
-    <%= form_tag(update_document_lead_image_path(@document, @image, next: params[:next]), method: :patch) do %>
+    <%= form_tag(update_document_lead_image_path(@document, @image, next_screen: params[:next_screen]), method: :patch) do %>
       <%= render "govuk_publishing_components/components/input", {
         label: {
           text: t("document_lead_image.edit.form_labels.caption")

--- a/app/views/document_lead_image/index.html.erb
+++ b/app/views/document_lead_image/index.html.erb
@@ -1,0 +1,31 @@
+<%= content_for :back_link, document_path(@document) %>
+<% content_for :title, t("document_lead_image.index.title") %>
+
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-two-thirds">
+    <% if flash[:errors].present? %>
+      <ul>
+        <% flash[:errors].each do |error| %>
+          <li><%= error %></li>
+        <% end %>
+    <% end %>
+    <%= form_tag(document_lead_image_path(@document), multipart: true) do %>
+      <%= file_field_tag "document[image]" %>
+      <%= render "govuk_publishing_components/components/button", {
+        text: "Upload"
+      } %>
+    <% end %>
+    <%= render "govuk_publishing_components/components/heading", {
+      text: t("document_lead_image.index.existing_image")
+    } %>
+    <% @document.images.order(blob_id: :desc).each do |image| %>
+      <% if image.metadata["crop"] %>
+        <% crop = image.metadata["crop"] %>
+        <% argument = "#{crop['width']}x#{crop['height']}+#{crop['x']}+#{crop['y']}" %>
+        <img src="<%= url_for(image.variant(crop: argument, resize: "960x640")) %> alt="">
+      <% else %>
+        <img src="<%= url_for(image.variant(resize: "960x640")) %> alt="">
+      <% end %>
+    <% end %>
+  </div>
+</div>

--- a/app/views/document_lead_image/index.html.erb
+++ b/app/views/document_lead_image/index.html.erb
@@ -18,14 +18,5 @@
     <%= render "govuk_publishing_components/components/heading", {
       text: t("document_lead_image.index.existing_image")
     } %>
-    <% @document.images.order(blob_id: :desc).each do |image| %>
-      <% if image.metadata["crop"] %>
-        <% crop = image.metadata["crop"] %>
-        <% argument = "#{crop['width']}x#{crop['height']}+#{crop['x']}+#{crop['y']}" %>
-        <img src="<%= url_for(image.variant(crop: argument, resize: "960x640")) %> alt="">
-      <% else %>
-        <img src="<%= url_for(image.variant(resize: "960x640")) %> alt="">
-      <% end %>
-    <% end %>
   </div>
 </div>

--- a/app/views/document_lead_image/index.html.erb
+++ b/app/views/document_lead_image/index.html.erb
@@ -10,7 +10,7 @@
         <% end %>
     <% end %>
     <%= form_tag(document_lead_image_path(@document), multipart: true) do %>
-      <%= file_field_tag "document[image]" %>
+      <%= file_field_tag "image" %>
       <%= render "govuk_publishing_components/components/button", {
         text: "Upload"
       } %>

--- a/app/views/document_lead_image/index.html.erb
+++ b/app/views/document_lead_image/index.html.erb
@@ -35,6 +35,9 @@
                   <strong><%= t("document_lead_image.index.caption") %></strong>: <%= image.caption %> <br \>
                   <strong><%= t("document_lead_image.index.credit") %></strong>: <%= image.credit %> <br \>
                 </p>
+                <p>
+                  <%= link_to "Choose image", update_document_lead_image_path(@document, image),  class: "app-c-summary__change-link" %>
+                </p>
               </td>
             </div>
           </tr>

--- a/app/views/document_lead_image/index.html.erb
+++ b/app/views/document_lead_image/index.html.erb
@@ -36,7 +36,9 @@
                   <strong><%= t("document_lead_image.index.credit") %></strong>: <%= image.credit %> <br \>
                 </p>
                 <p>
-                  <%= link_to "Choose image", update_document_lead_image_path(@document, image),  class: "app-c-summary__change-link" %>
+                  <%= form_tag update_document_lead_image_path(@document, image), method: :patch do %>
+                    <button>Choose image</button>
+                  <% end %>
                 </p>
               </td>
             </div>

--- a/app/views/document_lead_image/index.html.erb
+++ b/app/views/document_lead_image/index.html.erb
@@ -33,6 +33,7 @@
                   <%= form_tag update_document_lead_image_path(@document, image), method: :patch do %>
                     <button>Choose image</button>
                   <% end %>
+                  <%= link_to("Edit details", edit_document_lead_image_path(@document, image, next: "lead-image")) %>
                 </p>
               </td>
             </div>

--- a/app/views/document_lead_image/index.html.erb
+++ b/app/views/document_lead_image/index.html.erb
@@ -23,7 +23,12 @@
             </td>
             <div>
               <td valign="top" class="govuk-body" id=<%= "image-#{i}-metadata" %>>
-                <% if image == @document.lead_image %><strong>Lead image</strong><% end %>
+                <% if image == @document.lead_image %>
+                  <%= form_tag remove_document_lead_image_path(@document), method: :delete do %>
+                    <strong>Lead image</strong>
+                    <button>Remove</button>
+                  <% end %>
+                <% end %>
                 <p>
                   <strong><%= t("document_lead_image.index.alt_text") %></strong>: <%= image.alt_text %> <br \>
                   <strong><%= t("document_lead_image.index.caption") %></strong>: <%= image.caption %> <br \>

--- a/app/views/document_lead_image/index.html.erb
+++ b/app/views/document_lead_image/index.html.erb
@@ -11,6 +11,7 @@
     <% end %>
     <%= form_tag(document_lead_image_path(@document), multipart: true) do %>
       <%= file_field_tag "image" %>
+      <p>
       <%= render "govuk_publishing_components/components/button", {
         text: "Upload"
       } %>
@@ -20,6 +21,22 @@
       <%= render "govuk_publishing_components/components/heading", {
         text: t("document_lead_image.index.existing_image")
       } %>
+      <table>
+        <% @document.images.each_with_index do |image, i| %>
+          <tr>
+            <td>
+              <%= image_tag(url_for(image.blob.variant(resize: "300x195")), id: "image-#{i}") %>
+            </td>
+            <div>
+              <td valign="top" class="govuk-body">
+                <strong><%= image.filename %></strong>
+                <p>
+                Last updated: <%= image.updated_at.strftime("%l:%M%P on %d %B %Y") %>
+              </td>
+            </div>
+          </tr>
+        <% end %>
+      </table>
     <% else %>
       <%= render "govuk_publishing_components/components/heading", {
         text: t("document_lead_image.index.no_existing_image")

--- a/app/views/document_lead_image/index.html.erb
+++ b/app/views/document_lead_image/index.html.erb
@@ -28,10 +28,13 @@
               <%= image_tag(url_for(image.blob.variant(resize: "300x195")), id: "image-#{i}") %>
             </td>
             <div>
-              <td valign="top" class="govuk-body">
-                <strong><%= image.filename %></strong>
+              <td valign="top" class="govuk-body" id=<%= "image-#{i}-metadata" %>>
+                <% if image == @document.lead_image %><strong>Lead image</strong><% end %>
                 <p>
-                Last updated: <%= image.updated_at.strftime("%l:%M%P on %d %B %Y") %>
+                  <strong><%= t("document_lead_image.index.alt_text") %></strong>: <%= image.alt_text %> <br \>
+                  <strong><%= t("document_lead_image.index.caption") %></strong>: <%= image.caption %> <br \>
+                  <strong><%= t("document_lead_image.index.credit") %></strong>: <%= image.credit %> <br \>
+                </p>
               </td>
             </div>
           </tr>

--- a/app/views/document_lead_image/index.html.erb
+++ b/app/views/document_lead_image/index.html.erb
@@ -3,6 +3,9 @@
 
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
+    <%= render "govuk_publishing_components/components/heading", {
+      text: t("document_lead_image.index.upload_image")
+    } %>
     <%= form_tag(document_lead_image_path(@document), multipart: true) do %>
       <%= file_field_tag "image" %>
       <p>

--- a/app/views/document_lead_image/index.html.erb
+++ b/app/views/document_lead_image/index.html.erb
@@ -15,8 +15,15 @@
         text: "Upload"
       } %>
     <% end %>
-    <%= render "govuk_publishing_components/components/heading", {
-      text: t("document_lead_image.index.existing_image")
-    } %>
+
+    <% if @document.images.any? %>
+      <%= render "govuk_publishing_components/components/heading", {
+        text: t("document_lead_image.index.existing_image")
+      } %>
+    <% else %>
+      <%= render "govuk_publishing_components/components/heading", {
+        text: t("document_lead_image.index.no_existing_image")
+      } %>
+    <% end %>
   </div>
 </div>

--- a/app/views/document_lead_image/index.html.erb
+++ b/app/views/document_lead_image/index.html.erb
@@ -18,36 +18,7 @@
       <%= render "govuk_publishing_components/components/heading", {
         text: t("document_lead_image.index.existing_image")
       } %>
-      <table>
-        <% @document.images.each_with_index do |image, i| %>
-          <tr>
-            <td>
-              <%= image_tag(url_for(image.thumbnail), id: "image-#{i}") %>
-            </td>
-            <div>
-              <td valign="top" class="govuk-body" id=<%= "image-#{i}-metadata" %>>
-                <% if image == @document.lead_image %>
-                  <%= form_tag remove_document_lead_image_path(@document), method: :delete do %>
-                    <strong>Lead image</strong>
-                    <button>Remove</button>
-                  <% end %>
-                <% end %>
-                <p>
-                  <strong><%= t("document_lead_image.index.alt_text") %></strong>: <%= image.alt_text %> <br \>
-                  <strong><%= t("document_lead_image.index.caption") %></strong>: <%= image.caption %> <br \>
-                  <strong><%= t("document_lead_image.index.credit") %></strong>: <%= image.credit %> <br \>
-                </p>
-                <p>
-                  <%= form_tag update_document_lead_image_path(@document, image), method: :patch do %>
-                    <button>Choose image</button>
-                  <% end %>
-                  <%= link_to("Edit details", edit_document_lead_image_path(@document, image, next: "lead-image")) %>
-                </p>
-              </td>
-            </div>
-          </tr>
-        <% end %>
-      </table>
+      <%= render "image_list" %>
     <% else %>
       <%= render "govuk_publishing_components/components/heading", {
         text: t("document_lead_image.index.no_existing_image")

--- a/app/views/document_lead_image/index.html.erb
+++ b/app/views/document_lead_image/index.html.erb
@@ -19,7 +19,7 @@
         <% @document.images.each_with_index do |image, i| %>
           <tr>
             <td>
-              <%= image_tag(url_for(image.blob.variant(resize: "300x195")), id: "image-#{i}") %>
+              <%= image_tag(url_for(image.thumbnail), id: "image-#{i}") %>
             </td>
             <div>
               <td valign="top" class="govuk-body" id=<%= "image-#{i}-metadata" %>>

--- a/app/views/document_lead_image/index.html.erb
+++ b/app/views/document_lead_image/index.html.erb
@@ -3,12 +3,6 @@
 
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
-    <% if flash[:errors].present? %>
-      <ul>
-        <% flash[:errors].each do |error| %>
-          <li><%= error %></li>
-        <% end %>
-    <% end %>
     <%= form_tag(document_lead_image_path(@document), multipart: true) do %>
       <%= file_field_tag "image" %>
       <p>

--- a/app/views/documents/show/_lead_image.html.erb
+++ b/app/views/documents/show/_lead_image.html.erb
@@ -1,12 +1,35 @@
-<%= render "components/summary", {
-  title: {
-    text: t("documents.show.lead_image.title"),
-    change_url: document_lead_image_path(@document)
-  },
-  items: [
-    {
-      field: t("documents.show.lead_image.field_name"),
-      value: t("documents.show.lead_image.no_lead_image")
+<% if @document.lead_image %>
+  <%= render "components/summary", {
+    title: {
+      text: t("documents.show.lead_image.title"),
+      change_url: document_lead_image_path(@document)
     },
-  ]
-} %>
+    items: [
+      {
+        field: t("documents.show.lead_image.fields.alt_text"),
+        value: @document.lead_image.alt_text
+      },
+      {
+        field: t("documents.show.lead_image.fields.caption"),
+        value: @document.lead_image.caption
+      },
+      {
+        field: t("documents.show.lead_image.fields.credit"),
+        value: @document.lead_image.credit
+      },
+    ]
+  } %>
+<% else %>
+  <%= render "components/summary", {
+    title: {
+      text: t("documents.show.lead_image.title"),
+      change_url: document_lead_image_path(@document)
+    },
+    items: [
+      {
+        field: t("documents.show.lead_image.fields.image"),
+        value: t("documents.show.lead_image.no_lead_image")
+      },
+    ]
+  } %>
+<% end %>

--- a/app/views/documents/show/_lead_image.html.erb
+++ b/app/views/documents/show/_lead_image.html.erb
@@ -1,0 +1,12 @@
+<%= render "components/summary", {
+  title: {
+    text: t("documents.show.lead_image.title"),
+    change_url: document_lead_image_path(@document)
+  },
+  items: [
+    {
+      field: t("documents.show.lead_image.field_name"),
+      value: t("documents.show.lead_image.no_lead_image")
+    },
+  ]
+} %>

--- a/app/views/documents/show/_lead_image.html.erb
+++ b/app/views/documents/show/_lead_image.html.erb
@@ -17,6 +17,10 @@
         field: t("documents.show.lead_image.fields.credit"),
         value: @document.lead_image.credit
       },
+      {
+        field: t("documents.show.lead_image.fields.image"),
+        value: image_tag(url_for(@document.lead_image_thumbnail), alt: @document.lead_image.alt_text, id: "lead-image")
+      },
     ]
   } %>
 <% else %>

--- a/app/views/documents/show/_lead_image.html.erb
+++ b/app/views/documents/show/_lead_image.html.erb
@@ -19,7 +19,7 @@
       },
       {
         field: t("documents.show.lead_image.fields.image"),
-        value: image_tag(url_for(@document.lead_image_thumbnail), alt: @document.lead_image.alt_text, id: "lead-image")
+        value: image_tag(url_for(@document.lead_image.thumbnail), alt: @document.lead_image.alt_text, id: "lead-image")
       },
     ]
   } %>

--- a/app/views/documents/show/_summary_tab.html.erb
+++ b/app/views/documents/show/_summary_tab.html.erb
@@ -6,6 +6,10 @@
 
     <%= render "documents/show/contents" %>
 
+    <% if @document.document_type_schema.lead_image %>
+      <%= render "documents/show/lead_image" %>
+    <% end %>
+
     <% tags = @document.document_type_schema.tags.map { |schema|
       {
         field: schema.label,

--- a/app/views/documents/show_api_down.html.erb
+++ b/app/views/documents/show_api_down.html.erb
@@ -5,6 +5,10 @@
   <div class="govuk-grid-column-two-thirds">
     <%= render "documents/show/contents" %>
 
+    <% if @document.document_type_schema.lead_image %>
+      <%= render "documents/show/lead_image" %>
+    <% end %>
+
     <h2 class="govuk-header-s"><%= t("documents.show.tags.title") %></h2>
 
     <p class="govuk-body">

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -40,9 +40,16 @@
     <% end %>
 
     <% if flash[:alert] %>
-      <%= render "components/error_alert", {
-        message: flash[:alert]
-      } %>
+      <% if flash[:alert].is_a? Enumerable %>
+        <%= render "govuk_publishing_components/components/error_summary", {
+          title: "TODO: Update gem to not require title",
+          items: flash[:alert].map { |alert| {text: alert} }
+        } %>
+      <% else %>
+        <%= render "components/error_alert", {
+          message: flash[:alert]
+        } %>
+      <% end %>
     <% end %>
 
     <main class="govuk-main-wrapper<%= " govuk-main-wrapper--l" if yield(:back_link).blank?%>" id="main-content" role="main">

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -33,21 +33,21 @@
       <%= render "govuk_publishing_components/components/back_link", href: yield(:back_link) %>
     <% end %>
 
-    <% if flash[:notice] %>
+    <% if flash["notice"] %>
       <%= render "govuk_publishing_components/components/success_alert", {
-        message: flash[:notice]
+        message: flash["notice"]
       } %>
     <% end %>
 
-    <% if flash[:alert] %>
-      <% if flash[:alert].is_a? Enumerable %>
+    <% if flash["alert"] %>
+      <% if flash["alert"].is_a? Hash %>
         <%= render "govuk_publishing_components/components/error_summary", {
-          title: "TODO: Update gem to not require title",
-          items: flash[:alert].map { |alert| {text: alert} }
+          title: flash["alert"]["title"],
+          items: flash["alert"]["alerts"].map { |alert| {text: alert} }
         } %>
       <% else %>
         <%= render "components/error_alert", {
-          message: flash[:alert]
+          message: flash["alert"]
         } %>
       <% end %>
     <% end %>

--- a/config/locales/en/document_lead_image/edit.yml
+++ b/config/locales/en/document_lead_image/edit.yml
@@ -1,0 +1,8 @@
+en:
+  document_lead_image:
+    edit:
+      title: Edit lead image
+      form_labels:
+        caption: Caption
+        alt_text: Alt text
+        credit: Credit

--- a/config/locales/en/document_lead_image/index.yml
+++ b/config/locales/en/document_lead_image/index.yml
@@ -1,0 +1,5 @@
+en:
+  document_lead_image:
+    index:
+      title: Lead image
+      existing_image: Choose existing image

--- a/config/locales/en/document_lead_image/index.yml
+++ b/config/locales/en/document_lead_image/index.yml
@@ -8,3 +8,4 @@ en:
       alt_text: Alt text
       caption: Image caption
       credit: Image credit
+      no_file_selected: You must select a file

--- a/config/locales/en/document_lead_image/index.yml
+++ b/config/locales/en/document_lead_image/index.yml
@@ -4,3 +4,6 @@ en:
       title: Lead image
       existing_image: Choose existing image
       no_existing_image: No images available
+      alt_text: Alt text
+      caption: Image caption
+      credit: Image credit

--- a/config/locales/en/document_lead_image/index.yml
+++ b/config/locales/en/document_lead_image/index.yml
@@ -2,6 +2,7 @@ en:
   document_lead_image:
     index:
       title: Lead image
+      upload_image: Upload existing image
       existing_image: Choose existing image
       no_existing_image: No images available
       alt_text: Alt text

--- a/config/locales/en/document_lead_image/index.yml
+++ b/config/locales/en/document_lead_image/index.yml
@@ -3,3 +3,4 @@ en:
     index:
       title: Lead image
       existing_image: Choose existing image
+      no_existing_image: No images available

--- a/config/locales/en/document_lead_image/index.yml
+++ b/config/locales/en/document_lead_image/index.yml
@@ -9,3 +9,4 @@ en:
       caption: Image caption
       credit: Image credit
       no_file_selected: You must select a file
+      error_summary_title: You need to

--- a/config/locales/en/documents/show.yml
+++ b/config/locales/en/documents/show.yml
@@ -21,6 +21,10 @@ en:
       sidebar:
         error_publishing: |
           Something went wrong when saving your draft. Please try again or [raise a support request](https://support.publishing.service.gov.uk/technical_fault_report/new).
+      lead_image:
+        title: Lead image
+        field_name: Image
+        no_lead_image: No lead image.
       metadata:
         status: Status
         updated_at: Last updated

--- a/config/locales/en/documents/show.yml
+++ b/config/locales/en/documents/show.yml
@@ -23,8 +23,12 @@ en:
           Something went wrong when saving your draft. Please try again or [raise a support request](https://support.publishing.service.gov.uk/technical_fault_report/new).
       lead_image:
         title: Lead image
-        field_name: Image
         no_lead_image: No lead image.
+        fields:
+          alt_text: Alt text
+          caption: Caption
+          credit: Credit
+          image: Image
       metadata:
         status: Status
         updated_at: Last updated

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -30,6 +30,8 @@ Rails.application.routes.draw do
   post "/documents/:document_id/images" => "document_images#create", as: :create_document_image
   patch "/documents/:document_id/images/:id" => "document_images#update", as: :update_document_image
 
+  get "/documents/:document_id/lead-image" => "document_lead_image#index", as: :document_lead_image
+
   get "/healthcheck", to: proc { [200, {}, %w[OK]] }
 
   get "/documentation" => "documentation#index"

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -34,6 +34,7 @@ Rails.application.routes.draw do
   post "/documents/:document_id/lead-image" => "document_lead_image#create"
   get "/documents/:document_id/lead-image/:image_id/edit" => "document_lead_image#edit", as: :edit_document_lead_image
   patch "/documents/:document_id/lead-image/:image_id/edit" => "document_lead_image#update", as: :update_document_lead_image
+  post "/documents/:document_id/lead-image/:image_id/choose" => "document_lead_image#choose_image", as: :choose_document_lead_image
   delete "/documents/:document_id/lead-image" => "document_lead_image#destroy", as: :remove_document_lead_image
 
   get "/healthcheck", to: proc { [200, {}, %w[OK]] }

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -31,6 +31,9 @@ Rails.application.routes.draw do
   patch "/documents/:document_id/images/:id" => "document_images#update", as: :update_document_image
 
   get "/documents/:document_id/lead-image" => "document_lead_image#index", as: :document_lead_image
+  post "/documents/:document_id/lead-image" => "document_lead_image#create"
+  get "/documents/:document_id/lead-image/:image_id/edit" => "document_lead_image#edit", as: :edit_document_lead_image
+  patch "/documents/:document_id/lead-image/:image_id/edit" => "document_lead_image#update"
 
   get "/healthcheck", to: proc { [200, {}, %w[OK]] }
 

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -34,6 +34,7 @@ Rails.application.routes.draw do
   post "/documents/:document_id/lead-image" => "document_lead_image#create"
   get "/documents/:document_id/lead-image/:image_id/edit" => "document_lead_image#edit", as: :edit_document_lead_image
   patch "/documents/:document_id/lead-image/:image_id/edit" => "document_lead_image#update", as: :update_document_lead_image
+  delete "/documents/:document_id/lead-image" => "document_lead_image#destroy", as: :remove_document_lead_image
 
   get "/healthcheck", to: proc { [200, {}, %w[OK]] }
 

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -33,7 +33,7 @@ Rails.application.routes.draw do
   get "/documents/:document_id/lead-image" => "document_lead_image#index", as: :document_lead_image
   post "/documents/:document_id/lead-image" => "document_lead_image#create"
   get "/documents/:document_id/lead-image/:image_id/edit" => "document_lead_image#edit", as: :edit_document_lead_image
-  patch "/documents/:document_id/lead-image/:image_id/edit" => "document_lead_image#update"
+  patch "/documents/:document_id/lead-image/:image_id/edit" => "document_lead_image#update", as: :update_document_lead_image
 
   get "/healthcheck", to: proc { [200, {}, %w[OK]] }
 

--- a/db/migrate/20180905142136_add_lead_image_to_document.rb
+++ b/db/migrate/20180905142136_add_lead_image_to_document.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+class AddLeadImageToDocument < ActiveRecord::Migration[5.2]
+  def change
+    add_reference :documents, :lead_image, foreign_key: { to_table: :images }
+  end
+end

--- a/db/migrate/20180905150545_add_image_metadata_fields.rb
+++ b/db/migrate/20180905150545_add_image_metadata_fields.rb
@@ -1,0 +1,11 @@
+# frozen_string_literal: true
+
+class AddImageMetadataFields < ActiveRecord::Migration[5.2]
+  def change
+    change_table :images, bulk: true do |t|
+      t.string :caption
+      t.string :alt_text
+      t.string :credit
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -44,8 +44,8 @@ ActiveRecord::Schema.define(version: 2018_09_07_121447) do
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.json "contents", default: {}
-    t.text "summary"
     t.string "base_path"
+    t.text "summary"
     t.json "tags", default: {}
     t.string "publication_state", null: false
     t.bigint "creator_id"
@@ -53,9 +53,11 @@ ActiveRecord::Schema.define(version: 2018_09_07_121447) do
     t.text "change_note"
     t.string "update_type"
     t.boolean "has_live_version_on_govuk", default: false, null: false
+    t.bigint "lead_image_id"
     t.index ["base_path"], name: "index_documents_on_base_path", unique: true
     t.index ["content_id", "locale"], name: "index_documents_on_content_id_and_locale", unique: true
     t.index ["creator_id"], name: "index_documents_on_creator_id"
+    t.index ["lead_image_id"], name: "index_documents_on_lead_image_id"
   end
 
   create_table "images", force: :cascade do |t|
@@ -88,6 +90,7 @@ ActiveRecord::Schema.define(version: 2018_09_07_121447) do
     t.datetime "updated_at", null: false
   end
 
+  add_foreign_key "documents", "images", column: "lead_image_id"
   add_foreign_key "documents", "users", column: "creator_id"
   add_foreign_key "images", "active_storage_blobs", column: "blob_id", on_delete: :cascade
   add_foreign_key "images", "documents", on_delete: :cascade

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -72,6 +72,9 @@ ActiveRecord::Schema.define(version: 2018_09_07_121447) do
     t.integer "crop_height", null: false
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
+    t.string "caption"
+    t.string "alt_text"
+    t.string "credit"
     t.index ["blob_id"], name: "index_images_on_blob_id"
     t.index ["document_id"], name: "index_images_on_document_id"
   end

--- a/spec/features/choose_lead_image_spec.rb
+++ b/spec/features/choose_lead_image_spec.rb
@@ -1,0 +1,32 @@
+# frozen_string_literal: true
+
+RSpec.feature "Choose a lead image" do
+  scenario "User chooses an existing image as lead image" do
+    given_there_is_a_document_with_existing_images
+    when_i_visit_the_summary_page
+    and_i_visit_the_lead_images_page
+    then_i_should_be_able_to_see_a_list_of_existing_images
+  end
+
+  def given_there_is_a_document_with_existing_images
+    document_type_schema = build(:document_type_schema, lead_image: true)
+    document = create(:document, document_type: document_type_schema.id)
+    create(:image, document: document, filename: "image-1.jpg")
+    create(:image, document: document, filename: "image-2.jpg")
+  end
+
+  def when_i_visit_the_summary_page
+    visit document_path(Document.last)
+  end
+
+  def and_i_visit_the_lead_images_page
+    click_on "Change Lead image"
+  end
+
+  def then_i_should_be_able_to_see_a_list_of_existing_images
+    expect(find("#image-0")["src"]).to include("image-1.jpg")
+    expect(page).to have_content("image-1.jpg")
+    expect(find("#image-1")["src"]).to include("image-2.jpg")
+    expect(page).to have_content("image-2.jpg")
+  end
+end

--- a/spec/features/choose_lead_image_spec.rb
+++ b/spec/features/choose_lead_image_spec.rb
@@ -7,6 +7,7 @@ RSpec.feature "Choose a lead image" do
     and_i_visit_the_lead_images_page
     then_i_should_be_able_to_see_a_list_of_existing_images
     when_i_select_an_image_to_be_the_lead_image
+    then_i_should_see_the_new_lead_image_on_the_summary_page
   end
 
   def given_there_is_a_document_with_existing_images
@@ -40,6 +41,13 @@ RSpec.feature "Choose a lead image" do
   end
 
   def when_i_select_an_image_to_be_the_lead_image
-    click_on()
+    within("td#image-1-metadata") do
+      click_on "Choose image"
+    end
+    click_on "Save and choose"
+  end
+
+  def then_i_should_see_the_new_lead_image_on_the_summary_page
+    expect(find("#lead-image")["src"]).to include("image-2.jpg")
   end
 end

--- a/spec/features/choose_lead_image_spec.rb
+++ b/spec/features/choose_lead_image_spec.rb
@@ -6,13 +6,17 @@ RSpec.feature "Choose a lead image" do
     when_i_visit_the_summary_page
     and_i_visit_the_lead_images_page
     then_i_should_be_able_to_see_a_list_of_existing_images
+    when_i_select_an_image_to_be_the_lead_image
   end
 
   def given_there_is_a_document_with_existing_images
     document_type_schema = build(:document_type_schema, lead_image: true)
     document = create(:document, document_type: document_type_schema.id)
-    create(:image, document: document, filename: "image-1.jpg")
+    @image1 = create(:image, document: document, filename: "image-1.jpg",
+                              alt_text: "image 1 alt text", caption: "image 1 caption",
+                              credit: "image 1 credit")
     create(:image, document: document, filename: "image-2.jpg")
+    document.update(lead_image: @image1)
   end
 
   def when_i_visit_the_summary_page
@@ -25,8 +29,17 @@ RSpec.feature "Choose a lead image" do
 
   def then_i_should_be_able_to_see_a_list_of_existing_images
     expect(find("#image-0")["src"]).to include("image-1.jpg")
-    expect(page).to have_content("image-1.jpg")
+    within("td#image-0-metadata") do
+      expect(page).to have_content(@image1.alt_text)
+      expect(page).to have_content(@image1.caption)
+      expect(page).to have_content(@image1.credit)
+      expect(page).to have_content("Lead image")
+    end
+
     expect(find("#image-1")["src"]).to include("image-2.jpg")
-    expect(page).to have_content("image-2.jpg")
+  end
+
+  def when_i_select_an_image_to_be_the_lead_image
+    click_on()
   end
 end

--- a/spec/features/choose_lead_image_spec.rb
+++ b/spec/features/choose_lead_image_spec.rb
@@ -41,7 +41,7 @@ RSpec.feature "Choose a lead image" do
   end
 
   def when_i_select_an_image_to_be_the_lead_image
-    within("td#image-1-metadata") do
+    within("td#image-1-choose-action") do
       click_on "Choose image"
     end
   end

--- a/spec/features/choose_lead_image_spec.rb
+++ b/spec/features/choose_lead_image_spec.rb
@@ -44,7 +44,6 @@ RSpec.feature "Choose a lead image" do
     within("td#image-1-metadata") do
       click_on "Choose image"
     end
-    click_on "Save and choose"
   end
 
   def then_i_should_see_the_new_lead_image_on_the_summary_page

--- a/spec/features/edit_lead_image_spec.rb
+++ b/spec/features/edit_lead_image_spec.rb
@@ -7,6 +7,7 @@ RSpec.feature "Edit a lead image" do
     then_i_see_there_is_no_lead_image
     when_i_visit_the_lead_images_page
     and_i_upload_a_new_image
+    and_i_fill_in_the_metadata
     then_i_should_be_able_to_see_the_image
   end
 

--- a/spec/features/edit_lead_image_spec.rb
+++ b/spec/features/edit_lead_image_spec.rb
@@ -20,16 +20,16 @@ RSpec.feature "Edit a lead image" do
   end
 
   def then_i_see_there_is_no_lead_image
-    expect(page).to have_content(I18n.t("documents.show.no_lead_image"))
+    expect(page).to have_content(I18n.t("documents.show.lead_image.no_lead_image"))
   end
 
   def when_i_visit_the_lead_images_page
-    click "Change lead image"
+    click_on "Change Lead image"
   end
 
   def and_i_upload_a_new_image
     find('form input[type="file"]').set(file_fixture("960x640.jpg"))
-    click "Upload"
+    click_on "Upload"
   end
 
   def and_i_fill_in_the_metadata

--- a/spec/features/edit_lead_image_spec.rb
+++ b/spec/features/edit_lead_image_spec.rb
@@ -39,7 +39,7 @@ RSpec.feature "Edit a lead image" do
   end
 
   def and_i_fill_in_the_metadata
-    expect(find(:img)["src"]).to include("960x640.jpg")
+    expect(find("#selected-image")["src"]).to include("960x640.jpg")
     fill_in "alt_text", with: "Some alt text"
     fill_in "caption", with: "Image caption"
     fill_in "credit", with: "Image credit"

--- a/spec/features/edit_lead_image_spec.rb
+++ b/spec/features/edit_lead_image_spec.rb
@@ -6,6 +6,7 @@ RSpec.feature "Edit a lead image" do
     when_i_visit_the_summary_page
     then_i_see_there_is_no_lead_image
     when_i_visit_the_lead_images_page
+    then_i_should_see_no_images_available
     and_i_upload_a_new_image
     and_i_fill_in_the_metadata
     then_i_should_be_able_to_see_the_image
@@ -26,6 +27,10 @@ RSpec.feature "Edit a lead image" do
 
   def when_i_visit_the_lead_images_page
     click_on "Change Lead image"
+  end
+
+  def then_i_should_see_no_images_available
+    expect(page).to have_content(I18n.t("document_lead_image.index.no_existing_image"))
   end
 
   def and_i_upload_a_new_image

--- a/spec/features/edit_lead_image_spec.rb
+++ b/spec/features/edit_lead_image_spec.rb
@@ -43,7 +43,7 @@ RSpec.feature "Edit a lead image" do
   def then_i_should_be_able_to_see_the_image
     expect(page).to have_content("Image caption")
     expect(page).to have_content("Image credit")
-    expect(find("#lead-image")["href"]).to include("960x640.jpg")
+    expect(find("#lead-image")["src"]).to include("960x640.jpg")
     expect(find("#lead-image")["alt"]).to eq("Some alt text")
   end
 end

--- a/spec/features/edit_lead_image_spec.rb
+++ b/spec/features/edit_lead_image_spec.rb
@@ -39,6 +39,7 @@ RSpec.feature "Edit a lead image" do
   end
 
   def and_i_fill_in_the_metadata
+    expect(find(:img)["src"]).to include("960x640.jpg")
     fill_in "alt_text", with: "Some alt text"
     fill_in "caption", with: "Image caption"
     fill_in "credit", with: "Image credit"

--- a/spec/features/edit_lead_image_spec.rb
+++ b/spec/features/edit_lead_image_spec.rb
@@ -1,55 +1,44 @@
 # frozen_string_literal: true
 
-RSpec.feature "Edit a lead image" do
-  scenario "User edits a lead image" do
-    given_there_is_a_document
-    when_i_visit_the_summary_page
-    then_i_see_there_is_no_lead_image
+RSpec.feature "Edit an existing lead image" do
+  scenario "User edits lead image" do
+    given_there_is_a_document_with_existing_images
     when_i_visit_the_lead_images_page
-    then_i_should_see_no_images_available
-    and_i_upload_a_new_image
-    and_i_fill_in_the_metadata
-    then_i_should_be_able_to_see_the_image
+    and_i_click_edit_details
+    then_i_edit_the_image_metadata
+    then_i_am_redirected_to_the_lead_images_page
+    and_i_should_be_able_to_see_the_edited_metadata
   end
 
-  def given_there_is_a_document
+  def given_there_is_a_document_with_existing_images
     document_type_schema = build(:document_type_schema, lead_image: true)
-    create(:document, document_type: document_type_schema.id)
-  end
-
-  def when_i_visit_the_summary_page
-    visit document_path(Document.last)
-  end
-
-  def then_i_see_there_is_no_lead_image
-    expect(page).to have_content(I18n.t("documents.show.lead_image.no_lead_image"))
+    document = create(:document, document_type: document_type_schema.id)
+    create(:image, document: document)
   end
 
   def when_i_visit_the_lead_images_page
+    visit document_path(Document.last)
     click_on "Change Lead image"
   end
 
-  def then_i_should_see_no_images_available
-    expect(page).to have_content(I18n.t("document_lead_image.index.no_existing_image"))
+  def and_i_click_edit_details
+    click_on "Edit details"
   end
 
-  def and_i_upload_a_new_image
-    find('form input[type="file"]').set(file_fixture("960x640.jpg"))
-    click_on "Upload"
-  end
-
-  def and_i_fill_in_the_metadata
-    expect(find("#selected-image")["src"]).to include("960x640.jpg")
+  def then_i_edit_the_image_metadata
     fill_in "alt_text", with: "Some alt text"
     fill_in "caption", with: "Image caption"
     fill_in "credit", with: "Image credit"
-    click_on "Save and choose"
+    click_on "Save image"
   end
 
-  def then_i_should_be_able_to_see_the_image
+  def then_i_am_redirected_to_the_lead_images_page
+    expect(page).to have_current_path(document_lead_image_path(Document.last))
+  end
+
+  def and_i_should_be_able_to_see_the_edited_metadata
+    expect(page).to have_content("Some alt text")
     expect(page).to have_content("Image caption")
     expect(page).to have_content("Image credit")
-    expect(find("#lead-image")["src"]).to include("960x640.jpg")
-    expect(find("#lead-image")["alt"]).to eq("Some alt text")
   end
 end

--- a/spec/features/edit_lead_image_spec.rb
+++ b/spec/features/edit_lead_image_spec.rb
@@ -29,7 +29,7 @@ RSpec.feature "Edit an existing lead image" do
     fill_in "alt_text", with: "Some alt text"
     fill_in "caption", with: "Image caption"
     fill_in "credit", with: "Image credit"
-    click_on "Save image"
+    click_on "Save and choose"
   end
 
   def then_i_am_redirected_to_the_lead_images_page

--- a/spec/features/edit_lead_image_spec.rb
+++ b/spec/features/edit_lead_image_spec.rb
@@ -34,16 +34,16 @@ RSpec.feature "Edit a lead image" do
   end
 
   def and_i_fill_in_the_metadata
-    fill_in "lead_image[alt_text]", with: "Some alt text"
-    fill_in "lead_image[caption]", with: "Image caption"
-    fill_in "lead_image[credit]", with: "Image credit"
-    click "Save and choose"
+    fill_in "alt_text", with: "Some alt text"
+    fill_in "caption", with: "Image caption"
+    fill_in "credit", with: "Image credit"
+    click_on "Save and choose"
   end
 
   def then_i_should_be_able_to_see_the_image
-    expect(find("#lead-image")["href"]).to include("960x640.jpg")
-    expect(find("#lead-image")["alt"]).to eq("Some alt text")
     expect(page).to have_content("Image caption")
     expect(page).to have_content("Image credit")
+    expect(find("#lead-image")["href"]).to include("960x640.jpg")
+    expect(find("#lead-image")["alt"]).to eq("Some alt text")
   end
 end

--- a/spec/features/edit_lead_image_spec.rb
+++ b/spec/features/edit_lead_image_spec.rb
@@ -1,0 +1,48 @@
+# frozen_string_literal: true
+
+RSpec.feature "Edit a lead image" do
+  scenario "User edits a lead image" do
+    given_there_is_a_document
+    when_i_visit_the_summary_page
+    then_i_see_there_is_no_lead_image
+    when_i_visit_the_lead_images_page
+    and_i_upload_a_new_image
+    then_i_should_be_able_to_see_the_image
+  end
+
+  def given_there_is_a_document
+    document_type_schema = build(:document_type_schema, lead_image: true)
+    create(:document, document_type: document_type_schema.id)
+  end
+
+  def when_i_visit_the_summary_page
+    visit document_path(Document.last)
+  end
+
+  def then_i_see_there_is_no_lead_image
+    expect(page).to have_content(I18n.t("documents.show.no_lead_image"))
+  end
+
+  def when_i_visit_the_lead_images_page
+    click "Change lead image"
+  end
+
+  def and_i_upload_a_new_image
+    find('form input[type="file"]').set(file_fixture("960x640.jpg"))
+    click "Upload"
+  end
+
+  def and_i_fill_in_the_metadata
+    fill_in "lead_image[alt_text]", with: "Some alt text"
+    fill_in "lead_image[caption]", with: "Image caption"
+    fill_in "lead_image[credit]", with: "Image credit"
+    click "Save and choose"
+  end
+
+  def then_i_should_be_able_to_see_the_image
+    expect(find("#lead-image")["href"]).to include("960x640.jpg")
+    expect(find("#lead-image")["alt"]).to eq("Some alt text")
+    expect(page).to have_content("Image caption")
+    expect(page).to have_content("Image credit")
+  end
+end

--- a/spec/features/remove_lead_image_spec.rb
+++ b/spec/features/remove_lead_image_spec.rb
@@ -1,0 +1,44 @@
+# frozen_string_literal: true
+
+RSpec.feature "Remove a lead image" do
+  scenario "User removes an existing lead image" do
+    given_there_is_a_document_with_a_lead_image
+    when_i_visit_the_lead_images_page
+    then_i_should_be_able_to_see_the_lead_image
+    when_i_remove_the_lead_image
+    then_i_should_not_see_a_lead_image_on_the_summary_page
+  end
+
+  def given_there_is_a_document_with_a_lead_image
+    document_type_schema = build(:document_type_schema, lead_image: true)
+    document = create(:document, document_type: document_type_schema.id)
+    @image = create(:image, document: document, filename: "image-1.jpg",
+                              alt_text: "image 1 alt text", caption: "image 1 caption",
+                              credit: "image 1 credit")
+    document.update(lead_image: @image)
+  end
+
+  def when_i_visit_the_lead_images_page
+    visit document_lead_image_path(Document.last)
+  end
+
+  def then_i_should_be_able_to_see_the_lead_image
+    expect(find("#image-0")["src"]).to include("image-1.jpg")
+    within("td#image-0-metadata") do
+      expect(page).to have_content(@image.alt_text)
+      expect(page).to have_content(@image.caption)
+      expect(page).to have_content(@image.credit)
+      expect(page).to have_content("Lead image")
+    end
+  end
+
+  def when_i_remove_the_lead_image
+    within("td#image-0-metadata") do
+      click_on "Remove"
+    end
+  end
+
+  def then_i_should_not_see_a_lead_image_on_the_summary_page
+    expect(page).to have_content(I18n.t("documents.show.lead_image.no_lead_image"))
+  end
+end

--- a/spec/features/upload_invalid_lead_image_spec.rb
+++ b/spec/features/upload_invalid_lead_image_spec.rb
@@ -1,0 +1,33 @@
+# frozen_string_literal: true
+
+RSpec.feature "Edit a lead image" do
+  scenario "User edits a lead image" do
+    given_there_is_a_document
+    when_i_visit_the_summary_page
+    and_i_visit_the_lead_images_page
+    and_i_upload_an_invalid_image
+    then_i_should_see_an_error
+  end
+
+  def given_there_is_a_document
+    document_type_schema = build(:document_type_schema, lead_image: true)
+    create(:document, document_type: document_type_schema.id)
+  end
+
+  def when_i_visit_the_summary_page
+    visit document_path(Document.last)
+  end
+
+  def and_i_visit_the_lead_images_page
+    click_on "Change Lead image"
+  end
+
+  def and_i_upload_an_invalid_image
+    find('form input[type="file"]').set(file_fixture("text-file.txt"))
+    click_on "Upload"
+  end
+
+  def then_i_should_see_an_error
+    expect(page).to have_content(I18n.t("validations.images.invalid_format"))
+  end
+end

--- a/spec/features/upload_lead_image_spec.rb
+++ b/spec/features/upload_lead_image_spec.rb
@@ -1,0 +1,55 @@
+# frozen_string_literal: true
+
+RSpec.feature "Upload a lead image" do
+  scenario "User uploads a lead image" do
+    given_there_is_a_document
+    when_i_visit_the_summary_page
+    then_i_see_there_is_no_lead_image
+    when_i_visit_the_lead_images_page
+    then_i_should_see_no_images_available
+    when_i_upload_a_new_image
+    and_i_fill_in_the_metadata
+    then_i_should_be_able_to_see_the_lead_image_on_the_summary_page
+  end
+
+  def given_there_is_a_document
+    document_type_schema = build(:document_type_schema, lead_image: true)
+    create(:document, document_type: document_type_schema.id)
+  end
+
+  def when_i_visit_the_summary_page
+    visit document_path(Document.last)
+  end
+
+  def then_i_see_there_is_no_lead_image
+    expect(page).to have_content(I18n.t("documents.show.lead_image.no_lead_image"))
+  end
+
+  def when_i_visit_the_lead_images_page
+    click_on "Change Lead image"
+  end
+
+  def then_i_should_see_no_images_available
+    expect(page).to have_content(I18n.t("document_lead_image.index.no_existing_image"))
+  end
+
+  def when_i_upload_a_new_image
+    find('form input[type="file"]').set(file_fixture("960x640.jpg"))
+    click_on "Upload"
+  end
+
+  def and_i_fill_in_the_metadata
+    expect(find("#selected-image")["src"]).to include("960x640.jpg")
+    fill_in "alt_text", with: "Some alt text"
+    fill_in "caption", with: "Image caption"
+    fill_in "credit", with: "Image credit"
+    click_on "Save image"
+  end
+
+  def then_i_should_be_able_to_see_the_lead_image_on_the_summary_page
+    expect(page).to have_content("Image caption")
+    expect(page).to have_content("Image credit")
+    expect(find("#lead-image")["src"]).to include("960x640.jpg")
+    expect(find("#lead-image")["alt"]).to eq("Some alt text")
+  end
+end

--- a/spec/features/upload_lead_image_spec.rb
+++ b/spec/features/upload_lead_image_spec.rb
@@ -43,7 +43,7 @@ RSpec.feature "Upload a lead image" do
     fill_in "alt_text", with: "Some alt text"
     fill_in "caption", with: "Image caption"
     fill_in "credit", with: "Image credit"
-    click_on "Save image"
+    click_on "Save and choose"
   end
 
   def then_i_should_be_able_to_see_the_lead_image_on_the_summary_page

--- a/spec/features/upload_no_file_as_lead_image_spec.rb
+++ b/spec/features/upload_no_file_as_lead_image_spec.rb
@@ -1,0 +1,27 @@
+# frozen_string_literal: true
+
+RSpec.feature "Upload no file as a lead image" do
+  scenario "User uploads no file" do
+    given_there_is_a_document
+    when_i_visit_the_lead_images_page
+    when_i_upload_no_file
+    then_i_should_see_an_error
+  end
+
+  def given_there_is_a_document
+    document_type_schema = build(:document_type_schema, lead_image: true)
+    create(:document, document_type: document_type_schema.id)
+  end
+
+  def when_i_visit_the_lead_images_page
+    visit document_lead_image_path(Document.last)
+  end
+
+  def when_i_upload_no_file
+    click_on "Upload"
+  end
+
+  def then_i_should_see_an_error
+    expect(page).to have_content(I18n.t("document_lead_image.index.no_file_selected"))
+  end
+end


### PR DESCRIPTION
For https://trello.com/c/kwumHz3Q/189-set-up-a-minimal-lead-image-workflow-upload-and-select-xl
Paired with @davbo 

This adds a minimal lead image workflow in order for users to be able to perform basic tasks relating to a document's lead image:
- Uploading an image
- Adding and modifying metadata relating to a lead image
- Selecting an image from a list of existing images as a lead image
- Removing an image as a lead image

We also display the chosen lead image on the summary page for a document and display an error if a user chooses an invalid image to upload.

We expect some new components to be built after this PR has been merged, for a example for the image list, so there is some temporary code here which will need to be removed after these components have been created.
