### PR TITLE
Associate document with user who last edited it

### DIFF
--- a/app/controllers/new_document_controller.rb
+++ b/app/controllers/new_document_controller.rb
@@ -49,6 +49,7 @@ class NewDocumentController < ApplicationController
       update_type: "major",
       change_note: "First published.",
       current_edition_number: 1,
+      last_editor_id: current_user.id,
     )
 
     TimelineEntry.create!(document: document, user: current_user, entry_type: "created")

--- a/app/models/document.rb
+++ b/app/models/document.rb
@@ -7,6 +7,7 @@ class Document < ApplicationRecord
   has_many :timeline_entries, dependent: :destroy
   belongs_to :lead_image, class_name: "Image", optional: true, foreign_key: :lead_image_id, inverse_of: :document
   belongs_to :creator, class_name: "User", optional: true, foreign_key: :creator_id, inverse_of: :documents
+  belongs_to :last_editor, class_name: "User", optional: true, foreign_key: :last_editor_id, inverse_of: :documents
 
   PUBLICATION_STATES = %w[
     changes_not_sent_to_draft

--- a/app/services/document_update_service.rb
+++ b/app/services/document_update_service.rb
@@ -8,6 +8,7 @@ class DocumentUpdateService
 
     document.publication_state = "changes_not_sent_to_draft"
     document.review_state = "unreviewed"
+    document.last_editor = user if document_edited?(type)
 
     document.assign_attributes(attributes_to_update)
 
@@ -17,5 +18,9 @@ class DocumentUpdateService
     end
 
     DocumentPublishingService.new.publish_draft(document)
+  end
+
+  def self.document_edited?(type)
+    %w(updated_content updated_tags).include?(type)
   end
 end

--- a/app/views/documents/index/_results.html.erb
+++ b/app/views/documents/index/_results.html.erb
@@ -40,7 +40,7 @@
           %>
           <br/>
           <%= t "documents.index.search_results.last_edited_by",
-            user: document.last_editor&.name || document.creator&.name || I18n.t("documents.index.search_results.unknown_creator")
+            user: document.last_editor&.name || I18n.t("documents.index.search_results.unknown_creator")
           %>
         </td>
 

--- a/app/views/documents/index/_results.html.erb
+++ b/app/views/documents/index/_results.html.erb
@@ -38,6 +38,10 @@
           <%= t "documents.index.search_results.state",
             state: t("user_facing_states.#{document.user_facing_state}.name")
           %>
+          <br/>
+          <%= t "documents.index.search_results.last_edited_by",
+            user: document.last_editor&.name || document.creator&.name || I18n.t("documents.index.search_results.unknown_creator")
+          %>
         </td>
 
         <td class="govuk-table__cell ">

--- a/app/views/documents/index/_results.html.erb
+++ b/app/views/documents/index/_results.html.erb
@@ -32,7 +32,7 @@
           <%= document.document_type_schema.label %>
           <br/>
           <%= t "documents.index.search_results.creator",
-            creator: document.creator&.name || I18n.t("documents.index.search_results.unknown_creator")
+            creator: document.creator&.name || I18n.t("documents.index.search_results.unknown_user")
           %>
           <br/>
           <%= t "documents.index.search_results.state",
@@ -40,7 +40,7 @@
           %>
           <br/>
           <%= t "documents.index.search_results.last_edited_by",
-            user: document.last_editor&.name || I18n.t("documents.index.search_results.unknown_creator")
+            user: document.last_editor&.name || I18n.t("documents.index.search_results.unknown_user")
           %>
         </td>
 

--- a/app/views/documents/show/_document_metadata.html.erb
+++ b/app/views/documents/show/_document_metadata.html.erb
@@ -15,11 +15,11 @@
       },
       {
         field: t("documents.show.metadata.created_by"),
-        value: @document.creator&.name || I18n.t("documents.show.metadata.unknown_creator")
+        value: @document.creator&.name || I18n.t("documents.show.metadata.unknown_user")
       },
       {
         field: t("documents.show.metadata.last_edited_by"),
-        value: @document.last_editor&.name || I18n.t("documents.show.metadata.unknown_creator")
+        value: @document.last_editor&.name || I18n.t("documents.show.metadata.unknown_user")
       },
     ]
   } %>

