### PR TITLE
Overwrite govuk-link to allow buttons to be styled as link

### DIFF
--- a/app/assets/stylesheets/utilities/_overwrites.scss
+++ b/app/assets/stylesheets/utilities/_overwrites.scss
@@ -1,3 +1,6 @@
+@import "../../../node_modules/govuk-frontend/core/links";
+@import "../../../node_modules/govuk-frontend/core/typography";
+
 .gem-c-success-alert__message {
   margin: 0;
 }
@@ -8,4 +11,16 @@
 
 .govuk-select[multiple] {
   height: 100%;
+}
+
+.govuk-link {
+  @extend %govuk-link;
+  @extend %govuk-body-m;
+  margin: 0;
+  padding: 0;
+  border: 0;
+  color: $govuk-link-colour;
+  background: transparent;
+  text-decoration: underline;
+  cursor: pointer;
 }

--- a/app/views/document_lead_image/_image_list.html.erb
+++ b/app/views/document_lead_image/_image_list.html.erb
@@ -3,13 +3,13 @@
 
   <% remove_lead_image_button = capture do %>
     <%= form_tag remove_document_lead_image_path(@document), method: :delete do %>
-      <button>Remove</button>
+      <button class="govuk-link">Remove</button>
     <% end %>
   <% end %>
 
   <% choose_lead_image_button = capture do %>
     <%= form_tag choose_document_lead_image_path(@document, image) do %>
-      <button>Choose image</button>
+      <button class="govuk-link">Choose image</button>
     <% end %>
   <% end %>
 


### PR DESCRIPTION
Overwrite `.govuk-link` to allow buttons to be styled as link.
This is not something that we would promote, but currently we use a mix of buttons and links to choose/edit/remove an image and we need them to look consistent.

One way to avoid this is to use links/GET actions for remove and choose actions.

### Before
<img width="635" alt="screen shot 2018-09-14 at 09 47 43" src="https://user-images.githubusercontent.com/788096/45540016-4eb99d00-b803-11e8-8a0c-94d6328794e7.png">

### After
<img width="633" alt="screen shot 2018-09-14 at 09 48 59" src="https://user-images.githubusercontent.com/788096/45540087-714bb600-b803-11e8-9051-2f7eade4f667.png">

[Trello card](https://trello.com/c/k5BjyOKw)
