### PR TITLE
Add Jasmin for testing our JavaScript

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -36,6 +36,7 @@ group :development, :test do
   gem "govuk-lint", "~> 3"
   gem "govuk_schemas", "~> 3.2"
   gem "govuk_test", "~> 0.2"
+  gem "jasmine", "~> 2.4"
   gem "rspec-rails", "~> 3"
   gem "webmock", "~> 3"
 end

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -174,6 +174,12 @@ GEM
       ruby-vips (>= 2.0.11, < 3)
     io-like (0.3.0)
     jaro_winkler (1.5.1)
+    jasmine (2.99.0)
+      jasmine-core (>= 2.99.0, < 3.0.0)
+      phantomjs
+      rack (>= 1.2.1)
+      rake
+    jasmine-core (2.99.2)
     jmespath (1.4.0)
     json (2.1.0)
     json-schema (2.8.0)
@@ -251,6 +257,7 @@ GEM
     parser (2.5.1.2)
       ast (~> 2.4.0)
     pg (1.1.3)
+    phantomjs (2.1.1.0)
     plek (2.1.1)
     powerpack (0.1.2)
     public_suffix (3.0.3)
@@ -422,6 +429,7 @@ DEPENDENCIES
   govuk_schemas (~> 3.2)
   govuk_test (~> 0.2)
   image_processing (~> 1)
+  jasmine (~> 2.4)
   kaminari (~> 1)
   listen (~> 3)
   pg (~> 1)

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -17,7 +17,7 @@ node {
     rubyLintDirs: "",
     overrideTestTask: {
       stage("Run tests") {
-        govuk.runTests("spec")
+        govuk.runTests("spec jasmine:ci")
       }
     }
   )

--- a/Rakefile
+++ b/Rakefile
@@ -6,4 +6,4 @@
 require_relative "config/application"
 
 Rails.application.load_tasks
-task default: %i(spec lint brakeman)
+task default: %i(spec jasmine:ci lint brakeman)

--- a/spec/javascripts/jasmine_examples/PlayerSpec.js
+++ b/spec/javascripts/jasmine_examples/PlayerSpec.js
@@ -1,0 +1,5 @@
+describe("test", function() {
+  it("works", function () {
+    expect(true).toEqual(true)
+  })
+})

--- a/spec/javascripts/support/jasmine.yml
+++ b/spec/javascripts/support/jasmine.yml
@@ -1,0 +1,145 @@
+# src_files
+#
+# Return an array of filepaths relative to src_dir to include before jasmine specs.
+# Default: []
+#
+# EXAMPLE:
+#
+# src_files:
+#   - lib/source1.js
+#   - lib/source2.js
+#   - 'dist/**/*.js'
+#
+src_files:
+  - assets/application.js
+
+# stylesheets
+#
+# Return an array of stylesheet filepaths relative to src_dir to include before jasmine specs.
+# Default: []
+#
+# EXAMPLE:
+#
+# stylesheets:
+#   - css/style.css
+#   - 'stylesheets/*.css'
+#
+stylesheets:
+  - assets/application.css
+
+# helpers
+#
+# Return an array of filepaths relative to spec_dir to include before jasmine specs.
+# Default: ["helpers/**/*.js"]
+#
+# EXAMPLE:
+#
+# helpers:
+#   - 'helpers/**/*.js'
+#
+helpers:
+  - 'helpers/**/*.js'
+
+# spec_files
+#
+# Return an array of filepaths relative to spec_dir to include.
+# Default: ["**/*[sS]pec.js"]
+#
+# EXAMPLE:
+#
+# spec_files:
+#   - '**/*[sS]pec.js'
+#
+spec_files:
+  - '**/*[sS]pec.js'
+
+# src_dir
+#
+# Source directory path. Your src_files must be returned relative to this path. Will use root if left blank.
+# Default: project root
+#
+# EXAMPLE:
+#
+# src_dir: public
+#
+src_dir:
+
+# spec_dir
+#
+# Spec directory path. Your spec_files must be returned relative to this path.
+# Default: spec/javascripts
+#
+# EXAMPLE:
+#
+# spec_dir: spec/javascripts
+#
+spec_dir:
+
+# spec_helper
+#
+# Ruby file that Jasmine server will require before starting.
+# Returned relative to your root path
+# Default spec/javascripts/support/jasmine_helper.rb
+#
+# EXAMPLE:
+#
+# spec_helper: spec/javascripts/support/jasmine_helper.rb
+#
+spec_helper: spec/javascripts/support/jasmine_helper.rb
+
+# boot_dir
+#
+# Boot directory path. Your boot_files must be returned relative to this path.
+# Default: Built in boot file
+#
+# EXAMPLE:
+#
+# boot_dir: spec/javascripts/support/boot
+#
+boot_dir:
+
+# boot_files
+#
+# Return an array of filepaths relative to boot_dir to include in order to boot Jasmine
+# Default: Built in boot file
+#
+# EXAMPLE
+#
+# boot_files:
+#   - '**/*.js'
+#
+boot_files:
+
+# rack_options
+#
+# Extra options to be passed to the rack server
+# by default, Port and AccessLog are passed.
+#
+# This is an advanced options, and left empty by default
+#
+# EXAMPLE
+#
+# rack_options:
+#   server: 'thin'
+
+# phantom_cli_options
+#
+# Extra options to be passed to the phantomjs cli,
+# e.g. to enable localStorage in PhantomJs 2.5
+#
+# EXAMPLE
+#
+# phantom_cli_options:
+#   local-storage-quota: 5000
+
+# random
+#
+# Run specs in semi-random order.
+# Default: true
+#
+# EXAMPLE:
+#
+# random: false
+#
+random:
+

--- a/spec/javascripts/support/jasmine_helper.rb
+++ b/spec/javascripts/support/jasmine_helper.rb
@@ -1,0 +1,16 @@
+# frozen_string_literal: true
+
+# Use this file to set/override Jasmine configuration options
+# You can remove it if you don't need it.
+# This file is loaded *after* jasmine.yml is interpreted.
+#
+# Example: using a different boot file.
+# Jasmine.configure do |config|
+#    config.boot_dir = '/absolute/path/to/boot_dir'
+#    config.boot_files = lambda { ['/absolute/path/to/boot_dir/file.js'] }
+# end
+#
+# Example: prevent PhantomJS auto install, uses PhantomJS already on your path.
+Jasmine.configure do |config|
+  config.prevent_phantom_js_auto_install = true
+end


### PR DESCRIPTION
https://trello.com/c/AgFY5UN1/214-setup-jasmine-testing-for-javascript-and-add-some-tests-m

This is based on the approach taken in govuk_publishing_components,
which uses the 'jasmine' gem locked to a 2.x version - there seems to be
a problem running 'rake jasmine:ci' for version 3.x.