### PR TITLE
Support gov responses and world news stories

### DIFF
--- a/app/formats/document_types.yml
+++ b/app/formats/document_types.yml
@@ -108,6 +108,110 @@
       type: multi_tag
       document_type: worldwide_organisation
 
+- id: government_response
+  label: Government response
+  edit_only: true
+  lead_image: true
+  path_prefix: /news
+  publishing_metadata:
+    schema_name: news_article
+    rendering_app: government-frontend
+  guidance:
+    - id: title
+      title: Create a news title
+      body: The title must make clear what the content offers users. Use the words your users do to help them find this. Avoid wordplay or teases.
+    - id: summary
+      title: Writing a news summary
+      body: The summary should explain the main point of the content. It's the first line of the content so don’t repeat it below and end with a full stop.
+    - id: body
+      title: Writing news
+      body: Tell the story in the first lines with the most important information at the top. Use short words, short sentences, and short paragraphs. Use subheadings in longer content.
+    - id: primary_publishing_organisation
+      title: Primary organisation
+      body: The organisation responsible for publishing and maintaining this content.
+    - id: organisations
+      title: Organisations
+      body: Any organisations who share responsibility for this content.
+  contents:
+    - id: body
+      label: Body
+      type: govspeak
+      validations:
+        min_length: 10
+  tags:
+    - id: primary_publishing_organisation
+      label: Primary organisation
+      type: single_tag
+      document_type: organisation
+    - id: organisations
+      label: Organisations
+      type: multi_tag
+      document_type: organisation
+    - id: topical_events
+      label: Topical events
+      type: multi_tag
+      document_type: topical_event
+    - id: world_locations
+      label: World locations
+      type: multi_tag
+      document_type: world_location
+    - id: worldwide_organisations
+      label: Worldwide organisations
+      type: multi_tag
+      document_type: worldwide_organisation
+
+- id: world_news_story
+  label: World news story
+  edit_only: true
+  lead_image: true
+  path_prefix: /news
+  publishing_metadata:
+    schema_name: news_article
+    rendering_app: government-frontend
+  guidance:
+    - id: title
+      title: Create a news title
+      body: The title must make clear what the content offers users. Use the words your users do to help them find this. Avoid wordplay or teases.
+    - id: summary
+      title: Writing a news summary
+      body: The summary should explain the main point of the content. It's the first line of the content so don’t repeat it below and end with a full stop.
+    - id: body
+      title: Writing news
+      body: Tell the story in the first lines with the most important information at the top. Use short words, short sentences, and short paragraphs. Use subheadings in longer content.
+    - id: primary_publishing_organisation
+      title: Primary organisation
+      body: The organisation responsible for publishing and maintaining this content.
+    - id: organisations
+      title: Organisations
+      body: Any organisations who share responsibility for this content.
+  contents:
+    - id: body
+      label: Body
+      type: govspeak
+      validations:
+        min_length: 10
+  tags:
+    - id: primary_publishing_organisation
+      label: Primary organisation
+      type: single_tag
+      document_type: organisation
+    - id: organisations
+      label: Organisations
+      type: multi_tag
+      document_type: organisation
+    - id: topical_events
+      label: Topical events
+      type: multi_tag
+      document_type: topical_event
+    - id: world_locations
+      label: World locations
+      type: multi_tag
+      document_type: world_location
+    - id: worldwide_organisations
+      label: Worldwide organisations
+      type: multi_tag
+      document_type: worldwide_organisation
+
 - id: fatality_notice
   label: Fatality notice
   description: Initial fatality notices and subsequent obituaries of forces and MOD personnel
@@ -121,13 +225,6 @@
   managed_elsewhere:
     hostname: whitehall-admin
     path: /government/admin/speeches/new
-
-- id: world_news_story
-  label: World news story
-  description: Announcements specific to one or more world location
-  managed_elsewhere:
-    hostname: whitehall-admin
-    path: /government/admin/news/new
 
 - id: detailed_guide
   label: Detailed guide

