### PR TITLE
Drop the repetitious text in "scenario '...' do"

### DIFF
--- a/spec/features/creating_documents/choose_a_format_spec.rb
+++ b/spec/features/creating_documents/choose_a_format_spec.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 RSpec.feature "Choosing a format" do
-  scenario "User forgets to choose a format" do
+  scenario do
     when_i_dont_choose_a_supertype
     then_i_see_a_supertype_error
     when_i_choose_a_supertype

--- a/spec/features/creating_documents/create_a_document_spec.rb
+++ b/spec/features/creating_documents/create_a_document_spec.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 RSpec.feature "Create a document" do
-  scenario "User creates a document" do
+  scenario do
     when_i_choose_a_format
     then_i_wont_be_able_to_choose_an_update_type_or_change_note
 

--- a/spec/features/documentation_spec.rb
+++ b/spec/features/documentation_spec.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
-RSpec.feature "Documentation" do
-  scenario "GDS staff visits the docs page" do
+RSpec.feature "GDS Documentation" do
+  scenario do
     when_i_visit_the_documentation_page
     then_i_see_the_documentation_page
   end

--- a/spec/features/editing_content/change_notes_spec.rb
+++ b/spec/features/editing_content/change_notes_spec.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 RSpec.feature "Change notes" do
-  scenario "User updates change notes and update type" do
+  scenario do
     given_there_is_a_previously_published_document
     when_i_go_to_edit_the_document
     and_i_fill_in_the_change_note_and_update_type

--- a/spec/features/editing_content/edit_a_document_api_down_spec.rb
+++ b/spec/features/editing_content/edit_a_document_api_down_spec.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 RSpec.feature "Edit a document when the API is down" do
-  scenario "User tries to edit document without API" do
+  scenario do
     given_there_is_a_document
     and_the_publishing_api_is_down
 

--- a/spec/features/editing_content/edit_a_document_spec.rb
+++ b/spec/features/editing_content/edit_a_document_spec.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 RSpec.feature "Edit a document" do
-  scenario "User edits a document" do
+  scenario do
     given_there_is_a_document
     when_i_go_to_edit_the_document
     and_i_fill_in_the_content_fields

--- a/spec/features/editing_content/previews_a_url_when_editing_title_spec.rb
+++ b/spec/features/editing_content/previews_a_url_when_editing_title_spec.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 RSpec.feature "Shows a preview of the URL", js: true do
-  scenario "when a user edits the title of a document" do
+  scenario do
     given_there_is_a_document
     when_i_go_to_edit_the_document
     and_i_delete_the_title

--- a/spec/features/editing_content/previews_govspeak_when_editing_spec.rb
+++ b/spec/features/editing_content/previews_govspeak_when_editing_spec.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 RSpec.feature "Shows a preview of Govspeak", js: true do
-  scenario "when a user previews some Govspeak" do
+  scenario do
     given_there_is_a_document
     when_i_go_to_edit_the_document
     and_i_enter_some_govspeak

--- a/spec/features/editing_content/show_a_document_api_down_spec.rb
+++ b/spec/features/editing_content/show_a_document_api_down_spec.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 RSpec.feature "Showing a document when the API is down" do
-  scenario "User views a document without API" do
+  scenario do
     given_there_is_a_document_with_tags
     and_the_publishing_api_is_down
     when_i_visit_the_document_page

--- a/spec/features/editing_content/showing_a_document_summary_spec.rb
+++ b/spec/features/editing_content/showing_a_document_summary_spec.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 RSpec.feature "Showing a document summary" do
-  scenario "User views a document" do
+  scenario do
     given_there_is_a_document
     when_i_visit_the_document_page
     then_i_see_the_document_summary

--- a/spec/features/editing_images/choose_lead_image_spec.rb
+++ b/spec/features/editing_images/choose_lead_image_spec.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 RSpec.feature "Choose a lead image" do
-  scenario "Choose a lead image" do
+  scenario do
     given_there_is_a_document_with_images
     when_i_visit_the_summary_page
     and_i_visit_the_lead_images_page

--- a/spec/features/editing_images/delete_image_asset_manager_down_spec.rb
+++ b/spec/features/editing_images/delete_image_asset_manager_down_spec.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 RSpec.feature "Delete an image with Asset Manager down" do
-  scenario "Delete an image with Asset Manager down" do
+  scenario do
     given_there_is_a_document_with_images
     when_i_visit_the_lead_images_page
     and_asset_manager_is_down

