### PR TITLE
Delete images

### DIFF
--- a/app/assets/stylesheets/components/_image_meta.scss
+++ b/app/assets/stylesheets/components/_image_meta.scss
@@ -34,20 +34,11 @@
   }
 }
 
-.app-c-image-meta__lead-image-section {
+.app-c-image-meta__primary-action-section {
   margin-bottom: govuk-spacing(3);
   @include govuk-clearfix;
 }
 
-.app-c-image-meta__lead-image-tag {
-  float: left;
-}
-
-.app-c-image-meta__remove-button {
-  margin-left: govuk-spacing(3);
-  float: left;
-}
-
-.app-c-image-meta__choose-image {
-  float: left;
+.app-c-image-meta__primary-action-tag {
+  margin-right: govuk-spacing(3);
 }

--- a/app/assets/stylesheets/core/_link.scss
+++ b/app/assets/stylesheets/core/_link.scss
@@ -3,8 +3,9 @@
 @import "../../../node_modules/govuk-frontend/tools/all";
 @import "../../../node_modules/govuk-frontend/core/links";
 
-.app-link--destructive {
-  @include govuk-link-common;
+
+// TODO: support this modifier in govuk-frontend
+.govuk-link.app-link--destructive {
   color: $govuk-error-colour;
 
   &:hover {

--- a/app/assets/stylesheets/utilities/_display.scss
+++ b/app/assets/stylesheets/utilities/_display.scss
@@ -1,3 +1,7 @@
 .app-hidden {
   display: none;
 }
+
+.app-inline-block {
+  display: inline-block;
+}

--- a/app/controllers/document_lead_image_controller.rb
+++ b/app/controllers/document_lead_image_controller.rb
@@ -117,6 +117,30 @@ class DocumentLeadImageController < ApplicationController
     redirect_to document_path(document)
   end
 
+  def delete_image
+    document = Document.find_by_param(params[:document_id])
+    image = document.images.find(params[:image_id])
+
+    begin
+      if image.id == document.lead_image_id
+        DocumentUpdateService.update!(
+          document: document,
+          user: current_user,
+          type: "lead_image_removed",
+          attributes_to_update: { lead_image_id: nil },
+        )
+      end
+
+      AssetManagerService.new.delete(image)
+      image.destroy
+    rescue GdsApi::BaseError
+      redirect_to document_lead_image_path(document), alert_with_description: t("document_lead_image.index.flashes.api_error")
+      return
+    end
+
+    redirect_to document_lead_image_path(document), notice: t("document_lead_image.index.flashes.image_deleted")
+  end
+
   def destroy
     document = Document.find_by_param(params[:document_id])
 

--- a/app/views/components/_image_meta.html.erb
+++ b/app/views/components/_image_meta.html.erb
@@ -5,6 +5,8 @@
   meta ||= {}
   lead_image ||= false
   no_border ||= false
+  primary_action ||= nil
+  secondary_actions ||= []
 
   if meta.key?(:alt_text)
     alt_text = meta[:alt_text]
@@ -42,23 +44,30 @@
         } %>
       <% end %>
 
-      <% if lead_image %>
-        <div class="app-c-image-meta__lead-image-section">
-          <div class="app-c-image-meta__lead-image-tag">Lead image</div>
-          <div class="app-c-image-meta__remove-button"><%= actions[:remove_button] %></div>
+      <% if primary_action %>
+        <div class="app-c-image-meta__primary-action-section">
+          <% if primary_action[:tag] %>
+            <span class="app-c-image-meta__primary-action-tag">
+              <%= primary_action[:tag] %>
+            </span>
+          <% end %>
+
+          <%= primary_action[:action] %>
         </div>
       <% end %>
 
+      <% if lead_image %>
+          <div><%= primary_action %></div>
+        </div>
+      <% end %>
     </div>
   </div>
 
-  <% if actions.any? %>
+  <% if secondary_actions.any? %>
     <ul class="app-c-image-meta__actions">
-      <% if actions[:choose_button] %>
-        <li class="app-c-image-meta__choose-image"><%= actions[:choose_button] %></li>
+      <% secondary_actions.each do |action| %>
+        <li><%= action %></li>
       <% end %>
-      <li><%= link_to("Edit crop", actions[:crop_link], class: "govuk-link") %></li>
-      <li><%= link_to("Edit details", actions[:edit_link], class: "govuk-link") %></li>
     </ul>
   <% end %>
 </div>

--- a/app/views/document_lead_image/_image_list.html.erb
+++ b/app/views/document_lead_image/_image_list.html.erb
@@ -2,31 +2,31 @@
 <% @document.images.each_with_index do |image, i| %>
 
   <% remove_lead_image_button = capture do %>
-    <%= form_tag remove_document_lead_image_path(@document), method: :delete do %>
+    <%= form_tag remove_document_lead_image_path(@document), method: :delete, class: "app-inline-block" do %>
       <button class="govuk-link">Remove</button>
     <% end %>
   <% end %>
 
-  <% choose_lead_image_button = capture do %>
-    <%= form_tag choose_document_lead_image_path(@document, image) do %>
+  <% choose_image_button = capture do %>
+    <%= form_tag choose_document_lead_image_path(@document, image), class: "app-inline-block" do %>
       <button class="govuk-link">Choose image</button>
     <% end %>
   <% end %>
 
   <%= render "components/image_meta", {
-    id: "image-#{i}",
+    id: "image-#{image.id}",
     src: url_for(image.thumbnail),
-    lead_image: image == @document.lead_image,
     meta: {
       alt_text: image.alt_text,
       caption: image.caption,
-      credit: image.credit,
+      credit: image.credit
     },
-    actions: {
-      crop_link: crop_document_lead_image_path(@document, image, next_screen: "lead-image"),
-      edit_link: edit_document_lead_image_path(@document, image, next_screen: "lead-image"),
-      remove_button: remove_lead_image_button,
-      choose_button: choose_lead_image_button
-    }
+    primary_action: image.id == @document.lead_image_id ?
+      { tag: t("document_lead_image.index.lead_image"), action: remove_lead_image_button } :
+      { action: choose_image_button },
+    secondary_actions: [
+      link_to("Edit crop", crop_document_lead_image_path(@document, image, next_screen: "lead-image"), class: "govuk-link"),
+      link_to("Edit details", edit_document_lead_image_path(@document, image, next_screen: "lead-image"), class: "govuk-link")
+    ]
   } %>
 <% end %>

--- a/app/views/document_lead_image/_image_list.html.erb
+++ b/app/views/document_lead_image/_image_list.html.erb
@@ -1,5 +1,4 @@
-
-<% @document.images.each_with_index do |image, i| %>
+<% @document.images.each_with_index do |image| %>
 
   <% remove_lead_image_button = capture do %>
     <%= form_tag remove_document_lead_image_path(@document), method: :delete, class: "app-inline-block" do %>
@@ -10,6 +9,12 @@
   <% choose_image_button = capture do %>
     <%= form_tag choose_document_lead_image_path(@document, image), class: "app-inline-block" do %>
       <button class="govuk-link">Choose image</button>
+    <% end %>
+  <% end %>
+
+  <% delete_image_button = capture do %>
+    <%= form_tag delete_document_lead_image_path(@document, image), method: :delete, class: "app-inline-block" do %>
+      <button class="govuk-link app-link--destructive">Delete image</button>
     <% end %>
   <% end %>
 
@@ -26,7 +31,8 @@
       { action: choose_image_button },
     secondary_actions: [
       link_to("Edit crop", crop_document_lead_image_path(@document, image, next_screen: "lead-image"), class: "govuk-link"),
-      link_to("Edit details", edit_document_lead_image_path(@document, image, next_screen: "lead-image"), class: "govuk-link")
+      link_to("Edit details", edit_document_lead_image_path(@document, image, next_screen: "lead-image"), class: "govuk-link"),
+      delete_image_button
     ]
   } %>
 <% end %>

--- a/app/views/documents/show/_actions.html.erb
+++ b/app/views/documents/show/_actions.html.erb
@@ -24,18 +24,18 @@
       <%= render "govuk_publishing_components/components/button", text: "Create new edition", href: edit_document_path(@document), secondary: true %>
 
       <%= link_to "Retire", retire_document_path(@document), class: "govuk-link" %>
-      <%= link_to "Remove", remove_document_path(@document), class: "app-link--destructive app-link--right" %>
+      <%= link_to "Remove", remove_document_path(@document), class: "govuk-link app-link--destructive app-link--right" %>
     <% elsif @document.user_facing_state == "published" %>
       <%= render "govuk_publishing_components/components/button", text: "Create new edition", href: edit_document_path(@document) %>
 
       <%= link_to "Retire", retire_document_path(@document), class: "govuk-link" %>
-      <%= link_to "Remove", remove_document_path(@document), class: "app-link--destructive app-link--right" %>
+      <%= link_to "Remove", remove_document_path(@document), class: "govuk-link app-link--destructive app-link--right" %>
     <% elsif @document.user_facing_state == "submitted_for_review" %>
       <%= render "govuk_publishing_components/components/button", text: "Publish", href: publish_document_path(@document) %>
       <%= render "govuk_publishing_components/components/button", text: "Preview", href: preview_document_path(@document), secondary: true, target: "_blank" %>
 
       <% unless @document.has_live_version_on_govuk %>
-        <%= link_to "Delete draft", delete_draft_path(@document), class: "app-link--destructive app-link--right" %>
+        <%= link_to "Delete draft", delete_draft_path(@document), class: "govuk-link app-link--destructive app-link--right" %>
       <% end %>
     <% elsif @document.user_facing_state == "draft" %>
       <%= form_tag submit_document_for_2i_path(@document) do %>
@@ -47,7 +47,7 @@
       <%= link_to "Publish", publish_document_path(@document), class: "govuk-link" %>
 
       <% unless @document.has_live_version_on_govuk %>
-        <%= link_to "Delete draft", delete_draft_path(@document), class: "app-link--destructive app-link--right" %>
+        <%= link_to "Delete draft", delete_draft_path(@document), class: "govuk-link app-link--destructive app-link--right" %>
       <% end %>
     <% end %>
 

--- a/config/locales/en/document_lead_image/index.yml
+++ b/config/locales/en/document_lead_image/index.yml
@@ -13,9 +13,6 @@ en:
       error_summary_title: You need to
       lead_image: Lead image
       flashes:
-        asset_manager_error:
+        api_error:
           title: Something has gone wrong
           description: Something went wrong when uploading your file. Please try again or [raise a support request](https://support.publishing.service.gov.uk/technical_fault_report/new).
-        publishing_api_error:
-          title: Something has gone wrong
-          description: Something went wrong when choosing your lead image. Please try again or [raise a support request](https://support.publishing.service.gov.uk/technical_fault_report/new).

--- a/config/locales/en/document_lead_image/index.yml
+++ b/config/locales/en/document_lead_image/index.yml
@@ -13,6 +13,7 @@ en:
       error_summary_title: You need to
       lead_image: Lead image
       flashes:
+        image_deleted: Image deleted
         api_error:
           title: Something has gone wrong
           description: Something went wrong when uploading your file. Please try again or [raise a support request](https://support.publishing.service.gov.uk/technical_fault_report/new).

--- a/config/locales/en/document_lead_image/index.yml
+++ b/config/locales/en/document_lead_image/index.yml
@@ -11,6 +11,7 @@ en:
       credit: Image credit
       no_file_selected: You must select a file
       error_summary_title: You need to
+      lead_image: Lead image
       flashes:
         asset_manager_error:
           title: Something has gone wrong

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -41,6 +41,7 @@ Rails.application.routes.draw do
   patch "/documents/:document_id/lead-image/:image_id/edit" => "document_lead_image#update", as: :update_document_lead_image
   post "/documents/:document_id/lead-image/:image_id/choose" => "document_lead_image#choose_image", as: :choose_document_lead_image
   delete "/documents/:document_id/lead-image" => "document_lead_image#destroy", as: :remove_document_lead_image
+  delete "/documents/:document_id/lead-image/:image_id" => "document_lead_image#delete_image", as: :delete_document_lead_image
 
   get "/healthcheck", to: proc { [200, {}, %w[OK]] }
 

--- a/spec/factories/image_factory.rb
+++ b/spec/factories/image_factory.rb
@@ -3,7 +3,7 @@
 FactoryBot.define do
   factory :image do
     document
-    filename { "my-image.jpg" }
+    filename { SecureRandom.hex(8) }
     width { 1000 }
     height { 1000 }
     crop_x { 0 }
@@ -13,6 +13,7 @@ FactoryBot.define do
 
     transient do
       fixture { "1000x1000.jpg" }
+      asset_id { SecureRandom.hex(8) }
     end
 
     after(:build) do |image, evaluator|
@@ -25,7 +26,7 @@ FactoryBot.define do
     end
 
     trait :in_asset_manager do
-      asset_manager_file_url { "https://asset-manager.test.gov.uk/media/asset-id-123/#{filename}" }
+      asset_manager_file_url { "https://asset-manager.test.gov.uk/media/asset-id#{asset_id}/#{filename}" }
     end
   end
 end

--- a/spec/features/editing_images/delete_image_asset_manager_down_spec.rb
+++ b/spec/features/editing_images/delete_image_asset_manager_down_spec.rb
@@ -1,0 +1,43 @@
+# frozen_string_literal: true
+
+RSpec.feature "Delete an image with Asset Manager down" do
+  scenario "Delete an image with Asset Manager down" do
+    given_there_is_a_document_with_images
+    when_i_visit_the_lead_images_page
+    and_asset_manager_is_down
+    and_i_delete_the_lead_image
+    then_i_see_the_operation_failed
+    and_the_document_has_no_lead_image
+  end
+
+  def given_there_is_a_document_with_images
+    document_type_schema = build(:document_type_schema, lead_image: true)
+    document = create(:document, document_type: document_type_schema.id)
+
+    @image = create(:image, :in_asset_manager, document: document)
+    document.update(lead_image: @image)
+  end
+
+  def when_i_visit_the_lead_images_page
+    visit document_lead_image_path(Document.last)
+  end
+
+  def and_asset_manager_is_down
+    asset_manager_delete_asset_failure(@image.asset_manager_id)
+  end
+
+  def and_i_delete_the_lead_image
+    stub_publishing_api_put_content(Document.last.content_id, {})
+    click_on "Delete image"
+  end
+
+  def then_i_see_the_operation_failed
+    expect(page).to have_content(I18n.t("document_lead_image.index.flashes.api_error.title"))
+  end
+
+  def and_the_document_has_no_lead_image
+    within("#image-#{@image.id}") do
+      expect(page).to_not have_content(I18n.t("document_lead_image.index.lead_image"))
+    end
+  end
+end

--- a/spec/features/editing_images/delete_image_publishing_api_down_spec.rb
+++ b/spec/features/editing_images/delete_image_publishing_api_down_spec.rb
@@ -1,0 +1,35 @@
+# frozen_string_literal: true
+
+RSpec.feature "Delete an image with Publishing API down" do
+  scenario "Delete an image with Publishing API down" do
+    given_there_is_a_document_with_images
+    when_i_visit_the_lead_images_page
+    and_the_publishing_api_is_down
+    and_i_delete_the_lead_image
+    then_i_see_the_preview_creation_failed
+  end
+
+  def given_there_is_a_document_with_images
+    document_type_schema = build(:document_type_schema, lead_image: true)
+    document = create(:document, document_type: document_type_schema.id)
+
+    @image = create(:image, :in_asset_manager, document: document)
+    document.update(lead_image: @image)
+  end
+
+  def when_i_visit_the_lead_images_page
+    visit document_lead_image_path(Document.last)
+  end
+
+  def and_the_publishing_api_is_down
+    publishing_api_isnt_available
+  end
+
+  def and_i_delete_the_lead_image
+    click_on "Delete image"
+  end
+
+  def then_i_see_the_preview_creation_failed
+    expect(page).to have_content(I18n.t("document_lead_image.index.flashes.api_error.title"))
+  end
+end

--- a/spec/features/editing_images/delete_image_spec.rb
+++ b/spec/features/editing_images/delete_image_spec.rb
@@ -1,0 +1,70 @@
+# frozen_string_literal: true
+
+RSpec.feature "Delete an image" do
+  scenario "Delete an image" do
+    given_there_is_a_document_with_images
+    when_i_visit_the_lead_images_page
+    and_i_delete_the_non_lead_image
+    then_i_see_the_image_is_gone
+    when_i_delete_the_lead_image
+    and_i_visit_the_document_page
+    then_i_see_the_document_has_no_lead_image
+    and_the_preview_creation_succeeded
+  end
+
+  def given_there_is_a_document_with_images
+    document_type_schema = build(:document_type_schema, lead_image: true)
+    document = create(:document, document_type: document_type_schema.id)
+
+    @image = create(:image, :in_asset_manager, document: document)
+    @lead_image = create(:image, :in_asset_manager, document: document)
+
+    document.update(lead_image: @lead_image)
+  end
+
+  def when_i_visit_the_lead_images_page
+    visit document_lead_image_path(Document.last)
+  end
+
+  def and_i_delete_the_non_lead_image
+    @image_request = asset_manager_delete_asset(@image.asset_manager_id)
+
+    within("#image-#{@image.id}") do
+      click_on "Delete image"
+    end
+  end
+
+  def then_i_see_the_image_is_gone
+    expect(all("#image-#{@image.id}").count).to be_zero
+    expect(page).to have_content(I18n.t("document_lead_image.index.flashes.image_deleted"))
+    expect(@image_request).to have_been_requested
+    expect(ActiveStorage::Blob.service.exist?(@image.blob.key)).to be_falsey
+  end
+
+  def when_i_delete_the_lead_image
+    @lead_image_request = asset_manager_delete_asset(@lead_image.asset_manager_id)
+    @request = stub_publishing_api_put_content(Document.last.content_id, {})
+
+    within("#image-#{@lead_image.id}") do
+      click_on "Delete image"
+    end
+  end
+
+  def and_i_visit_the_document_page
+    click_on "Back"
+  end
+
+  def then_i_see_the_document_has_no_lead_image
+    expect(page).to have_content(I18n.t("documents.show.lead_image.no_lead_image"))
+    expect(page).to have_content(I18n.t("documents.history.entry_types.lead_image_removed"))
+  end
+
+  def and_the_preview_creation_succeeded
+    expect(@request).to have_been_requested
+    expect(page).to have_content(I18n.t("user_facing_states.draft.name"))
+
+    expect(a_request(:put, /content/).with { |req|
+      expect(JSON.parse(req.body)["details"].keys).to_not include("image")
+    }).to have_been_requested
+  end
+end

--- a/spec/features/editing_images/remove_lead_image_spec.rb
+++ b/spec/features/editing_images/remove_lead_image_spec.rb
@@ -1,12 +1,12 @@
 # frozen_string_literal: true
 
 RSpec.feature "Remove a lead image" do
-  scenario "User removes an existing lead image" do
+  scenario "Remove a lead image" do
     given_there_is_a_document_with_a_lead_image
     when_i_visit_the_lead_images_page
-    then_i_should_be_able_to_see_the_lead_image
+    then_i_see_the_lead_image
     when_i_remove_the_lead_image
-    then_i_should_not_see_a_lead_image_on_the_summary_page
+    then_the_document_has_no_lead_image
   end
 
   def given_there_is_a_document_with_a_lead_image
@@ -22,28 +22,30 @@ RSpec.feature "Remove a lead image" do
     visit document_lead_image_path(Document.last)
   end
 
-  def then_i_should_be_able_to_see_the_lead_image
-    expect(find("#image-0 .app-c-image-meta__image")["src"]).to include("image-1.jpg")
-    within("#image-0 .app-c-metadata") do
+  def then_i_see_the_lead_image
+    expect(find("#image-#{@image.id} img")["src"]).to include("image-1.jpg")
+
+    within("#image-#{@image.id}") do
       expect(page).to have_content(@image.alt_text)
       expect(page).to have_content(@image.caption)
       expect(page).to have_content(@image.credit)
-    end
-
-    within("#image-0 .app-c-image-meta__lead-image-section") do
-      expect(page).to have_content("Lead image")
+      expect(page).to have_content(I18n.t("document_lead_image.index.lead_image"))
     end
   end
 
   def when_i_remove_the_lead_image
     @request = stub_publishing_api_put_content(Document.last.content_id, {})
-    within("#image-0") do
-      click_on "Remove"
-    end
+    click_on "Remove"
   end
 
-  def then_i_should_not_see_a_lead_image_on_the_summary_page
+  def then_the_document_has_no_lead_image
     expect(@request).to have_been_requested
+    expect(page).to have_link("Preview")
+
+    expect(a_request(:put, /content/).with { |req|
+      expect(JSON.parse(req.body)["details"].keys).to_not include("image")
+    }).to have_been_requested
+
     expect(page).to have_content(I18n.t("documents.show.lead_image.no_lead_image"))
   end
 end

--- a/spec/features/editing_images/upload_lead_image_asset_manager_down_spec.rb
+++ b/spec/features/editing_images/upload_lead_image_asset_manager_down_spec.rb
@@ -1,11 +1,13 @@
 # frozen_string_literal: true
 
 RSpec.feature "Upload a lead image when Asset Manager is down" do
-  scenario "User uploads a lead image and asset manager fails to upload it" do
+  scenario "User uploads a lead image and Asset Manager is down" do
     given_there_is_a_document
-    when_i_upload_a_new_image_and_asset_manager_is_unable_to_upload_it
+    when_i_visit_the_lead_images_page
+    and_asset_manager_is_down
+    and_i_upload_an_image
     then_i_should_see_an_error
-    and_i_should_not_be_able_to_see_the_image_on_the_lead_images_page
+    and_the_image_does_not_exist
   end
 
   def given_there_is_a_document
@@ -13,18 +15,24 @@ RSpec.feature "Upload a lead image when Asset Manager is down" do
     create(:document, document_type: document_type_schema.id)
   end
 
-  def when_i_upload_a_new_image_and_asset_manager_is_unable_to_upload_it
+  def when_i_visit_the_lead_images_page
     visit document_lead_image_path(Document.last)
+  end
+
+  def and_asset_manager_is_down
     asset_manager_upload_failure
+  end
+
+  def and_i_upload_an_image
     find('form input[type="file"]').set(file_fixture("960x640.jpg"))
     click_on "Upload"
   end
 
   def then_i_should_see_an_error
-    expect(page).to have_content(I18n.t("document_lead_image.index.flashes.asset_manager_error.title"))
+    expect(page).to have_content(I18n.t("document_lead_image.index.flashes.api_error.title"))
   end
 
-  def and_i_should_not_be_able_to_see_the_image_on_the_lead_images_page
-    expect(page).not_to have_select("#lead-image")
+  def and_the_image_does_not_exist
+    expect(page).to have_content(I18n.t("document_lead_image.index.no_existing_image"))
   end
 end

--- a/spec/features/editing_images/upload_lead_image_publishing_api_down_spec.rb
+++ b/spec/features/editing_images/upload_lead_image_publishing_api_down_spec.rb
@@ -1,10 +1,13 @@
 # frozen_string_literal: true
 
 RSpec.feature "Upload a lead image when Publishing API is down" do
-  scenario "User uploads a lead image and the draft document is not sent to Publishing API" do
+  scenario "User uploads a lead image when Publishing API is down" do
     given_there_is_a_document
-    when_i_upload_a_new_image_and_publishing_api_is_down
-    then_i_should_see_an_error
+    when_i_visit_the_lead_images_page
+    and_the_publishing_api_is_down
+    when_i_upload_an_image
+    then_i_see_the_image_is_the_lead_image
+    and_i_see_the_preview_creation_failed
   end
 
   def given_there_is_a_document
@@ -12,21 +15,36 @@ RSpec.feature "Upload a lead image when Publishing API is down" do
     create(:document, document_type: document_type_schema.id)
   end
 
-  def when_i_upload_a_new_image_and_publishing_api_is_down
+  def when_i_visit_the_lead_images_page
+    visit document_lead_image_path(Document.last)
+  end
+
+  def and_the_publishing_api_is_down
     publishing_api_isnt_available
+  end
+
+  def when_i_upload_an_image
     @asset_id = SecureRandom.uuid
     asset_url = "https://asset-manager.test.gov.uk/media/#{@asset_id}/960x640.jpg"
     asset_manager_receives_an_asset(asset_url)
-    visit document_lead_image_path(Document.last)
+
     find('form input[type="file"]').set(file_fixture("960x640.jpg"))
     click_on "Upload"
+
     asset_manager_delete_asset(@asset_id)
     click_on "Crop image"
+
     fill_in "alt_text", with: "Some alt text"
     click_on "Save and choose"
   end
 
-  def then_i_should_see_an_error
-    expect(page).to have_content(I18n.t("document_lead_image.index.flashes.publishing_api_error.title"))
+  def then_i_see_the_image_is_the_lead_image
+    within("#image-#{Image.last.id}") do
+      expect(page).to have_content(I18n.t("document_lead_image.index.lead_image"))
+    end
+  end
+
+  def and_i_see_the_preview_creation_failed
+    expect(page).to have_content(I18n.t("document_lead_image.index.flashes.api_error.title"))
   end
 end

--- a/spec/features/editing_tags/edit_document_tags_spec.rb
+++ b/spec/features/editing_tags/edit_document_tags_spec.rb
@@ -62,7 +62,7 @@ RSpec.feature "Edit document tags" do
 
   def and_the_preview_creation_succeeded
     expect(@request).to have_been_requested
-    expect(page).to have_link("Preview")
+    expect(page).to have_content(I18n.t("user_facing_states.draft.name"))
 
     expect(a_request(:put, /content/).with { |req|
       expect(JSON.parse(req.body)["links"]).to include(edition_links)


### PR DESCRIPTION
https://trello.com/c/AJnfoZhI/271-provide-functionality-to-delete-an-uploaded-lead-image

This adds the ability to delete a (lead) image for a document. Related changes:

   - Making the red destructive class work for buttons (553330d)
   - Making the actions for each image more flexible (853ac49)
   - Making the API errors for images more generic (d19ed2a)

Looking through the code has highlighted a few issues to address separately:

   - The lead images controller is very long and complicated
   - The update_crop action doesn't cope with Asset Manager down
   - Some of the image specs still don't validate the preview payload