--- a/app/formats/supertypes.yml
+++ b/app/formats/supertypes.yml
@@ -6,9 +6,10 @@
   display_document_types:
     - news_story
     - press_release
+    - world_news_story
+    - government_response
     - fatality_notice
     - speech
-    - world_news_story
 
 - id: guidance
   label: Guidance

--- a/app/services/document_type_schema.rb
+++ b/app/services/document_type_schema.rb
@@ -2,7 +2,7 @@
 
 class DocumentTypeSchema
   attr_reader :contents, :id, :label, :managed_elsewhere, :publishing_metadata,
-    :path_prefix, :tags, :guidance, :description, :hint, :lead_image
+    :path_prefix, :tags, :guidance, :description, :hint, :lead_image, :edit_only
 
   def initialize(params = {})
     @id = params["id"]
@@ -16,6 +16,7 @@ class DocumentTypeSchema
     @description = params["description"]
     @hint = params["hint"]
     @lead_image = params["lead_image"]
+    @edit_only = params["edit_only"]
   end
 
   def self.find(document_type_id)

--- a/app/views/new_document/choose_document_type.html.erb
+++ b/app/views/new_document/choose_document_type.html.erb
@@ -6,7 +6,7 @@
     <%= form_tag create_document_path do %>
       <%= render "govuk_publishing_components/components/radio", {
         name: "document_type",
-        items: @document_types.map { |document_type|
+        items: @document_types.reject(&:edit_only).map { |document_type|
           {
             value: document_type.id,
             text: document_type.label,

--- a/spec/formats/government_response_spec.rb
+++ b/spec/formats/government_response_spec.rb
@@ -1,0 +1,84 @@
+# frozen_string_literal: true
+
+RSpec.feature "government response", format: true do
+  scenario "User cannot create a government response" do
+    when_i_try_to_choose_this_document_type
+    then_i_see_it_is_missing_from_the_list
+  end
+
+  scenario "User edit a government response" do
+    when_i_edit_an_existing_document
+    and_i_fill_in_the_form_fields
+    and_i_add_some_tags
+    then_i_can_publish_the_document
+  end
+
+  def when_i_try_to_choose_this_document_type
+    visit "/"
+    click_on "New document"
+    choose SupertypeSchema.find("news").label
+    click_on "Continue"
+  end
+
+  def then_i_see_it_is_missing_from_the_list
+    expect(page).to_not have_content(DocumentTypeSchema.find("government_response").label)
+  end
+
+  def when_i_edit_an_existing_document
+    create(:document, document_type: "government_response", update_type: "major")
+    visit document_path(Document.last)
+    click_on "Change Content"
+  end
+
+  def and_i_fill_in_the_form_fields
+    stub_any_publishing_api_put_content
+    fill_in "document[title]", with: "A great title"
+    fill_in "document[summary]", with: "A great summary"
+    click_on "Save"
+    WebMock.reset!
+  end
+
+  def and_i_add_some_tags
+    stub_any_publishing_api_put_content
+    expect(Document.last.document_type_schema.tags.count).to eq(5)
+    publishing_api_has_linkables([linkable], document_type: "topical_event")
+    publishing_api_has_linkables([linkable], document_type: "worldwide_organisation")
+    publishing_api_has_linkables([linkable], document_type: "world_location")
+    publishing_api_has_linkables([linkable], document_type: "organisation")
+
+    click_on "Change Tags"
+
+    select linkable["internal_name"], from: "tags[topical_events][]"
+    select linkable["internal_name"], from: "tags[worldwide_organisations][]"
+    select linkable["internal_name"], from: "tags[world_locations][]"
+    select linkable["internal_name"], from: "tags[organisations][]"
+
+    click_on "Save"
+  end
+
+  def then_i_can_publish_the_document
+    expect(a_request(:put, /content/).with { |req|
+             expect(req.body).to be_valid_against_schema("news_article")
+             expect(JSON.parse(req.body)).to match a_hash_including(content_body)
+           }).to have_been_requested
+  end
+
+  def content_body
+    {
+      "links" => {
+        "topical_events" => [linkable["content_id"]],
+        "worldwide_organisations" => [linkable["content_id"]],
+        "world_locations" => [linkable["content_id"]],
+        "organisations" => [linkable["content_id"]],
+        "primary_publishing_organisation" => [linkable["content_id"]],
+      },
+      "title" => "A great title",
+      "document_type" => "government_response",
+      "description" => "A great summary",
+    }
+  end
+
+  def linkable
+    @linkable ||= { "content_id" => SecureRandom.uuid, "internal_name" => "Linkable" }
+  end
+end

--- a/spec/formats/world_news_story_spec.rb
+++ b/spec/formats/world_news_story_spec.rb
@@ -1,0 +1,84 @@
+# frozen_string_literal: true
+
+RSpec.feature "government response", format: true do
+  scenario "User cannot create a government response" do
+    when_i_try_to_choose_this_document_type
+    then_i_see_it_is_missing_from_the_list
+  end
+
+  scenario "User edit a government response" do
+    when_i_edit_an_existing_document
+    and_i_fill_in_the_form_fields
+    and_i_add_some_tags
+    then_i_can_publish_the_document
+  end
+
+  def when_i_try_to_choose_this_document_type
+    visit "/"
+    click_on "New document"
+    choose SupertypeSchema.find("news").label
+    click_on "Continue"
+  end
+
+  def then_i_see_it_is_missing_from_the_list
+    expect(page).to_not have_content(DocumentTypeSchema.find("world_news_story").label)
+  end
+
+  def when_i_edit_an_existing_document
+    create(:document, document_type: "world_news_story", update_type: "major")
+    visit document_path(Document.last)
+    click_on "Change Content"
+  end
+
+  def and_i_fill_in_the_form_fields
+    stub_any_publishing_api_put_content
+    fill_in "document[title]", with: "A great title"
+    fill_in "document[summary]", with: "A great summary"
+    click_on "Save"
+    WebMock.reset!
+  end
+
+  def and_i_add_some_tags
+    stub_any_publishing_api_put_content
+    expect(Document.last.document_type_schema.tags.count).to eq(5)
+    publishing_api_has_linkables([linkable], document_type: "topical_event")
+    publishing_api_has_linkables([linkable], document_type: "worldwide_organisation")
+    publishing_api_has_linkables([linkable], document_type: "world_location")
+    publishing_api_has_linkables([linkable], document_type: "organisation")
+
+    click_on "Change Tags"
+
+    select linkable["internal_name"], from: "tags[topical_events][]"
+    select linkable["internal_name"], from: "tags[worldwide_organisations][]"
+    select linkable["internal_name"], from: "tags[world_locations][]"
+    select linkable["internal_name"], from: "tags[organisations][]"
+
+    click_on "Save"
+  end
+
+  def then_i_can_publish_the_document
+    expect(a_request(:put, /content/).with { |req|
+             expect(req.body).to be_valid_against_schema("news_article")
+             expect(JSON.parse(req.body)).to match a_hash_including(content_body)
+           }).to have_been_requested
+  end
+
+  def content_body
+    {
+      "links" => {
+        "topical_events" => [linkable["content_id"]],
+        "worldwide_organisations" => [linkable["content_id"]],
+        "world_locations" => [linkable["content_id"]],
+        "organisations" => [linkable["content_id"]],
+        "primary_publishing_organisation" => [linkable["content_id"]],
+      },
+      "title" => "A great title",
+      "document_type" => "world_news_story",
+      "description" => "A great summary",
+    }
+  end
+
+  def linkable
+    @linkable ||= { "content_id" => SecureRandom.uuid, "internal_name" => "Linkable" }
+  end
+end


### PR DESCRIPTION
https://trello.com/c/KhxwyMKK/243-fix-not-supporting-government-response-and-world-new-story

This commit adds two new 'edit only' document types, for which documents
can only be edited and not created - they are hidden in the selection.

Format specs for this kind of document are slightly different, as we
need to simulate importing them, rather than creating new ones.