### PR TITLE
Remove default change history

### DIFF
--- a/app/services/publishing_api_payload.rb
+++ b/app/services/publishing_api_payload.rb
@@ -70,12 +70,6 @@ private
       "government" => {
         "title" => "Hey", "slug" => "what", "current" => true
       },
-      "change_history" => [
-        {
-          "public_timestamp" => Time.now.iso8601,
-          "note" => "To support email alerts",
-        },
-      ],
       "political" => false,
     }
   end


### PR DESCRIPTION
This is overriding the actual change history that the publishing-api builds from the change note.