### PR TITLE
Disable image deletion for published documents

### DIFF
--- a/app/controllers/document_lead_image_controller.rb
+++ b/app/controllers/document_lead_image_controller.rb
@@ -162,6 +162,7 @@ class DocumentLeadImageController < ApplicationController
 
   def destroy
     document = Document.find_by_param(params[:document_id])
+    raise "Trying to delete image for a live document" if document.has_live_version_on_govuk
 
     begin
       DocumentUpdateService.update!(

--- a/app/views/document_lead_image/_image_list.html.erb
+++ b/app/views/document_lead_image/_image_list.html.erb
@@ -16,8 +16,18 @@ end %>
   <% end %>
 
   <% delete_image_button = capture do %>
-    <%= form_tag delete_document_lead_image_path(@document, image), method: :delete, class: "app-inline-block" do %>
-      <button class="govuk-link app-link--destructive">Delete image</button>
+  <% end %>
+
+  <% secondary_actions = [
+    link_to("Edit crop", crop_document_lead_image_path(@document, image), class: "govuk-link"),
+    link_to("Edit details", edit_document_lead_image_path(@document, image), class: "govuk-link")
+  ] %>
+
+  <% unless @document.has_live_version_on_govuk %>
+    <% secondary_actions << capture do %>
+      <%= form_tag delete_document_lead_image_path(@document, image), method: :delete, class: "app-inline-block" do %>
+        <button class="govuk-link app-link--destructive">Delete image</button>
+      <% end %>
     <% end %>
   <% end %>
 
@@ -32,10 +42,6 @@ end %>
     primary_action: image.id == @document.lead_image_id ?
       { tag: t("document_lead_image.index.lead_image"), action: remove_lead_image_button } :
       { action: choose_image_button },
-    secondary_actions: [
-      link_to("Edit crop", crop_document_lead_image_path(@document, image), class: "govuk-link"),
-      link_to("Edit details", edit_document_lead_image_path(@document, image), class: "govuk-link"),
-      delete_image_button
-    ]
+    secondary_actions: secondary_actions
   } %>
 <% end %>

--- a/spec/features/editing_images/delete_image_after_publishing_spec.rb
+++ b/spec/features/editing_images/delete_image_after_publishing_spec.rb
@@ -1,0 +1,28 @@
+# frozen_string_literal: true
+
+RSpec.feature "Delete an image after publishing" do
+  scenario "Delete an image after publishing" do
+    given_there_is_a_document_with_images
+    and_the_document_is_live_on_govuk
+    when_i_visit_the_lead_images_page
+    then_i_cannot_delete_any_of_the_images
+  end
+
+  def given_there_is_a_document_with_images
+    document_type_schema = build(:document_type_schema, lead_image: true)
+    document = create(:document, document_type: document_type_schema.id)
+    create(:image, :in_asset_manager, document: document)
+  end
+
+  def and_the_document_is_live_on_govuk
+    Document.last.update(has_live_version_on_govuk: true)
+  end
+
+  def when_i_visit_the_lead_images_page
+    visit document_lead_image_path(Document.last)
+  end
+
+  def then_i_cannot_delete_any_of_the_images
+    expect(page).to_not have_content("Delete image")
+  end
+end


### PR DESCRIPTION
https://trello.com/c/AJnfoZhI/271-provide-functionality-to-delete-an-uploaded-lead-image