### PR TITLE
Add placeholder screens for retire/remove

### DIFF
--- a/app/controllers/remove_document_controller.rb
+++ b/app/controllers/remove_document_controller.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+class RemoveDocumentController < ApplicationController
+  def remove
+    @document = Document.find_by_param(params[:id])
+  end
+end

--- a/app/controllers/retire_document_controller.rb
+++ b/app/controllers/retire_document_controller.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+class RetireDocumentController < ApplicationController
+  def retire
+    @document = Document.find_by_param(params[:id])
+  end
+end

--- a/app/views/documents/show/_actions.html.erb
+++ b/app/views/documents/show/_actions.html.erb
@@ -23,13 +23,13 @@
 
       <%= render "govuk_publishing_components/components/button", text: "Create new edition", href: edit_document_path(@document), secondary: true %>
 
-      <%= link_to "Retire", "#", class: "govuk-link" %>
-      <%= link_to "Remove", "#", class: "app-link--destructive app-link--right" %>
+      <%= link_to "Retire", retire_document_path(@document), class: "govuk-link" %>
+      <%= link_to "Remove", remove_document_path(@document), class: "app-link--destructive app-link--right" %>
     <% elsif @document.user_facing_state == "published" %>
       <%= render "govuk_publishing_components/components/button", text: "Create new edition", href: edit_document_path(@document) %>
 
-      <%= link_to "Retire", "#", class: "govuk-link" %>
-      <%= link_to "Remove", "#", class: "app-link--destructive app-link--right" %>
+      <%= link_to "Retire", retire_document_path(@document), class: "govuk-link" %>
+      <%= link_to "Remove", remove_document_path(@document), class: "app-link--destructive app-link--right" %>
     <% elsif @document.user_facing_state == "submitted_for_review" %>
       <%= render "govuk_publishing_components/components/button", text: "Publish", href: publish_document_path(@document) %>
       <%= render "govuk_publishing_components/components/button", text: "Preview", href: preview_document_path(@document), secondary: true, target: "_blank" %>

--- a/app/views/remove_document/remove.govspeak.md
+++ b/app/views/remove_document/remove.govspeak.md
@@ -1,0 +1,5 @@
+If you need to remove this content please [raise a support request and we’ll do it for you](https://support.publishing.service.gov.uk/).
+
+You must include any public explanation or new web address required.
+
+[Full guidance on removing content](https://www.gov.uk/guidance/content-design/gov-uk-content-retention-and-withdrawal-archiving-policy)

--- a/app/views/remove_document/remove.html.erb
+++ b/app/views/remove_document/remove.html.erb
@@ -1,0 +1,10 @@
+<% content_for :back_link, document_path(@document) %>
+<% content_for :title, t("remove_document.remove.title") %>
+
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-two-thirds">
+    <%= render "govuk_publishing_components/components/govspeak" do %>
+      <%= govspeak_to_html File.read("app/views/remove_document/remove.govspeak.md") %>
+    <% end %>
+  </div>
+</div>

--- a/app/views/retire_document/retire.govspeak.md
+++ b/app/views/retire_document/retire.govspeak.md
@@ -1,0 +1,5 @@
+If you need to retire this content please [raise a support request and we’ll do it for you](https://support.publishing.service.gov.uk/).
+
+You must include any public explanation or new web address required.
+
+[Full guidance on retire content](https://www.gov.uk/guidance/content-design/gov-uk-content-retention-and-withdrawal-archiving-policy)

--- a/app/views/retire_document/retire.html.erb
+++ b/app/views/retire_document/retire.html.erb
@@ -1,0 +1,10 @@
+<% content_for :back_link, document_path(@document) %>
+<% content_for :title, t("retire_document.retire.title") %>
+
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-two-thirds">
+    <%= render "govuk_publishing_components/components/govspeak" do %>
+      <%= govspeak_to_html File.read("app/views/retire_document/retire.govspeak.md") %>
+    <% end %>
+  </div>
+</div>

--- a/config/locales/en/remove_document/remove.yml
+++ b/config/locales/en/remove_document/remove.yml
@@ -1,0 +1,4 @@
+en:
+  remove_document:
+    remove:
+      title: Sorry, this hasn't been built yet

--- a/config/locales/en/retire_document/retire.yml
+++ b/config/locales/en/retire_document/retire.yml
@@ -1,0 +1,4 @@
+en:
+  retire_document:
+    retire:
+      title: Sorry, this hasn't been built yet

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -30,6 +30,9 @@ Rails.application.routes.draw do
 
   get "/documents/:id/preview" => "preview#show", as: :preview_document
 
+  get "/documents/:id/retire" => "retire_document#retire", as: :retire_document
+  get "/documents/:id/remove" => "remove_document#remove", as: :remove_document
+
   get "/documents/:document_id/lead-image" => "document_lead_image#index", as: :document_lead_image
   post "/documents/:document_id/lead-image" => "document_lead_image#create"
   get "/documents/:document_id/lead-image/:image_id/crop" => "document_lead_image#crop", as: :crop_document_lead_image


### PR DESCRIPTION
https://trello.com/c/QAEhhJdf/244-build-workflow-for-delete-draft-remove-and-retire-document-m

This adds two separate placeholder screens for retiring/removing a
document, so that a user can see the feature isn't supported and know
what to do. I wanted to keep the new actions out of the already bulging
DocumentsController, so I've created two completely separate placeholder
routes, which will allow these features to be implemented separately.
In order to render the textual content on the page, I've used the same
pattern as for new_document/guidance.html.erb.