--- a/spec/features/editing_images/delete_image_publishing_api_down_spec.rb
+++ b/spec/features/editing_images/delete_image_publishing_api_down_spec.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 RSpec.feature "Delete an image with Publishing API down" do
-  scenario "Delete an image with Publishing API down" do
+  scenario do
     given_there_is_a_document_with_images
     when_i_visit_the_lead_images_page
     and_the_publishing_api_is_down

--- a/spec/features/editing_images/delete_image_spec.rb
+++ b/spec/features/editing_images/delete_image_spec.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 RSpec.feature "Delete an image" do
-  scenario "Delete an image" do
+  scenario do
     given_there_is_a_document_with_images
     when_i_visit_the_lead_images_page
     and_i_delete_the_non_lead_image

--- a/spec/features/editing_images/edit_lead_image_crop_spec.rb
+++ b/spec/features/editing_images/edit_lead_image_crop_spec.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 RSpec.feature "Edit an existing lead image's crop dimensions", js: true do
-  scenario "User edits lead image crop" do
+  scenario do
     given_there_is_a_document_with_existing_images
     when_i_visit_the_lead_images_page
     and_i_click_edit_crop

--- a/spec/features/editing_images/edit_lead_image_spec.rb
+++ b/spec/features/editing_images/edit_lead_image_spec.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 RSpec.feature "Edit an existing lead image" do
-  scenario "User edits lead image" do
+  scenario do
     given_there_is_a_document_with_existing_images
     when_i_visit_the_lead_images_page
     and_i_click_edit_details

--- a/spec/features/editing_images/remove_lead_image_spec.rb
+++ b/spec/features/editing_images/remove_lead_image_spec.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 RSpec.feature "Remove a lead image" do
-  scenario "Remove a lead image" do
+  scenario do
     given_there_is_a_document_with_a_lead_image
     when_i_visit_the_lead_images_page
     then_i_see_the_lead_image

--- a/spec/features/editing_images/upload_invalid_lead_image_spec.rb
+++ b/spec/features/editing_images/upload_invalid_lead_image_spec.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 RSpec.feature "Edit a lead image" do
-  scenario "User edits a lead image" do
+  scenario do
     given_there_is_a_document
     when_i_visit_the_summary_page
     and_i_visit_the_lead_images_page

--- a/spec/features/editing_images/upload_lead_image_asset_manager_down_spec.rb
+++ b/spec/features/editing_images/upload_lead_image_asset_manager_down_spec.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 RSpec.feature "Upload a lead image when Asset Manager is down" do
-  scenario "User uploads a lead image and Asset Manager is down" do
+  scenario do
     given_there_is_a_document
     when_i_visit_the_lead_images_page
     and_asset_manager_is_down

--- a/spec/features/editing_images/upload_lead_image_publishing_api_down_spec.rb
+++ b/spec/features/editing_images/upload_lead_image_publishing_api_down_spec.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 RSpec.feature "Upload a lead image when Publishing API is down" do
-  scenario "User uploads a lead image when Publishing API is down" do
+  scenario do
     given_there_is_a_document
     when_i_visit_the_lead_images_page
     and_the_publishing_api_is_down

--- a/spec/features/editing_images/upload_lead_image_spec.rb
+++ b/spec/features/editing_images/upload_lead_image_spec.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 RSpec.feature "Upload a lead image" do
-  scenario "User uploads a lead image" do
+  scenario do
     given_there_is_a_document
     when_i_visit_the_summary_page
     then_i_see_there_is_no_lead_image

--- a/spec/features/editing_images/upload_no_file_as_lead_image_spec.rb
+++ b/spec/features/editing_images/upload_no_file_as_lead_image_spec.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 RSpec.feature "Upload no file as a lead image" do
-  scenario "User uploads no file" do
+  scenario do
     given_there_is_a_document
     when_i_visit_the_lead_images_page
     when_i_upload_no_file

--- a/spec/features/editing_tags/edit_document_tags_api_down_spec.rb
+++ b/spec/features/editing_tags/edit_document_tags_api_down_spec.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 RSpec.feature "Edit document tags when the API is down" do
-  scenario "User tries to edit tags without API" do
+  scenario do
     given_there_is_a_document
     and_the_publishing_api_is_down
     when_i_visit_the_document_page

