### PR TITLE
Filter out unwanted new document types

### DIFF
--- a/lib/tasks/import.rake
+++ b/lib/tasks/import.rake
@@ -11,6 +11,9 @@ namespace :import do
     input = ENV["INPUT"] ? File.open(ENV["INPUT"]) : STDIN
 
     input.each_line do |line|
+      next if line.include?("government_response")
+      next if line.include?("world_news_story")
+
       importer.import(JSON.parse(line))
       imported += 1
     end


### PR DESCRIPTION
This is an alternative to https://trello.com/c/KhxwyMKK/243-fix-not-supporting-government-response-and-world-new-story.

We currently don't support 'government response' and 'world news story'
document types, so we should avoid importing them until the migration
path is clear.