### PR TITLE
Split the document images controller in two

### DIFF
--- a/app/controllers/document_images_controller.rb
+++ b/app/controllers/document_images_controller.rb
@@ -45,7 +45,6 @@ class DocumentImagesController < ApplicationController
     document = Document.find_by_param(params[:document_id])
     image = Image.find(params[:image_id])
 
-
     begin
       Image.transaction do
         image.update!(update_crop_params)

--- a/app/controllers/document_images_controller.rb
+++ b/app/controllers/document_images_controller.rb
@@ -1,0 +1,145 @@
+# frozen_string_literal: true
+
+class DocumentImagesController < ApplicationController
+  def index
+    @document = Document.find_by_param(params[:document_id])
+  end
+
+  def create
+    document = Document.find_by_param(params[:document_id])
+
+    unless params[:image]
+      redirect_to document_images_path, alert: t("document_images.index.no_file_selected")
+      return
+    end
+
+    image_uploader = ImageUploader.new(params.require(:image))
+
+    unless image_uploader.valid?
+      redirect_to document_images_path, alert: {
+        "alerts" => image_uploader.errors,
+        "title" => t("document_images.index.error_summary_title"),
+      }
+      return
+    end
+
+    begin
+      image = image_uploader.upload(document)
+      image.asset_manager_file_url = upload_image_to_asset_manager(image)
+    rescue GdsApi::BaseError => e
+      Rails.logger.error(e)
+      redirect_to document_images_path, alert_with_description: t("document_images.index.flashes.api_error")
+      return
+    end
+
+    image.save!
+    redirect_to crop_document_image_path(params[:document_id], image.id, wizard: params[:wizard])
+  end
+
+  def crop
+    @document = Document.find_by_param(params[:document_id])
+    @image = @document.images.find(params[:image_id])
+  end
+
+  def update_crop
+    document = Document.find_by_param(params[:document_id])
+    image = Image.find(params[:image_id])
+
+
+    begin
+      Image.transaction do
+        image.update!(update_crop_params)
+        asset_manager_file_url = upload_image_to_asset_manager(image)
+        delete_image_from_asset_manager(image)
+        image.asset_manager_file_url = asset_manager_file_url
+        image.save!
+      end
+
+      DocumentUpdateService.update!(
+        document: document,
+        user: current_user,
+        type: "image_updated",
+        attributes_to_update: {},
+      )
+    rescue GdsApi::BaseError => e
+      Rails.logger.error(e)
+      redirect_to document_images_path(document), alert_with_description: t("document_images.index.flashes.api_error")
+      return
+    end
+
+    if params[:wizard].present?
+      redirect_to edit_document_image_path(document, image, params.permit(:wizard))
+      return
+    end
+
+    redirect_to document_images_path(document)
+  end
+
+  def edit
+    @document = Document.find_by_param(params[:document_id])
+    @image = Image.find_by(id: params[:image_id])
+  end
+
+  def update
+    document = Document.find_by_param(params[:document_id])
+    image = document.images.find(params[:image_id])
+    image.update!(update_params)
+
+    begin
+      DocumentUpdateService.update!(
+        document: document,
+        user: current_user,
+        type: "image_updated",
+        attributes_to_update: {},
+      )
+    rescue GdsApi::BaseError => e
+      Rails.logger.error(e)
+      redirect_to document_images_path(document), alert_with_description: t("document_images.index.flashes.api_error")
+      return
+    end
+
+    redirect_to document_images_path(document)
+  end
+
+  def destroy
+    document = Document.find_by_param(params[:document_id])
+    image = document.images.find(params[:image_id])
+    raise "Trying to delete image for a live document" if document.has_live_version_on_govuk
+
+    begin
+      DocumentUpdateService.update!(
+        document: document,
+        user: current_user,
+        type: "image_removed",
+        attributes_to_update: {},
+      )
+
+      AssetManagerService.new.delete(image)
+      image.destroy
+    rescue GdsApi::BaseError => e
+      Rails.logger.error(e)
+      redirect_to document_images_path(document), alert_with_description: t("document_images.index.flashes.api_error")
+      return
+    end
+
+    redirect_to document_images_path(document), notice: t("document_images.index.flashes.image_deleted")
+  end
+
+private
+
+  def update_params
+    params.permit(:caption, :alt_text, :credit)
+  end
+
+  def upload_image_to_asset_manager(image)
+    AssetManagerService.new.upload_bytes(image, image.cropped_bytes)
+  end
+
+  def delete_image_from_asset_manager(image)
+    AssetManagerService.new.delete(image)
+  end
+
+  def update_crop_params
+    params.permit(:crop_x, :crop_y, :crop_width, :crop_height)
+  end
+end

--- a/app/controllers/document_lead_image_controller.rb
+++ b/app/controllers/document_lead_image_controller.rb
@@ -70,14 +70,12 @@ class DocumentLeadImageController < ApplicationController
     raise "Trying to delete image for a live document" if document.has_live_version_on_govuk
 
     begin
-      if image.id == document.lead_image_id
-        DocumentUpdateService.update!(
-          document: document,
-          user: current_user,
-          type: "lead_image_removed",
-          attributes_to_update: { lead_image_id: nil },
-        )
-      end
+      DocumentUpdateService.update!(
+        document: document,
+        user: current_user,
+        type: "lead_image_removed",
+        attributes_to_update: { lead_image_id: nil },
+      )
 
       AssetManagerService.new.delete(image)
       image.destroy

--- a/app/controllers/document_lead_image_controller.rb
+++ b/app/controllers/document_lead_image_controller.rb
@@ -5,81 +5,6 @@ class DocumentLeadImageController < ApplicationController
     @document = Document.find_by_param(params[:document_id])
   end
 
