### PR TITLE
Index filter by state

### DIFF
--- a/app/controllers/documents_controller.rb
+++ b/app/controllers/documents_controller.rb
@@ -50,7 +50,7 @@ private
 
   def filter_params
     {
-      filters: params.permit(:title_or_url, :document_type).to_hash,
+      filters: params.permit(:title_or_url, :document_type, :state).to_hash,
       sort: params[:sort],
       page: params[:page],
       per_page: 50,

--- a/app/services/document_filter.rb
+++ b/app/services/document_filter.rb
@@ -45,6 +45,8 @@ private
                    "%#{sanitize_sql_like(value)}%")
       when :document_type
         memo.where(document_type: value)
+      when :state
+        UserFacingState.scope(memo, value)
       else
         memo
       end

--- a/app/services/user_facing_state.rb
+++ b/app/services/user_facing_state.rb
@@ -22,7 +22,7 @@ class UserFacingState
       # quirk we've inherited.
       query.where(publication_state: %w[sending_to_live sent_to_live error_sending_to_live])
     else
-      raise "Unknown user_facing_state: #{state}"
+      query.none
     end
   end
 

--- a/app/views/documents/index/_filters.html.erb
+++ b/app/views/documents/index/_filters.html.erb
@@ -21,7 +21,7 @@
       bold: true
     },
     # TODO: implement allow_blank so we don't have to add a blank option
-    options: document_type_select + ["",""],
+    options: [["", ""]] + document_type_select,
     selected_options: [params[:document_type]],
     size: 10,
     data: {
@@ -40,7 +40,7 @@
       bold: true
     },
     # TODO: implement allow_blank so we don't have to add a blank option
-    options: state_select + ["",""],
+    options: [["", ""]] + state_select,
     selected_options: [params[:state]],
     size: 10,
     data: {

--- a/app/views/documents/index/_filters.html.erb
+++ b/app/views/documents/index/_filters.html.erb
@@ -29,6 +29,25 @@
     }
   } %>
 
+  <% state_select = UserFacingState::STATES
+    .map { |state| [t("user_facing_states.#{state}.name"), state] }
+  %>
+
+  <%= render "components/autocomplete", {
+    name: "state",
+    label: {
+      text: t("documents.index.filter.state"),
+      bold: true
+    },
+    # TODO: implement allow_blank so we don't have to add a blank option
+    options: state_select + ["",""],
+    selected_options: [params[:state]],
+    size: 10,
+    data: {
+      module: "autocomplete"
+    }
+  } %>
+
   <%= hidden_field_tag "sort", @sort %>
 
   <%= render "govuk_publishing_components/components/button", {

--- a/config/locales/en/documents/index.yml
+++ b/config/locales/en/documents/index.yml
@@ -26,4 +26,5 @@ en:
       filter:
         title_or_url: Search for a title or URL slug
         document_type: Document type
+        state: State
 

--- a/spec/features/index_filtering_spec.rb
+++ b/spec/features/index_filtering_spec.rb
@@ -6,10 +6,17 @@ RSpec.feature "User filters documents" do
     when_i_visit_the_index_page
     and_i_filter_by_title
     then_i_see_just_the_ones_that_match
+
     when_i_clear_the_filters
     then_i_see_all_the_documents
+
     when_i_filter_by_document_type
     then_i_see_just_the_ones_that_match
+
+    when_i_clear_the_filters
+    and_filter_by_state
+    then_i_see_just_the_ones_that_match
+
     when_i_filter_too_much
     then_i_see_there_are_no_results
   end
@@ -18,12 +25,14 @@ RSpec.feature "User filters documents" do
     relevant_schema = build(:document_type_schema)
     @relevant_document = create(:document,
                                 title: "Super relevant",
-                                document_type: relevant_schema.id)
+                                document_type: relevant_schema.id,
+                                publication_state: "sent_to_draft")
 
     irrelevant_schema = build(:document_type_schema)
     create(:document,
            title: "Totally irrelevant",
-           document_type: irrelevant_schema.id)
+           document_type: irrelevant_schema.id,
+           publication_state: "sent_to_live")
   end
 
   def when_i_visit_the_index_page
@@ -50,6 +59,11 @@ RSpec.feature "User filters documents" do
 
   def when_i_filter_by_document_type
     select @relevant_document.document_type_schema.label, from: "document_type"
+    click_on "Filter"
+  end
+
+  def and_filter_by_state
+    select I18n.t("user_facing_states.draft.name"), from: "state"
     click_on "Filter"
   end
 

--- a/spec/services/document_filter_spec.rb
+++ b/spec/services/document_filter_spec.rb
@@ -44,6 +44,20 @@ RSpec.describe DocumentFilter do
       expect(documents).to eq([document1])
     end
 
+    it "filters the documents by state" do
+      document1 = create(:document, publication_state: "sent_to_draft")
+      document2 = create(:document, publication_state: "sent_to_live")
+
+      documents = DocumentFilter.new(filters: { state: " " }).documents
+      expect(documents).to match_array([document1, document2])
+
+      documents = DocumentFilter.new(filters: { state: "non-existant" }).documents
+      expect(documents).to be_empty
+
+      documents = DocumentFilter.new(filters: { state: "draft" }).documents
+      expect(documents).to eq([document1])
+    end
+
     it "ignores other kinds of filter" do
       document1 = create(:document)
 

--- a/spec/services/user_facing_state_spec.rb
+++ b/spec/services/user_facing_state_spec.rb
@@ -44,9 +44,8 @@ RSpec.describe UserFacingState do
         .to match([published_but_needs_2i])
     end
 
-    it "raises an error for an unknown state" do
-      expect { UserFacingState.scope(Document, "surprise") }
-        .to raise_error "Unknown user_facing_state: surprise"
+    it "finds nothing for an unknown state" do
+      expect(UserFacingState.scope(Document, "surprise")).to be_empty
     end
   end
 


### PR DESCRIPTION
Trello: https://trello.com/c/rCESaDMh/240-filter-index-page-by-state

This adds in the state filter for the index page.

It does have a bit of a WTF going on for handling the scenario where there is a state passed in that is unknown to us: https://github.com/alphagov/content-publisher/blob/25c6b5d786600a50baf2e0096c67a1152357ded8/app/services/document_filter.rb#L49-L51

Alternative options if people dislike this approach are:
1 - moving the where("1 = 2") into [UserFacingState](https://github.com/alphagov/content-publisher/blob/master/app/services/user_facing_state.rb#L23) instead of exception
2 - be inconsistent with other query string filters and return all results
