### PR TITLE
Create MVP for history feature

### DIFF
--- a/app/controllers/document_tags_controller.rb
+++ b/app/controllers/document_tags_controller.rb
@@ -13,6 +13,7 @@ class DocumentTagsController < ApplicationController
   def update
     document = Document.find_by_param(params[:id])
     document.update!(tags: update_params(document))
+    TimelineEntry.create!(document: document, user: current_user, entry_type: "updated_tags")
     DocumentPublishingService.new.publish_draft(document)
     redirect_to document, notice: t("documents.show.flashes.draft_success")
   rescue GdsApi::BaseError

--- a/app/controllers/documents_controller.rb
+++ b/app/controllers/documents_controller.rb
@@ -24,6 +24,7 @@ class DocumentsController < ApplicationController
   def update
     document = Document.find_by_param(params[:id])
     document.update!(update_params(document))
+    TimelineEntry.create!(document: document, user: current_user, entry_type: "updated_content")
     DocumentPublishingService.new.publish_draft(document)
     redirect_to document, notice: t("documents.show.flashes.draft_success")
   rescue GdsApi::BaseError

--- a/app/controllers/new_document_controller.rb
+++ b/app/controllers/new_document_controller.rb
@@ -50,6 +50,8 @@ class NewDocumentController < ApplicationController
       change_note: "First published.",
     )
 
+    TimelineEntry.create!(document: document, user: current_user, entry_type: "created")
+
     redirect_to edit_document_path(document)
   end
 

--- a/app/controllers/publish_document_controller.rb
+++ b/app/controllers/publish_document_controller.rb
@@ -9,6 +9,13 @@ class PublishDocumentController < ApplicationController
     document = Document.find_by_param(params[:id])
     review_state = params[:self_declared_review_state] == "has-been-reviewed" ? "reviewed" : "published_without_review"
     DocumentPublishingService.new.publish(document, review_state)
+
+    if review_state == "has-been-reviewed"
+      TimelineEntry.create!(document: document, user: current_user, entry_type: "published")
+    else
+      TimelineEntry.create!(document: document, user: current_user, entry_type: "published_without_review")
+    end
+
     redirect_to document_published_path(document)
   rescue GdsApi::BaseError
     redirect_to document, alert: t("documents.show.flashes.publish_error")

--- a/app/controllers/review_controller.rb
+++ b/app/controllers/review_controller.rb
@@ -4,6 +4,7 @@ class ReviewController < ApplicationController
   def submit_for_2i
     document = Document.find_by_param(params[:id])
     document.update!(review_state: "submitted_for_review")
+    TimelineEntry.create!(document: document, user: current_user, entry_type: "submitted")
     flash[:submitted_for_review] = true
     redirect_to document
   end
@@ -11,6 +12,7 @@ class ReviewController < ApplicationController
   def approve
     document = Document.find_by_param(params[:id])
     document.update!(review_state: "reviewed")
+    TimelineEntry.create!(document: document, user: current_user, entry_type: "approved")
     redirect_to document, notice: t("documents.show.flashes.approved")
   end
 end

--- a/app/models/document.rb
+++ b/app/models/document.rb
@@ -2,6 +2,7 @@
 
 class Document < ApplicationRecord
   has_many :images, dependent: :destroy
+  has_many :timeline_entries, dependent: :destroy
   belongs_to :lead_image, class_name: "Image", optional: true, foreign_key: :lead_image_id, inverse_of: :document
   belongs_to :creator, class_name: "User", optional: true, foreign_key: :creator_id, inverse_of: :documents
 

--- a/app/models/timeline_entry.rb
+++ b/app/models/timeline_entry.rb
@@ -1,0 +1,13 @@
+# frozen_string_literal: true
+
+class TimelineEntry < ApplicationRecord
+  belongs_to :document
+  belongs_to :user
+
+  ENTRY_TYPES = %w[updated_content updated_tags submitted published_without_review approved].freeze
+  validates_presence_of :entry_type, in: ENTRY_TYPES
+
+  def username_or_unknown
+    user ? user.name : "Unknown user"
+  end
+end

--- a/app/views/documents/show/_history_tab.html.erb
+++ b/app/views/documents/show/_history_tab.html.erb
@@ -1,1 +1,11 @@
-Document history is not available right now.
+<% @document.timeline_entries.includes(:user).order(created_at: :desc).each do |entry| %>
+  <div class="timeline-entry govuk-!-margin-bottom-6">
+    <h4 class="govuk-heading-s govuk-!-margin-bottom-1">
+      <%= t "documents.history.entry_types.#{entry.entry_type}" %>
+    </h4>
+
+    <div class="govuk-body">
+      <%= entry.created_at.strftime("%l:%M%P on %d %B %Y") %> by <%= entry.username_or_unknown %>
+    </div>
+  </div>
+<% end %>

--- a/config/locales/en/documents/history.yml
+++ b/config/locales/en/documents/history.yml
@@ -1,0 +1,10 @@
+en:
+  documents:
+    history:
+      entry_types:
+        created: "First created"
+        submitted: "Submitted for review"
+        updated_content: "Document updated"
+        published_without_review: "Published without review"
+        approved: "Approved for publication"
+        updated_tags: "Tags updated"

