### PR TITLE
RFC: possible fix for translating buttons

### DIFF
--- a/spec/features/change_notes_spec.rb
+++ b/spec/features/change_notes_spec.rb
@@ -28,7 +28,7 @@ RSpec.feature "Change notes" do
     fill_in "document[change_note]", with: "Updated banana pricing"
     choose I18n.t("documents.edit.update_type.minor_name")
 
-    click_on "Save"
+    click_save
   end
 
   def then_the_summary_page_displays_change_note_and_update_type
@@ -57,7 +57,7 @@ RSpec.feature "Change notes" do
     # the document editing feature test.
     stub_any_publishing_api_publish
 
-    click_on "Confirm publish"
+    click_confirm_publish_button
   end
 
   def then_the_change_note_and_update_type_should_be_cleared_for_the_next_edition

--- a/spec/features/choose_a_format_spec.rb
+++ b/spec/features/choose_a_format_spec.rb
@@ -11,8 +11,8 @@ RSpec.feature "Choosing a format" do
 
   def when_i_dont_choose_a_supertype
     visit "/"
-    click_on "New document"
-    click_on "Continue"
+    click_new_document_button
+    click_continue
   end
 
   def then_i_see_a_supertype_error
@@ -21,11 +21,11 @@ RSpec.feature "Choosing a format" do
 
   def when_i_choose_a_supertype
     choose SupertypeSchema.all.first.label
-    click_on "Continue"
+    click_continue
   end
 
   def and_i_dont_choose_a_document_type
-    click_on "Continue"
+    click_continue
   end
 
   def then_i_see_a_document_type_error

--- a/spec/features/create_a_document_api_down_spec.rb
+++ b/spec/features/create_a_document_api_down_spec.rb
@@ -15,11 +15,11 @@ RSpec.feature "Create a document when the API is down" do
   def given_i_start_to_create_a_document
     @schema = DocumentTypeSchema.find("news_story")
     visit "/"
-    click_on "New document"
+    click_new_document_button
     choose SupertypeSchema.find("news").label
-    click_on "Continue"
+    click_continue
     choose @schema.label
-    click_on "Continue"
+    click_continue
   end
 
   def and_the_publishing_api_is_down
@@ -30,7 +30,7 @@ RSpec.feature "Create a document when the API is down" do
 
   def when_i_submit_the_form
     fill_in "document[title]", with: "A great title"
-    click_on "Save"
+    click_save
   end
 
   def then_i_see_the_document_exists
@@ -47,7 +47,7 @@ RSpec.feature "Create a document when the API is down" do
   def when_the_api_is_up_again_and_i_click_the_retry_button
     @request = stub_publishing_api_put_content(Document.last.content_id,
                                                hash_including(title: "A great title"))
-    click_on "Try again"
+    click_try_again_button
   end
 
   def then_the_document_is_saved_again

--- a/spec/features/create_a_document_spec.rb
+++ b/spec/features/create_a_document_spec.rb
@@ -15,11 +15,11 @@ RSpec.feature "Create a document" do
 
     schema = DocumentTypeSchema.find("news_story")
     visit "/"
-    click_on "New document"
+    click_new_document_button
     choose SupertypeSchema.find("news").label
-    click_on "Continue"
+    click_continue
     choose schema.label
-    click_on "Continue"
+    click_continue
   end
 
   def then_i_wont_be_able_to_choose_an_update_type_or_change_note

--- a/spec/features/edit_a_document_spec.rb
+++ b/spec/features/edit_a_document_spec.rb
@@ -28,7 +28,7 @@ RSpec.feature "Edit a document" do
   def and_i_fill_in_the_content_fields
     fill_in "document[contents][body]", with: "Edited body."
     @request = stub_publishing_api_put_content(Document.last.content_id, {})
-    click_on "Save"
+    click_save
   end
 
   def then_i_see_the_document_is_saved

--- a/spec/features/edit_document_tags_spec.rb
+++ b/spec/features/edit_document_tags_spec.rb
@@ -51,7 +51,7 @@ RSpec.feature "Edit document tags" do
     unselect "Initial tag", from: "tags[multi_tag_id][]"
 
     select "Tag to select 1", from: "tags[single_tag_id][]"