--- a/app/views/documents/show/_document_metadata.html.erb
+++ b/app/views/documents/show/_document_metadata.html.erb
@@ -17,6 +17,10 @@
         field: t("documents.show.metadata.created_by"),
         value: @document.creator&.name || I18n.t("documents.show.metadata.unknown_creator")
       },
+      {
+        field: t("documents.show.metadata.last_edited_by"),
+        value: @document.last_editor&.name || @document.creator&.name || I18n.t("documents.show.metadata.unknown_creator")
+      },
     ]
   } %>
 </div>

--- a/app/views/documents/show/_document_metadata.html.erb
+++ b/app/views/documents/show/_document_metadata.html.erb
@@ -19,7 +19,7 @@
       },
       {
         field: t("documents.show.metadata.last_edited_by"),
-        value: @document.last_editor&.name || @document.creator&.name || I18n.t("documents.show.metadata.unknown_creator")
+        value: @document.last_editor&.name || I18n.t("documents.show.metadata.unknown_creator")
       },
     ]
   } %>

--- a/config/locales/en/documents/index.yml
+++ b/config/locales/en/documents/index.yml
@@ -24,7 +24,7 @@ en:
             * removing filters
             * searching for something less specific
             * double-checking your spelling
-        unknown_creator: Unknown
+        unknown_user: Unknown
       filter:
         title_or_url: Search for a title or URL slug
         document_type: Document type

--- a/config/locales/en/documents/index.yml
+++ b/config/locales/en/documents/index.yml
@@ -12,6 +12,7 @@ en:
           last_updated_desc: Sort by last updated descending
         creator: "Creator: %{creator}"
         state: "State: %{state}"
+        last_edited_by: "Last edited by: %{user}"
         summary_html:
           one: "<strong>1</strong> document"
           other: "<strong>%{count}</strong> documents"

--- a/config/locales/en/documents/show.yml
+++ b/config/locales/en/documents/show.yml
@@ -41,7 +41,7 @@ en:
         updated_at: Last updated
         created_at: Created
         created_by: Document created by
-        unknown_creator: Unknown
+        unknown_user: Unknown
         last_edited_by: Last edited by
       flashes:
         draft_error:

--- a/config/locales/en/documents/show.yml
+++ b/config/locales/en/documents/show.yml
@@ -42,6 +42,7 @@ en:
         created_at: Created
         created_by: Document created by
         unknown_creator: Unknown
+        last_edited_by: Last edited by
       flashes:
         draft_error:
           title: Something has gone wrong

--- a/db/migrate/20180925082624_add_last_editor_to_document.rb
+++ b/db/migrate/20180925082624_add_last_editor_to_document.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+class AddLastEditorToDocument < ActiveRecord::Migration[5.2]
+  def change
+    add_reference :documents, :last_editor, foreign_key: { to_table: :users }
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2018_09_19_150956) do
+ActiveRecord::Schema.define(version: 2018_09_25_082624) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -44,8 +44,8 @@ ActiveRecord::Schema.define(version: 2018_09_19_150956) do
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.json "contents", default: {}
-    t.text "summary"
     t.string "base_path"
+    t.text "summary"
     t.json "tags", default: {}
     t.string "publication_state", null: false
     t.bigint "creator_id"
@@ -55,9 +55,11 @@ ActiveRecord::Schema.define(version: 2018_09_19_150956) do
     t.text "change_note"
     t.string "update_type"
     t.integer "current_edition_number", null: false
+    t.bigint "last_editor_id"
     t.index ["base_path"], name: "index_documents_on_base_path", unique: true
     t.index ["content_id", "locale"], name: "index_documents_on_content_id_and_locale", unique: true
     t.index ["creator_id"], name: "index_documents_on_creator_id"
+    t.index ["last_editor_id"], name: "index_documents_on_last_editor_id"
     t.index ["lead_image_id"], name: "index_documents_on_lead_image_id"
   end
 
@@ -119,6 +121,7 @@ ActiveRecord::Schema.define(version: 2018_09_19_150956) do
 
   add_foreign_key "documents", "images", column: "lead_image_id", on_delete: :nullify
   add_foreign_key "documents", "users", column: "creator_id"
