### PR TITLE
Consistently save-bang records

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -37,3 +37,6 @@ Style/TrailingCommaInArguments:
 Rails/DynamicFindBy:
   Whitelist:
     - find_by_param
+
+Rails/SaveBang:
+  Enabled: true

--- a/app/controllers/document_images_controller.rb
+++ b/app/controllers/document_images_controller.rb
@@ -19,7 +19,7 @@ class DocumentImagesController < ApplicationController
     image.assign_attributes(image_params)
 
     if image.valid?
-      image.save
+      image.save!
       render json: ImageJsonPresenter.new(image).present, status: :ok
     else
       render json: { errors: image.errors }, status: :unprocessable_entity

--- a/app/controllers/document_lead_image_controller.rb
+++ b/app/controllers/document_lead_image_controller.rb
@@ -33,8 +33,8 @@ class DocumentLeadImageController < ApplicationController
   def update
     document = Document.find_by_param(params[:document_id])
     image = Image.find_by(id: params[:image_id])
-    image.update(update_params)
-    document.update(lead_image_id: image.id)
+    image.update!(update_params)
+    document.update!(lead_image_id: image.id)
     if params[:next_screen] == "lead-image"
       redirect_to document_lead_image_path(document)
       return
@@ -44,13 +44,13 @@ class DocumentLeadImageController < ApplicationController
 
   def choose_image
     document = Document.find_by_param(params[:document_id])
-    document.update(lead_image_id: params[:image_id])
+    document.update!(lead_image_id: params[:image_id])
     redirect_to document_path(document)
   end
 
   def destroy
     document = Document.find_by_param(params[:document_id])
-    document.update(lead_image_id: nil)
+    document.update!(lead_image_id: nil)
     redirect_to document_path(document)
   end
 

--- a/app/services/document_type_schema.rb
+++ b/app/services/document_type_schema.rb
@@ -30,7 +30,7 @@ class DocumentTypeSchema
     end
   end
 
-  def self.create(params)
+  def self.add_schema(params)
     schema = new(params)
     all << schema
     schema

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -1,3 +1,3 @@
 # frozen_string_literal: true
 
-User.find_or_create_by name: "publisher"
+User.find_or_create_by! name: "publisher"

--- a/spec/factories/document_type_schema_factory.rb
+++ b/spec/factories/document_type_schema_factory.rb
@@ -7,7 +7,7 @@ FactoryBot.define do
     document_type { SecureRandom.alphanumeric(8) }
 
     initialize_with do
-      schema = DocumentTypeSchema.create(attributes.stringify_keys)
+      schema = DocumentTypeSchema.add_schema(attributes.stringify_keys)
       SupertypeSchema.all.first.document_types << schema
       schema
     end

--- a/spec/services/document_url_spec.rb
+++ b/spec/services/document_url_spec.rb
@@ -10,7 +10,7 @@ RSpec.describe DocumentUrl do
     end
 
     it "returns nil without a base_path" do
-      document.update(base_path: nil)
+      document.update!(base_path: nil)
       url = DocumentUrl.new(document).public_url
       expect(url).to be_nil
     end
@@ -23,7 +23,7 @@ RSpec.describe DocumentUrl do
     end
 
     it "returns nil without a base_path" do
-      document.update(base_path: nil)
+      document.update!(base_path: nil)
       url = DocumentUrl.new(document).preview_url
       expect(url).to be_nil
     end
@@ -36,7 +36,7 @@ RSpec.describe DocumentUrl do
     end
 
     it "returns nil without a base_path" do
-      document.update(base_path: nil)
+      document.update!(base_path: nil)
       url = DocumentUrl.new(document).secret_preview_url
       expect(url).to be_nil
     end


### PR DESCRIPTION
More permanent fix to https://github.com/alphagov/content-publisher/pull/251.

If you save/create a record without checking the return value, there's a risk that your record won't be saved, but nothing will tell you.
  
This enables the Rubocop that checks for occurrences, so we don't do it again.

> This cop identifies possible cases where Active Record save! or related should be used instead of save because the model might have failed to save and an exception is better than unhandled failure.