### PR TITLE
Log exceptions so we can fix them ;-)

### DIFF
--- a/app/controllers/document_lead_image_controller.rb
+++ b/app/controllers/document_lead_image_controller.rb
@@ -26,7 +26,8 @@ class DocumentLeadImageController < ApplicationController
     begin
       image = image_uploader.upload(document)
       image.asset_manager_file_url = upload_image_to_asset_manager(image)
-    rescue GdsApi::BaseError
+    rescue GdsApi::BaseError => e
+      Rails.logger.error(e)
       redirect_to document_lead_image_path, alert_with_description: t("document_lead_image.index.flashes.api_error")
       return
     end
@@ -60,7 +61,8 @@ class DocumentLeadImageController < ApplicationController
         type: "image_updated",
         attributes_to_update: {},
       )
-    rescue GdsApi::BaseError
+    rescue GdsApi::BaseError => e
+      Rails.logger.error(e)
       redirect_to document_lead_image_path(document), alert_with_description: t("document_lead_image.index.flashes.api_error")
       return
     end
@@ -90,7 +92,8 @@ class DocumentLeadImageController < ApplicationController
         type: "image_updated",
         attributes_to_update: {},
       )
-    rescue GdsApi::BaseError
+    rescue GdsApi::BaseError => e
+      Rails.logger.error(e)
       redirect_to document_lead_image_path(document), alert_with_description: t("document_lead_image.index.flashes.api_error")
       return
     end
@@ -110,7 +113,8 @@ class DocumentLeadImageController < ApplicationController
         type: "lead_image_updated",
         attributes_to_update: { lead_image_id: params[:image_id] },
       )
-    rescue GdsApi::BaseError
+    rescue GdsApi::BaseError => e
+      Rails.logger.error(e)
       redirect_to document_lead_image_path(document), alert_with_description: t("document_lead_image.index.flashes.api_error")
       return
     end
@@ -128,7 +132,8 @@ class DocumentLeadImageController < ApplicationController
         type: "lead_image_updated",
         attributes_to_update: { lead_image_id: params[:image_id] },
       )
-    rescue GdsApi::BaseError
+    rescue GdsApi::BaseError => e
+      Rails.logger.error(e)
       redirect_to document_lead_image_path(document), alert_with_description: t("document_lead_image.index.flashes.api_error")
       return
     end
@@ -152,7 +157,8 @@ class DocumentLeadImageController < ApplicationController
 
       AssetManagerService.new.delete(image)
       image.destroy
-    rescue GdsApi::BaseError
+    rescue GdsApi::BaseError => e
+      Rails.logger.error(e)
       redirect_to document_lead_image_path(document), alert_with_description: t("document_lead_image.index.flashes.api_error")
       return
     end
@@ -171,7 +177,8 @@ class DocumentLeadImageController < ApplicationController
         type: "lead_image_removed",
         attributes_to_update: { lead_image_id: nil },
       )
-    rescue GdsApi::BaseError
+    rescue GdsApi::BaseError => e
+      Rails.logger.error(e)
       redirect_to document_lead_image_path(document), alert_with_description: t("document_lead_image.index.flashes.api_error")
       return
     end

--- a/app/controllers/document_tags_controller.rb
+++ b/app/controllers/document_tags_controller.rb
@@ -2,7 +2,7 @@
 
 class DocumentTagsController < ApplicationController
   rescue_from GdsApi::BaseError do |e|
-    GovukError.notify(e)
+    Rails.logger.error(e)
     render "#{action_name}_api_down", status: :service_unavailable
   end
 
@@ -21,7 +21,8 @@ class DocumentTagsController < ApplicationController
     )
 
     redirect_to document
-  rescue GdsApi::BaseError
+  rescue GdsApi::BaseError => e
+    Rails.logger.error(e)
     redirect_to document, alert_with_description: t("documents.show.flashes.draft_error")
   end
 

--- a/app/controllers/documents_controller.rb
+++ b/app/controllers/documents_controller.rb
@@ -2,7 +2,7 @@
 
 class DocumentsController < ApplicationController
   rescue_from GdsApi::BaseError do |e|
-    GovukError.notify(e)
+    Rails.logger.error(e)
     render "#{action_name}_api_down", status: :service_unavailable
   end
 
@@ -33,7 +33,8 @@ class DocumentsController < ApplicationController
     DocumentPublishingService.new.discard_draft(document)
     document.destroy!
     redirect_to documents_path
-  rescue GdsApi::BaseError
+  rescue GdsApi::BaseError => e
+    Rails.logger.error(e)
     redirect_to document, alert_with_description: t("documents.show.flashes.delete_draft_error")
   end
 
@@ -48,7 +49,8 @@ class DocumentsController < ApplicationController
     )
 
     redirect_to document
-  rescue GdsApi::BaseError
+  rescue GdsApi::BaseError => e
+    Rails.logger.error(e)
     redirect_to document, alert_with_description: t("documents.show.flashes.draft_error")
   end
 
@@ -56,7 +58,8 @@ class DocumentsController < ApplicationController
     document = Document.find_by_param(params[:id])
     DocumentPublishingService.new.publish_draft(document)
     redirect_to document
-  rescue GdsApi::BaseError
+  rescue GdsApi::BaseError => e
+    Rails.logger.error(e)
     redirect_to document, alert_with_description: t("documents.show.flashes.draft_error")
   end
 
@@ -64,8 +67,6 @@ class DocumentsController < ApplicationController
     document = Document.find_by_param(params[:id])
     base_path = PathGeneratorService.new.path(document, params[:title])
     render plain: base_path
-  rescue PathGeneratorService::ErrorGeneratingPath
-    render status: :conflict
   end
 
   def debug

--- a/app/controllers/publish_document_controller.rb
+++ b/app/controllers/publish_document_controller.rb
@@ -22,7 +22,8 @@ class PublishDocumentController < ApplicationController
     end
 
     redirect_to document_published_path(document)
-  rescue GdsApi::BaseError
+  rescue GdsApi::BaseError => e
+    Rails.logger.error(e)
     redirect_to document, alert_with_description: t("documents.show.flashes.publish_error")
   end
 


### PR DESCRIPTION
This ensures we call 'Rails.logger.error(e)' whenever we rescue an
exception, so that we have sufficient information to fix the error. Most
of the errors are 'Intermittent retryable' and not right for Sentry.

https://github.com/alphagov/govuk-rfcs/blob/master/rfc-087-dealing-with-errors.md#intermittent-retryable-errors

This also removes an untested rescue for when we cannot generate a
unique path for a document, as this behaviour was not consistent for the
no-javascript path and it feels like we should solve this problem first.

This also removes Sentry reporting for exceptions originating from the
views, as we anticipate these are 'Intermittent errors with user
impact', such as timeouts, which don't require immediate attention.