### PR TITLE
Support deletion of drafts (with confirmation)

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -5,5 +5,5 @@ class ApplicationController < ActionController::Base
 
   before_action :authenticate_user!
 
-  add_flash_types :alert_with_description
+  add_flash_types :alert_with_description, :confirmation
 end

--- a/app/controllers/documents_controller.rb
+++ b/app/controllers/documents_controller.rb
@@ -23,11 +23,13 @@ class DocumentsController < ApplicationController
 
   def confirm_delete_draft
     document = Document.find_by_param(params[:id])
+    raise "Trying to delete a live document" if document.has_live_version_on_govuk
     redirect_to document_path(document), confirmation: "documents/show/delete_draft"
   end
 
   def destroy
     document = Document.find_by_param(params[:id])
+    raise "Trying to delete a live document" if document.has_live_version_on_govuk
     DocumentPublishingService.new.discard_draft(document)
     document.destroy!
     redirect_to documents_path

--- a/app/controllers/documents_controller.rb
+++ b/app/controllers/documents_controller.rb
@@ -21,6 +21,16 @@ class DocumentsController < ApplicationController
     @document = Document.find_by_param(params[:id])
   end
 
+  def confirm_delete_draft
+    document = Document.find_by_param(params[:id])
+    redirect_to document_path(document), confirmation: "documents/show/delete_draft"
+  end
+
+  def destroy
+    Document.find_by_param(params[:id]).destroy!
+    redirect_to documents_path
+  end
+
   def update
     document = Document.find_by_param(params[:id])
 

--- a/app/controllers/documents_controller.rb
+++ b/app/controllers/documents_controller.rb
@@ -27,8 +27,12 @@ class DocumentsController < ApplicationController
   end
 
   def destroy
-    Document.find_by_param(params[:id]).destroy!
+    document = Document.find_by_param(params[:id])
+    DocumentPublishingService.new.discard_draft(document)
+    document.destroy!
     redirect_to documents_path
+  rescue GdsApi::BaseError
+    redirect_to document, alert_with_description: t("documents.show.flashes.delete_draft_error")
   end
 
   def update

--- a/app/models/document.rb
+++ b/app/models/document.rb
@@ -14,6 +14,7 @@ class Document < ApplicationRecord
     sending_to_live
     sent_to_live
     error_sending_to_live
+    error_deleting_draft
   ].freeze
 
   REVIEW_STATES = %w[

--- a/app/services/document_publishing_service.rb
+++ b/app/services/document_publishing_service.rb
@@ -24,6 +24,15 @@ class DocumentPublishingService
     raise
   end
 
+  def discard_draft(document)
+    publishing_api.discard_draft(document.content_id)
+    document.update!(publication_state: "changes_not_sent_to_draft")
+  rescue GdsApi::BaseError => e
+    GovukError.notify(e)
+    document.update!(publication_state: "error_deleting_draft")
+    raise
+  end
+
 private
 
   def publishing_api

--- a/app/services/document_publishing_service.rb
+++ b/app/services/document_publishing_service.rb
@@ -15,7 +15,7 @@ class DocumentPublishingService
 
   def publish(document, review_state)
     document.update!(publication_state: "sending_to_live", review_state: review_state)
-    publish_images(document.images)
+    publish_assets(document.images)
     publishing_api.publish(document.content_id, nil, locale: document.locale)
     document.update!(publication_state: "sent_to_live", change_note: nil, update_type: "major", has_live_version_on_govuk: true)
   rescue GdsApi::BaseError => e
@@ -25,6 +25,7 @@ class DocumentPublishingService
   end
 
   def discard_draft(document)
+    delete_assets(document.images)
     publishing_api.discard_draft(document.content_id)
     document.update!(publication_state: "changes_not_sent_to_draft")
   rescue GdsApi::BaseError => e
@@ -43,8 +44,13 @@ private
     )
   end
 
-  def publish_images(images)
+  def publish_assets(assets)
     asset_manager = AssetManagerService.new
-    images.each { |image| asset_manager.publish(image) }
+    assets.each { |asset| asset_manager.publish(asset) }
+  end
+
+  def delete_assets(assets)
+    asset_manager = AssetManagerService.new
+    assets.each { |asset| asset_manager.delete(asset) }
   end
 end

