### PR TITLE
Display user that last edited a document

### DIFF
--- a/app/models/document.rb
+++ b/app/models/document.rb
@@ -54,4 +54,12 @@ class Document < ApplicationRecord
   def title_or_fallback
     title.presence || I18n.t!("documents.untitled_document")
   end
+
+  def last_edited_by
+    entries = self.timeline_entries
+      .where(entry_type: %w(updated_content updated_tags))
+      .order(:created_at)
+
+    entries.last.user if entries.any?
+  end
 end

--- a/app/views/documents/index/_results.html.erb
+++ b/app/views/documents/index/_results.html.erb
@@ -38,6 +38,10 @@
           <%= t "documents.index.search_results.state",
             state: t("user_facing_states.#{document.user_facing_state}.name")
           %>
+          <br/>
+          <%= t "documents.index.search_results.last_edited_by",
+            user: document.last_edited_by&.name || document.creator&.name || I18n.t("documents.index.search_results.unknown_creator")
+          %>
         </td>
 
         <td class="govuk-table__cell ">

--- a/app/views/documents/show/_document_metadata.html.erb
+++ b/app/views/documents/show/_document_metadata.html.erb
@@ -17,6 +17,10 @@
         field: t("documents.show.metadata.created_by"),
         value: @document.creator&.name || I18n.t("documents.show.metadata.unknown_creator")
       },
+      {
+        field: t("documents.show.metadata.last_edited_by"),
+        value: @document.last_edited_by&.name || @document.creator&.name || I18n.t("documents.show.metadata.unknown_creator")
+      }
     ]
   } %>
 </div>

--- a/config/locales/en/documents/index.yml
+++ b/config/locales/en/documents/index.yml
@@ -12,6 +12,7 @@ en:
           last_updated_desc: Sort by last updated descending
         creator: "Creator: %{creator}"
         state: "State: %{state}"
+        last_edited_by: "Last edited by: %{user}"
         summary_html:
           one: "<strong>1</strong> document"
           other: "<strong>%{count}</strong> documents"

--- a/config/locales/en/documents/show.yml
+++ b/config/locales/en/documents/show.yml
@@ -42,6 +42,7 @@ en:
         created_at: Created
         created_by: Document created by
         unknown_creator: Unknown
+        last_edited_by: Document last edited by
       flashes:
         draft_error:
           title: Something has gone wrong

--- a/spec/factories/timeline_entry_factory.rb
+++ b/spec/factories/timeline_entry_factory.rb
@@ -1,0 +1,10 @@
+# frozen_string_literal: true
+
+FactoryBot.define do
+  factory :timeline_entry do
+    document
+    user
+    entry_type { TimelineEntry::ENTRY_TYPES.sample }
+    edition_number { (rand * 100).to_i }
+  end
+end

--- a/spec/features/editing_content/edit_a_document_spec.rb
+++ b/spec/features/editing_content/edit_a_document_spec.rb
@@ -10,6 +10,7 @@ RSpec.feature "Edit a document" do
     and_the_content_is_available_for_preview
     and_the_content_needs_review
     and_i_see_the_content_is_in_draft_state
+    and_i_see_the_document_was_last_edited_by_me
   end
 
   def given_there_is_a_document
@@ -50,5 +51,11 @@ RSpec.feature "Edit a document" do
 
   def and_i_see_the_content_is_in_draft_state
     expect(page).to have_content(I18n.t("user_facing_states.draft.name"))
+  end
+
+  def and_i_see_the_document_was_last_edited_by_me
+    within("div.app-c-metadata") do
+      expect(page).to have_content(I18n.t("documents.show.metadata.last_edited_by") + ": #{User.last.name}")
+    end
   end
 end

--- a/spec/features/editing_content/edit_a_document_spec.rb
+++ b/spec/features/editing_content/edit_a_document_spec.rb
@@ -11,6 +11,8 @@ RSpec.feature "Edit a document" do
     and_the_content_needs_review
     and_i_see_the_content_is_in_draft_state
     and_i_see_the_document_was_last_edited_by_me
