### PR TITLE
Update upload image section

### DIFF
--- a/app/views/document_lead_image/index.html.erb
+++ b/app/views/document_lead_image/index.html.erb
@@ -3,20 +3,23 @@
 
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
-    <h2 class="govuk-heading-m">
-      <%= t("document_lead_image.index.upload_image") %>
-    </h2>
-    <%= render "govuk_publishing_components/components/govspeak" do %>
-      <%= govspeak_to_html t("document_lead_image.index.description") %>
+    <% upload_image_heading = capture do %>
+      <h2 class="govuk-heading-m">
+        <%= t("document_lead_image.index.upload_image") %>
+      </h2>
     <% end %>
 
     <%= form_tag(document_lead_image_path(@document), multipart: true) do %>
       <%= render "govuk_publishing_components/components/file_upload", {
         label: {
-          text: "Upload an image",
+          text: upload_image_heading,
         },
         name: "image"
       } %>
+
+      <%= render "govuk_publishing_components/components/govspeak" do %>
+        <%= govspeak_to_html t("document_lead_image.index.description") %>
+      <% end %>
 
       <%= render "govuk_publishing_components/components/button", {
         text: "Upload",

--- a/config/locales/en/document_lead_image/index.yml
+++ b/config/locales/en/document_lead_image/index.yml
@@ -2,10 +2,7 @@ en:
   document_lead_image:
     index:
       title: "Lead image for ‘%{title}’"
-      description: |
-        Select an image file to upload. Images can be jpg, png, gif, or svg files.
-
-        [Full guidance on images](https://www.gov.uk/guidance/how-to-publish-on-gov-uk/images-and-videos)
+      description: Images can be jpg, png, gif, or svg files. [Full guidance on images](https://www.gov.uk/guidance/how-to-publish-on-gov-uk/images-and-videos)
       upload_image: Upload an image
       existing_image: Choose existing image
       no_existing_image: No images available


### PR DESCRIPTION
This PR updates the `Upload image section` on lead image page to align it with the updated design.
[Trello card](https://trello.com/c/RCoMnQcK)