--- a/app/services/user_facing_state.rb
+++ b/app/services/user_facing_state.rb
@@ -10,7 +10,7 @@ class UserFacingState
     case state.to_sym
     when :draft
       query
-        .where(publication_state: %w[changes_not_sent_to_draft sent_to_draft sending_to_draft error_sending_to_draft error_sending_to_live])
+        .where(publication_state: %w[changes_not_sent_to_draft sent_to_draft sending_to_draft error_sending_to_draft error_sending_to_live error_deleting_draft])
         .where.not(review_state: "submitted_for_review")
     when :submitted_for_review
       query.where(review_state: "submitted_for_review")
@@ -33,7 +33,7 @@ class UserFacingState
   def to_s
     if review_state == "submitted_for_review"
       "submitted_for_review"
-    elsif publication_state.in?(%w[changes_not_sent_to_draft sent_to_draft sending_to_draft error_sending_to_draft error_sending_to_live])
+    elsif publication_state.in?(%w[changes_not_sent_to_draft sent_to_draft sending_to_draft error_sending_to_draft error_sending_to_live error_deleting_draft])
       "draft"
     elsif review_state == "published_without_review"
       "published_but_needs_2i"

--- a/app/views/documents/show/_actions.html.erb
+++ b/app/views/documents/show/_actions.html.erb
@@ -28,7 +28,7 @@
       <%= render "govuk_publishing_components/components/button", text: "Publish", href: publish_document_path(@document) %>
       <%= render "govuk_publishing_components/components/button", text: "Preview", href: preview_document_path(@document), secondary: true, target: "_blank" %>
 
-      <%= link_to "Delete draft", '#', class: "app-link--destructive app-link--right" %>
+      <%= link_to "Delete draft", delete_draft_path(@document), class: "app-link--destructive app-link--right" %>
     <% elsif @document.user_facing_state == "draft" %>
       <%= form_tag submit_document_for_2i_path(@document) do %>
         <%= render "govuk_publishing_components/components/button", text: "Submit for 2i review" %>
@@ -37,7 +37,7 @@
       <%= render "govuk_publishing_components/components/button", text: "Preview", href: preview_document_path(@document), secondary: true, target: "_blank" %>
 
       <%= link_to "Publish", publish_document_path(@document), class: "govuk-link" %>
-      <%= link_to "Delete draft", "#", class: "app-link--destructive app-link--right" %>
+      <%= link_to "Delete draft", delete_draft_path(@document), class: "app-link--destructive app-link--right" %>
     <% end %>
 
     <% if @document.has_live_version_on_govuk? %>

--- a/app/views/documents/show/_actions.html.erb
+++ b/app/views/documents/show/_actions.html.erb
@@ -6,6 +6,12 @@
       <%= form_tag retry_draft_save_path(@document) do %>
         <%= render "govuk_publishing_components/components/button", text: "Try again" %>
       <% end %>
+    <% elsif @document.publication_state == "error_deleting_draft" %>
+      <%= govspeak_to_html t("documents.show.sidebar.error_deleting_draft") %>
+
+      <%= form_tag document_path(@document), method: :delete do %>
+        <%= render "govuk_publishing_components/components/button", text: "Try again" %>
+      <% end %>
     <% elsif @document.publication_state == "error_sending_to_live" %>
       <%= govspeak_to_html t("documents.show.sidebar.error_publishing_live") %>
 

--- a/app/views/documents/show/_actions.html.erb
+++ b/app/views/documents/show/_actions.html.erb
@@ -34,7 +34,9 @@
       <%= render "govuk_publishing_components/components/button", text: "Publish", href: publish_document_path(@document) %>
       <%= render "govuk_publishing_components/components/button", text: "Preview", href: preview_document_path(@document), secondary: true, target: "_blank" %>
 
-      <%= link_to "Delete draft", delete_draft_path(@document), class: "app-link--destructive app-link--right" %>
+      <% unless @document.has_live_version_on_govuk %>
+        <%= link_to "Delete draft", delete_draft_path(@document), class: "app-link--destructive app-link--right" %>
+      <% end %>
     <% elsif @document.user_facing_state == "draft" %>
       <%= form_tag submit_document_for_2i_path(@document) do %>
         <%= render "govuk_publishing_components/components/button", text: "Submit for 2i review" %>
