### PR TITLE
Remove no image text when no images

### DIFF
--- a/app/views/document_images/index.html.erb
+++ b/app/views/document_images/index.html.erb
@@ -34,10 +34,6 @@
         <%= t("document_images.index.existing_image") %>
       </h2>
       <%= render "image_list" %>
-    <% else %>
-      <h2 class="govuk-heading-m">
-        <%= t("document_images.index.no_existing_image") %>
-      </h2>
     <% end %>
   </div>
 </div>

--- a/config/locales/en/document_images/index.yml
+++ b/config/locales/en/document_images/index.yml
@@ -5,7 +5,6 @@ en:
       description: Images can be jpg, png, gif, or svg files. [Full guidance on images](https://www.gov.uk/guidance/how-to-publish-on-gov-uk/images-and-videos)
       upload_image: Upload an image
       existing_image: Choose existing image
-      no_existing_image: No images available
       alt_text: Alt text
       caption: Image caption
       credit: Image credit

--- a/spec/features/editing_images/upload_lead_image_asset_manager_down_spec.rb
+++ b/spec/features/editing_images/upload_lead_image_asset_manager_down_spec.rb
@@ -33,6 +33,6 @@ RSpec.feature "Upload a lead image when Asset Manager is down" do
   end
 
   def and_the_image_does_not_exist
-    expect(page).to have_content(I18n.t("document_images.index.no_existing_image"))
+    expect(page).to_not have_content(I18n.t("document_images.index.existing_image"))
   end
 end


### PR DESCRIPTION
Remove the text of "No images uploaded" when we have no images

This applies to documents which have no images on the upload images
page.

## Before
<img width="722" alt="screen shot 2018-10-09 at 16 36 53" src="https://user-images.githubusercontent.com/24479188/46725273-be407200-cc73-11e8-8413-40df650b9eff.png">

## After 
<img width="719" alt="screen shot 2018-10-09 at 16 37 26" src="https://user-images.githubusercontent.com/24479188/46725245-b1238300-cc73-11e8-895d-4f5f7a9ba2b6.png">

Trello: 
https://trello.com/c/IMdJcbEs/303-remove-the-text-of-no-images-uploaded-when-we-have-no-images