### PR TITLE
Fix CORS errors caused by cropper

### DIFF
--- a/app/assets/javascripts/components/image_cropper.js
+++ b/app/assets/javascripts/components/image_cropper.js
@@ -60,6 +60,8 @@ if ($imageCroppers) {
           highlight: false,
           minCropBoxWidth: minCropBoxWidth,
           minCropBoxHeight: minCropBoxHeight,
+          rotatable: false,
+          scalable: false,
           ready: function () {
             // Get canvas data
             var canvasData = this.cropper.getCanvasData()


### PR DESCRIPTION
Disables rotation and scaling in the cropper. This prevents cropper.js from
making an additional XHR request to download the image again. This XHR request
creates CORS errors and isn't necessary for us unless we want the rotation
feature to work.

Digging into why it makes the request it seems to be to download the image into
an arraybuffer to parse the exif data for things like handling image rotation.
The code which makes the XHR is here:

  https://github.com/fengyuanchen/cropperjs/blob/23b2e6c07c0c636082cc3bbf3509e3cb3d531271/src/js/cropper.js#L98-L159

Disabling these options stops the XHR from being sent.