### PR TITLE
Use `Services` module for consistency

### DIFF
--- a/app/services/asset_manager_service.rb
+++ b/app/services/asset_manager_service.rb
@@ -5,26 +5,19 @@ require "gds_api/asset_manager"
 class AssetManagerService
   def upload_bytes(asset, content)
     file = AssetManagerFile.from_bytes(asset, content)
-    upload = asset_manager.create_asset(file: file, draft: true)
+    upload = Services.asset_manager.create_asset(file: file, draft: true)
     upload["file_url"]
   end
 
   def publish(asset)
-    asset_manager.update_asset(asset.asset_manager_id, file: asset, draft: false)
+    Services.asset_manager.update_asset(asset.asset_manager_id, file: asset, draft: false)
   end
 
   def delete(asset)
-    asset_manager.delete_asset(asset.asset_manager_id)
+    Services.asset_manager.delete_asset(asset.asset_manager_id)
   end
 
 private
-
-  def asset_manager
-    @asset_manager ||= GdsApi::AssetManager.new(
-      Plek.new.find("asset-manager"),
-      bearer_token: ENV.fetch("ASSET_MANAGER_BEARER_TOKEN", "example"),
-    )
-  end
 
   # Used as a stand-in for a File / Rack::Multipart::UploadedFile object when
   # passed to GdsApi::AssetManager#create_asset. The interface is required for

--- a/app/services/document_publishing_service.rb
+++ b/app/services/document_publishing_service.rb
@@ -1,11 +1,9 @@
 # frozen_string_literal: true
 
-require "gds_api/publishing_api_v2"
-
 class DocumentPublishingService
   def publish_draft(document)
     document.update!(publication_state: "sending_to_draft")
-    publishing_api.put_content(document.content_id, PublishingApiPayload.new(document).payload)
+    Services.publishing_api.put_content(document.content_id, PublishingApiPayload.new(document).payload)
     document.update!(publication_state: "sent_to_draft")
   rescue GdsApi::BaseError => e
     GovukError.notify(e)
@@ -16,7 +14,7 @@ class DocumentPublishingService
   def publish(document, review_state)
     document.update!(publication_state: "sending_to_live", review_state: review_state)
     publish_assets(document.images)
-    publishing_api.publish(document.content_id, nil, locale: document.locale)
+    Services.publishing_api.publish(document.content_id, nil, locale: document.locale)
     document.update!(publication_state: "sent_to_live", change_note: nil, update_type: "major", has_live_version_on_govuk: true)
   rescue GdsApi::BaseError => e
     GovukError.notify(e)
@@ -26,7 +24,7 @@ class DocumentPublishingService
 
   def discard_draft(document)
     delete_assets(document.images)
-    publishing_api.discard_draft(document.content_id)
+    Services.publishing_api.discard_draft(document.content_id)
     document.update!(publication_state: "changes_not_sent_to_draft")
   rescue GdsApi::BaseError => e
     GovukError.notify(e)
@@ -35,14 +33,6 @@ class DocumentPublishingService
   end
 
 private
-
-  def publishing_api
-    GdsApi::PublishingApiV2.new(
-      Plek.new.find("publishing-api"),
-      disable_cache: true,
-      bearer_token: ENV["PUBLISHING_API_BEARER_TOKEN"] || "example",
-    )
-  end
 
   def publish_assets(assets)
     asset_manager = AssetManagerService.new

--- a/app/services/linkables_service.rb
+++ b/app/services/linkables_service.rb
@@ -1,7 +1,5 @@
 # frozen_string_literal: true
 
-require "gds_api/publishing_api_v2"
-
 class LinkablesService
   CACHE_OPTIONS = { expires_in: 5.minutes, race_condition_ttl: 10.seconds }.freeze
 
@@ -25,16 +23,7 @@ private
     # Maybe we'll need to go further with this a la:
     # https://github.com/alphagov/whitehall/blob/fc62edcd5a9b1ba8bfb22911f69f128083535127/app/models/policy.rb#L45-L58
     @linkables ||= Rails.cache.fetch("linkables.#{document_type}", CACHE_OPTIONS) do
-      publishing_api.get_linkables(document_type: document_type).to_hash
+      Services.publishing_api.get_linkables(document_type: document_type).to_hash
     end
-  end
-
-  def publishing_api
-    GdsApi::PublishingApiV2.new(
-      Plek.new.find("publishing-api"),
-      disable_cache: true,
-      timeout: 1,
-      bearer_token: ENV["PUBLISHING_API_BEARER_TOKEN"] || "example",
-    )
   end
 end

--- a/app/services/path_generator_service.rb
+++ b/app/services/path_generator_service.rb
@@ -1,7 +1,5 @@
 # frozen_string_literal: true
 
-require "gds_api/publishing_api_v2"
-
 class PathGeneratorService
   class ErrorGeneratingPath < RuntimeError
   end

--- a/lib/services.rb
+++ b/lib/services.rb
@@ -1,0 +1,22 @@
+# frozen_string_literal: true
+
+require "gds_api/publishing_api_v2"
+
+module Services
+  def self.publishing_api
+    @publishing_api ||= begin
+      GdsApi::PublishingApiV2.new(
+        Plek.new.find("publishing-api"),
+        disable_cache: true,
+        bearer_token: ENV["PUBLISHING_API_BEARER_TOKEN"] || "example",
+      )
+    end
+  end
+
+  def self.asset_manager
+    @asset_manager ||= GdsApi::AssetManager.new(
+      Plek.new.find("asset-manager"),
+      bearer_token: ENV.fetch("ASSET_MANAGER_BEARER_TOKEN", "example"),
+    )
+  end
+end


### PR DESCRIPTION
Almost all other apps on GOV.UK use a `Services` module to instantiate the API clients.