### PR TITLE
Simplify `find_by` usage

### DIFF
--- a/app/controllers/document_images_controller.rb
+++ b/app/controllers/document_images_controller.rb
@@ -23,7 +23,7 @@ class DocumentImagesController < ApplicationController
 
   def update
     document = Document.find_by_param(params[:document_id])
-    image = Image.find_by!(id: params[:id], document_id: document.id)
+    image = document.images.find(params[:id])
     image.assign_attributes(image_params)
 
     if image.valid?

--- a/app/controllers/document_lead_image_controller.rb
+++ b/app/controllers/document_lead_image_controller.rb
@@ -38,12 +38,12 @@ class DocumentLeadImageController < ApplicationController
 
   def edit
     @document = Document.find_by_param(params[:document_id])
-    @image = Image.find_by(id: params[:image_id])
+    @image = @document.images.find(params[:image_id])
   end
 
   def update
     document = Document.find_by_param(params[:document_id])
-    image = Image.find_by(id: params[:image_id])
+    image = document.images.find(params[:image_id])
     image.update!(update_params)
     document.update!(lead_image_id: image.id)
     begin


### PR DESCRIPTION
`find_by` will return nil if the record is not found, while `find` (or `find_by!`) will raise an exception. `find` takes an ID, so we can simplify these calls.