--- a/db/migrate/20180907121447_create_timeline_entries.rb
+++ b/db/migrate/20180907121447_create_timeline_entries.rb
@@ -1,0 +1,17 @@
+# frozen_string_literal: true
+
+class CreateTimelineEntries < ActiveRecord::Migration[5.2]
+  def change
+    create_table :timeline_entries do |t|
+      t.string :entry_type, null: false
+
+      # Delete all timeline_entries if a document is deleted
+      t.references :document, foreign_key: { on_delete: :cascade }, null: false
+
+      # Don't allow users to be deleted if they're related to a timeline entry
+      t.references :user, foreign_key: { on_delete: :restrict }
+
+      t.timestamps
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -79,6 +79,16 @@ ActiveRecord::Schema.define(version: 2018_09_07_121447) do
     t.index ["document_id"], name: "index_images_on_document_id"
   end
 
+  create_table "timeline_entries", force: :cascade do |t|
+    t.string "entry_type", null: false
+    t.bigint "document_id", null: false
+    t.bigint "user_id"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["document_id"], name: "index_timeline_entries_on_document_id"
+    t.index ["user_id"], name: "index_timeline_entries_on_user_id"
+  end
+
   create_table "users", force: :cascade do |t|
     t.string "name"
     t.string "email"
@@ -97,4 +107,6 @@ ActiveRecord::Schema.define(version: 2018_09_07_121447) do
   add_foreign_key "documents", "users", column: "creator_id"
   add_foreign_key "images", "active_storage_blobs", column: "blob_id", on_delete: :cascade
   add_foreign_key "images", "documents", on_delete: :cascade
+  add_foreign_key "timeline_entries", "documents", on_delete: :cascade
+  add_foreign_key "timeline_entries", "users", on_delete: :restrict
 end

--- a/spec/features/document_timeline_spec.rb
+++ b/spec/features/document_timeline_spec.rb
@@ -1,0 +1,89 @@
+# frozen_string_literal: true
+
+RSpec.feature "Document timeline" do
+  scenario "User edits the document and looks at timeline" do
+    when_i_start_to_create_a_document
+    the_timeline_has_a_create_entry
+
+    when_i_update_the_document
+    the_timeline_has_a_update_entry
+
+    when_i_submit_the_document
+    the_timeline_has_a_submit_entry
+
+    when_i_publish_the_document_without_review
+    the_timeline_has_a_publish_without_review_entry
+
+    when_i_approve_the_document
+    the_timeline_has_a_approval_entry
+  end
+
+  def when_i_start_to_create_a_document
+    @schema = DocumentTypeSchema.find("news_story")
+    visit "/"
+    click_on "New document"
+    choose SupertypeSchema.find("news").label
+    click_on "Continue"
+    choose @schema.label
+    click_on "Continue"
+
+    @document = Document.last
+  end
+
+  def the_timeline_has_a_create_entry
+    visit document_path(@document)
+
+    within find(".timeline-entry:first") do
+      expect(page).to have_content I18n.t!("documents.history.entry_types.created")
+    end
+  end
+
+  def when_i_update_the_document
+    stub_any_publishing_api_put_content
+
+    visit edit_document_path(@document)
+    fill_in "Title", with: "This is a new title"
+    click_on "Save"
+  end
+
+  def the_timeline_has_a_update_entry
+    within find(".timeline-entry:first") do
+      expect(page).to have_content I18n.t!("documents.history.entry_types.updated_content")
+    end
+  end
+
+  def when_i_submit_the_document
+    click_on "Submit for 2i review"
+  end
+
+  def the_timeline_has_a_submit_entry
+    within find(".timeline-entry:first") do
+      expect(page).to have_content I18n.t!("documents.history.entry_types.submitted")
+    end
+  end
+
+  def when_i_publish_the_document_without_review
+    stub_any_publishing_api_publish
+
+    click_on "Publish"
+    click_on "Confirm publish"
+  end
+
+  def the_timeline_has_a_publish_without_review_entry
+    visit document_path(@document)
+
+    within find(".timeline-entry:first") do
+      expect(page).to have_content I18n.t!("documents.history.entry_types.published_without_review")
+    end
+  end
+
+  def when_i_approve_the_document
+    click_on "Approve"
+  end
+
+  def the_timeline_has_a_approval_entry
+    within find(".timeline-entry:first") do
+      expect(page).to have_content I18n.t!("documents.history.entry_types.approved")
+    end
+  end
+end

--- a/spec/models/timeline_entry_spec.rb
+++ b/spec/models/timeline_entry_spec.rb
@@ -1,0 +1,11 @@
+# frozen_string_literal: true
+
+RSpec.describe TimelineEntry do
+  describe "#entry_type" do
+    TimelineEntry::ENTRY_TYPES.each do |type|
+      it "`#{type}` has a translation" do
+        expect(I18n.exists?("documents.history.entry_types.#{type}")).to eql(true)
+      end
+    end
+  end
+end


### PR DESCRIPTION
This is a first PR for the "history" feature. It's very rudimentary:

Whenever a relevant action takes place, we create a `TimelineEntry` record. I've called this a "timeline entry", because I couldn't come up with a better generic name. We expect that this page will also include comments, so "timeline entry" seems appropriate for that too. We display the timeline entry in the history tab:

<img width="998" alt="screen shot 2018-09-12 at 12 47 49" src="https://user-images.githubusercontent.com/233676/45423075-1773b080-b68a-11e8-8d14-99e99d80eee2.png">

## How to review

Note that this doesn't implement all of the things from the Trello ticket, there will be follow up PRs (see "To do" checklist).

- Does the naming of "timeline entry" make sense?
- Have we captured entries for all the relevant user-initiated actions at the moment?

https://trello.com/c/TVcThaKi