-    click_on "Save"
+    click_save
   end
 
   def then_i_can_view_the_tags

--- a/spec/features/force_publishing_spec.rb
+++ b/spec/features/force_publishing_spec.rb
@@ -23,7 +23,7 @@ RSpec.feature "Force publishing" do
   end
 
   def and_i_click_on_the_publish_button
-    click_on "Publish"
+    click_publish_button
   end
 
   def and_i_say_that_the_document_has_not_been_reviewed
@@ -35,7 +35,7 @@ RSpec.feature "Force publishing" do
     # the main publishing feature test
     stub_any_publishing_api_publish
 
-    click_on "Confirm publish"
+    click_confirm_publish_button
   end
 
   def then_i_see_that_the_document_was_published_without_review

--- a/spec/features/publish_a_document_api_down_spec.rb
+++ b/spec/features/publish_a_document_api_down_spec.rb
@@ -19,8 +19,8 @@ RSpec.feature "Publishing a document when the API is down" do
 
   def when_i_try_to_publish_the_document
     visit document_path(@document)
-    click_on "Publish"
-    click_on "Confirm publish"
+    click_publish_button
+    click_confirm_publish_button
   end
 
   def then_i_see_the_publish_failed

--- a/spec/features/publish_a_document_spec.rb
+++ b/spec/features/publish_a_document_spec.rb
@@ -20,7 +20,7 @@ RSpec.feature "Publishing a document" do
   end
 
   def and_i_click_on_the_publish_button
-    click_on "Publish"
+    click_publish_button
   end
 
   def and_i_say_that_the_document_has_been_reviewed
@@ -29,7 +29,7 @@ RSpec.feature "Publishing a document" do
 
   def and_i_confirm_the_publishing
     @request = stub_publishing_api_publish(@document.content_id, update_type: nil, locale: @document.locale)
-    click_on "Confirm publish"
+    click_confirm_publish_button
   end
 
   def then_i_see_the_publish_succeeded

--- a/spec/features/publishing_validations_spec.rb
+++ b/spec/features/publishing_validations_spec.rb
@@ -33,7 +33,7 @@ RSpec.feature "Publish validations" do
     fill_in "document[title]", with: "A nice title of considerable length"
     fill_in "document[summary]", with: "A nice summary of considerable length"
     fill_in "document[contents][body]", with: "A very long body text."
-    click_on "Save"
+    click_save
   end
 
   def then_i_see_no_validation_warnings

--- a/spec/features/save_document_tags_api_down_spec.rb
+++ b/spec/features/save_document_tags_api_down_spec.rb
@@ -30,7 +30,7 @@ RSpec.feature "Save document tags when the API is down" do
   end
 
   def when_i_finish_editing_the_tags
-    click_on "Save"
+    click_save
   end
 
   def then_i_see_the_document_page

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -32,6 +32,7 @@ RSpec.configure do |config|
   config.include FactoryBot::Syntax::Methods
   config.include GdsApi::TestHelpers::PublishingApiV2
   config.include GovukSchemas::RSpecMatchers
+  config.include ReadableButtonsHelper
 
   config.fixture_path = "#{::Rails.root}/spec/fixtures"
 

--- a/spec/support/readable_buttons_helper.rb
+++ b/spec/support/readable_buttons_helper.rb
@@ -1,0 +1,26 @@
+module ReadableButtonsHelper
+  def click_save
+    # something like `click_on I18n.t("documents.edit.save_button")`
+    click_on "Save"
+  end
+
+  def click_confirm_publish_button
+    click_on "Confirm publish"
+  end
+
+  def click_continue
+    click_on "Continue"
+  end
+
+  def click_new_document_button
+    click_on "New document"
+  end
+
+  def click_try_again_button
+    click_on "Try again"
+  end
+
+  def click_publish_button
+    click_on "Publish"
+  end
+end


### PR DESCRIPTION
As discussed in https://github.com/alphagov/content-publisher/pull/249, we're currently not translating clickable text, primarily to aid the readability of the tests.

Another approach that helps readability is to extract all the `click_on "Thing"` calls into a helper. The helper can then refer to the translated string, but the tests still read like English.