-  def create
-    document = Document.find_by_param(params[:document_id])
-
-    unless params[:image]
-      redirect_to document_lead_image_path, alert: t("document_lead_image.index.no_file_selected")
-      return
-    end
-
-    image_uploader = ImageUploader.new(params.require(:image))
-
-    unless image_uploader.valid?
-      redirect_to document_lead_image_path, alert: {
-        "alerts" => image_uploader.errors,
-        "title" => t("document_lead_image.index.error_summary_title"),
-      }
-      return
-    end
-
-    begin
-      image = image_uploader.upload(document)
-      image.asset_manager_file_url = upload_image_to_asset_manager(image)
-    rescue GdsApi::BaseError => e
-      Rails.logger.error(e)
-      redirect_to document_lead_image_path, alert_with_description: t("document_lead_image.index.flashes.api_error")
-      return
-    end
-
-    image.save!
-    redirect_to crop_document_lead_image_path(params[:document_id], image.id, wizard: params[:wizard])
-  end
-
-  def crop
-    @document = Document.find_by_param(params[:document_id])
-    @image = @document.images.find(params[:image_id])
-  end
-
-  def update_crop
-    document = Document.find_by_param(params[:document_id])
-    image = Image.find(params[:image_id])
-
-
-    begin
-      Image.transaction do
-        image.update!(update_crop_params)
-        asset_manager_file_url = upload_image_to_asset_manager(image)
-        delete_image_from_asset_manager(image)
-        image.asset_manager_file_url = asset_manager_file_url
-        image.save!
-      end
-
-      DocumentUpdateService.update!(
-        document: document,
-        user: current_user,
-        type: "image_updated",
-        attributes_to_update: {},
-      )
-    rescue GdsApi::BaseError => e
-      Rails.logger.error(e)
-      redirect_to document_lead_image_path(document), alert_with_description: t("document_lead_image.index.flashes.api_error")
-      return
-    end
-
-    if params[:wizard].present?
-      redirect_to edit_document_lead_image_path(document, image, params.permit(:wizard))
-      return
-    end
-
-    redirect_to document_lead_image_path(document)
-  end
-
-  def edit
-    @document = Document.find_by_param(params[:document_id])
-    @image = Image.find_by(id: params[:image_id])
-  end
-
   def update
     document = Document.find_by_param(params[:document_id])
     image = document.images.find(params[:image_id])
@@ -89,40 +14,19 @@ class DocumentLeadImageController < ApplicationController
       DocumentUpdateService.update!(
         document: document,
         user: current_user,
-        type: "image_updated",
-        attributes_to_update: {},
-      )
-    rescue GdsApi::BaseError => e
-      Rails.logger.error(e)
-      redirect_to document_lead_image_path(document), alert_with_description: t("document_lead_image.index.flashes.api_error")
-      return
-    end
-
-    redirect_to document_lead_image_path(document)
-  end
-
-  def update_and_choose_image
-    document = Document.find_by_param(params[:document_id])
-    image = document.images.find(params[:image_id])
-    image.update!(update_params)
-
-    begin
-      DocumentUpdateService.update!(
-        document: document,
-        user: current_user,
         type: "lead_image_updated",
-        attributes_to_update: { lead_image_id: params[:image_id] },
+        attributes_to_update: { lead_image_id: image.id },
       )
     rescue GdsApi::BaseError => e
       Rails.logger.error(e)
-      redirect_to document_lead_image_path(document), alert_with_description: t("document_lead_image.index.flashes.api_error")
+      redirect_to document_images_path(document), alert_with_description: t("document_images.index.flashes.api_error")
       return
     end
 
     redirect_to document_path(document)
   end
 
-  def choose_image
+  def choose
     document = Document.find_by_param(params[:document_id])
 
     begin
@@ -134,16 +38,36 @@ class DocumentLeadImageController < ApplicationController
       )
     rescue GdsApi::BaseError => e
       Rails.logger.error(e)
-      redirect_to document_lead_image_path(document), alert_with_description: t("document_lead_image.index.flashes.api_error")
+      redirect_to document_images_path(document), alert_with_description: t("document_images.index.flashes.api_error")
       return
     end
 
     redirect_to document_path(document)
   end
 
-  def delete_image
+  def remove
+    document = Document.find_by_param(params[:document_id])
+
+    begin
+      DocumentUpdateService.update!(
+        document: document,
+        user: current_user,
+        type: "lead_image_removed",
+        attributes_to_update: { lead_image_id: nil },
+      )
+    rescue GdsApi::BaseError => e
+      Rails.logger.error(e)
+      redirect_to document_images_path(document), alert_with_description: t("document_images.index.flashes.api_error")
+      return
+    end
+
+    redirect_to document_path(document)
+  end
+
+  def destroy
     document = Document.find_by_param(params[:document_id])
     image = document.images.find(params[:image_id])
+    raise "Trying to delete image for a live document" if document.has_live_version_on_govuk
 
     begin
       if image.id == document.lead_image_id
@@ -159,27 +83,7 @@ class DocumentLeadImageController < ApplicationController
       image.destroy
     rescue GdsApi::BaseError => e
       Rails.logger.error(e)
-      redirect_to document_lead_image_path(document), alert_with_description: t("document_lead_image.index.flashes.api_error")
-      return
-    end
-
-    redirect_to document_lead_image_path(document), notice: t("document_lead_image.index.flashes.image_deleted")
-  end
-
-  def destroy
-    document = Document.find_by_param(params[:document_id])
-    raise "Trying to delete image for a live document" if document.has_live_version_on_govuk
-
-    begin
-      DocumentUpdateService.update!(
-        document: document,
-        user: current_user,
-        type: "lead_image_removed",
-        attributes_to_update: { lead_image_id: nil },
-      )
-    rescue GdsApi::BaseError => e
-      Rails.logger.error(e)
-      redirect_to document_lead_image_path(document), alert_with_description: t("document_lead_image.index.flashes.api_error")
+      redirect_to document_images_path(document), alert_with_description: t("document_images.index.flashes.api_error")
       return
     end
 

--- a/app/models/timeline_entry.rb
+++ b/app/models/timeline_entry.rb
@@ -15,6 +15,7 @@ class TimelineEntry < ApplicationRecord
     lead_image_updated
     lead_image_removed
     image_updated
+    image_removed
   ].freeze
 
   validates_inclusion_of :entry_type, in: ENTRY_TYPES

--- a/app/views/document_images/_image_list.html.erb
+++ b/app/views/document_images/_image_list.html.erb
@@ -15,18 +15,25 @@ end %>
     <% end %>
   <% end %>
 
+<<<<<<< HEAD:app/views/document_lead_image/_image_list.html.erb
   <% delete_image_button = capture do %>
   <% end %>
 
   <% secondary_actions = [
-    link_to("Edit crop", crop_document_lead_image_path(@document, image), class: "govuk-link"),
-    link_to("Edit details", edit_document_lead_image_path(@document, image), class: "govuk-link")
+    link_to("Edit crop", crop_document_image_path(@document, image), class: "govuk-link"),
+    link_to("Edit details", edit_document_image_path(@document, image), class: "govuk-link"),
   ] %>
 
   <% unless @document.has_live_version_on_govuk %>
     <% secondary_actions << capture do %>
