### PR TITLE
Update edit image page

### DIFF
--- a/app/assets/stylesheets/components/_image_meta.scss
+++ b/app/assets/stylesheets/components/_image_meta.scss
@@ -14,6 +14,10 @@
   }
 }
 
+.app-c-image-meta--no-border {
+  border-bottom: 0;
+}
+
 .app-c-image-meta__image {
   display: block;
   max-width: 100%;

--- a/app/views/components/_image_meta.html.erb
+++ b/app/views/components/_image_meta.html.erb
@@ -1,12 +1,16 @@
 <%
   id ||= "image-meta-#{SecureRandom.hex(4)}"
   alt_text ||= nil
-  caption ||= nil
-  credit ||= nil
   actions ||= []
+  meta ||= {}
   lead_image ||= false
+  no_border ||= false
+
+  if meta.key?(:alt_text)
+    alt_text = meta[:alt_text]
+  end
 %>
-<div class="app-c-image-meta" id="<%= id %>">
+<div class="app-c-image-meta <%= 'app-c-image-meta--no-border' if no_border %>" id="<%= id %>">
   <div class="govuk-grid-row">
     <div class="govuk-grid-column-one-third">
 
@@ -18,23 +22,25 @@
     </div>
     <div class="govuk-grid-column-two-thirds">
 
-      <%= render "components/metadata", {
-        inline: true,
-        items: [
-          {
-            field: t("documents.show.lead_image.fields.alt_text"),
-            value: alt_text
-          },
-          {
-            field: t("documents.show.lead_image.fields.caption"),
-            value: caption
-          },
-          {
-            field: t("documents.show.lead_image.fields.credit"),
-            value: credit
-          }
-        ]
-      } %>
+      <% if meta.any? %>
+        <%= render "components/metadata", {
+          inline: true,
+          items: [
+            {
+              field: t("documents.show.lead_image.fields.alt_text"),
+              value: meta[:alt_text]
+            },
+            {
+              field: t("documents.show.lead_image.fields.caption"),
+              value: meta[:caption]
+            },
+            {
+              field: t("documents.show.lead_image.fields.credit"),
+              value: meta[:credit]
+            }
+          ]
+        } %>
+      <% end %>
 
       <% if lead_image %>
         <div class="app-c-image-meta__lead-image-section">
@@ -52,6 +58,6 @@
         <li class="app-c-image-meta__choose-image"><%= actions[:choose_button] %></li>
       <% end %>
       <li><%= link_to("Edit details", actions[:edit_link], class: "govuk-link") %></li>
-    <ul>
+    </ul>
   <% end %>
 </div>

--- a/app/views/components/docs/image_meta.yml
+++ b/app/views/components/docs/image_meta.yml
@@ -13,7 +13,8 @@ examples:
   default:
     data:
       src: https://assets.publishing.service.gov.uk/government/assets/history/buildings/larry-the-cat-a47549e08bdbc6cd0e3e042eea943f65b7a4590d95642586e51acb44bb2dcea2.jpg
-      alt_text: Larry the cat
-      caption: Larry, Chief Mouser to the Cabinet Office
-      credit: Her Majesty's Government
+      meta:
+        alt_text: Larry the cat
+        caption: Larry, Chief Mouser to the Cabinet Office
+        credit: Her Majesty's Government
 

--- a/app/views/document_lead_image/_image_list.html.erb
+++ b/app/views/document_lead_image/_image_list.html.erb
@@ -16,10 +16,12 @@
   <%= render "components/image_meta", {
     id: "image-#{i}",
     src: url_for(image.thumbnail),
-    alt_text: image.alt_text,
-    caption: image.caption,
-    credit: image.credit,
     lead_image: image == @document.lead_image,
+    meta: {
+      alt_text: image.alt_text,
+      caption: image.caption,
+      credit: image.credit,
+    },
     actions: {
       edit_link: edit_document_lead_image_path(@document, image, next_screen: "lead-image"),
       remove_button: remove_lead_image_button,

--- a/app/views/document_lead_image/edit.html.erb
+++ b/app/views/document_lead_image/edit.html.erb
@@ -1,34 +1,97 @@
-<% content_for :back_link, document_lead_image_path(@document) %>
 <% content_for :title, t("document_lead_image.edit.title", title: @document.title_or_fallback) %>
+<% content_for :back_link, document_lead_image_path(@document) %>
 
-<div class="govuk-grid-row">
-  <div class="govuk-grid-column-two-thirds">
-    <%= image_tag(url_for(@image.thumbnail), id: "selected-image") %>
-    <%= form_tag(update_document_lead_image_path(@document, @image, next_screen: params[:next_screen]), method: :patch) do %>
+<%= render "components/image_meta", {
+  id: "selected-image",
+  src: url_for(@image.thumbnail),
+  alt_text: @image.alt_text,
+  no_border: true
+} %>
+
+<%= form_tag(update_document_lead_image_path(@document, @image, next_screen: params[:next_screen]), method: :patch) do %>
+  <div class="govuk-grid-row">
+    <div class="govuk-grid-column-two-thirds">
       <%= render "govuk_publishing_components/components/input", {
         label: {
-          text: t("document_lead_image.edit.form_labels.caption")
-        },
-        name: "caption",
-        value: @image.caption,
-      } %>
-      <%= render "govuk_publishing_components/components/input", {
-        label: {
-          text: t("document_lead_image.edit.form_labels.alt_text")
+          text: t("document_lead_image.edit.form_labels.alt_text"),
+          bold: true
         },
         name: "alt_text",
         value: @image.alt_text,
+        data: {
+          "contextual-guidance": "alt-text-guidance"
+        }
       } %>
+    </div>
+
+    <div class="govuk-grid-column-one-third">
+      <%= render "components/contextual_guidance", {
+        id: "alt-text-guidance",
+        title: t("document_lead_image.edit.form_labels.alt_text"),
+      } do %>
+        <%= render "govuk_publishing_components/components/govspeak" do %>
+          <%= govspeak_to_html t("document_lead_image.edit.guidance.alt_text") %>
+        <% end %>
+      <% end %>
+    </div>
+  </div>
+
+  <div class="govuk-grid-row">
+    <div class="govuk-grid-column-two-thirds">
       <%= render "govuk_publishing_components/components/input", {
         label: {
-          text: t("document_lead_image.edit.form_labels.credit")
+          text: t("document_lead_image.edit.form_labels.caption"),
+          bold: true
+        },
+        name: "caption",
+        value: @image.caption,
+        data: {
+          "contextual-guidance": "caption-guidance"
+        }
+      } %>
+    </div>
+
+    <div class="govuk-grid-column-one-third">
+      <%= render "components/contextual_guidance", {
+        id: "caption-guidance",
+        title: t("document_lead_image.edit.form_labels.caption"),
+      } do %>
+        <%= render "govuk_publishing_components/components/govspeak" do %>
+          <%= govspeak_to_html t("document_lead_image.edit.guidance.caption") %>
+        <% end %>
+      <% end %>
+    </div>
+  </div>
+
+  <div class="govuk-grid-row">
+    <div class="govuk-grid-column-two-thirds">
+      <%= render "govuk_publishing_components/components/input", {
+        label: {
+          text: t("document_lead_image.edit.form_labels.credit"),
+          bold: true
         },
         name: "credit",
         value: @image.credit,
+        data: {
+          "contextual-guidance": "credit-guidance"
+        }
       } %>
-      <%= render "govuk_publishing_components/components/button", {
-        text: "Save and choose"
-      } %>
-    <% end %>
+    </div>
+
+    <div class="govuk-grid-column-one-third">
+      <%= render "components/contextual_guidance", {
+        id: "credit-guidance",
+        title: t("document_lead_image.edit.form_labels.credit"),
+      } do %>
+        <%= render "govuk_publishing_components/components/govspeak" do %>
+          <%= govspeak_to_html t("document_lead_image.edit.guidance.credit") %>
+        <% end %>
+      <% end %>
+    </div>
   </div>
-</div>
+
+  <%= render "govuk_publishing_components/components/button", {
+    text: "Save and choose",
+    margin_bottom: true
+  } %>
+<% end %>

--- a/app/views/documents/show/_lead_image.html.erb
+++ b/app/views/documents/show/_lead_image.html.erb
@@ -3,9 +3,11 @@
     <%= render "components/image_meta", {
       id: "lead-image",
       src: url_for(@document.lead_image.thumbnail),
-      alt_text: @document.lead_image.alt_text,
-      caption: @document.lead_image.caption,
-      credit: @document.lead_image.credit
+      meta: {
+        alt_text: @document.lead_image.alt_text,
+        caption: @document.lead_image.caption,
+        credit: @document.lead_image.credit
+      }
     } %>
   <% end %>
 
@@ -17,11 +19,16 @@
     block: lead_image_block
   } %>
 <% else %>
+  <% no_lead_image_block = capture do %>
+    <%= t("documents.show.lead_image.no_lead_image") %>
+    <%= link_to t("documents.show.lead_image.upload_image"), document_lead_image_path(@document), class: "govuk-link" %>
+  <% end %>
+
   <%= render "components/summary", {
     title: {
       text: t("documents.show.lead_image.title"),
       change_url: document_lead_image_path(@document)
     },
-    block: t("documents.show.lead_image.no_lead_image")
+    block: no_lead_image_block
   } %>
 <% end %>

--- a/config/locales/en/document_lead_image/edit.yml
+++ b/config/locales/en/document_lead_image/edit.yml
@@ -3,6 +3,10 @@ en:
     edit:
       title: "Edit lead image for ‘%{title}’"
       form_labels:
-        caption: Caption
         alt_text: Alt text
-        credit: Credit
+        caption: Image caption
+        credit: Image credit
+      guidance:
+        alt_text: A simple and specific description of what the image shows. This helps screen-readers and search engines.
+        caption: This text appears on the page under the image.
+        credit: You must have the rights to use this image. Images should be credited to their source. For example, Getty Images. Open Government Licence (OGL) images do not need to be credited.

--- a/spec/features/upload_lead_image_spec.rb
+++ b/spec/features/upload_lead_image_spec.rb
@@ -39,7 +39,7 @@ RSpec.feature "Upload a lead image" do
   end
 
   def and_i_fill_in_the_metadata
-    expect(find("#selected-image")["src"]).to include("960x640.jpg")
+    expect(find(".app-c-image-meta__image")["src"]).to include("960x640.jpg")
     fill_in "alt_text", with: "Some alt text"
     fill_in "caption", with: "Image caption"
     fill_in "credit", with: "Image credit"


### PR DESCRIPTION
This PR:
- updates the image meta component to group meta attributes and only display meta list when presented
- updates the image meta component to allow no_border modifier
- updates the edit image page to use the updated image meta component
- updates tests to reflect changes

### Preview
<img width="964" alt="screen shot 2018-09-13 at 18 17 07" src="https://user-images.githubusercontent.com/788096/45504263-46b91900-b781-11e8-85d2-12be2f0d3fa2.png">

[Trello card](https://trello.com/c/RCoMnQcK)