### PR TITLE
Set state on imported documents

### DIFF
--- a/lib/tasks/whitehall_news_importer.rb
+++ b/lib/tasks/whitehall_news_importer.rb
@@ -65,18 +65,14 @@ module Tasks
     end
 
     def publication_state(edition)
-      return "sent_to_draft" if edition["state"] == "draft"
-      return "sent_to_live" if edition["state"] == "published"
-      return "sent_to_draft" if edition["state"] == "rejected"
-      return "sent_to_draft" if edition["state"] == "submitted"
+      edition["state"] == "published" ? "sent_to_live" : "sent_to_draft"
     end
 
     def review_state(edition)
       return "published_without_review" if edition["force_published"]
       return "unreviewed" if edition["state"] == "draft"
       return "reviewed" if edition["state"] == "published"
-      return "submitted_for_review" if edition["state"] == "rejected"
-      return "submitted_for_review" if edition["state"] == "submitted"
+      "submitted_for_review"
     end
   end
 end

--- a/lib/tasks/whitehall_news_importer.rb
+++ b/lib/tasks/whitehall_news_importer.rb
@@ -64,12 +64,14 @@ module Tasks
     def publication_state(edition)
       return "sent_to_draft" if edition["state"] == "draft"
       return "sent_to_live" if edition["state"] == "published"
+      return "sent_to_draft" if edition["state"] == "rejected"
     end
 
     def review_state(edition)
       return "published_without_review" if edition["force_published"]
       return "unreviewed" if edition["state"] == "draft"
       return "reviewed" if edition["state"] == "published"
+      return "submitted_for_review" if edition["state"] == "rejected"
     end
   end
 end

--- a/lib/tasks/whitehall_news_importer.rb
+++ b/lib/tasks/whitehall_news_importer.rb
@@ -67,8 +67,9 @@ module Tasks
     end
 
     def review_state(edition)
+      return "published_without_review" if edition["force_published"]
       return "unreviewed" if edition["state"] == "draft"
-      return "reviewed" if edition["state"] == "published" && !edition["force_published"]
+      return "reviewed" if edition["state"] == "published"
     end
   end
 end

--- a/lib/tasks/whitehall_news_importer.rb
+++ b/lib/tasks/whitehall_news_importer.rb
@@ -63,10 +63,12 @@ module Tasks
 
     def publication_state(edition)
       return "sent_to_draft" if edition["state"] == "draft"
+      return "sent_to_live" if edition["state"] == "published"
     end
 
     def review_state(edition)
       return "unreviewed" if edition["state"] == "draft"
+      return "reviewed" if edition["state"] == "published" && !edition["force_published"]
     end
   end
 end

--- a/lib/tasks/whitehall_news_importer.rb
+++ b/lib/tasks/whitehall_news_importer.rb
@@ -27,8 +27,8 @@ module Tasks
         },
         document_type: edition["news_article_type"]["key"],
         title: translation["title"],
-        publication_state: "changes_not_sent_to_draft",
-        review_state: "unreviewed",
+        publication_state: publication_state(edition),
+        review_state: review_state(edition),
         summary: translation["summary"],
         tags: tags(edition),
         current_edition_number: document["editions"].count,
@@ -59,6 +59,14 @@ module Tasks
 
     def lead_organisations(edition)
       edition["lead_organisations"]
+    end
+
+    def publication_state(edition)
+      return "sent_to_draft" if edition["state"] == "draft"
+    end
+
+    def review_state(edition)
+      return "unreviewed" if edition["state"] == "draft"
     end
   end
 end

--- a/lib/tasks/whitehall_news_importer.rb
+++ b/lib/tasks/whitehall_news_importer.rb
@@ -2,10 +2,13 @@
 
 module Tasks
   class WhitehallNewsImporter
+    SUPPORTED_WHITEHALL_STATES = %w(draft published rejected submitted).freeze
+
     def import(document)
       edition = most_recent_edition(document)
 
       edition["translations"].each do |translation|
+        next unless SUPPORTED_WHITEHALL_STATES.include?(edition["state"])
         create_or_update_document(translation, edition, document)
       end
     end

--- a/lib/tasks/whitehall_news_importer.rb
+++ b/lib/tasks/whitehall_news_importer.rb
@@ -65,6 +65,7 @@ module Tasks
       return "sent_to_draft" if edition["state"] == "draft"
       return "sent_to_live" if edition["state"] == "published"
       return "sent_to_draft" if edition["state"] == "rejected"
+      return "sent_to_draft" if edition["state"] == "submitted"
     end
 
     def review_state(edition)
@@ -72,6 +73,7 @@ module Tasks
       return "unreviewed" if edition["state"] == "draft"
       return "reviewed" if edition["state"] == "published"
       return "submitted_for_review" if edition["state"] == "rejected"
+      return "submitted_for_review" if edition["state"] == "submitted"
     end
   end
 end

--- a/spec/tasks/whitehall_news_importer_spec.rb
+++ b/spec/tasks/whitehall_news_importer_spec.rb
@@ -25,7 +25,7 @@ RSpec.describe Tasks::WhitehallNewsImporter do
           topical_events: [SecureRandom.uuid, SecureRandom.uuid],
           world_locations: [SecureRandom.uuid, SecureRandom.uuid],
           state: "draft",