--- a/spec/features/editing_tags/edit_document_tags_spec.rb
+++ b/spec/features/editing_tags/edit_document_tags_spec.rb
@@ -5,7 +5,7 @@ RSpec.feature "Edit document tags" do
   let(:tag_to_select_1) { { "content_id" => SecureRandom.uuid, "internal_name" => "Tag to select 1" } }
   let(:tag_to_select_2) { { "content_id" => SecureRandom.uuid, "internal_name" => "Tag to select 2" } }
 
-  scenario "User edits tags to a document" do
+  scenario do
     given_there_is_a_document
     when_i_visit_the_document_page
     and_i_click_on_edit_tags

--- a/spec/features/editing_tags/save_document_tags_api_down_spec.rb
+++ b/spec/features/editing_tags/save_document_tags_api_down_spec.rb
@@ -3,7 +3,7 @@
 require "spec_helper"
 
 RSpec.feature "Save document tags when the API is down" do
-  scenario "User tries to save tags without API" do
+  scenario do
     given_there_is_a_document_with_tags
     and_i_am_editing_the_tags
     and_the_publishing_api_is_down

--- a/spec/features/finding/index_filtering_api_down_spec.rb
+++ b/spec/features/finding/index_filtering_api_down_spec.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 RSpec.feature "User filters documents without Publishing API" do
-  scenario "User filters documents without Publishing API" do
+  scenario do
     given_there_are_some_documents
     and_the_publishing_api_is_down
     when_i_visit_the_index_page

--- a/spec/features/finding/index_filtering_spec.rb
+++ b/spec/features/finding/index_filtering_spec.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 RSpec.feature "User filters documents" do
-  scenario "User filters documents" do
+  scenario do
     given_there_are_some_documents
     when_i_visit_the_index_page
     and_i_filter_by_title

--- a/spec/features/finding/index_ordering_spec.rb
+++ b/spec/features/finding/index_ordering_spec.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 RSpec.feature "User orders documents" do
-  scenario "User orders documents" do
+  scenario do
     given_there_are_some_documents
     when_i_visit_the_index_page
     then_i_see_the_most_recently_updated_first

--- a/spec/features/finding/index_pagination_spec.rb
+++ b/spec/features/finding/index_pagination_spec.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 RSpec.feature "User pages through a list of documents" do
-  scenario "User pages through a list of documents" do
+  scenario do
     given_there_are_lots_of_documents
     when_i_visit_the_index_page
     then_i_should_see_the_first_results

--- a/spec/features/finding/index_results_spec.rb
+++ b/spec/features/finding/index_results_spec.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 RSpec.feature "Users views document results on index page" do
-  scenario "User views document information on index page" do
+  scenario do
     given_there_is_a_document
     when_i_visit_the_index_page
     then_i_can_see_the_document_title

--- a/spec/features/workflow/delete_draft_after_publishing_spec.rb
+++ b/spec/features/workflow/delete_draft_after_publishing_spec.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 RSpec.feature "Delete draft after publishing" do
-  scenario "Delete draft after publishing" do
+  scenario do
     given_there_is_a_document
     when_i_visit_the_document_page
     and_i_publish_the_document

--- a/spec/features/workflow/delete_draft_asset_manager_down_spec.rb
+++ b/spec/features/workflow/delete_draft_asset_manager_down_spec.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 RSpec.feature "Delete draft with Asset Manager down" do
-  scenario "Delete draft with Asset Manager down" do
+  scenario do
     given_there_is_a_document
     when_i_visit_the_document_page
     and_asset_manager_is_down

--- a/spec/features/workflow/delete_draft_publishing_api_down_spec.rb
+++ b/spec/features/workflow/delete_draft_publishing_api_down_spec.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 RSpec.feature "Delete draft with Publishing API down" do
-  scenario "Delete draft with Publishing API down" do
+  scenario do
     given_there_is_a_document
     when_i_visit_the_document_page
     and_the_publishing_api_is_down

