### PR TITLE
Change how current_edition_number is set on import

### DIFF
--- a/lib/tasks/whitehall_news_importer.rb
+++ b/lib/tasks/whitehall_news_importer.rb
@@ -31,7 +31,7 @@ module Tasks
         review_state: "unreviewed",
         summary: translation["summary"],
         tags: tags(edition),
-        current_edition_number: edition["published_major_version"] + 1,
+        current_edition_number: document["editions"].count,
       )
 
       doc.save!

--- a/spec/tasks/whitehall_news_importer_spec.rb
+++ b/spec/tasks/whitehall_news_importer_spec.rb
@@ -9,7 +9,6 @@ RSpec.describe Tasks::WhitehallNewsImporter do
       editions: [
         {
           created_at: Time.zone.now,
-          published_major_version: 12,
           news_article_type: { key: "news_story" },
           translations: [
             {
@@ -56,6 +55,6 @@ RSpec.describe Tasks::WhitehallNewsImporter do
     expect(document_tags["world_locations"])
       .to eq(imported_edition["world_locations"])
 
-    expect(Document.last.current_edition_number).to eql(13)
+    expect(Document.last.current_edition_number).to eql(1)
   end
 end


### PR DESCRIPTION
This changes `current_edition_number` to be set to the number of editions
belonging to a document when imported from Whitehall. The previous
implementation didn't take into account minor editions, so this should be more
accurate.