### PR TITLE
Implement edition numbering

### DIFF
--- a/app/controllers/documents_controller.rb
+++ b/app/controllers/documents_controller.rb
@@ -23,6 +23,11 @@ class DocumentsController < ApplicationController
 
   def update
     document = Document.find_by_param(params[:id])
+
+    if document.publication_state == "sent_to_live"
+      document.current_edition_number += 1
+    end
+
     document.update!(update_params(document))
     TimelineEntry.create!(document: document, user: current_user, entry_type: "updated_content")
     DocumentPublishingService.new.publish_draft(document)

--- a/app/controllers/new_document_controller.rb
+++ b/app/controllers/new_document_controller.rb
@@ -48,6 +48,7 @@ class NewDocumentController < ApplicationController
       creator_id: current_user.id,
       update_type: "major",
       change_note: "First published.",
+      current_edition_number: 1,
     )
 
     TimelineEntry.create!(document: document, user: current_user, entry_type: "created")

--- a/app/models/timeline_entry.rb
+++ b/app/models/timeline_entry.rb
@@ -10,4 +10,9 @@ class TimelineEntry < ApplicationRecord
   def username_or_unknown
     user ? user.name : "Unknown user"
   end
+
+  def self.create!(params)
+    edition_number = params[:document].current_edition_number
+    super(params.merge(edition_number: edition_number))
+  end
 end

--- a/app/views/documents/show/_history_tab.html.erb
+++ b/app/views/documents/show/_history_tab.html.erb
@@ -1,5 +1,12 @@
+<% displayed_edition_number = nil %>
+
 <% @document.timeline_entries.includes(:user).order(created_at: :desc).each do |entry| %>
   <div class="timeline-entry govuk-!-margin-bottom-6">
+    <% if displayed_edition_number != entry.edition_number %>
+      <h3 class="govuk-heading-m"><%= t "documents.history.edition_header", number: entry.edition_number.ordinalize %></h3>
+      <% displayed_edition_number = entry.edition_number %>
+    <% end %>
+
     <h4 class="govuk-heading-s govuk-!-margin-bottom-1">
       <%= t "documents.history.entry_types.#{entry.entry_type}" %>
     </h4>

--- a/config/locales/en/documents/history.yml
+++ b/config/locales/en/documents/history.yml
@@ -1,6 +1,7 @@
 en:
   documents:
     history:
+      edition_header: "%{number} edition"
       entry_types:
         created: "First created"
         submitted: "Submitted for review"

--- a/db/migrate/20180919150956_current_edition_number_to_documents.rb
+++ b/db/migrate/20180919150956_current_edition_number_to_documents.rb
@@ -1,0 +1,14 @@
+# frozen_string_literal: true
+
+class CurrentEditionNumberToDocuments < ActiveRecord::Migration[5.2]
+  def up
+    execute "TRUNCATE documents CASCADE"
+    add_column :documents, :current_edition_number, :integer, null: false # rubocop:disable Rails/NotNullColumn
+    add_column :timeline_entries, :edition_number, :integer, null: false # rubocop:disable Rails/NotNullColumn
+  end
+
+  def down
+    remove_column :documents, :current_edition_number
+    remove_column :timeline_entries, :edition_number
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2018_09_13_105125) do
+ActiveRecord::Schema.define(version: 2018_09_19_150956) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -54,6 +54,7 @@ ActiveRecord::Schema.define(version: 2018_09_13_105125) do
     t.boolean "has_live_version_on_govuk", default: false, null: false
     t.text "change_note"
     t.string "update_type"
+    t.integer "current_edition_number", null: false
     t.index ["base_path"], name: "index_documents_on_base_path", unique: true
     t.index ["content_id", "locale"], name: "index_documents_on_content_id_and_locale", unique: true
     t.index ["creator_id"], name: "index_documents_on_creator_id"
@@ -86,6 +87,7 @@ ActiveRecord::Schema.define(version: 2018_09_13_105125) do
     t.bigint "user_id"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
+    t.integer "edition_number", null: false
     t.index ["document_id"], name: "index_timeline_entries_on_document_id"
     t.index ["user_id"], name: "index_timeline_entries_on_user_id"
   end

--- a/lib/tasks/whitehall_news_importer.rb
+++ b/lib/tasks/whitehall_news_importer.rb
@@ -31,6 +31,7 @@ module Tasks
         review_state: "unreviewed",
         summary: translation["summary"],
         tags: tags(edition),
+        current_edition_number: edition["published_major_version"] + 1,
       )
 
       doc.save!

--- a/spec/factories/document_factory.rb
+++ b/spec/factories/document_factory.rb
@@ -9,5 +9,6 @@ FactoryBot.define do
     document_type { build(:document_type_schema, path_prefix: "/prefix").id }
     publication_state { "changes_not_sent_to_draft" }
     review_state { "unreviewed" }
+    current_edition_number { (rand * 100).to_i }
   end
 end

--- a/spec/features/document_timeline_spec.rb
+++ b/spec/features/document_timeline_spec.rb
@@ -16,6 +16,9 @@ RSpec.feature "Document timeline" do
 
     when_i_approve_the_document
     the_timeline_has_a_approval_entry
+
+    when_i_update_the_document
+    the_timeline_shows_a_new_version_number
   end
 
   def when_i_start_to_create_a_document
@@ -85,5 +88,12 @@ RSpec.feature "Document timeline" do
     within find(".timeline-entry:first") do
       expect(page).to have_content I18n.t!("documents.history.entry_types.approved")
     end
+  end
+
+  def the_timeline_shows_a_new_version_number
+    visit document_path(@document)
+
+    expect(page).to have_content "1st edition"
+    expect(page).to have_content "2nd edition"
   end
 end

--- a/spec/tasks/whitehall_news_importer_spec.rb
+++ b/spec/tasks/whitehall_news_importer_spec.rb
@@ -9,6 +9,7 @@ RSpec.describe Tasks::WhitehallNewsImporter do
       editions: [
         {
           created_at: Time.zone.now,
+          published_major_version: 12,
           news_article_type: { key: "news_story" },
           translations: [
             {
@@ -54,5 +55,7 @@ RSpec.describe Tasks::WhitehallNewsImporter do
       .to eq(imported_edition["topical_events"])
     expect(document_tags["world_locations"])
       .to eq(imported_edition["world_locations"])
+
+    expect(Document.last.current_edition_number).to eql(13)
   end
 end


### PR DESCRIPTION
This PR adds an edition number to documents. This number will be shown in the document history, where it increases every time a new draft is created.

## What it looks like

<img width="805" alt="screen shot 2018-09-19 at 15 14 42" src="https://user-images.githubusercontent.com/233676/45758975-ce3dd680-bc1e-11e8-8195-aa92dece0140.png">

https://trello.com/c/TVcThaKi