### PR TITLE
Tagging to role appointments

### DIFF
--- a/app/formats/document_types.yml
+++ b/app/formats/document_types.yml
@@ -41,6 +41,10 @@
       label: Organisations
       type: multi_tag
       document_type: organisation
+    - id: role_appointments
+      label: Ministers and government appointments
+      type: multi_tag
+      document_type: role_appointment
     - id: topical_events
       label: Topical events
       type: multi_tag
@@ -96,6 +100,10 @@
       label: Organisations
       type: multi_tag
       document_type: organisation
+    - id: role_appointments
+      label: Ministers and government appointments
+      type: multi_tag
+      document_type: role_appointment
     - id: topical_events
       label: Topical events
       type: multi_tag

--- a/app/services/publishing_api_payload.rb
+++ b/app/services/publishing_api_payload.rb
@@ -1,5 +1,7 @@
 # frozen_string_literal: true
 
+require "gds_api/publishing_api_v2"
+
 class PublishingApiPayload
   PUBLISHING_APP = "content-publisher"
 
@@ -40,8 +42,10 @@ private
     links = document.tags["primary_publishing_organisation"].to_a +
       document.tags["organisations"].to_a
 
+    role_appointments = document.tags["role_appointments"]
     document.tags
       .except("role_appointments")
+      .merge(roles_and_people(role_appointments))
       .merge("organisations" => links.uniq)
   end
 
@@ -76,6 +80,21 @@ private
     }
   end
 
+  def roles_and_people(role_appointments)
+    return {} if !role_appointments || role_appointments.count.zero?
+
+    role_appointments
+      .each_with_object("roles" => [], "people" => []) do |appointment_id, memo|
+        response = publishing_api.get_links(appointment_id).to_hash
+
+        roles = response.dig("links", "role") || []
+        people = response.dig("links", "person") || []
+
+        memo["roles"] = (memo["roles"] + roles).uniq
+        memo["people"] = (memo["people"] + people).uniq
+      end
+  end
+
   # Note: once this grows to a sufficient size, move it over into a new class
   # or class system.
   def perform_input_type_specific_transformations(field)
@@ -84,5 +103,12 @@ private
     else
       document.contents[field.id]
     end
+  end
+
+  def publishing_api
+    @publishing_api ||= GdsApi::PublishingApiV2.new(
+      Plek.new.find("publishing-api"),
+      bearer_token: ENV["PUBLISHING_API_BEARER_TOKEN"] || "example",
+    )
   end
 end

--- a/app/services/publishing_api_payload.rb
+++ b/app/services/publishing_api_payload.rb
@@ -40,7 +40,9 @@ private
     links = document.tags["primary_publishing_organisation"].to_a +
       document.tags["organisations"].to_a
 
-    document.tags.merge("organisations" => links.uniq)
+    document.tags
+      .except("role_appointments")
+      .merge("organisations" => links.uniq)
   end
 
   def image

--- a/spec/formats/news_story_spec.rb
+++ b/spec/formats/news_story_spec.rb
@@ -27,7 +27,7 @@ RSpec.feature "Create a news story", format: true do
 
   def and_i_add_some_tags
     stub_any_publishing_api_put_content
-    expect(Document.last.document_type_schema.tags.count).to eq(5)
+    expect(Document.last.document_type_schema.tags.count).to eq(6)
     publishing_api_has_linkables([linkable], document_type: "topical_event")
     publishing_api_has_linkables([linkable], document_type: "worldwide_organisation")
     publishing_api_has_linkables([linkable], document_type: "world_location")

--- a/spec/formats/news_story_spec.rb
+++ b/spec/formats/news_story_spec.rb
@@ -27,6 +27,9 @@ RSpec.feature "Create a news story", format: true do
 
   def and_i_add_some_tags
     stub_any_publishing_api_put_content
+
+    publishing_api_has_links(role_appointment_links)
+
     expect(Document.last.document_type_schema.tags.count).to eq(6)
     publishing_api_has_linkables([linkable], document_type: "topical_event")
     publishing_api_has_linkables([linkable], document_type: "worldwide_organisation")
@@ -60,10 +63,22 @@ RSpec.feature "Create a news story", format: true do
         "world_locations" => [linkable["content_id"]],
         "organisations" => [linkable["content_id"]],
         "primary_publishing_organisation" => [linkable["content_id"]],
+        "roles" => role_appointment_links["links"]["role"],
+        "people" => role_appointment_links["links"]["person"],
       },
       "title" => "A great title",
       "document_type" => "news_story",
       "description" => "A great summary",
+    }
+  end
+
+  def role_appointment_links
+    @role_appointment_links ||= {
+      "content_id" => linkable["content_id"],
+      "links" => {
+        "person" => [SecureRandom.uuid],
+        "role" => [SecureRandom.uuid],
+      },
     }
   end
 

--- a/spec/formats/news_story_spec.rb
+++ b/spec/formats/news_story_spec.rb
@@ -32,6 +32,7 @@ RSpec.feature "Create a news story", format: true do
     publishing_api_has_linkables([linkable], document_type: "worldwide_organisation")
     publishing_api_has_linkables([linkable], document_type: "world_location")
     publishing_api_has_linkables([linkable], document_type: "organisation")
+    publishing_api_has_linkables([linkable], document_type: "role_appointment")
 
     click_on "Change Tags"
 
@@ -39,6 +40,7 @@ RSpec.feature "Create a news story", format: true do
     select linkable["internal_name"], from: "tags[worldwide_organisations][]"
     select linkable["internal_name"], from: "tags[world_locations][]"
     select linkable["internal_name"], from: "tags[organisations][]"
+    select linkable["internal_name"], from: "tags[role_appointments][]"
 
     click_on "Save"
   end

