### PR TITLE
Fix N+1 query on index page

### DIFF
--- a/app/services/document_filter.rb
+++ b/app/services/document_filter.rb
@@ -19,7 +19,8 @@ class DocumentFilter
   end
 
   def documents
-    scope = filtered_scope(Document)
+    scope = Document.includes(:creator, :last_editor)
+    scope = filtered_scope(scope)
     scope = ordered_scope(scope)
     scope.page(page).per(per_page)
   end


### PR DESCRIPTION
This loads the related creators and editors for the documents in 1 query, instead of 1 query per document. Potentially saves up to 100 queries per page.