-      <%= form_tag delete_document_lead_image_path(@document, image), method: :delete, class: "app-inline-block" do %>
-        <button class="govuk-link app-link--destructive">Delete image</button>
+      <% if image.id == @document.lead_image_id %>
+        <%= form_tag destroy_document_lead_image_path(@document, image), method: :delete, class: "app-inline-block" do %>
+          <button class="govuk-link app-link--destructive">Delete lead image</button>
+        <% end %>
+      <% else %>
+        <%= form_tag destroy_document_image_path(@document, image), method: :delete, class: "app-inline-block" do %>
+          <button class="govuk-link app-link--destructive">Delete image</button>
+        <% end %>
       <% end %>
     <% end %>
   <% end %>
@@ -40,7 +47,7 @@ end %>
       credit: image.credit
     },
     primary_action: image.id == @document.lead_image_id ?
-      { tag: t("document_lead_image.index.lead_image"), action: remove_lead_image_button } :
+      { tag: t("document_images.index.lead_image"), action: remove_lead_image_button } :
       { action: choose_image_button },
     secondary_actions: secondary_actions
   } %>

--- a/app/views/document_images/_image_list.html.erb
+++ b/app/views/document_images/_image_list.html.erb
@@ -15,10 +15,6 @@ end %>
     <% end %>
   <% end %>
 
