### PR TITLE
Add "View on GOV.UK" link

### DIFF
--- a/app/views/documents/show/_actions.html.erb
+++ b/app/views/documents/show/_actions.html.erb
@@ -39,5 +39,10 @@
       <%= link_to "Publish", publish_document_path(@document), class: "govuk-link" %>
       <%= link_to "Delete draft", "#", class: "app-link--destructive app-link--right" %>
     <% end %>
+
+    <% if @document.has_live_version_on_govuk? %>
+      <hr class="govuk-section-break govuk-section-break--m govuk-section-break--visible" />
+      <%= link_to "View published edition on GOV.UK", DocumentUrl.new(@document).public_url, class: "govuk-link" %>
+    <% end %>
   </div>
 </div>

--- a/spec/features/publish_a_document_spec.rb
+++ b/spec/features/publish_a_document_spec.rb
@@ -9,10 +9,11 @@ RSpec.feature "Publishing a document" do
     and_i_confirm_the_publishing
     then_i_see_the_publish_succeeded
     and_i_see_the_content_is_in_published_state
+    and_i_see_the_view_on_govuk_link
   end
 
   def given_there_is_a_document_in_draft
-    @document = create(:document, publication_state: "sent_to_draft")
+    @document = create(:document, publication_state: "sent_to_draft", base_path: "/news/banana-pricing-updates")
     @asset_id = SecureRandom.uuid
   end
 
@@ -42,6 +43,10 @@ RSpec.feature "Publishing a document" do
   def and_i_see_the_content_is_in_published_state
     visit document_path(@document)
     expect(page).to have_content(I18n.t("user_facing_states.published.name"))
+  end
+
+  def and_i_see_the_view_on_govuk_link
+    expect(page).to have_link("View published edition on GOV.UK", href: "https://www.test.gov.uk/news/banana-pricing-updates")
   end
 
   def stub_asset_manager_update_request(asset_id)


### PR DESCRIPTION
When a document was ever published you'll be able to click this link to view it on GOV.UK.

<img width="1018" alt="screen shot 2018-09-19 at 12 28 36" src="https://user-images.githubusercontent.com/233676/45750638-94150a80-bc07-11e8-8b7a-1d7c84ede238.png">

https://trello.com/c/mOwMX0fW