### PR TITLE
Fix importing current edition number from Whitehall

### DIFF
--- a/lib/tasks/whitehall_news_importer.rb
+++ b/lib/tasks/whitehall_news_importer.rb
@@ -31,7 +31,7 @@ module Tasks
         review_state: "unreviewed",
         summary: translation["summary"],
         tags: tags(edition),
-        current_edition_number: edition["published_major_version"] + 1,
+        current_edition_number: (edition["published_major_version"] || 0) + 1,
       )
 
       doc.save!


### PR DESCRIPTION
We found a bug when running the "Whitehall Import" job where sometimes an edition imported from Whitehall may not have a `published_major_version`, which was causing a NilClass error when trying to
increment the version number.