### PR TITLE
Fix bug with publish history on timeline

### DIFF
--- a/app/controllers/publish_document_controller.rb
+++ b/app/controllers/publish_document_controller.rb
@@ -15,7 +15,7 @@ class PublishDocumentController < ApplicationController
     review_state = params[:self_declared_review_state] == "has-been-reviewed" ? "reviewed" : "published_without_review"
     DocumentPublishingService.new.publish(document, review_state)
 
-    if review_state == "has-been-reviewed"
+    if review_state == "reviewed"
       TimelineEntry.create!(document: document, user: current_user, entry_type: "published")
     else
       TimelineEntry.create!(document: document, user: current_user, entry_type: "published_without_review")

--- a/config/locales/en/documents/history.yml
+++ b/config/locales/en/documents/history.yml
@@ -6,6 +6,7 @@ en:
         created: "First created"
         submitted: "Submitted for review"
         updated_content: "Document updated"
+        published: "Published with review"
         published_without_review: "Published without review"
         approved: "Approved for publication"
         updated_tags: "Tags updated"

--- a/spec/features/workflow/publish_a_document_spec.rb
+++ b/spec/features/workflow/publish_a_document_spec.rb
@@ -10,6 +10,7 @@ RSpec.feature "Publishing a document" do
     then_i_see_the_publish_succeeded
     and_i_see_the_content_is_in_published_state
     and_i_see_the_view_on_govuk_link
+    and_there_is_a_history_entry
   end
 
   def given_there_is_a_document_in_draft
@@ -46,5 +47,10 @@ RSpec.feature "Publishing a document" do
 
   def and_i_see_the_view_on_govuk_link
     expect(page).to have_link("View published edition on GOV.UK", href: "https://www.test.gov.uk/news/banana-pricing-updates")
+  end
+
+  def and_there_is_a_history_entry
+    visit document_path(@document)
+    expect(page).to have_content(I18n.t("documents.history.entry_types.published"))
   end
 end


### PR DESCRIPTION
This fixes a bug where we accidentally only show the "Published without review" entry on the timeline, even if the document was reviewed. Also adds a test.