### PR TITLE
Pass Asset Manager bearer token to API adapters

### DIFF
--- a/app/services/asset_manager_service.rb
+++ b/app/services/asset_manager_service.rb
@@ -16,7 +16,10 @@ class AssetManagerService
 private
 
   def asset_manager
-    @asset_manager ||= GdsApi::AssetManager.new(Plek.new.find("asset-manager"))
+    @asset_manager ||= GdsApi::AssetManager.new(
+      Plek.new.find("asset-manager"),
+      bearer_token: ENV.fetch("ASSET_MANAGER_BEARER_TOKEN", "example"),
+    )
   end
 
   def asset_id(file_url)


### PR DESCRIPTION
For https://trello.com/c/2BSsLGFS/239-upload-images-to-asset-manager-and-set-lead-image-in-publishing-api