+  add_foreign_key "documents", "users", column: "last_editor_id"
   add_foreign_key "images", "active_storage_blobs", column: "blob_id", on_delete: :cascade
   add_foreign_key "images", "documents", on_delete: :cascade
   add_foreign_key "timeline_entries", "documents", on_delete: :cascade

--- a/spec/features/editing_content/edit_a_document_spec.rb
+++ b/spec/features/editing_content/edit_a_document_spec.rb
@@ -10,6 +10,7 @@ RSpec.feature "Edit a document" do
     and_the_content_is_available_for_preview
     and_the_content_needs_review
     and_i_see_the_content_is_in_draft_state
+    and_i_see_i_was_the_last_user_to_edit_the_document
   end
 
   def given_there_is_a_document
@@ -50,5 +51,9 @@ RSpec.feature "Edit a document" do
 
   def and_i_see_the_content_is_in_draft_state
     expect(page).to have_content(I18n.t("user_facing_states.draft.name"))
+  end
+
+  def and_i_see_i_was_the_last_user_to_edit_the_document
+    expect(page).to have_content(I18n.t("documents.show.metadata.last_edited_by") + ": #{User.last.name}")
   end
 end

--- a/spec/features/finding/index_results_spec.rb
+++ b/spec/features/finding/index_results_spec.rb
@@ -1,0 +1,49 @@
+# frozen_string_literal: true
+
+RSpec.feature "Users views document results on index page" do
+  scenario "User views document information on index page" do
+    given_there_is_a_document
+    when_i_visit_the_index_page
+    then_i_can_see_the_document_title
+    and_i_can_see_the_document_type
+    and_i_can_see_the_document_creator
+    and_i_can_see_the_document_state
+    and_i_can_see_the_document_last_editor
+  end
+
+  def given_there_is_a_document
+    creator = create(:user)
+    editor = create(:user)
+    create(:document, creator: creator, last_editor: editor)
+  end
+
+  def when_i_visit_the_index_page
+    visit documents_path
+  end
+
+  def then_i_can_see_the_document_title
+    expect(page).to have_content(Document.last.title)
+  end
+
+  def and_i_can_see_the_document_type
+    expect(page).to have_content(Document.last.document_type_schema.label)
+  end
+
+  def and_i_can_see_the_document_creator
+    expect(page).to have_content(
+      I18n.t("documents.index.search_results.creator",
+        creator: Document.last.creator.name),
+    )
+  end
+
+  def and_i_can_see_the_document_state
+    expect(page).to have_content("Draft")
+  end
+
+  def and_i_can_see_the_document_last_editor
+    expect(page).to have_content(
+      I18n.t("documents.index.search_results.last_edited_by",
+        user: Document.last.last_editor.name),
+    )
+  end
+end

--- a/spec/features/workflow/viewing_a_document_with_no_creator_or_editor_spec.rb
+++ b/spec/features/workflow/viewing_a_document_with_no_creator_or_editor_spec.rb
@@ -1,13 +1,14 @@
 # frozen_string_literal: true
 
-RSpec.feature "Viewing a document with no creator" do
-  scenario "User finds an unedited document without a creator and views it" do
+RSpec.feature "Viewing a document with no creator or editor" do
+  scenario "User finds a document without a creator or editor and views it" do
     given_there_is_a_document_with_no_creator
     when_i_visit_the_index_page
     then_i_see_we_dont_know_who_created_the_document
+    and_i_see_the_document_has_no_last_editor
     when_i_visit_the_document_page
     then_i_again_see_we_dont_know_who_created_the_document
-    then_i_see_the_document_has_no_last_editor
+    and_i_again_see_the_document_has_no_last_editor
   end
 
   def given_there_is_a_document_with_no_creator
@@ -25,6 +26,13 @@ RSpec.feature "Viewing a document with no creator" do
     )
   end
 
+  def and_i_see_the_document_has_no_last_editor
+    expect(page).to have_content(
+      I18n.t("documents.index.search_results.last_edited_by",
+        user: I18n.t("documents.index.search_results.unknown_creator")),
+    )
+  end
+
   def when_i_visit_the_document_page
     click_on @document.title
   end