@@ -43,7 +45,10 @@
       <%= render "govuk_publishing_components/components/button", text: "Preview", href: preview_document_path(@document), secondary: true, target: "_blank" %>
 
       <%= link_to "Publish", publish_document_path(@document), class: "govuk-link" %>
-      <%= link_to "Delete draft", delete_draft_path(@document), class: "app-link--destructive app-link--right" %>
+
+      <% unless @document.has_live_version_on_govuk %>
+        <%= link_to "Delete draft", delete_draft_path(@document), class: "app-link--destructive app-link--right" %>
+      <% end %>
     <% end %>
 
     <% if @document.has_live_version_on_govuk? %>

--- a/app/views/documents/show/_delete_draft.html.erb
+++ b/app/views/documents/show/_delete_draft.html.erb
@@ -1,0 +1,17 @@
+<% confirmation = capture do %>
+  <%= form_tag document_path(@document), method: :delete do %>
+    <%= render "govuk_publishing_components/components/button", {
+      text: "Yes, delete draft"
+    } %>
+
+    <div style="display: inline-block; padding-left: 15px; padding-top: 8px">
+      <%= link_to "Cancel", document_path(@document), class: "govuk-link" %>
+    </div>
+  <% end %>
+
+<% end %>
+
+<%= render "govuk_publishing_components/components/error_alert", {
+  message: t("documents.show.flashes.delete_draft"),
+  description: confirmation
+} %>

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -39,6 +39,10 @@
       } %>
     <% end %>
 