-          force_published: false
+          force_published: false,
         },
       ],
     }
@@ -72,5 +72,15 @@ RSpec.describe Tasks::WhitehallNewsImporter do
 
     expect(Document.last.publication_state).to eq("sent_to_live")
     expect(Document.last.review_state).to eq("reviewed")
+  end
+
+  it "sets the correct publication state and review state when Whitehall document is force published" do
+    import_data[:editions][0][:state] = "published"
+    import_data[:editions][0][:force_published] = true
+    parsed_json = JSON.parse(import_data.to_json)
+    Tasks::WhitehallNewsImporter.new.import(parsed_json)
+
+    expect(Document.last.publication_state).to eq("sent_to_live")
+    expect(Document.last.review_state).to eq("published_without_review")
   end
 end

--- a/spec/tasks/whitehall_news_importer_spec.rb
+++ b/spec/tasks/whitehall_news_importer_spec.rb
@@ -24,6 +24,7 @@ RSpec.describe Tasks::WhitehallNewsImporter do
           worldwide_organisations: [SecureRandom.uuid, SecureRandom.uuid],
           topical_events: [SecureRandom.uuid, SecureRandom.uuid],
           world_locations: [SecureRandom.uuid, SecureRandom.uuid],
+          state: "draft",
         },
       ],
     }.to_json
@@ -56,5 +57,8 @@ RSpec.describe Tasks::WhitehallNewsImporter do
       .to eq(imported_edition["world_locations"])
 
     expect(Document.last.current_edition_number).to eql(1)
+
+    expect(Document.last.publication_state).to eq("sent_to_draft")
+    expect(Document.last.review_state).to eq("unreviewed")
   end
 end

--- a/spec/tasks/whitehall_news_importer_spec.rb
+++ b/spec/tasks/whitehall_news_importer_spec.rb
@@ -92,4 +92,13 @@ RSpec.describe Tasks::WhitehallNewsImporter do
     expect(Document.last.publication_state).to eq("sent_to_draft")
     expect(Document.last.review_state).to eq("submitted_for_review")
   end
+
+  it "sets the correct publication state and review state when Whitehall document state is 'submitted'" do
+    import_data[:editions][0][:state] = "submitted"
+    parsed_json = JSON.parse(import_data.to_json)
+    Tasks::WhitehallNewsImporter.new.import(parsed_json)
+
+    expect(Document.last.publication_state).to eq("sent_to_draft")
+    expect(Document.last.review_state).to eq("submitted_for_review")
+  end
 end

--- a/spec/tasks/whitehall_news_importer_spec.rb
+++ b/spec/tasks/whitehall_news_importer_spec.rb
@@ -101,4 +101,11 @@ RSpec.describe Tasks::WhitehallNewsImporter do
     expect(Document.last.publication_state).to eq("sent_to_draft")
     expect(Document.last.review_state).to eq("submitted_for_review")
   end
+
+  it "skips importing documents with Whitheall states that are not supported" do
+    import_data[:editions][0][:state] = "not_supported"
+    parsed_json = JSON.parse(import_data.to_json)
+    importer = Tasks::WhitehallNewsImporter.new
+    expect { importer.import(parsed_json) }.not_to(change { Document.count })
+  end
 end

--- a/spec/tasks/whitehall_news_importer_spec.rb
+++ b/spec/tasks/whitehall_news_importer_spec.rb
@@ -83,4 +83,13 @@ RSpec.describe Tasks::WhitehallNewsImporter do
     expect(Document.last.publication_state).to eq("sent_to_live")
     expect(Document.last.review_state).to eq("published_without_review")
   end
+
+  it "sets the correct publication state and review state when Whitehall document state is 'rejected'" do
+    import_data[:editions][0][:state] = "rejected"
+    parsed_json = JSON.parse(import_data.to_json)
+    Tasks::WhitehallNewsImporter.new.import(parsed_json)
+
+    expect(Document.last.publication_state).to eq("sent_to_draft")
+    expect(Document.last.review_state).to eq("submitted_for_review")
+  end
 end


### PR DESCRIPTION
For https://trello.com/c/uBqWwIqu/234-set-the-correct-state-when-importing-from-whitehall-m

This sets `publication_state` and `review_state` on documents that are imported from Whitehall based on their Whitehall state.  Whitehall states have been mapped to Content Publisher publication states and review states in this document: https://docs.google.com/spreadsheets/d/1R3tfzhWDsO2zize6s-8EzjW7rvgKZQhu3NLYEVXouWk/edit#gid=0

We have chosen not to import documents with the following states:
- `imported` - There are only 4 imported documents which were last updated in 2013 it seems unncessary to import these.
- `scheduled` - We don't currently support scheduling in this app, so for now we won't import documents that are scheduled for publication.
- `superseded` - These are documents that have been superseded by other documents, so it seems unnecessary to import these for future editing.
- `withdrawn` - It seems unnecessary to import withdrawn documents for future editing.

In order to safeguard against any documents with rare/unidentified states from being imported we've created a whitelist of 'supported' states and will only import documents with these states.  As and when other states are deemed 'supported', we can add them to this whitelist.