@@ -36,7 +44,7 @@ RSpec.feature "Viewing a document with no creator" do
     )
   end
 
-  def then_i_see_the_document_has_no_last_editor
+  def and_i_again_see_the_document_has_no_last_editor
     expect(page).to have_content(
       I18n.t("documents.show.metadata.last_edited_by") + ": " +
       I18n.t("documents.show.metadata.unknown_creator"),

--- a/spec/features/workflow/viewing_a_document_with_no_creator_or_editor_spec.rb
+++ b/spec/features/workflow/viewing_a_document_with_no_creator_or_editor_spec.rb
@@ -22,14 +22,14 @@ RSpec.feature "Viewing a document with no creator or editor" do
   def then_i_see_we_dont_know_who_created_the_document
     expect(page).to have_content(@document.title)
     expect(page).to have_content(
-      I18n.t("documents.index.search_results.unknown_creator"),
+      I18n.t("documents.index.search_results.unknown_user"),
     )
   end
 
   def and_i_see_the_document_has_no_last_editor
     expect(page).to have_content(
       I18n.t("documents.index.search_results.last_edited_by",
-        user: I18n.t("documents.index.search_results.unknown_creator")),
+        user: I18n.t("documents.index.search_results.unknown_user")),
     )
   end
 
@@ -40,14 +40,14 @@ RSpec.feature "Viewing a document with no creator or editor" do
   def then_i_again_see_we_dont_know_who_created_the_document
     expect(page).to have_content(
       I18n.t("documents.show.metadata.created_by") + ": " +
-      I18n.t("documents.show.metadata.unknown_creator"),
+      I18n.t("documents.show.metadata.unknown_user"),
     )
   end
 
   def and_i_again_see_the_document_has_no_last_editor
     expect(page).to have_content(
       I18n.t("documents.show.metadata.last_edited_by") + ": " +
-      I18n.t("documents.show.metadata.unknown_creator"),
+      I18n.t("documents.show.metadata.unknown_user"),
     )
   end
 end

--- a/spec/features/workflow/viewing_a_document_with_no_creator_spec.rb
+++ b/spec/features/workflow/viewing_a_document_with_no_creator_spec.rb
@@ -1,12 +1,13 @@
 # frozen_string_literal: true
 
 RSpec.feature "Viewing a document with no creator" do
-  scenario "User finds document without a creator and views it" do
+  scenario "User finds an unedited document without a creator and views it" do
     given_there_is_a_document_with_no_creator
     when_i_visit_the_index_page
     then_i_see_we_dont_know_who_created_the_document
     when_i_visit_the_document_page
     then_i_again_see_we_dont_know_who_created_the_document
+    then_i_see_the_document_has_no_last_editor
   end
 
   def given_there_is_a_document_with_no_creator
@@ -31,6 +32,13 @@ RSpec.feature "Viewing a document with no creator" do
   def then_i_again_see_we_dont_know_who_created_the_document
     expect(page).to have_content(
       I18n.t("documents.show.metadata.created_by") + ": " +
+      I18n.t("documents.show.metadata.unknown_creator"),
+    )
+  end
+
+  def then_i_see_the_document_has_no_last_editor
+    expect(page).to have_content(
+      I18n.t("documents.show.metadata.last_edited_by") + ": " +
       I18n.t("documents.show.metadata.unknown_creator"),
     )
   end


### PR DESCRIPTION
For https://trello.com/c/OdqQe7J2/269-store-and-present-the-user-that-last-edited-a-document

This adds a `last_editor` to Document which is updated every time an edit is made to a document.  We have defined an edit to mean a change to the document itself rather than a state change such as sending for review or publishing.

Make `last_editor` available allows us to display that last person who edited a document:

**Summary page**
<img width="317" alt="screen shot 2018-09-25 at 09 51 07" src="https://user-images.githubusercontent.com/13434452/46010653-5f97c780-c0bb-11e8-904f-5ad8299d6c83.png">

**Index page results**
<img width="273" alt="screen shot 2018-09-25 at 12 10 05" src="https://user-images.githubusercontent.com/13434452/46010854-fd8b9200-c0bb-11e8-978f-d19fdf855421.png">