+
+    and_on_the_index_page_i_see_the_document_was_last_edited_by_me
   end
 
   def given_there_is_a_document
@@ -57,5 +59,10 @@ RSpec.feature "Edit a document" do
     within("div.app-c-metadata") do
       expect(page).to have_content(I18n.t("documents.show.metadata.last_edited_by") + ": #{User.last.name}")
     end
+  end
+
+  def and_on_the_index_page_i_see_the_document_was_last_edited_by_me
+    visit documents_path
+    expect(page).to have_content(I18n.t("documents.index.search_results.last_edited_by", user: User.last.name))
   end
 end

--- a/spec/features/workflow/viewing_a_document_with_a_creator_spec.rb
+++ b/spec/features/workflow/viewing_a_document_with_a_creator_spec.rb
@@ -31,5 +31,8 @@ RSpec.feature "Viewing a document with a creator" do
     expect(page).to have_content(
       I18n.t("documents.show.metadata.created_by") + ": " + @user.name,
     )
+    expect(page).to have_content(
+      I18n.t("documents.show.metadata.last_edited_by") + ": " + @user.name,
+    )
   end
 end

--- a/spec/features/workflow/viewing_a_document_with_no_creator_spec.rb
+++ b/spec/features/workflow/viewing_a_document_with_no_creator_spec.rb
@@ -33,5 +33,10 @@ RSpec.feature "Viewing a document with no creator" do
       I18n.t("documents.show.metadata.created_by") + ": " +
       I18n.t("documents.show.metadata.unknown_creator"),
     )
+
+    expect(page).to have_content(
+      I18n.t("documents.show.metadata.last_edited_by") + ": " +
+      I18n.t("documents.show.metadata.unknown_creator"),
+    )
   end
 end

--- a/spec/models/document_spec.rb
+++ b/spec/models/document_spec.rb
@@ -8,5 +8,25 @@ RSpec.describe Document do
         I18n.t!("publication_states.#{state}.description")
       end
     end
+
+    describe "#last_edited_by" do
+      it "returns the user who last edited a document" do
+        user1 = create(:user)
+        user2 = create(:user)
+        document = create(:document)
+        create(:timeline_entry, entry_type: "updated_content", document: document, user: user1)
+        create(:timeline_entry, entry_type: "updated_tags", document: document, user: user2)
+        create(:timeline_entry, entry_type: "submitted", document: document, user: user1)
+
+        expect(document.last_edited_by).to eq(user2)
+      end
+
+      it "returns nil if there are no edit-related timeline entries associated with a document" do
+        document = create(:document)
+        create(:timeline_entry, entry_type: "submitted", document: document)
+
+        expect(document.last_edited_by).to be nil
+      end
+    end
   end
 end


### PR DESCRIPTION
For https://trello.com/c/OdqQe7J2/269-store-and-present-the-user-that-last-edited-a-document

This adds a method to retrieves the user that last edited a document by querying the most recent
Timeline Entry with type `updated_content` or `updated_tags`.  We have decided to perform a query on Timeline Entries so that we're using these entries as the source of truth for a document's history. We considered associating a `last_edited_by` user to a document and updating this every time
a document is edited, which could be a simpler approach. However since we are already storing the user in the Timeline Entry anyway it doesn't seem particularly useful to store this information again elsewhere. This approach also should also prevent any discrepancies that could occur between the user stored on the Document and the Timeline Entries.

Using `last_edited_by` we then display the user on the summary page:
<img width="332" alt="screen shot 2018-09-24 at 15 24 31" src="https://user-images.githubusercontent.com/13434452/45958532-8f899100-c00f-11e8-8307-c01073992c8e.png">

And the index page:
<img width="652" alt="screen shot 2018-09-24 at 15 24 48" src="https://user-images.githubusercontent.com/13434452/45958544-97e1cc00-c00f-11e8-9b65-262f534ffba8.png">

