### PR TITLE
Handle unknown document creator on index page

### DIFF
--- a/app/views/documents/index/_results.html.erb
+++ b/app/views/documents/index/_results.html.erb
@@ -31,7 +31,9 @@
           <br/>
           <%= document.document_type_schema.label %>
           <br/>
-          <%= t "documents.index.search_results.headings.creator", creator: document.creator.name %>
+          <%= t "documents.index.search_results.headings.creator",
+            creator: document.creator&.name || I18n.t("documents.index.search_results.unknown_creator")
+          %>
         </td>
 
         <td class="govuk-table__cell ">

--- a/app/views/documents/show/_document_metadata.html.erb
+++ b/app/views/documents/show/_document_metadata.html.erb
@@ -15,7 +15,7 @@
       },
       {
         field: t("documents.show.metadata.created_by"),
-        value: @document.creator&.name || I18n.t("documents.show.metadata.unknown_data")
+        value: @document.creator&.name || I18n.t("documents.show.metadata.unknown_creator")
       },
     ]
   } %>

--- a/config/locales/en/documents/index.yml
+++ b/config/locales/en/documents/index.yml
@@ -22,6 +22,7 @@ en:
             * removing filters
             * searching for something less specific
             * double-checking your spelling
+        unknown_creator: Unknown
       filter:
         title_or_url: Search for a title or URL slug
         document_type: Document type

--- a/config/locales/en/documents/show.yml
+++ b/config/locales/en/documents/show.yml
@@ -26,7 +26,7 @@ en:
         updated_at: Last updated
         created_at: Created
         created_by: Document created by
-        unknown_data: Unknown
+        unknown_creator: Unknown
       flashes:
         draft_success: Preview creation successful
         draft_error: Error creating preview

--- a/spec/features/show_a_document_with_no_creator_spec.rb
+++ b/spec/features/show_a_document_with_no_creator_spec.rb
@@ -18,7 +18,7 @@ RSpec.feature "Showing a document summary" do
   def the_document_creator_is_shown_as_unknown
     within("div.app-c-metadata") do
       expect(page).to have_content(I18n.t("documents.show.metadata.created_by") +
-        ": " + I18n.t("documents.show.metadata.unknown_data"))
+        ": " + I18n.t("documents.show.metadata.unknown_creator"))
     end
   end
 end


### PR DESCRIPTION
This is to fix the index page currently throwing an exception when the
user who created the document does not exist.

I felt the key unknown_data was a bit abstract so went for a more
explicit unknown_creator