### PR TITLE
Remove redundant org stub

### DIFF
--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -39,10 +39,6 @@ RSpec.configure do |config|
     Rails.application.load_seed
   end
 
-  config.before :each, format: true do
-    publishing_api_has_linkables([{ "content_id" => User.first.organisation_content_id, "internal_name" => "Linkable" }], document_type: "organisation")
-  end
-
   config.after :each, type: :feature, js: true do
     Capybara::Chromedriver::Logger::TestHooks.after_example!
   end


### PR DESCRIPTION
https://trello.com/c/AZHmdkPM/251-spechelper-has-a-before-block-that-stubs-the-publishing-api-with-unclear-purpose

This is apparently not needed for the tests to pass, and it's not clear
why it was added.