-<<<<<<< HEAD:app/views/document_lead_image/_image_list.html.erb
-  <% delete_image_button = capture do %>
-  <% end %>
-
   <% secondary_actions = [
     link_to("Edit crop", crop_document_image_path(@document, image), class: "govuk-link"),
     link_to("Edit details", edit_document_image_path(@document, image), class: "govuk-link"),

--- a/app/views/document_images/crop.html.erb
+++ b/app/views/document_images/crop.html.erb
@@ -1,15 +1,15 @@
-<% content_for :back_link, document_lead_image_path(@document) %>
-<% content_for :title, t("document_lead_image.crop.title", title: @document.title_or_fallback) %>
+<% content_for :back_link, document_images_path(@document) %>
+<% content_for :title, t("document_images.crop.title", title: @document.title_or_fallback) %>
 
 <p class="govuk-body">
-  <%= t("document_lead_image.crop.description") %>
+  <%= t("document_images.crop.description") %>
 </p>
 
-<%= form_tag(crop_document_lead_image_path(@document, @image), method: :patch) do %>
+<%= form_tag(crop_document_image_path(@document, @image), method: :patch) do %>
   <%= hidden_field_tag :wizard, params[:wizard] %>
 
   <%= render "/components/image_cropper", {
-    id: "cropp-image",
+    id: "crop-image",
     src: url_for(@image.blob),
     alt_text: @image.alt_text,
     crop_x: @image.crop_x,

--- a/app/views/document_images/edit.html.erb
+++ b/app/views/document_images/edit.html.erb
@@ -1,5 +1,5 @@
-<% content_for :title, t("document_lead_image.edit.title", title: @document.title_or_fallback) %>
-<% content_for :back_link, document_lead_image_path(@document) %>
+<% content_for :title, t("document_images.edit.title", title: @document.title_or_fallback) %>
+<% content_for :back_link, document_images_path(@document) %>
 
 <%= render "components/image_meta", {
   id: "selected-image",
@@ -9,15 +9,15 @@
 } %>
 
 <% submit_path = params[:wizard] == "lead_image" ?
-    update_and_choose_document_lead_image_path(@document, @image) :
-    update_document_lead_image_path(@document, @image) %>
+    choose_document_lead_image_path(@document, @image) :
+    update_document_image_path(@document, @image) %>
 
 <%= form_tag(submit_path, method: :patch) do %>
   <div class="govuk-grid-row">
     <div class="govuk-grid-column-two-thirds">
       <%= render "govuk_publishing_components/components/input", {
         label: {
-          text: t("document_lead_image.edit.form_labels.alt_text"),
+          text: t("document_images.edit.form_labels.alt_text"),
           bold: true
         },
         name: "alt_text",
@@ -31,10 +31,10 @@
     <div class="govuk-grid-column-one-third">
       <%= render "components/contextual_guidance", {
         id: "alt-text-guidance",
-        title: t("document_lead_image.edit.form_labels.alt_text"),
+        title: t("document_images.edit.form_labels.alt_text"),
       } do %>
         <%= render "govuk_publishing_components/components/govspeak" do %>
-          <%= govspeak_to_html t("document_lead_image.edit.guidance.alt_text") %>
+          <%= govspeak_to_html t("document_images.edit.guidance.alt_text") %>
         <% end %>
       <% end %>
     </div>
@@ -44,7 +44,7 @@
     <div class="govuk-grid-column-two-thirds">
       <%= render "govuk_publishing_components/components/input", {
         label: {
-          text: t("document_lead_image.edit.form_labels.caption"),
+          text: t("document_images.edit.form_labels.caption"),
           bold: true
         },
         name: "caption",
@@ -58,10 +58,10 @@
     <div class="govuk-grid-column-one-third">
       <%= render "components/contextual_guidance", {
         id: "caption-guidance",
-        title: t("document_lead_image.edit.form_labels.caption"),
+        title: t("document_images.edit.form_labels.caption"),
       } do %>
         <%= render "govuk_publishing_components/components/govspeak" do %>
-          <%= govspeak_to_html t("document_lead_image.edit.guidance.caption") %>
+          <%= govspeak_to_html t("document_images.edit.guidance.caption") %>
         <% end %>
       <% end %>
     </div>
@@ -71,7 +71,7 @@
     <div class="govuk-grid-column-two-thirds">
       <%= render "govuk_publishing_components/components/input", {
         label: {
-          text: t("document_lead_image.edit.form_labels.credit"),
+          text: t("document_images.edit.form_labels.credit"),
           bold: true
         },
         name: "credit",
@@ -85,10 +85,10 @@
     <div class="govuk-grid-column-one-third">
       <%= render "components/contextual_guidance", {
         id: "credit-guidance",
-        title: t("document_lead_image.edit.form_labels.credit"),
+        title: t("document_images.edit.form_labels.credit"),
       } do %>
         <%= render "govuk_publishing_components/components/govspeak" do %>
-          <%= govspeak_to_html t("document_lead_image.edit.guidance.credit") %>
+          <%= govspeak_to_html t("document_images.edit.guidance.credit") %>
         <% end %>
       <% end %>
     </div>

--- a/app/views/document_images/index.html.erb
+++ b/app/views/document_images/index.html.erb
@@ -1,15 +1,15 @@
-<% content_for :title, t("document_lead_image.index.title", title: @document.title_or_fallback) %>
+<% content_for :title, t("document_images.index.title", title: @document.title_or_fallback) %>
 <% content_for :back_link, document_path(@document) %>
 
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
     <% upload_image_heading = capture do %>
       <h2 class="govuk-heading-m">
-        <%= t("document_lead_image.index.upload_image") %>
+        <%= t("document_images.index.upload_image") %>
       </h2>
     <% end %>
 
-    <%= form_tag(document_lead_image_path(@document), multipart: true) do %>
+    <%= form_tag(create_document_image_path(@document), multipart: true) do %>
       <%= hidden_field_tag :wizard, "lead_image" %>
 
       <%= render "govuk_publishing_components/components/file_upload", {
@@ -20,7 +20,7 @@
       } %>
 
       <%= render "govuk_publishing_components/components/govspeak" do %>
-        <%= govspeak_to_html t("document_lead_image.index.description") %>
+        <%= govspeak_to_html t("document_images.index.description") %>
       <% end %>
 
       <%= render "govuk_publishing_components/components/button", {
@@ -31,12 +31,12 @@
 
     <% if @document.images.any? %>
       <h2 class="govuk-heading-m">
-        <%= t("document_lead_image.index.existing_image") %>
+        <%= t("document_images.index.existing_image") %>
       </h2>
       <%= render "image_list" %>
     <% else %>
       <h2 class="govuk-heading-m">
-        <%= t("document_lead_image.index.no_existing_image") %>
+        <%= t("document_images.index.no_existing_image") %>
       </h2>
     <% end %>
   </div>

--- a/app/views/documents/show/_lead_image.html.erb
+++ b/app/views/documents/show/_lead_image.html.erb
@@ -14,20 +14,20 @@
   <%= render "components/summary", {
     title: {
       text: t("documents.show.lead_image.title"),
-      change_url: document_lead_image_path(@document)
+      change_url: document_images_path(@document)
     },
     block: lead_image_block
   } %>
 <% else %>
   <% no_lead_image_block = capture do %>
     <%= t("documents.show.lead_image.no_lead_image") %>
-    <%= link_to t("documents.show.lead_image.upload_image"), document_lead_image_path(@document), class: "govuk-link" %>
+    <%= link_to t("documents.show.lead_image.upload_image"), document_images_path(@document), class: "govuk-link" %>
   <% end %>
 
   <%= render "components/summary", {
     title: {
       text: t("documents.show.lead_image.title"),
-      change_url: document_lead_image_path(@document)
+      change_url: document_images_path(@document)
     },
     block: no_lead_image_block
   } %>

--- a/config/locales/en/document_images/crop.yml
+++ b/config/locales/en/document_images/crop.yml
@@ -1,5 +1,5 @@
 en:
-  document_lead_image:
+  document_images:
     crop:
       title: "Crop lead image for ‘%{title}’"
       description: "Select the part of the image to use. Images on GOV.UK are a fixed shape."

--- a/config/locales/en/document_images/edit.yml
+++ b/config/locales/en/document_images/edit.yml
@@ -1,5 +1,5 @@
 en:
-  document_lead_image:
+  document_images:
     edit:
       title: "Edit lead image for ‘%{title}’"
       form_labels:

--- a/config/locales/en/document_images/index.yml
+++ b/config/locales/en/document_images/index.yml
@@ -1,7 +1,7 @@
 en:
-  document_lead_image:
+  document_images:
     index:
-      title: "Lead image for ‘%{title}’"
+      title: "Images for ‘%{title}’"
       description: Images can be jpg, png, gif, or svg files. [Full guidance on images](https://www.gov.uk/guidance/how-to-publish-on-gov-uk/images-and-videos)
       upload_image: Upload an image
       existing_image: Choose existing image

--- a/config/locales/en/documents/history.yml
+++ b/config/locales/en/documents/history.yml
@@ -13,3 +13,4 @@ en:
         lead_image_updated: "Updated lead image"
         lead_image_removed: "Removed lead image"
         image_updated: "Updated image"
+        image_removed: "Removed image"

--- a/config/locales/en/documents/show.yml
+++ b/config/locales/en/documents/show.yml
@@ -44,6 +44,7 @@ en:
         unknown_user: Unknown
         last_edited_by: Last edited by
       flashes:
+        image_deleted: Image deleted
         draft_error:
           title: Something has gone wrong
           description: Something went wrong when saving your draft. Please try again or [raise a support request](https://support.publishing.service.gov.uk/technical_fault_report/new).

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -33,16 +33,18 @@ Rails.application.routes.draw do
   get "/documents/:id/retire" => "retire_document#retire", as: :retire_document
   get "/documents/:id/remove" => "remove_document#remove", as: :remove_document
 
-  get "/documents/:document_id/lead-image" => "document_lead_image#index", as: :document_lead_image
-  post "/documents/:document_id/lead-image" => "document_lead_image#create"
-  get "/documents/:document_id/lead-image/:image_id/crop" => "document_lead_image#crop", as: :crop_document_lead_image
-  patch "/documents/:document_id/lead-image/:image_id/crop" => "document_lead_image#update_crop"
-  get "/documents/:document_id/lead-image/:image_id/edit" => "document_lead_image#edit", as: :edit_document_lead_image
-  patch "/documents/:document_id/lead-image/:image_id/edit" => "document_lead_image#update", as: :update_document_lead_image
-  post "/documents/:document_id/lead-image/:image_id/choose" => "document_lead_image#choose_image", as: :choose_document_lead_image
-  patch "/documents/:document_id/lead-image/:image_id/choose" => "document_lead_image#update_and_choose_image", as: :update_and_choose_document_lead_image
-  delete "/documents/:document_id/lead-image" => "document_lead_image#destroy", as: :remove_document_lead_image
-  delete "/documents/:document_id/lead-image/:image_id" => "document_lead_image#delete_image", as: :delete_document_lead_image
+  get "/documents/:document_id/images" => "document_images#index", as: :document_images
+  post "/documents/:document_id/images" => "document_images#create", as: :create_document_image
+  get "/documents/:document_id/images/:image_id/crop" => "document_images#crop", as: :crop_document_image
+  patch "/documents/:document_id/images/:image_id/crop" => "document_images#update_crop"
+  get "/documents/:document_id/images/:image_id/edit" => "document_images#edit", as: :edit_document_image
+  patch "/documents/:document_id/images/:image_id/edit" => "document_images#update", as: :update_document_image
+  delete "/documents/:document_id/images/:image_id" => "document_images#destroy", as: :destroy_document_image
+
+  post "/documents/:document_id/lead-image/:image_id" => "document_lead_image#choose", as: :choose_document_lead_image
+  patch "/documents/:document_id/lead-image/:image_id" => "document_lead_image#update", as: :update_document_lead_image
+  delete "/documents/:document_id/lead-image/:image_id" => "document_lead_image#destroy", as: :destroy_document_lead_image
+  delete "/documents/:document_id/lead-image" => "document_lead_image#remove", as: :remove_document_lead_image
 
   get "/healthcheck", to: proc { [200, {}, %w[OK]] }
 

--- a/spec/features/editing_images/delete_image_after_publishing_spec.rb
+++ b/spec/features/editing_images/delete_image_after_publishing_spec.rb
@@ -3,8 +3,9 @@
 RSpec.feature "Delete an image after publishing" do
   scenario "Delete an image after publishing" do
     given_there_is_a_document_with_images
-    and_the_document_is_live_on_govuk
-    when_i_visit_the_lead_images_page
+    when_i_visit_the_document_images_page
+    then_i_can_choose_to_delete_the_images
+    when_i_publish_the_document_on_govuk
     then_i_cannot_delete_any_of_the_images
   end
 
@@ -12,17 +13,26 @@ RSpec.feature "Delete an image after publishing" do
     document_type_schema = build(:document_type_schema, lead_image: true)
     document = create(:document, document_type: document_type_schema.id)
     create(:image, :in_asset_manager, document: document)
+    lead_image = create(:image, :in_asset_manager, document: document)
+    document.update(lead_image_id: lead_image.id)
   end
 
-  def and_the_document_is_live_on_govuk
-    Document.last.update(has_live_version_on_govuk: true)
+  def then_i_can_choose_to_delete_the_images
+    expect(page).to have_content("Delete image")
+    expect(page).to have_content("Delete lead image")
   end
 
-  def when_i_visit_the_lead_images_page
-    visit document_lead_image_path(Document.last)
+  def when_i_publish_the_document_on_govuk
+    Document.last.update!(has_live_version_on_govuk: true)
+    visit document_images_path(Document.last)
+  end
+
+  def when_i_visit_the_document_images_page
+    visit document_images_path(Document.last)
   end
 
   def then_i_cannot_delete_any_of_the_images
     expect(page).to_not have_content("Delete image")
+    expect(page).to_not have_content("Delete lead image")
   end
 end

--- a/spec/features/editing_images/delete_image_asset_manager_down_spec.rb
+++ b/spec/features/editing_images/delete_image_asset_manager_down_spec.rb
@@ -3,41 +3,37 @@
 RSpec.feature "Delete an image with Asset Manager down" do
   scenario do
     given_there_is_a_document_with_images
-    when_i_visit_the_lead_images_page
+    when_i_visit_the_images_page
     and_asset_manager_is_down
-    and_i_delete_the_lead_image
-    then_i_see_the_document_has_no_lead_image
+    and_i_delete_the_non_lead_image
+    then_i_see_the_image_still_exists
     and_the_api_operation_failed
   end
 
   def given_there_is_a_document_with_images
     document_type_schema = build(:document_type_schema, lead_image: true)
     document = create(:document, document_type: document_type_schema.id)
-
     @image = create(:image, :in_asset_manager, document: document)
-    document.update(lead_image: @image)
   end
 
-  def when_i_visit_the_lead_images_page
-    visit document_lead_image_path(Document.last)
+  def when_i_visit_the_images_page
+    visit document_images_path(Document.last)
   end
 
   def and_asset_manager_is_down
     asset_manager_delete_asset_failure(@image.asset_manager_id)
   end
 
-  def and_i_delete_the_lead_image
+  def and_i_delete_the_non_lead_image
     stub_publishing_api_put_content(Document.last.content_id, {})
     click_on "Delete image"
   end
 
-  def then_i_see_the_document_has_no_lead_image
-    within("#image-#{@image.id}") do
-      expect(page).to_not have_content(I18n.t("document_lead_image.index.lead_image"))
-    end
+  def then_i_see_the_image_still_exists
+    expect(all("#image-#{@image.id}").count).to eq 1
   end
 
   def and_the_api_operation_failed
-    expect(page).to have_content(I18n.t("document_lead_image.index.flashes.api_error.title"))
+    expect(page).to have_content(I18n.t("document_images.index.flashes.api_error.title"))
   end
 end

--- a/spec/features/editing_images/delete_lead_image_asset_manager_down_spec.rb
+++ b/spec/features/editing_images/delete_lead_image_asset_manager_down_spec.rb
@@ -1,38 +1,46 @@
 # frozen_string_literal: true
 
-RSpec.feature "Delete an image with Publishing API down" do
+RSpec.feature "Delete an image with Asset Manager down" do
   scenario do
     given_there_is_a_document_with_images
     when_i_visit_the_images_page
-    and_the_publishing_api_is_down
-    and_i_delete_the_non_lead_image
+    and_asset_manager_is_down
+    and_i_delete_the_lead_image
     then_i_see_the_image_still_exists
-    and_the_preview_creation_failed
+    and_the_api_operation_failed
+    and_the_document_has_no_lead_image
   end
 
   def given_there_is_a_document_with_images
     document_type_schema = build(:document_type_schema, lead_image: true)
     document = create(:document, document_type: document_type_schema.id)
     @image = create(:image, :in_asset_manager, document: document)
+    document.update(lead_image: @image)
   end
 
   def when_i_visit_the_images_page
     visit document_images_path(Document.last)
   end
 
-  def and_the_publishing_api_is_down
-    publishing_api_isnt_available
+  def and_asset_manager_is_down
+    asset_manager_delete_asset_failure(@image.asset_manager_id)
   end
 
-  def and_i_delete_the_non_lead_image
-    click_on "Delete image"
+  def and_i_delete_the_lead_image
+    stub_publishing_api_put_content(Document.last.content_id, {})
+    click_on "Delete lead image"
   end
 
   def then_i_see_the_image_still_exists
     expect(all("#image-#{@image.id}").count).to eq 1
   end
 
-  def and_the_preview_creation_failed
+  def and_the_api_operation_failed
     expect(page).to have_content(I18n.t("document_images.index.flashes.api_error.title"))
+  end
+
+  def and_the_document_has_no_lead_image
+    click_on "Back"
+    expect(page).to have_content(I18n.t("documents.show.lead_image.no_lead_image"))
   end
 end

--- a/spec/features/editing_images/delete_lead_image_publishing_api_down_spec.rb
+++ b/spec/features/editing_images/delete_lead_image_publishing_api_down_spec.rb
@@ -1,47 +1,45 @@
 # frozen_string_literal: true
 
-RSpec.feature "Choose a lead image when the Publishing API is down" do
+RSpec.feature "Delete a lead image with Publishing API down" do
   scenario do
     given_there_is_a_document_with_images
-    when_i_visit_the_summary_page
-    and_i_visit_the_lead_images_page
+    when_i_visit_the_images_page
     and_the_publishing_api_is_down
-    and_i_choose_one_of_the_images
-    then_i_see_the_document_has_a_lead_image
+    and_i_delete_the_lead_image
+    then_i_see_the_image_still_exists
     and_the_preview_creation_failed
+    and_the_document_has_no_lead_image
   end
 
   def given_there_is_a_document_with_images
     document_type_schema = build(:document_type_schema, lead_image: true)
     document = create(:document, document_type: document_type_schema.id)
     @image = create(:image, :in_asset_manager, document: document)
+    document.update(lead_image: @image)
   end
 
-  def when_i_visit_the_summary_page
-    visit document_path(Document.last)
-  end
-
-  def and_i_visit_the_lead_images_page
-    click_on "Change Lead image"
+  def when_i_visit_the_images_page
+    visit document_images_path(Document.last)
   end
 
   def and_the_publishing_api_is_down
     publishing_api_isnt_available
   end
 
-  def and_i_choose_one_of_the_images
-    within("#image-#{@image.id}") do
-      click_on "Choose image"
-    end
+  def and_i_delete_the_lead_image
+    click_on "Delete lead image"
   end
 
-  def then_i_see_the_document_has_a_lead_image
-    within("#image-#{@image.id}") do
-      expect(page).to have_content(I18n.t("document_images.index.lead_image"))
-    end
+  def then_i_see_the_image_still_exists
+    expect(all("#image-#{@image.id}").count).to eq 1
   end
 
   def and_the_preview_creation_failed
     expect(page).to have_content(I18n.t("document_images.index.flashes.api_error.title"))
+  end
+
+  def and_the_document_has_no_lead_image
+    click_on "Back"
+    expect(page).to have_content(I18n.t("documents.show.lead_image.no_lead_image"))
   end
 end

--- a/spec/features/editing_images/delete_lead_image_spec.rb
+++ b/spec/features/editing_images/delete_lead_image_spec.rb
@@ -4,8 +4,8 @@ RSpec.feature "Delete an image" do
   scenario do
     given_there_is_a_document_with_images
     when_i_visit_the_images_page
-    and_i_delete_the_non_lead_image
-    then_i_see_the_image_is_gone
+    when_i_delete_the_lead_image
+    then_i_see_the_document_has_no_lead_image
     and_the_preview_creation_succeeded
   end
 
@@ -13,27 +13,24 @@ RSpec.feature "Delete an image" do
     document_type_schema = build(:document_type_schema, lead_image: true)
     document = create(:document, document_type: document_type_schema.id)
     @image = create(:image, :in_asset_manager, document: document)
+    document.update(lead_image: @image)
   end
 
   def when_i_visit_the_images_page
     visit document_images_path(Document.last)
   end
 
-  def and_i_delete_the_non_lead_image
+  def when_i_delete_the_lead_image
     @image_request = asset_manager_delete_asset(@image.asset_manager_id)
     @request = stub_publishing_api_put_content(Document.last.content_id, {})
-    click_on "Delete image"
+    click_on "Delete lead image"
   end
 
-  def then_i_see_the_image_is_gone
-    expect(all("#image-#{@image.id}").count).to be_zero
-    expect(page).to have_content(I18n.t("document_images.index.flashes.image_deleted"))
-
+  def then_i_see_the_document_has_no_lead_image
+    expect(page).to have_content(I18n.t("documents.show.lead_image.no_lead_image"))
+    expect(page).to have_content(I18n.t("documents.history.entry_types.lead_image_removed"))
     expect(@image_request).to have_been_requested
     expect(ActiveStorage::Blob.service.exist?(@image.blob.key)).to be_falsey
-
-    click_on "Back"
-    expect(page).to have_content(I18n.t("documents.history.entry_types.image_removed"))
   end
 
   def and_the_preview_creation_succeeded

--- a/spec/features/editing_images/edit_image_crop_asset_manager_down_spec.rb
+++ b/spec/features/editing_images/edit_image_crop_asset_manager_down_spec.rb
@@ -3,7 +3,7 @@
 RSpec.feature "Edit image crop when Asset Manager is down", js: true do
   scenario do
     given_there_is_a_document_with_images
-    when_i_visit_the_lead_images_page
+    when_i_visit_the_images_page
     and_asset_manager_is_down
     and_i_crop_the_image
     then_i_see_the_image_is_unchanged
@@ -16,9 +16,8 @@ RSpec.feature "Edit image crop when Asset Manager is down", js: true do
     create(:image, :in_asset_manager, document: document, crop_y: 167, fixture: "1000x1000.jpg")
   end
 
-  def when_i_visit_the_lead_images_page
-    visit document_path(Document.last)
-    click_on "Change Lead image"
+  def when_i_visit_the_images_page
+    visit document_images_path(Document.last)
   end
 
   def and_asset_manager_is_down
@@ -40,6 +39,6 @@ RSpec.feature "Edit image crop when Asset Manager is down", js: true do
   end
 
   def and_the_api_operation_failed
-    expect(page).to have_content(I18n.t("document_lead_image.index.flashes.api_error.title"))
+    expect(page).to have_content(I18n.t("document_images.index.flashes.api_error.title"))
   end
 end

--- a/spec/features/editing_images/edit_image_crop_publishing_api_down_spec.rb
+++ b/spec/features/editing_images/edit_image_crop_publishing_api_down_spec.rb
@@ -3,7 +3,7 @@
 RSpec.feature "Edit image crop when Publishing API is down", js: true do
   scenario do
     given_there_is_a_document_with_images
-    when_i_visit_the_lead_images_page
+    when_i_visit_the_images_page
     and_the_publishing_api_is_down
     and_i_crop_the_image
     then_i_see_the_image_is_updated
@@ -16,9 +16,8 @@ RSpec.feature "Edit image crop when Publishing API is down", js: true do
     create(:image, :in_asset_manager, document: document, crop_y: 167, fixture: "1000x1000.jpg")
   end
 
-  def when_i_visit_the_lead_images_page
-    visit document_path(Document.last)
-    click_on "Change Lead image"
+  def when_i_visit_the_images_page
+    visit document_images_path(Document.last)
   end
 
   def and_the_publishing_api_is_down
@@ -45,6 +44,6 @@ RSpec.feature "Edit image crop when Publishing API is down", js: true do
   end
 
   def and_the_preview_creation_failed
-    expect(page).to have_content(I18n.t("document_lead_image.index.flashes.api_error.title"))
+    expect(page).to have_content(I18n.t("document_images.index.flashes.api_error.title"))
   end
 end

--- a/spec/features/editing_images/edit_image_crop_spec.rb
+++ b/spec/features/editing_images/edit_image_crop_spec.rb
@@ -3,7 +3,7 @@
 RSpec.feature "Edit image crop", js: true do
   scenario do
     given_there_is_a_document_with_images
-    when_i_visit_the_lead_images_page
+    when_i_visit_the_images_page
     and_i_edit_the_image_crop
     then_the_image_crop_is_updated
     and_the_preview_creation_succeeded
@@ -23,9 +23,8 @@ RSpec.feature "Edit image crop", js: true do
            fixture: "1000x1000.jpg")
   end
 
-  def when_i_visit_the_lead_images_page
-    visit document_path(Document.last)
-    click_on "Change Lead image"
+  def when_i_visit_the_images_page
+    visit document_images_path(Document.last)
   end
 
   def and_i_edit_the_image_crop

--- a/spec/features/editing_images/edit_image_metadata_publishing_api_down_spec.rb
+++ b/spec/features/editing_images/edit_image_metadata_publishing_api_down_spec.rb
@@ -3,7 +3,7 @@
 RSpec.feature "Edit image metadata when the Publishing API is down" do
   scenario do
     given_there_is_a_document_with_images
-    when_i_visit_the_lead_images_page
+    when_i_visit_the_images_page
     and_the_publishing_api_is_down
     and_i_edit_the_image_metadata
     then_i_see_the_image_is_updated
@@ -16,9 +16,8 @@ RSpec.feature "Edit image metadata when the Publishing API is down" do
     create(:image, document: document)
   end
 
-  def when_i_visit_the_lead_images_page
-    visit document_path(Document.last)
-    click_on "Change Lead image"
+  def when_i_visit_the_images_page
+    visit document_images_path(Document.last)
   end
 
   def and_the_publishing_api_is_down
@@ -40,6 +39,6 @@ RSpec.feature "Edit image metadata when the Publishing API is down" do
   end
 
   def and_the_preview_creation_failed
-    expect(page).to have_content(I18n.t("document_lead_image.index.flashes.api_error.title"))
+    expect(page).to have_content(I18n.t("document_images.index.flashes.api_error.title"))
   end
 end

--- a/spec/features/editing_images/edit_image_metadata_spec.rb
+++ b/spec/features/editing_images/edit_image_metadata_spec.rb
@@ -3,7 +3,7 @@
 RSpec.feature "Edit image metadata" do
   scenario do
     given_there_is_a_document_with_images
-    when_i_visit_the_lead_images_page
+    when_i_visit_the_images_page
     and_i_edit_the_image_metadata
     then_i_see_the_image_is_updated
     and_the_preview_creation_succeeded
@@ -15,9 +15,8 @@ RSpec.feature "Edit image metadata" do
     create(:image, document: document)
   end
 
-  def when_i_visit_the_lead_images_page
-    visit document_path(Document.last)
-    click_on "Change Lead image"
+  def when_i_visit_the_images_page
+    visit document_images_path(Document.last)
   end
 
   def and_i_edit_the_image_metadata

--- a/spec/features/editing_images/remove_lead_image_publishing_api_down_spec.rb
+++ b/spec/features/editing_images/remove_lead_image_publishing_api_down_spec.rb
@@ -3,7 +3,7 @@
 RSpec.feature "Remove a lead image when Publishing API is down" do
   scenario do
     given_there_is_a_document_with_a_lead_image
-    when_i_visit_the_lead_images_page
+    when_i_visit_the_images_page
     and_the_publishing_api_is_down
     and_i_remove_the_lead_image
     then_i_see_the_document_has_no_lead_image
@@ -16,8 +16,8 @@ RSpec.feature "Remove a lead image when Publishing API is down" do
     document.update(lead_image: @image)
   end
 
-  def when_i_visit_the_lead_images_page
-    visit document_lead_image_path(Document.last)
+  def when_i_visit_the_images_page
+    visit document_images_path(Document.last)
   end
 
   def and_the_publishing_api_is_down
@@ -30,11 +30,11 @@ RSpec.feature "Remove a lead image when Publishing API is down" do
 
   def then_i_see_the_document_has_no_lead_image
     within("#image-#{@image.id}") do
-      expect(page).to_not have_content(I18n.t("document_lead_image.index.lead_image"))
+      expect(page).to_not have_content(I18n.t("document_images.index.lead_image"))
     end
   end
 
   def and_the_preview_creation_failed
-    expect(page).to have_content(I18n.t("document_lead_image.index.flashes.api_error.title"))
+    expect(page).to have_content(I18n.t("document_images.index.flashes.api_error.title"))
   end
 end

--- a/spec/features/editing_images/remove_lead_image_spec.rb
+++ b/spec/features/editing_images/remove_lead_image_spec.rb
@@ -3,7 +3,7 @@
 RSpec.feature "Remove a lead image" do
   scenario do
     given_there_is_a_document_with_a_lead_image
-    when_i_visit_the_lead_images_page
+    when_i_visit_the_images_page
     and_i_remove_the_lead_image
     then_the_document_has_no_lead_image
   end
@@ -15,8 +15,8 @@ RSpec.feature "Remove a lead image" do
     document.update(lead_image: @image)
   end
 
-  def when_i_visit_the_lead_images_page
-    visit document_lead_image_path(Document.last)
+  def when_i_visit_the_images_page
+    visit document_images_path(Document.last)
   end
 
   def and_i_remove_the_lead_image

--- a/spec/features/editing_images/upload_invalid_lead_image_spec.rb
+++ b/spec/features/editing_images/upload_invalid_lead_image_spec.rb
@@ -3,8 +3,7 @@
 RSpec.feature "Edit a lead image" do
   scenario do
     given_there_is_a_document
-    when_i_visit_the_summary_page
-    and_i_visit_the_lead_images_page
+    when_i_visit_the_images_page
     and_i_upload_an_invalid_image
     then_i_should_see_an_error
   end
@@ -14,11 +13,8 @@ RSpec.feature "Edit a lead image" do
     create(:document, document_type: document_type_schema.id)
   end
 
-  def when_i_visit_the_summary_page
+  def when_i_visit_the_images_page
     visit document_path(Document.last)
-  end
-
-  def and_i_visit_the_lead_images_page
     click_on "Change Lead image"
   end
 

--- a/spec/features/editing_images/upload_lead_image_asset_manager_down_spec.rb
+++ b/spec/features/editing_images/upload_lead_image_asset_manager_down_spec.rb
@@ -3,7 +3,7 @@
 RSpec.feature "Upload a lead image when Asset Manager is down" do
   scenario do
     given_there_is_a_document
-    when_i_visit_the_lead_images_page
+    when_i_visit_the_images_page
     and_asset_manager_is_down
     and_i_upload_an_image
     then_i_should_see_an_error
@@ -15,8 +15,8 @@ RSpec.feature "Upload a lead image when Asset Manager is down" do
     create(:document, document_type: document_type_schema.id)
   end
 
-  def when_i_visit_the_lead_images_page
-    visit document_lead_image_path(Document.last)
+  def when_i_visit_the_images_page
+    visit document_images_path(Document.last)
   end
 
   def and_asset_manager_is_down
@@ -29,10 +29,10 @@ RSpec.feature "Upload a lead image when Asset Manager is down" do
   end
 
   def then_i_should_see_an_error
-    expect(page).to have_content(I18n.t("document_lead_image.index.flashes.api_error.title"))
+    expect(page).to have_content(I18n.t("document_images.index.flashes.api_error.title"))
   end
 
   def and_the_image_does_not_exist
-    expect(page).to have_content(I18n.t("document_lead_image.index.no_existing_image"))
+    expect(page).to have_content(I18n.t("document_images.index.no_existing_image"))
   end
 end

--- a/spec/features/editing_images/upload_lead_image_publishing_api_down_spec.rb
+++ b/spec/features/editing_images/upload_lead_image_publishing_api_down_spec.rb
@@ -3,9 +3,7 @@
 RSpec.feature "Upload a lead image when Publishing API is down" do
   scenario do
     given_there_is_a_document
-    when_i_visit_the_summary_page
-    then_i_see_there_is_no_lead_image
-    when_i_visit_the_lead_images_page
+    when_i_visit_the_images_page
     and_i_upload_a_new_image
     and_i_crop_the_image
     and_the_publishing_api_is_down
@@ -19,16 +17,8 @@ RSpec.feature "Upload a lead image when Publishing API is down" do
     create(:document, document_type: document_type_schema.id)
   end
 
-  def when_i_visit_the_summary_page
-    visit document_path(Document.last)
-  end
-
-  def then_i_see_there_is_no_lead_image
-    expect(page).to have_content(I18n.t("documents.show.lead_image.no_lead_image"))
-  end
-
-  def when_i_visit_the_lead_images_page
-    click_on "Change Lead image"
+  def when_i_visit_the_images_page
+    visit document_images_path(Document.last)
   end
 
   def and_i_upload_a_new_image
@@ -56,11 +46,11 @@ RSpec.feature "Upload a lead image when Publishing API is down" do
 
   def then_i_see_the_new_lead_image
     within("#image-#{Image.last.id}") do
-      expect(page).to have_content(I18n.t("document_lead_image.index.lead_image"))
+      expect(page).to have_content(I18n.t("document_images.index.lead_image"))
     end
   end
 
   def and_the_preview_creation_failed
-    expect(page).to have_content(I18n.t("document_lead_image.index.flashes.api_error.title"))
+    expect(page).to have_content(I18n.t("document_images.index.flashes.api_error.title"))
   end
 end

--- a/spec/features/editing_images/upload_lead_image_spec.rb
+++ b/spec/features/editing_images/upload_lead_image_spec.rb
@@ -3,8 +3,7 @@
 RSpec.feature "Upload a lead image" do
   scenario do
     given_there_is_a_document
-    when_i_visit_the_summary_page
-    and_i_visit_the_lead_images_page
+    when_i_visit_the_images_page
     and_i_upload_a_new_image
     and_i_crop_the_image
     and_i_fill_in_the_metadata
@@ -17,12 +16,8 @@ RSpec.feature "Upload a lead image" do
     create(:document, document_type: document_type_schema.id)
   end
 
-  def when_i_visit_the_summary_page
-    visit document_path(Document.last)
-  end
-
-  def and_i_visit_the_lead_images_page
-    click_on "Change Lead image"
+  def when_i_visit_the_images_page
+    visit document_images_path(Document.last)
   end
 
   def and_i_upload_a_new_image

--- a/spec/features/editing_images/upload_no_file_as_lead_image_spec.rb
+++ b/spec/features/editing_images/upload_no_file_as_lead_image_spec.rb
@@ -3,7 +3,7 @@
 RSpec.feature "Upload no file as a lead image" do
   scenario do
     given_there_is_a_document
-    when_i_visit_the_lead_images_page
+    when_i_visit_the_images_page
     when_i_upload_no_file
     then_i_should_see_an_error
   end
@@ -13,8 +13,8 @@ RSpec.feature "Upload no file as a lead image" do
     create(:document, document_type: document_type_schema.id)
   end
 
-  def when_i_visit_the_lead_images_page
-    visit document_lead_image_path(Document.last)
+  def when_i_visit_the_images_page
+    visit document_images_path(Document.last)
   end
 
   def when_i_upload_no_file
@@ -22,6 +22,6 @@ RSpec.feature "Upload no file as a lead image" do
   end
 
   def then_i_should_see_an_error
-    expect(page).to have_content(I18n.t("document_lead_image.index.no_file_selected"))
+    expect(page).to have_content(I18n.t("document_images.index.no_file_selected"))
   end
 end


### PR DESCRIPTION
https://trello.com/c/AJnfoZhI/271-provide-functionality-to-delete-an-uploaded-lead-image

The document (lead) images controller was getting large and complicated,
with a mixture of image- and lead-image-specific operations. Combing the
endpoints has lead to a few problems:

  * the routes don't make sense e.g. delete_document_lead_image_path has
nothing to do with the lead image
  * the redirect for for deleting lead images is inconsistent with the remove
workflow

Splitting the endpoints into two controllers - one for image operations
and another for lead image operations - should make it clearer to reason
about what each endpoint should do.

This split also makes the image pages more generic, moving towards an
'image management' workflow rather than something specific to lead
images.