### PR TITLE
Remove redundant file attribute in asset publish

### DIFF
--- a/app/services/asset_manager_service.rb
+++ b/app/services/asset_manager_service.rb
@@ -10,7 +10,7 @@ class AssetManagerService
   end
 
   def publish(asset)
-    asset_manager.update_asset(asset.asset_manager_id, file: asset, draft: false)
+    asset_manager.update_asset(asset.asset_manager_id, draft: false)
   end
 
   def delete(asset)


### PR DESCRIPTION
https://trello.com/c/WQYgUVRO/274-look-into-sentry-errors-related-to-image-uploads
https://sentry.io/govuk/app-content-publisher/issues/682768231/?query=is:unresolved

This attribute isn't required for publishing and seems to be causing the
exceptions which say the 'file is blank'. I'm struggling to reproduce this 
locally, which makes me think it's something to do with the dev 
environment - either way this is still a valid change to try.