### PR TITLE
Use `update!` to save documents

### DIFF
--- a/app/controllers/document_tags_controller.rb
+++ b/app/controllers/document_tags_controller.rb
@@ -12,7 +12,7 @@ class DocumentTagsController < ApplicationController
 
   def update
     document = Document.find_by_param(params[:id])
-    document.update(tags: update_params(document))
+    document.update!(tags: update_params(document))
     DocumentPublishingService.new.publish_draft(document)
     redirect_to document, notice: t("documents.show.flashes.draft_success")
   rescue GdsApi::BaseError => e


### PR DESCRIPTION
This will raise an error is the document is invalid, instead of silently swallowing it. `Model#update` is only to be used if we're using the return value to check if the update was successful or not.