### PR TITLE
Keep track edition numbers for documents

### DIFF
--- a/app/controllers/new_document_controller.rb
+++ b/app/controllers/new_document_controller.rb
@@ -48,6 +48,7 @@ class NewDocumentController < ApplicationController
       creator_id: current_user.id,
       update_type: "major",
       change_note: "First published.",
+      edition_number: 1,
     )
 
     redirect_to edit_document_path(document)

--- a/app/services/document_publishing_service.rb
+++ b/app/services/document_publishing_service.rb
@@ -16,7 +16,7 @@ class DocumentPublishingService
   def publish(document, review_state)
     document.update!(publication_state: "sending_to_live", review_state: review_state)
     publishing_api.publish(document.content_id, nil, locale: document.locale)
-    document.update!(publication_state: "sent_to_live", change_note: nil, update_type: "major", has_live_version_on_govuk: true)
+    document.update!(edition_number: document.edition_number + 1, publication_state: "sent_to_live", change_note: nil, update_type: "major", has_live_version_on_govuk: true)
   rescue GdsApi::BaseError => e
     GovukError.notify(e)
     document.update!(publication_state: "error_sending_to_live")

--- a/db/migrate/20180912150956_current_edition_number_to_documents.rb
+++ b/db/migrate/20180912150956_current_edition_number_to_documents.rb
@@ -1,0 +1,12 @@
+# frozen_string_literal: true
+
+class CurrentEditionNumberToDocuments < ActiveRecord::Migration[5.2]
+  def up
+    execute "TRUNCATE documents CASCADE"
+    add_column :documents, :edition_number, :integer, null: false # rubocop:disable Rails/NotNullColumn
+  end
+
+  def down
+    remove_column :documents, :edition_number
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2018_09_07_121447) do
+ActiveRecord::Schema.define(version: 2018_09_12_150956) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -54,6 +54,7 @@ ActiveRecord::Schema.define(version: 2018_09_07_121447) do
     t.string "update_type"
     t.boolean "has_live_version_on_govuk", default: false, null: false
     t.bigint "lead_image_id"
+    t.integer "edition_number", null: false
     t.index ["base_path"], name: "index_documents_on_base_path", unique: true
     t.index ["content_id", "locale"], name: "index_documents_on_content_id_and_locale", unique: true
     t.index ["creator_id"], name: "index_documents_on_creator_id"

--- a/lib/tasks/whitehall_news_importer.rb
+++ b/lib/tasks/whitehall_news_importer.rb
@@ -31,6 +31,7 @@ module Tasks
         review_state: "unreviewed",
         summary: translation["summary"],
         tags: tags(edition),
+        edition_number: edition["published_major_version"] + 1,
       )
 
       doc.save!

--- a/spec/factories/document_factory.rb
+++ b/spec/factories/document_factory.rb
@@ -9,5 +9,6 @@ FactoryBot.define do
     document_type { build(:document_type_schema, path_prefix: "/prefix").id }
     publication_state { "changes_not_sent_to_draft" }
     review_state { "unreviewed" }
+    edition_number { (rand * 100).to_i }
   end
 end

--- a/spec/services/document_publishing_service_spec.rb
+++ b/spec/services/document_publishing_service_spec.rb
@@ -19,13 +19,13 @@ RSpec.describe DocumentPublishingService do
   describe "#publish" do
     it "keeps track of the publication state" do
       stub_any_publishing_api_publish
-      document = create(:document)
+      document = create(:document, edition_number: 4)
       allow(document).to receive(:update!)
 
       DocumentPublishingService.new.publish(document, "reviewed")
 
       expect(document).to have_received(:update!).with(publication_state: "sending_to_live", review_state: "reviewed")
-      expect(document).to have_received(:update!).with(publication_state: "sent_to_live", has_live_version_on_govuk: true, change_note: nil, update_type: "major")
+      expect(document).to have_received(:update!).with(edition_number: 5, publication_state: "sent_to_live", has_live_version_on_govuk: true, change_note: nil, update_type: "major")
     end
   end
 end

--- a/spec/tasks/whitehall_news_importer_spec.rb
+++ b/spec/tasks/whitehall_news_importer_spec.rb
@@ -9,6 +9,7 @@ RSpec.describe Tasks::WhitehallNewsImporter do
       editions: [
         {
           created_at: Time.zone.now,
+          published_major_version: 12,
           news_article_type: { key: "news_story" },
           translations: [
             {
@@ -54,5 +55,7 @@ RSpec.describe Tasks::WhitehallNewsImporter do
       .to eq(imported_edition["topical_events"])
     expect(document_tags["world_locations"])
       .to eq(imported_edition["world_locations"])
+
+    expect(Document.last.edition_number).to eql(13)
   end
 end


### PR DESCRIPTION
This PR adds an edition number to documents. This number will be shown in the document history, where it increases every time the document is published.

This doesn't have feature tests because it's not used in the UI yet.

https://trello.com/c/TVcThaKi