### PR TITLE
Move internal metadata link to footer

### DIFF
--- a/app/views/documents/show.html.erb
+++ b/app/views/documents/show.html.erb
@@ -17,5 +17,3 @@
     }
   ]
 } %>
-
-<%= link_to "Internal metadata (not shown to publishers)", debug_document_path(@document) %>

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -77,6 +77,17 @@
     </main>
   </div>
 
+  <%
+    internal_metadata = {}
+
+    if @document && debug_document_path(@document)
+      internal_metadata = {
+        href: debug_document_path(@document),
+        text: "Internal metadata (not shown to publishers)"
+      }
+    end
+  %>
+
   <%= render "govuk_publishing_components/components/layout_footer", {
     navigation: [
       {
@@ -90,7 +101,7 @@
             href: "https://www.gov.uk/government/content-publishing",
             text: "How to write, publish, and improve content"
           }
-        ]
+        ].push(internal_metadata)
       }
     ]
   } %>


### PR DESCRIPTION
Code looks a bit overdone, let me know if there's a cleaner way.

### Before
<img width="1439" alt="screen shot 2018-10-08 at 17 49 28" src="https://user-images.githubusercontent.com/788096/46622442-88d83f00-cb22-11e8-8a78-7bcbe8d166f0.png">


### After
<img width="1439" alt="screen shot 2018-10-08 at 17 47 28" src="https://user-images.githubusercontent.com/788096/46622444-8bd32f80-cb22-11e8-8f0b-339225bb2783.png">
