### PR TITLE
Support deleting assets from asset manager

### DIFF
--- a/app/controllers/document_images_controller.rb
+++ b/app/controllers/document_images_controller.rb
@@ -46,6 +46,6 @@ private
   end
 
   def upload_image_to_asset_manager(image)
-    AssetManagerService.new.upload(image.cropped_file)
+    AssetManagerService.new.upload_bytes(image, image.cropped_bytes)
   end
 end

--- a/app/controllers/document_lead_image_controller.rb
+++ b/app/controllers/document_lead_image_controller.rb
@@ -80,6 +80,6 @@ private
   end
 
   def upload_image_to_asset_manager(image)
-    AssetManagerService.new.upload(image.cropped_file)
+    AssetManagerService.new.upload_bytes(image, image.cropped_bytes)
   end
 end

--- a/app/services/asset_manager_service.rb
+++ b/app/services/asset_manager_service.rb
@@ -3,14 +3,18 @@
 require "gds_api/asset_manager"
 
 class AssetManagerService
-  def upload(file)
+  def upload_bytes(asset, content)
+    file = AssetManagerFile.from_bytes(asset, content)
     upload = asset_manager.create_asset(file: file, draft: true)
     upload["file_url"]
   end
 
   def publish(asset)
-    id = asset_id(asset.url)
-    asset_manager.update_asset(id, file: asset, draft: false)
+    asset_manager.update_asset(asset.asset_manager_id, file: asset, draft: false)
+  end
+
+  def delete(asset)
+    asset_manager.delete_asset(asset.asset_manager_id)
   end
 
 private
@@ -22,9 +26,32 @@ private
     )
   end
 
-  def asset_id(file_url)
-    url_array = file_url.split("/")
-    # the second to last element of the array contains the asset_id
-    url_array[url_array.length - 2]
+  # Used as a stand-in for a File / Rack::Multipart::UploadedFile object when
+  # passed to GdsApi::AssetManager#create_asset. The interface is required for
+  # uploading a file using the restclient we used in the backend.
+  #
+  # https://github.com/rest-client/rest-client/blob/master/lib/restclient/payload.rb#L181-L194
+  #
+  # This is done by delegating to 'io' which should implement the IO interface
+  # (e.g. StringIO) and adds methods to return filename, content_type and path.
+  class AssetManagerFile < SimpleDelegator
+    attr_reader :asset
+
+    def initialize(asset, io)
+      super(io)
+      @asset = asset
+    end
+
+    def self.from_bytes(asset, content)
+      new(asset, StringIO.new(content))
+    end
+
+    def asset_manager_id
+      asset.asset_manager_id
+    end
+
+    def path
+      asset.filename
+    end
   end
 end

--- a/app/services/document_publishing_service.rb
+++ b/app/services/document_publishing_service.rb
@@ -36,6 +36,6 @@ private
 
   def publish_images(images)
     asset_manager = AssetManagerService.new
-    images.each { |image| asset_manager.publish(image.cropped_file) }
+    images.each { |image| asset_manager.publish(image) }
   end
 end

--- a/spec/factories/image_factory.rb
+++ b/spec/factories/image_factory.rb
@@ -23,5 +23,9 @@ FactoryBot.define do
         filename: image.filename,
       )
     end
+
+    trait :in_asset_manager do
+      asset_manager_file_url { "https://asset-manager.test.gov.uk/media/asset-id-123/#{filename}" }
+    end
   end
 end

--- a/spec/services/asset_manager_service_spec.rb
+++ b/spec/services/asset_manager_service_spec.rb
@@ -3,30 +3,40 @@
 require "spec_helper"
 
 RSpec.describe AssetManagerService do
-  describe "#upload" do
-    it "returns the asset's file URL if upload to Asset Manager is successful" do
+  describe "#upload_bytes" do
+    it "uploads a byte stream to Asset Manager and returns the asset URL" do
       image = create(:image)
-      asset_manager_file_url = "http://asset-manager.test.gov.uk/#{image.filename}"
-      asset_manager_receives_an_asset(asset_manager_file_url)
+      asset_manager_receives_an_asset("response_asset_manager_file_url")
 
-      response = AssetManagerService.new.upload(image.crop_variant)
-      expect(response).to eq(asset_manager_file_url)
+      response = AssetManagerService.new.upload_bytes(image, image.cropped_bytes)
+      expect(response).to eq("response_asset_manager_file_url")
     end
   end
 
   describe "#publish" do
     it "updates an asset's draft status to false in Asset Manager" do
-      asset_id = SecureRandom.uuid
-      image = create(:image)
-      file_url = "https://asset-manager.test.gov.uk/media/#{asset_id}/#{image.filename}"
-      image.update!(asset_manager_file_url: file_url)
+      image = create(:image, :in_asset_manager)
 
+      # TODO: add this to gds-api-adapters test helpers
       body = { "draft" => false }
-      stub_request(:put, "https://asset-manager.test.gov.uk/assets/#{asset_id}")
+      stub_request(:put, "https://asset-manager.test.gov.uk/assets/#{image.asset_manager_id}")
         .to_return(body: body.to_json, status: 200)
 
-      response = AssetManagerService.new.publish(image.cropped_file)
+      response = AssetManagerService.new.publish(image)
       expect(response["draft"]).to be false
+    end
+  end
+
+  describe "#delete" do
+    it "deletes an asset from Asset Manager" do
+      image = create(:image, :in_asset_manager)
+
+      # TODO: add this to gds-api-adapters test helpers
+      stub_request(:delete, "https://asset-manager.test.gov.uk/assets/#{image.asset_manager_id}")
+        .to_return(body: "", status: 200)
+
+      response = AssetManagerService.new.delete(image)
+      expect(response.code).to eq 200
     end
   end
 end


### PR DESCRIPTION
https://trello.com/c/QAEhhJdf/244-build-workflow-for-delete-draft-remove-and-retire-document-m

This adds #delete to the AssetManagerService so we can manage deleting
images and other assets, which will come in a subsequent PR.

I struggled quite a bit when adding this method, because there were a
few concepts that need to be understood. I've tried to make that easier:

  * asset_id: this was generated in AssetManagerService using 'url',
which came from AssetManagerFile, which came from Image. To make it
easier to understand how the value is generated, I've moved this method
directly onto the Image model, so that it's easier to see the data flow.

  * asset_manager_file_url: this is generated by Asset Manager itself.
Each test required 3 lines in order to mock it accurately, which was
distracting from the purpose of the test. I've DRY-ed this up into a
'in_asset_manager' trait on the Image factory.

  * AssetManagerFile: this was a nested class in the Image model, but
has no explicit relation to an Image and is only used by the
AssetManagerService. I've moved the class into AssetManagerService to
make this clearer and let the Image class concentrate on the cropping.