--- a/spec/features/workflow/delete_draft_spec.rb
+++ b/spec/features/workflow/delete_draft_spec.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 RSpec.feature "Delete draft" do
-  scenario "Delete draft" do
+  scenario do
     given_there_is_a_document
     when_i_visit_the_document_page
     and_i_delete_the_draft

--- a/spec/features/workflow/document_timeline_spec.rb
+++ b/spec/features/workflow/document_timeline_spec.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 RSpec.feature "Document timeline" do
-  scenario "User edits the document and looks at timeline" do
+  scenario do
     when_i_start_to_create_a_document
     the_timeline_has_a_create_entry
 

--- a/spec/features/workflow/force_publishing_spec.rb
+++ b/spec/features/workflow/force_publishing_spec.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 RSpec.feature "Force publishing" do
-  scenario "User force publishes and approves a document retroactively" do
+  scenario do
     given_there_is_a_document
     when_i_visit_the_document_page
     and_i_click_on_the_publish_button

--- a/spec/features/workflow/preview_document_spec.rb
+++ b/spec/features/workflow/preview_document_spec.rb
@@ -1,9 +1,7 @@
 # frozen_string_literal: true
 
-require "spec_helper"
-
 RSpec.feature "Preview a document" do
-  scenario "User previews a document" do
+  scenario do
     given_there_is_a_document_in_draft
     when_i_visit_the_preview_page
     then_i_see_the_previews

--- a/spec/features/workflow/publish_a_document_asset_manager_down_spec.rb
+++ b/spec/features/workflow/publish_a_document_asset_manager_down_spec.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 RSpec.feature "Publishing a document when Asset Manager is down" do
-  scenario "User publishes a document with a lead image" do
+  scenario do
     given_there_is_a_document_with_a_lead_image
     and_asset_manager_is_down
     when_i_try_to_publish_the_document

--- a/spec/features/workflow/publish_a_document_publishing_api_down_spec.rb
+++ b/spec/features/workflow/publish_a_document_publishing_api_down_spec.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 RSpec.feature "Publishing a document when the Publishing API is down" do
-  scenario "User publishes a document" do
+  scenario do
     given_there_is_a_document
     and_the_publishing_api_is_down
     when_i_try_to_publish_the_document

--- a/spec/features/workflow/publish_a_document_spec.rb
+++ b/spec/features/workflow/publish_a_document_spec.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 RSpec.feature "Publishing a document" do
-  scenario "User publishes a document" do
+  scenario do
     given_there_is_a_document_in_draft
     when_i_visit_the_document_page
     and_i_click_on_the_publish_button

--- a/spec/features/workflow/publishing_requirements_spec.rb
+++ b/spec/features/workflow/publishing_requirements_spec.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 RSpec.feature "Publishing requirements" do
-  scenario "A users works on an incomplete document" do
+  scenario do
     given_there_is_a_document_that_has_unfulfilled_requirements
     when_i_visit_the_document_page
     then_i_see_the_unfulfilled_publishing_requirements

--- a/spec/features/workflow/submit_for_2i_spec.rb
+++ b/spec/features/workflow/submit_for_2i_spec.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 RSpec.feature "2i" do
-  scenario "User submits document for 2i" do
+  scenario do
     given_there_is_a_document_in_draft
     when_i_visit_the_document
     and_i_click_submit_for_2i

--- a/spec/features/workflow/viewing_a_document_with_a_creator_spec.rb
+++ b/spec/features/workflow/viewing_a_document_with_a_creator_spec.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 RSpec.feature "Viewing a document with a creator" do
-  scenario "User finds document with a creator and views it" do
+  scenario do
     given_there_is_a_document_with_a_creator
     when_i_visit_the_index_page
     then_i_see_who_created_that_document

--- a/spec/features/workflow/viewing_a_document_with_no_creator_or_editor_spec.rb
+++ b/spec/features/workflow/viewing_a_document_with_no_creator_or_editor_spec.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 RSpec.feature "Viewing a document with no creator or editor" do
-  scenario "User finds a document without a creator or editor and views it" do
+  scenario do
     given_there_is_a_document_with_no_creator
     when_i_visit_the_index_page
     then_i_see_we_dont_know_who_created_the_document


### PR DESCRIPTION
This helps to suggest that each feature should have a single scenario,
while not enforcing this if multiple scenarios make sense. It also
removes the pressure to think of some slightly different text to write
in the scenario block in comparison to the feature block.