### PR TITLE
Deal consistently with errors publishing

### DIFF
--- a/app/services/user_facing_state.rb
+++ b/app/services/user_facing_state.rb
@@ -10,7 +10,7 @@ class UserFacingState
     case state.to_sym
     when :draft
       query
-        .where(publication_state: %w[changes_not_sent_to_draft sent_to_draft sending_to_draft error_sending_to_draft])
+        .where(publication_state: %w[changes_not_sent_to_draft sent_to_draft sending_to_draft error_sending_to_draft error_sending_to_live])
         .where.not(review_state: "submitted_for_review")
     when :submitted_for_review
       query.where(review_state: "submitted_for_review")
@@ -20,7 +20,7 @@ class UserFacingState
       # Note this includes published_but_needs_2i as this is expected to be
       # included when traversing published documents, this is a Whitehall
       # quirk we've inherited.
-      query.where(publication_state: %w[sending_to_live sent_to_live error_sending_to_live])
+      query.where(publication_state: %w[sending_to_live sent_to_live])
     else
       raise "Unknown user_facing_state: #{state}"
     end
@@ -33,11 +33,11 @@ class UserFacingState
   def to_s
     if review_state == "submitted_for_review"
       "submitted_for_review"
-    elsif publication_state.in?(%w[changes_not_sent_to_draft sent_to_draft sending_to_draft error_sending_to_draft])
+    elsif publication_state.in?(%w[changes_not_sent_to_draft sent_to_draft sending_to_draft error_sending_to_draft error_sending_to_live])
       "draft"
     elsif review_state == "published_without_review"
       "published_but_needs_2i"
-    elsif publication_state.in?(%w[sent_to_live sending_to_live error_sending_to_live])
+    elsif publication_state.in?(%w[sent_to_live sending_to_live])
       "published"
     else
       raise "Encountered an unknown user facing state. review_state: #{review_state}, publication_state: #{publication_state}"

--- a/app/views/documents/show/_actions.html.erb
+++ b/app/views/documents/show/_actions.html.erb
@@ -6,6 +6,10 @@
       <%= form_tag retry_draft_save_path(@document) do %>
         <%= render "govuk_publishing_components/components/button", text: "Try again" %>
       <% end %>
+    <% elsif @document.publication_state == "error_sending_to_live" %>
+      <%= govspeak_to_html t("documents.show.sidebar.error_publishing_live") %>
+
+      <%= render "govuk_publishing_components/components/button", text: "Retry publishing", href: publish_document_path(@document) %>
     <% elsif @document.user_facing_state == "published_but_needs_2i" %>
       <%= form_tag approve_document_path(@document) do %>
         <%= render "govuk_publishing_components/components/button", text: "Approve" %>

--- a/app/views/documents/show/_actions.html.erb
+++ b/app/views/documents/show/_actions.html.erb
@@ -1,7 +1,7 @@
 <div class="app-side">
   <div class="app-side__actions">
     <% if @document.publication_state == "error_sending_to_draft" %>
-      <%= govspeak_to_html t("documents.show.sidebar.error_publishing") %>
+      <%= govspeak_to_html t("documents.show.sidebar.error_publishing_draft") %>
 
       <%= form_tag retry_draft_save_path(@document) do %>
         <%= render "govuk_publishing_components/components/button", text: "Try again" %>

--- a/config/locales/en/documents/show.yml
+++ b/config/locales/en/documents/show.yml
@@ -19,7 +19,7 @@ en:
           update_type: Update type
           change_note: Change note
       sidebar:
-        error_publishing: |
+        error_publishing_draft: |
           Something went wrong when saving your draft. Please try again or [raise a support request](https://support.publishing.service.gov.uk/technical_fault_report/new).
       lead_image:
         title: Lead image

--- a/config/locales/en/documents/show.yml
+++ b/config/locales/en/documents/show.yml
@@ -21,6 +21,8 @@ en:
       sidebar:
         error_publishing_draft: |
           Something went wrong when saving your draft. Please try again or [raise a support request](https://support.publishing.service.gov.uk/technical_fault_report/new).
+        error_publishing_live: |
+          Something went wrong when publishing. Please try again or [raise a support request](https://support.publishing.service.gov.uk/technical_fault_report/new).
       lead_image:
         title: Lead image
         no_lead_image: No lead image.

--- a/spec/features/publish_a_document_api_down_spec.rb
+++ b/spec/features/publish_a_document_api_down_spec.rb
@@ -6,6 +6,9 @@ RSpec.feature "Publishing a document when the API is down" do
     and_the_publishing_api_is_down
     when_i_try_to_publish_the_document
     then_i_see_the_publish_failed
+
+    given_the_api_is_up_again_and_i_try_to_publish_the_document
+    then_i_see_the_publish_succeeded
   end
 
   def given_there_is_a_document
@@ -27,5 +30,17 @@ RSpec.feature "Publishing a document when the API is down" do
     expect(@request).to have_been_requested
     expect(page).to have_content(I18n.t("documents.show.flashes.publish_error"))
     expect(@document.reload.publication_state).to eq("error_sending_to_live")
+  end
+
+  def given_the_api_is_up_again_and_i_try_to_publish_the_document
+    @request = stub_publishing_api_publish(@document.content_id, {})
+    visit document_path(@document)
+    click_on "Retry publishing"
+    click_on "Confirm publish"
+  end
+
+  def then_i_see_the_publish_succeeded
+    expect(@request).to have_been_requested.twice
+    expect(page).to have_content(I18n.t("publish_document.published_document.reviewed.title"))
   end
 end

--- a/spec/services/user_facing_state_spec.rb
+++ b/spec/services/user_facing_state_spec.rb
@@ -114,5 +114,13 @@ RSpec.describe UserFacingState do
 
       expect(state).to eql("published")
     end
+
+    it "is draft if the publishing failed" do
+      document = build(:document, publication_state: "error_sending_to_live", review_state: "reviewed")
+
+      state = UserFacingState.new(document).to_s
+
+      expect(state).to eql("draft")
+    end
   end
 end


### PR DESCRIPTION
This is a continuation of https://github.com/alphagov/content-publisher/pull/250.

Something publishing to the publishing-api goes wrong, either because the publishing-api isn't available (in development), the publishing-api is slow to respond (when it's busy).

This commit adds a message and button to the summary page when something has gone wrong, so the user can fix the issue themselves.

<img width="987" alt="screen shot 2018-09-11 at 14 49 46" src="https://user-images.githubusercontent.com/233676/45364577-66f6a580-b5d2-11e8-8e92-e64a5832270b.png">

https://trello.com/c/VkVrVGeB

