### PR TITLE
Revert "Manually turn on brakeman"

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -13,7 +13,6 @@ node {
         sh("yarn run lint")
       }
     },
-    brakeman: true,
     rubyLintDiff: false,
     rubyLintDirs: "",
     overrideTestTask: {


### PR DESCRIPTION
Reverts alphagov/content-publisher#247, which should not be necessary anymore if https://github.com/alphagov/govuk-jenkinslib/pull/29 works correctly.