+    <% if flash["confirmation"] %>
+      <%= render flash["confirmation"] %>
+    <% end %>
+
     <% if flash["alert_with_description"] %>
       <%= render "govuk_publishing_components/components/error_alert", {
         message: flash["alert_with_description"].fetch("title"),

--- a/config/locales/en/documents/show.yml
+++ b/config/locales/en/documents/show.yml
@@ -22,6 +22,8 @@ en:
           Something went wrong when saving your draft. Please try again or [raise a support request](https://support.publishing.service.gov.uk/technical_fault_report/new).
         error_publishing_live: |
           Something went wrong when publishing. Please try again or [raise a support request](https://support.publishing.service.gov.uk/technical_fault_report/new).
+        error_deleting_draft: |
+          Something went wrong when deleting your draft. Please try again or [raise a support request](https://support.publishing.service.gov.uk/technical_fault_report/new).
       lead_image:
         title: Lead image
         no_lead_image: No image selected. The default image for your department will be used.
@@ -49,3 +51,6 @@ en:
           title: Content has been submitted for 2i review
           label: Send this document to another publisher for them to review. When content is ready you or they can publish it.
         delete_draft: Are you sure you want to delete this draft
+        delete_draft_error:
+          title: Something has gone wrong
+          description: Something went wrong when deleting your draft. Please try again or [raise a support request](https://support.publishing.service.gov.uk/technical_fault_report/new).

--- a/config/locales/en/documents/show.yml
+++ b/config/locales/en/documents/show.yml
@@ -48,3 +48,4 @@ en:
         submitted_for_review:
           title: Content has been submitted for 2i review
           label: Send this document to another publisher for them to review. When content is ready you or they can publish it.
+        delete_draft: Are you sure you want to delete this draft

--- a/config/locales/en/states.yml
+++ b/config/locales/en/states.yml
@@ -31,3 +31,6 @@ en:
     error_sending_to_live:
       name: Error publishing
       description: We've encountered a problem during the publishing.
+    error_deleting_draft:
+      name: Error deleting draft
+      description: We've encountered a problem when deleting the draft.

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -18,6 +18,8 @@ Rails.application.routes.draw do
   patch "/documents/:id" => "documents#update", as: :document
   get "/documents/:id" => "documents#show"
   get "/documents/:id/generate-path" => "documents#generate_path", as: :generate_path
+  get "/documents/:id/delete-draft" => "documents#confirm_delete_draft", as: :delete_draft
+  delete "/documents/:id" => "documents#destroy"
 
   post "/documents/:id/submit-for-2i" => "review#submit_for_2i", as: :submit_document_for_2i
   post "/documents/:id/approve" => "review#approve", as: :approve_document

--- a/db/migrate/20180917162353_nullify_lead_image_foreign_key.rb
+++ b/db/migrate/20180917162353_nullify_lead_image_foreign_key.rb
@@ -1,0 +1,8 @@
+# frozen_string_literal: true
+
+class NullifyLeadImageForeignKey < ActiveRecord::Migration[5.2]
+  def change
+    remove_foreign_key "documents", "images"
+    add_foreign_key "documents", "images", column: :lead_image_id, on_delete: :nullify
+  end
+end

--- a/spec/features/delete_draft_after_publishing_spec.rb
+++ b/spec/features/delete_draft_after_publishing_spec.rb
@@ -1,0 +1,43 @@
+# frozen_string_literal: true
+
+RSpec.feature "Delete draft after publishing" do
+  scenario "Delete draft after publishing" do
+    given_there_is_a_document
+    when_i_visit_the_document_page
+    and_i_publish_the_document
+    and_i_create_a_new_draft
+    then_i_cannot_delete_the_draft
+    when_i_submit_for_2i_review
+    then_i_cannot_delete_the_draft
+  end
+
+  def given_there_is_a_document
+    @document = create(:document, publication_state: "sent_to_draft")
+  end
+
+  def when_i_visit_the_document_page
+    visit document_path(@document)
+  end
+
+  def when_i_submit_for_2i_review
+    click_on "Submit for 2i review"
+  end
+
+  def and_i_publish_the_document
+    stub_any_publishing_api_publish
+    click_on "Publish"
+    choose I18n.t("publish_document.confirmation.should_be_reviewed")
+    click_on "Confirm publish"
+    click_on "Back"
+  end
+
+  def and_i_create_a_new_draft
+    stub_any_publishing_api_put_content
+    click_on "Change Content"
+    click_on "Save"
+  end
+
+  def then_i_cannot_delete_the_draft
+    expect(page).to_not have_content("Delete draft")
+  end
+end

--- a/spec/features/delete_draft_api_down_spec.rb
+++ b/spec/features/delete_draft_api_down_spec.rb
@@ -1,12 +1,14 @@
 # frozen_string_literal: true
 
-RSpec.feature "Delete draft" do
-  scenario "Delete draft" do
+RSpec.feature "Delete draft with API down" do
+  scenario "Delete draft with API down" do
     given_there_is_a_document
     when_i_visit_the_document_page
+    and_the_publishing_api_is_down
     and_i_delete_the_draft
+    then_i_see_the_deletion_failed
+    when_the_api_is_up_and_i_try_again
     then_i_see_the_document_is_gone
-    and_the_draft_is_discarded
   end
 
   def given_there_is_a_document
@@ -17,18 +19,27 @@ RSpec.feature "Delete draft" do
     visit document_path(@document)
   end
 
-  def and_i_delete_the_draft
+  def when_the_api_is_up_and_i_try_again
     @request = stub_publishing_api_discard_draft(@document.content_id)
+    click_on "Try again"
+  end
+
+  def and_the_publishing_api_is_down
+    publishing_api_isnt_available
+  end
+
+  def and_i_delete_the_draft
     click_on "Delete draft"
     click_on "Yes, delete draft"
+  end
+
+  def then_i_see_the_deletion_failed
+    expect(page).to have_content(I18n.t("documents.show.flashes.delete_draft_error.title"))
+    expect(page).to have_content(@document.title)
   end
 
   def then_i_see_the_document_is_gone
     expect(page).to have_current_path(documents_path)
     expect(page).to_not have_content @document.title
-  end
-
-  def and_the_draft_is_discarded
-    expect(@request).to have_been_requested
   end
 end

--- a/spec/features/delete_draft_asset_manager_down_spec.rb
+++ b/spec/features/delete_draft_asset_manager_down_spec.rb
@@ -1,0 +1,49 @@
+# frozen_string_literal: true
+
+RSpec.feature "Delete draft with Asset Manager down" do
+  scenario "Delete draft with Asset Manager down" do
+    given_there_is_a_document
+    when_i_visit_the_document_page
+    and_asset_manager_is_down
+    and_i_delete_the_draft
+    then_i_see_the_deletion_failed
+    when_asset_manager_is_up_and_i_try_again
+    then_i_see_the_document_is_gone
+  end
+
+  def given_there_is_a_document
+    @document = create(:document)
+    @image = create(:image, :in_asset_manager, document: @document)
+  end
+
+  def when_i_visit_the_document_page
+    visit document_path(@document)
+  end
+
+  def when_asset_manager_is_up_and_i_try_again
+    # TODO: add this to gds-api-adapters test helpers
+    stub_request(:delete, %r{https://asset-manager.test.gov.uk/assets})
+    click_on "Try again"
+  end
+
+  def and_asset_manager_is_down
+    # TODO: add this to gds-api-adapters test helpers
+    stub_request(:delete, %r{https://asset-manager.test.gov.uk/assets}).to_return(status: 500)
+  end
+
+  def and_i_delete_the_draft
+    stub_any_publishing_api_discard_draft
+    click_on "Delete draft"
+    click_on "Yes, delete draft"
+  end
+
+  def then_i_see_the_deletion_failed
+    expect(page).to have_content(I18n.t("documents.show.flashes.delete_draft_error.title"))
+    expect(page).to have_content(@document.title)
+  end
+
+  def then_i_see_the_document_is_gone
+    expect(page).to have_current_path(documents_path)
+    expect(page).to_not have_content @document.title
+  end
+end

--- a/spec/features/delete_draft_asset_manager_down_spec.rb
+++ b/spec/features/delete_draft_asset_manager_down_spec.rb
@@ -21,14 +21,12 @@ RSpec.feature "Delete draft with Asset Manager down" do
   end
 
   def when_asset_manager_is_up_and_i_try_again
-    # TODO: add this to gds-api-adapters test helpers
-    stub_request(:delete, %r{https://asset-manager.test.gov.uk/assets})
+    asset_manager_delete_asset(@image.asset_manager_id)
     click_on "Try again"
   end
 
   def and_asset_manager_is_down
-    # TODO: add this to gds-api-adapters test helpers
-    stub_request(:delete, %r{https://asset-manager.test.gov.uk/assets}).to_return(status: 500)
+    asset_manager_delete_asset_failure(@image.asset_manager_id)
   end
 
   def and_i_delete_the_draft

--- a/spec/features/delete_draft_publishing_api_down_spec.rb
+++ b/spec/features/delete_draft_publishing_api_down_spec.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
-RSpec.feature "Delete draft with API down" do
-  scenario "Delete draft with API down" do
+RSpec.feature "Delete draft with Publishing API down" do
+  scenario "Delete draft with Publishing API down" do
     given_there_is_a_document
     when_i_visit_the_document_page
     and_the_publishing_api_is_down

--- a/spec/features/delete_draft_spec.rb
+++ b/spec/features/delete_draft_spec.rb
@@ -33,6 +33,7 @@ RSpec.feature "Delete draft" do
   end
 
   def and_the_draft_is_discarded
+    expect(ActiveStorage::Blob.service.exist?(@image.blob.key)).to be_falsey
     expect(@content_request).to have_been_requested
     expect(@image_request).to have_been_requested
   end

--- a/spec/features/delete_draft_spec.rb
+++ b/spec/features/delete_draft_spec.rb
@@ -1,0 +1,28 @@
+# frozen_string_literal: true
+
+RSpec.feature "Delete draft" do
+  scenario "Delete draft" do
+    given_there_is_a_document
+    when_i_visit_the_document_page
+    and_i_delete_the_draft
+    then_i_see_the_document_is_gone
+  end
+
+  def given_there_is_a_document
+    @document = create(:document)
+  end
+
+  def when_i_visit_the_document_page
+    visit document_path(@document)
+  end
+
+  def and_i_delete_the_draft
+    click_on "Delete draft"
+    click_on "Yes, delete draft"
+  end
+
+  def then_i_see_the_document_is_gone
+    expect(page).to have_current_path(documents_path)
+    expect(page).to_not have_content @document.title
+  end
+end

--- a/spec/features/delete_draft_spec.rb
+++ b/spec/features/delete_draft_spec.rb
@@ -20,8 +20,7 @@ RSpec.feature "Delete draft" do
 
   def and_i_delete_the_draft
     @content_request = stub_publishing_api_discard_draft(@document.content_id)
-    # TODO: add this to gds-api-adapters test helpers
-    @image_request = stub_request(:delete, "https://asset-manager.test.gov.uk/assets/#{@image.asset_manager_id}")
+    @image_request = asset_manager_delete_asset(@image.asset_manager_id)
 
     click_on "Delete draft"
     click_on "Yes, delete draft"

--- a/spec/features/delete_draft_spec.rb
+++ b/spec/features/delete_draft_spec.rb
@@ -11,6 +11,7 @@ RSpec.feature "Delete draft" do
 
   def given_there_is_a_document
     @document = create(:document)
+    @image = create(:image, :in_asset_manager, document: @document)
   end
 
   def when_i_visit_the_document_page
@@ -18,7 +19,10 @@ RSpec.feature "Delete draft" do
   end
 
   def and_i_delete_the_draft
-    @request = stub_publishing_api_discard_draft(@document.content_id)
+    @content_request = stub_publishing_api_discard_draft(@document.content_id)
+    # TODO: add this to gds-api-adapters test helpers
+    @image_request = stub_request(:delete, "https://asset-manager.test.gov.uk/assets/#{@image.asset_manager_id}")
+
     click_on "Delete draft"
     click_on "Yes, delete draft"
   end
@@ -29,6 +33,7 @@ RSpec.feature "Delete draft" do
   end
 
   def and_the_draft_is_discarded
-    expect(@request).to have_been_requested
+    expect(@content_request).to have_been_requested
+    expect(@image_request).to have_been_requested
   end
 end

--- a/spec/services/document_publishing_service_spec.rb
+++ b/spec/services/document_publishing_service_spec.rb
@@ -28,4 +28,16 @@ RSpec.describe DocumentPublishingService do
       expect(document).to have_received(:update!).with(publication_state: "sent_to_live", has_live_version_on_govuk: true, change_note: nil, update_type: "major")
     end
   end
+
+  describe "#discard_draft" do
+    it "keeps track of the publication state" do
+      document = create(:document)
+      stub_publishing_api_discard_draft(document.content_id)
+      allow(document).to receive(:update!)
+
+      DocumentPublishingService.new.discard_draft(document)
+
+      expect(document).to have_received(:update!).with(publication_state: "changes_not_sent_to_draft")
+    end
+  end
 end

--- a/spec/services/user_facing_state_spec.rb
+++ b/spec/services/user_facing_state_spec.rb
@@ -90,6 +90,14 @@ RSpec.describe UserFacingState do
       expect(state).to eql("draft")
     end
 
+    it "is draft if in draft and we can't delete the draft" do
+      document = build(:document, publication_state: "error_deleting_draft")
+
+      state = UserFacingState.new(document).to_s
+
+      expect(state).to eql("draft")
+    end
+
     it "is published_but_needs_2i if it has unreviewed changes sent to live" do
       document = build(:document, publication_state: "sent_to_live", review_state: "published_without_review")
 


### PR DESCRIPTION
<img width="1197" alt="screen shot 2018-09-17 at 17 44 38" src="https://user-images.githubusercontent.com/9029009/45637526-97db4c80-baa2-11e8-8869-a91cccd5eafd.png">

This enables the 'Delete draft' button, which for now will delete a
document but in future should be changed to work on the current edition.

   * Added a new 'confirmation' flash type to support the interstitial "Yes, delete draft" box
   * Relaxed a foreign key constraint on lead images that was impeding deletion of images
   * Ensures we delete any associated images (S3, Asset Manager) including API down test
   * Restricts "Delete draft" so it's only available when the document hasn't been published
   * Ensures we delete the draft from the Publishing API including API down test

I took the long approach for the API down case (the short approach would just be 
to click "Delete draft" again), using a new publication state to display a "Try again" button 
as we do for other error states. Doing it this way accounts for the bulk of the changes 
in this PR but still feels like the cleaner approach as I'm copying the existing interaction.