### PR TITLE
Add missing page title for published screen

### DIFF
--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -16,7 +16,7 @@
 
 <%= render 'govuk_publishing_components/components/layout_for_admin',
   environment: GovukPublishingComponents::AppHelpers::Environment.current_acceptance_environment,
-  browser_title: yield(:title) do %>
+  browser_title: yield(:browser_title).presence || yield(:title) do %>
 
   <%= render "govuk_publishing_components/components/skip_link" %>
 

--- a/app/views/publish_document/published.html.erb
+++ b/app/views/publish_document/published.html.erb
@@ -1,4 +1,5 @@
 <% content_for :back_link, document_path(@document) %>
+<% content_for :browser_title, t("publish_document.published.title") %>
 
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">

--- a/config/locales/en/publish_document/published.yml
+++ b/config/locales/en/publish_document/published.yml
@@ -1,6 +1,7 @@
 en:
   publish_document:
     published:
+      title: Content has been published
       reviewed:
         title: Content has been published
         body: |


### PR DESCRIPTION
Content taken from the prototype here:

https://content-publisher-prototype.cloudapps.digital/content-summary-published