--- a/spec/formats/press_release_spec.rb
+++ b/spec/formats/press_release_spec.rb
@@ -32,6 +32,7 @@ RSpec.feature "Create a press release", format: true do
     publishing_api_has_linkables([linkable], document_type: "worldwide_organisation")
     publishing_api_has_linkables([linkable], document_type: "world_location")
     publishing_api_has_linkables([linkable], document_type: "organisation")
+    publishing_api_has_linkables([linkable], document_type: "role_appointment")
 
     click_on "Change Tags"
 
@@ -39,6 +40,7 @@ RSpec.feature "Create a press release", format: true do
     select linkable["internal_name"], from: "tags[worldwide_organisations][]"
     select linkable["internal_name"], from: "tags[world_locations][]"
     select linkable["internal_name"], from: "tags[organisations][]"
+    select linkable["internal_name"], from: "tags[role_appointments][]"
 
     click_on "Save"
   end

--- a/spec/formats/press_release_spec.rb
+++ b/spec/formats/press_release_spec.rb
@@ -27,7 +27,7 @@ RSpec.feature "Create a press release", format: true do
 
   def and_i_add_some_tags
     stub_any_publishing_api_put_content
-    expect(Document.last.document_type_schema.tags.count).to eq(5)
+    expect(Document.last.document_type_schema.tags.count).to eq(6)
     publishing_api_has_linkables([linkable], document_type: "topical_event")
     publishing_api_has_linkables([linkable], document_type: "worldwide_organisation")
     publishing_api_has_linkables([linkable], document_type: "world_location")

--- a/spec/formats/press_release_spec.rb
+++ b/spec/formats/press_release_spec.rb
@@ -27,6 +27,9 @@ RSpec.feature "Create a press release", format: true do
 
   def and_i_add_some_tags
     stub_any_publishing_api_put_content
+
+    publishing_api_has_links(role_appointment_links)
+
     expect(Document.last.document_type_schema.tags.count).to eq(6)
     publishing_api_has_linkables([linkable], document_type: "topical_event")
     publishing_api_has_linkables([linkable], document_type: "worldwide_organisation")
@@ -60,10 +63,22 @@ RSpec.feature "Create a press release", format: true do
         "world_locations" => [linkable["content_id"]],
         "organisations" => [linkable["content_id"]],
         "primary_publishing_organisation" => [linkable["content_id"]],
+        "roles" => role_appointment_links["links"]["role"],
+        "people" => role_appointment_links["links"]["person"],
       },
       "title" => "A great title",
       "document_type" => "press_release",
       "description" => "A great summary",
+    }
+  end
+
+  def role_appointment_links
+    @role_appointment_links ||= {
+      "content_id" => linkable["content_id"],
+      "links" => {
+        "person" => [SecureRandom.uuid],
+        "role" => [SecureRandom.uuid],
+      },
     }
   end
 

--- a/spec/services/publishing_api_payload_spec.rb
+++ b/spec/services/publishing_api_payload_spec.rb
@@ -61,6 +61,29 @@ RSpec.describe PublishingApiPayload do
       expect(payload).to match a_hash_including(payload_hash)
     end
 
+    it "converts role appointment links to role and person links" do
+      role_appointment_id = SecureRandom.uuid
+      role_appointments_schema = build(:tag_schema, type: "multi_tag", id: "role_appointments")
+      document_type_schema = build(:document_type_schema, tags: [role_appointments_schema])
+      document = build(:document, document_type: document_type_schema.id, tags: {
+                         role_appointments: [role_appointment_id],
+                       })
+
+      person_id = SecureRandom.uuid
+      role_id = SecureRandom.uuid
+      publishing_api_has_links({
+        "content_id" => role_appointment_id,
+        "links" => { "person" => [person_id], "role" => [role_id] },
+      })
+
+      payload = PublishingApiPayload.new(document).payload
+
+      expect(payload["links"]).to match a_hash_including(
+        "roles" => [role_id],
+        "people" => [person_id],
+      )
+    end
+
     it "transforms Govspeak before sending it to the publishing-api" do
       body_field_schema = build(:field_schema, type: "govspeak", id: "body")
       document_type_schema = build(:document_type_schema, contents: [body_field_schema])

--- a/spec/services/publishing_api_payload_spec.rb
+++ b/spec/services/publishing_api_payload_spec.rb
@@ -71,10 +71,10 @@ RSpec.describe PublishingApiPayload do
 
       person_id = SecureRandom.uuid
       role_id = SecureRandom.uuid
-      publishing_api_has_links({
+      publishing_api_has_links(
         "content_id" => role_appointment_id,
         "links" => { "person" => [person_id], "role" => [role_id] },
-      })
+      )
 
       payload = PublishingApiPayload.new(document).payload
 


### PR DESCRIPTION
Trello: https://trello.com/c/3GT17tkH/211-associate-content-with-ministers-l

This allows the functionality to tag news/press releases to ministers by allowing a tag to role appointments. It does this because there is currently no clear way to get a list of ministers from the Publishing API and there does not seem to be a particular reason why all roles/people can't be associated with a news story.

<img width="815" alt="screen shot 2018-09-24 at 10 35 30" src="https://user-images.githubusercontent.com/282717/45945487-93082280-bfe5-11e8-917b-18d3eba4b40f.png">

Things still to do:

- [x] Talk to a content designer about what to call the field (currently called government appointments) - after chat I've gone for Ministers and government appointments
- [x] Update the schemas to support adding roles and people as edition links (https://github.com/alphagov/govuk-content-schemas/pull/814)
- [x] Check/fix there is no where that relies on ministers that can rely people, and that we don't break anything with changes