### PR TITLE
Make sure we do a 404 when we can't find a doc

### DIFF
--- a/app/models/document.rb
+++ b/app/models/document.rb
@@ -45,7 +45,7 @@ class Document < ApplicationRecord
 
   def self.find_by_param(content_id_and_locale)
     content_id, locale = content_id_and_locale.split(":")
-    Document.find_by(content_id: content_id, locale: locale)
+    Document.find_by!(content_id: content_id, locale: locale)
   end
 
   def user_facing_state


### PR DESCRIPTION
This should fix this kind of Sentry error...

https://sentry.io/govuk/app-content-publisher/issues/702967549/?environment=integration-blue-aws