### PR TITLE
Fix metadata not being passed to Asset Manager

### DIFF
--- a/app/models/image.rb
+++ b/app/models/image.rb
@@ -46,6 +46,10 @@ class Image < ApplicationRecord
     url_array[url_array.length - 2]
   end
 
+  def content_type
+    blob.content_type
+  end
+
   def cropped_bytes
     processed_image = thumbnail.processed
     processed_image.service.download(processed_image.key)

--- a/app/services/asset_manager_service.rb
+++ b/app/services/asset_manager_service.rb
@@ -17,15 +17,6 @@ class AssetManagerService
     asset_manager.delete_asset(asset.asset_manager_id)
   end
 
-private
-
-  def asset_manager
-    @asset_manager ||= GdsApi::AssetManager.new(
-      Plek.new.find("asset-manager"),
-      bearer_token: ENV.fetch("ASSET_MANAGER_BEARER_TOKEN", "example"),
-    )
-  end
-
   # Used as a stand-in for a File / Rack::Multipart::UploadedFile object when
   # passed to GdsApi::AssetManager#create_asset. The interface is required for
   # uploading a file using the restclient we used in the backend.
@@ -50,8 +41,25 @@ private
       asset.asset_manager_id
     end
 
+    def content_type
+      asset.content_type
+    end
+
     def path
       asset.filename
     end
+
+    def filename
+      File.basename(asset.filename)
+    end
+  end
+
+private
+
+  def asset_manager
+    @asset_manager ||= GdsApi::AssetManager.new(
+      Plek.new.find("asset-manager"),
+      bearer_token: ENV.fetch("ASSET_MANAGER_BEARER_TOKEN", "example"),
+    )
   end
 end


### PR DESCRIPTION
The ensures the content type is passed explicitly to Asset Manager
instead of being inferred by Rest Client. It also ensures we pass the
filename without any surrounding path, which is what Rest Client looks
for by default.