### PR TITLE
Deal consistently with errors sending to draft

### DIFF
--- a/app/controllers/documents_controller.rb
+++ b/app/controllers/documents_controller.rb
@@ -29,6 +29,17 @@ class DocumentsController < ApplicationController
     redirect_to document, alert: t("documents.show.flashes.draft_error")
   end
 
+  # TODO: Refactor to reduce duplication with #update
+  def retry_draft_save
+    document = Document.find_by_param(params[:id])
+    DocumentPublishingService.new.publish_draft(document)
+    redirect_to document, notice: t("documents.show.flashes.draft_success")
+  rescue GdsApi::BaseError => e
+    Rails.logger.error(e)
+    document.update!(publication_state: "error_sending_to_draft")
+    redirect_to document, alert: t("documents.show.flashes.draft_error")
+  end
+
   def generate_path
     document = Document.find_by_param(params[:id])
     base_path = PathGeneratorService.new.path(document, params[:title])

--- a/app/views/documents/show/_actions.html.erb
+++ b/app/views/documents/show/_actions.html.erb
@@ -1,6 +1,12 @@
 <div class="app-side">
   <div class="app-side__actions">
-    <% if @document.user_facing_state == "published_but_needs_2i" %>
+    <% if @document.publication_state == "error_sending_to_draft" %>
+      <%= govspeak_to_html t("documents.show.sidebar.error_publishing") %>
+
+      <%= form_tag retry_draft_save_path(@document) do %>
+        <%= render "govuk_publishing_components/components/button", text: "Try again" %>
+      <% end %>
+    <% elsif @document.user_facing_state == "published_but_needs_2i" %>
       <%= form_tag approve_document_path(@document) do %>
         <%= render "govuk_publishing_components/components/button", text: "Approve" %>
       <% end %>

--- a/config/locales/en/documents/show.yml
+++ b/config/locales/en/documents/show.yml
@@ -18,6 +18,9 @@ en:
           summary: Summary
           update_type: Update type
           change_note: Change note
+      sidebar:
+        error_publishing: |
+          Something went wrong when saving your draft. Please try again or [raise a support request](https://support.publishing.service.gov.uk/technical_fault_report/new).
       metadata:
         status: Status
         updated_at: Last updated

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -14,6 +14,7 @@ Rails.application.routes.draw do
 
   get "/documents" => "documents#index"
   get "/documents/:id/edit" => "documents#edit", as: :edit_document
+  post "/documents/:id/retry-draft" => "documents#retry_draft_save", as: :retry_draft_save
   patch "/documents/:id" => "documents#update", as: :document
   get "/documents/:id" => "documents#show"
   get "/documents/:id/generate-path" => "documents#generate_path", as: :generate_path

--- a/spec/features/create_a_document_api_down_spec.rb
+++ b/spec/features/create_a_document_api_down_spec.rb
@@ -7,6 +7,9 @@ RSpec.feature "Create a document when the API is down" do
     when_i_submit_the_form
     then_i_see_the_document_exists
     and_the_preview_creation_failed
+
+    when_the_api_is_up_again_and_i_click_the_retry_button
+    then_the_document_is_saved_again
   end
 
   def given_i_start_to_create_a_document
@@ -39,6 +42,16 @@ RSpec.feature "Create a document when the API is down" do
   def and_the_preview_creation_failed
     expect(@request).to have_been_requested
     expect(page).to have_content(I18n.t("documents.show.flashes.draft_error"))
-    expect(Document.last.publication_state).to eq("error_sending_to_draft")
+  end
+
+  def when_the_api_is_up_again_and_i_click_the_retry_button
+    @request = stub_publishing_api_put_content(Document.last.content_id,
+                                               hash_including(title: "A great title"))
+    click_on "Try again"
+  end
+
+  def then_the_document_is_saved_again
+    expect(@request).to have_been_requested.twice
+    expect(page).to have_content(I18n.t("documents.show.flashes.draft_success"))
   end
 end


### PR DESCRIPTION
When a document is saved, we attempt to send it to the publishing-api as draft. This goes wrong sometimes, either because the publishing-api isn't available (in development), the publishing-api is slow to respond
(when it's busy) or when we're accidentally sending an invalid payload to the publishing-api (this should not be possible, but it's likely that we'll make mistakes in this).

This commit adds a "retry" button to the page when the draft publishing hasn't succeeded. This isn't a particularly elegant solution (as in, requiring fewer lines of code), but I can't think of anything better at the moment.

It's intent is to communicate to the user that something went wrong, and gives an option to fix the problem.

https://trello.com/c/VkVrVGeB