### PR TITLE
Rationalise page titles for document editing

### DIFF
--- a/app/models/document.rb
+++ b/app/models/document.rb
@@ -46,4 +46,8 @@ class Document < ApplicationRecord
   def user_facing_state
     UserFacingState.new(self).to_s
   end
+
+  def title_or_fallback
+    title.presence || I18n.t!("documents.untitled_document")
+  end
 end

--- a/app/views/document_lead_image/edit.html.erb
+++ b/app/views/document_lead_image/edit.html.erb
@@ -1,5 +1,5 @@
-<%= content_for :back_link, document_lead_image_path(@document) %>
-<% content_for :title, t("document_lead_image.edit.title") %>
+<% content_for :back_link, document_lead_image_path(@document) %>
+<% content_for :title, t("document_lead_image.edit.title", title: @document.title_or_fallback) %>
 
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">

--- a/app/views/document_lead_image/index.html.erb
+++ b/app/views/document_lead_image/index.html.erb
@@ -1,5 +1,4 @@
-<%= content_for :back_link, document_path(@document) %>
-<% content_for :title, t("document_lead_image.index.title") %>
+<% content_for :title, t("document_lead_image.index.title", title: @document.title_or_fallback) %>
 
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">

--- a/app/views/document_tags/edit.html.erb
+++ b/app/views/document_tags/edit.html.erb
@@ -1,5 +1,5 @@
-<%= content_for :back_link, document_path(@document) %>
-<% content_for :title, t("document_tags.edit.title") %>
+<% content_for :back_link, document_path(@document) %>
+<% content_for :title, t("document_tags.edit.title", title: @document.title_or_fallback) %>
 
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">

--- a/app/views/document_tags/edit_api_down.html.erb
+++ b/app/views/document_tags/edit_api_down.html.erb
@@ -1,5 +1,5 @@
-<%= content_for :back_link, document_path(@document) %>
-<% content_for :title, t("document_tags.edit.title") %>
+<% content_for :back_link, document_path(@document) %>
+<% content_for :title, t("document_tags.edit.title", title: @document.title_or_fallback) %>
 
 <p class="govuk-body">
   <%= t("document_tags.edit.api_down") %>

--- a/app/views/documents/edit.html.erb
+++ b/app/views/documents/edit.html.erb
@@ -1,5 +1,10 @@
-<%= content_for :back_link, document_path(@document) %>
-<% content_for :title, "#{@document.newly_created? ? 'Create' : 'Edit'} #{@document.document_type_schema.label.downcase}" %>
+<% content_for :back_link, document_path(@document) %>
+
+<% if @document.newly_created? %>
+  <% content_for :title, t("documents.edit.title_new", document_type: @document.document_type_schema.label.downcase) %>
+<% else %>
+  <% content_for :title, t("documents.edit.title", title: @document.title_or_fallback) %>
+<% end %>
 
   <%= form_for(@document, html: {'autocomplete': 'off'}, data: {'module': 'edit-document-form', 'url-preview-path': generate_path_path}) do |f| %>
   <div class="govuk-grid-row">

--- a/app/views/documents/show.html.erb
+++ b/app/views/documents/show.html.erb
@@ -1,5 +1,5 @@
 <% content_for :back_link, documents_path %>
-<% content_for :title, @document.title || t("documents.show.title_default") %>
+<% content_for :title, @document.title_or_fallback %>
 <% content_for :context, @document.document_type_schema.label %>
 
 <%= render "govuk_publishing_components/components/tabs", {

--- a/app/views/documents/show_api_down.html.erb
+++ b/app/views/documents/show_api_down.html.erb
@@ -1,5 +1,5 @@
 <% content_for :back_link, documents_path %>
-<% content_for :title, @document.title || t("documents.show.title_default") %>
+<% content_for :title, @document.title_or_fallback %>
 
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">

--- a/app/views/preview/show.html.erb
+++ b/app/views/preview/show.html.erb
@@ -1,5 +1,5 @@
-<%= content_for :back_link, document_path(@document) %>
-<%= content_for :title, "Preview #{@document.title.inspect}" %>
+<% content_for :back_link, document_path(@document) %>
+<% content_for :title, t("preview.show.title", title: @document.title_or_fallback) %>
 
 <%= render "components/page_preview",
   title: @document.title,

--- a/config/locales/en/document_lead_image/edit.yml
+++ b/config/locales/en/document_lead_image/edit.yml
@@ -1,7 +1,7 @@
 en:
   document_lead_image:
     edit:
-      title: Edit lead image
+      title: "Edit lead image for ‘%{title}’"
       form_labels:
         caption: Caption
         alt_text: Alt text

--- a/config/locales/en/document_lead_image/index.yml
+++ b/config/locales/en/document_lead_image/index.yml
@@ -1,7 +1,7 @@
 en:
   document_lead_image:
     index:
-      title: Lead image
+      title: "Lead image for ‘%{title}’"
       upload_image: Upload existing image
       existing_image: Choose existing image
       no_existing_image: No images available

--- a/config/locales/en/document_tags/edit.yml
+++ b/config/locales/en/document_tags/edit.yml
@@ -1,6 +1,6 @@
 en:
   document_tags:
     edit:
-      title: Tags
+      title: "Tags for ‘%{title}’"
       description: Add tags which describe what the content is about. Content will appear in lists on GOV.UK based on each tag.
       api_down: This content can't be edited right now. We're having trouble getting the data we need for you to make changes on this page.

--- a/config/locales/en/documents.yml
+++ b/config/locales/en/documents.yml
@@ -1,0 +1,3 @@
+en:
+  documents:
+    untitled_document: Untitled document

--- a/config/locales/en/documents/edit.yml
+++ b/config/locales/en/documents/edit.yml
@@ -1,7 +1,8 @@
 en:
   documents:
     edit:
-      title: Untitled
+      title: "Edit ‘%{title}’"
+      title_new: "New %{document_type}"
       fields:
         govspeak:
           title: Markdown

--- a/config/locales/en/documents/show.yml
+++ b/config/locales/en/documents/show.yml
@@ -1,7 +1,6 @@
 en:
   documents:
     show:
-      title_default: No title
       format:
         title: Document type
         items:

--- a/config/locales/en/preview/show.yml
+++ b/config/locales/en/preview/show.yml
@@ -1,0 +1,4 @@
+en:
+  preview:
+    show:
+      title: "Preview ‘%{title}’"


### PR DESCRIPTION
This makes the titles for the edit pages consistent.

They use the form "{thing} `{page title}`".