### PR TITLE
Adds a bottom margin to the success-alert message

### DIFF
--- a/app/views/documents/show/_submitted_for_review.html.erb
+++ b/app/views/documents/show/_submitted_for_review.html.erb
@@ -7,4 +7,5 @@
 
 <%= render "govuk_publishing_components/components/success_alert",
   message: t("documents.show.flashes.submitted_for_review.title"),
-  description: copy_to_clipboard %>
+  description: copy_to_clipboard,
+  margin_bottom: true %>


### PR DESCRIPTION
Previously, there was no bottom margin leading to the alert box being
squashed against the content below.

Depends on this pr: https://github.com/alphagov/govuk_publishing_components/pull/573

## Before
<img width="690" alt="screen shot 2018-10-10 at 15 06 47" src="https://user-images.githubusercontent.com/24479188/46745935-ef399a80-cca5-11e8-9b8f-96990a3acf0f.png">

## After 
<img width="661" alt="screen shot 2018-10-10 at 15 06 17" src="https://user-images.githubusercontent.com/24479188/46745993-011b3d80-cca6-11e8-91a2-e3c10d7665e6.png">

Trello:
https://trello.com/c/DYwko3da/313-no-margin-below-the-flash-banner-and-the-content-block-below
