### PR TITLE
Handle no-javascript/non-croppable experience for lead images

### DIFF
--- a/app/assets/stylesheets/components/_image_cropper.scss
+++ b/app/assets/stylesheets/components/_image_cropper.scss
@@ -3,6 +3,7 @@
 $cropper-point-size: 10px;
 
 .app-c-image-cropper {
+  @include govuk-font($size: 19);
   @include govuk-responsive-margin(6, "bottom");
 
   .cropper-view-box {
@@ -61,14 +62,34 @@ $cropper-point-size: 10px;
     top: -$cropper-point-size / 2;
     left: -$cropper-point-size / 2;
   }
-
 }
 
 .app-c-image-cropper__image {
-  display: block;
+  display: none;
   max-width: 100%;
   max-height: 640px;
   margin-right: auto;
   margin-left: auto;
 }
 
+.app-c-image-cropper__description {
+  display: none;
+  margin-top: 0;
+}
+
+.app-c-image-cropper__no-js-description {
+  margin-top: 0;
+}
+
+.js-enabled {
+  .app-c-image-cropper__no-js-description,
+  .app-c-image-cropper__no-js-image {
+    display: none;
+  }
+
+  .app-c-image-cropper__description,
+  .app-c-image-cropper__image {
+    display: block;
+  }
+
+}

--- a/app/assets/stylesheets/utilities/_display.scss
+++ b/app/assets/stylesheets/utilities/_display.scss
@@ -5,3 +5,17 @@
 .app-inline-block {
   display: inline-block;
 }
+
+.app-js-only {
+  display: none;
+}
+
+.js-enabled {
+  .app-no-js {
+    display: none;
+  }
+
+  .app-js-only {
+    display: block;
+  }
+}

--- a/app/models/image.rb
+++ b/app/models/image.rb
@@ -39,4 +39,8 @@ class Image < ApplicationRecord
     processed_image = thumbnail.processed
     processed_image.service.download(processed_image.key)
   end
+
+  def at_exact_dimensions?
+    width == WIDTH && height == HEIGHT
+  end
 end

--- a/app/views/components/_image_cropper.html.erb
+++ b/app/views/components/_image_cropper.html.erb
@@ -2,11 +2,28 @@
   id ||= "image-meta-#{SecureRandom.hex(4)}"
   alt_text ||= nil
 %>
+
 <div class="app-c-image-cropper" id="<%= id %>" data-module="image-cropper">
-  <%= tag.img class: "app-c-image-cropper__image",
-    src: src,
+
+  <%= tag.p class: "app-c-image-cropper__no-js-description" do %>
+    <%= no_js_description %>
+  <% end %>
+
+  <%= tag.img class: "app-c-image-cropper__no-js-image",
+    src: no_js_src,
     alt: alt_text
   %>
+
+  <%= tag.p class: "app-c-image-cropper__description" do %>
+    <%= description %>
+  <% end %>
+
+  <div class="app-c-image-cropper__container">
+    <%= tag.img class: "app-c-image-cropper__image",
+      src: src,
+      alt: alt_text
+    %>
+  </div>
 
   <%= hidden_field_tag 'crop_x', crop_x, class: "js-image-cropper-x" %>
   <%= hidden_field_tag 'crop_y', crop_y, class: "js-image-cropper-y" %>

--- a/app/views/components/_image_cropper.html.erb
+++ b/app/views/components/_image_cropper.html.erb
@@ -1,9 +1,10 @@
 <%
   id ||= "image-meta-#{SecureRandom.hex(4)}"
   alt_text ||= nil
+  exact_dimensions ||= false
 %>
 
-<div class="app-c-image-cropper" id="<%= id %>" data-module="image-cropper">
+<div class="app-c-image-cropper" id="<%= id %>" <%= "data-module=image-cropper" unless exact_dimensions %>>
 
   <%= tag.p class: "app-c-image-cropper__no-js-description" do %>
     <%= no_js_description %>
@@ -14,8 +15,14 @@
     alt: alt_text
   %>
 
-  <%= tag.p class: "app-c-image-cropper__description" do %>
-    <%= description %>
+  <% if exact_dimensions %>
+    <%= tag.p class: "app-c-image-cropper__description" do %>
+      <%= exact_dimensions_description %>
+    <% end %>
+  <% else %>
+    <%= tag.p class: "app-c-image-cropper__description" do %>
+      <%= description %>
+    <% end %>
   <% end %>
 
   <div class="app-c-image-cropper__container">

--- a/app/views/components/_image_cropper.html.erb
+++ b/app/views/components/_image_cropper.html.erb
@@ -7,7 +7,7 @@
 <div class="app-c-image-cropper" id="<%= id %>" <%= "data-module=image-cropper" unless exact_dimensions %>>
 
   <%= tag.p class: "app-c-image-cropper__no-js-description" do %>
-    <%= no_js_description %>
+    The image you selected has been automatically resized to fit on GOV.UK. If you have JavaScript enabled in your browser you will be able to manually crop and resize the image.
   <% end %>
 
   <%= tag.img class: "app-c-image-cropper__no-js-image",
@@ -17,11 +17,11 @@
 
   <% if exact_dimensions %>
     <%= tag.p class: "app-c-image-cropper__description" do %>
-      <%= exact_dimensions_description %>
+      The image you selected has exactly the required dimensions so it can not be cropped or resized.
     <% end %>
   <% else %>
     <%= tag.p class: "app-c-image-cropper__description" do %>
-      <%= description %>
+      Select the part of the image to use. Images on GOV.UK are a fixed shape.
     <% end %>
   <% end %>
 

--- a/app/views/document_images/crop.html.erb
+++ b/app/views/document_images/crop.html.erb
@@ -16,8 +16,18 @@
     crop_height: @image.crop_height,
   } %>
 
-  <%= render "govuk_publishing_components/components/button", {
-    text: (@image.at_exact_dimensions?) ? "Continue" : "Crop image",
-    margin_bottom: true
-  } %>
+  <div class="app-js-only">
+    <%= render "govuk_publishing_components/components/button", {
+      text: (@image.at_exact_dimensions?) ? "Continue" : "Crop image",
+      margin_bottom: true
+    } %>
+  </div>
+
+  <div class="app-no-js">
+    <%= render "govuk_publishing_components/components/button", {
+      text: "Continue",
+      margin_bottom: true
+    } %>
+  </div>
+
 <% end %>

--- a/app/views/document_images/crop.html.erb
+++ b/app/views/document_images/crop.html.erb
@@ -1,16 +1,15 @@
 <% content_for :back_link, document_images_path(@document) %>
 <% content_for :title, t("document_images.crop.title", title: @document.title_or_fallback) %>
 
-<p class="govuk-body">
-  <%= t("document_images.crop.description") %>
-</p>
-
 <%= form_tag(crop_document_image_path(@document, @image), method: :patch) do %>
   <%= hidden_field_tag :wizard, params[:wizard] %>
 
   <%= render "/components/image_cropper", {
     id: "crop-image",
+    description: t("document_images.crop.description"),
+    no_js_description: t("document_images.crop.no_js_description"),
     src: url_for(@image.blob),
+    no_js_src: url_for(@image.crop_variant('960x640')),
     alt_text: @image.alt_text,
     crop_x: @image.crop_x,
     crop_y: @image.crop_y,

--- a/app/views/document_images/crop.html.erb
+++ b/app/views/document_images/crop.html.erb
@@ -7,18 +7,20 @@
   <%= render "/components/image_cropper", {
     id: "crop-image",
     description: t("document_images.crop.description"),
-    no_js_description: t("document_images.crop.no_js_description"),
     src: url_for(@image.blob),
+    no_js_description: t("document_images.crop.no_js_description"),
     no_js_src: url_for(@image.crop_variant('960x640')),
+    exact_dimensions: @image.at_exact_dimensions?,
+    exact_dimensions_description: t("document_images.crop.exact_dimensions_description"),
     alt_text: @image.alt_text,
     crop_x: @image.crop_x,
     crop_y: @image.crop_y,
     crop_width: @image.crop_width,
-    crop_height: @image.crop_height
+    crop_height: @image.crop_height,
   } %>
 
   <%= render "govuk_publishing_components/components/button", {
-    text: "Crop image",
+    text: (@image.at_exact_dimensions?) ? "Continue" : "Crop image",
     margin_bottom: true
   } %>
 <% end %>

--- a/app/views/document_images/crop.html.erb
+++ b/app/views/document_images/crop.html.erb
@@ -6,12 +6,9 @@
 
   <%= render "/components/image_cropper", {
     id: "crop-image",
-    description: t("document_images.crop.description"),
     src: url_for(@image.blob),
-    no_js_description: t("document_images.crop.no_js_description"),
     no_js_src: url_for(@image.crop_variant('960x640')),
     exact_dimensions: @image.at_exact_dimensions?,
-    exact_dimensions_description: t("document_images.crop.exact_dimensions_description"),
     alt_text: @image.alt_text,
     crop_x: @image.crop_x,
     crop_y: @image.crop_y,

--- a/config/locales/en/document_images/crop.yml
+++ b/config/locales/en/document_images/crop.yml
@@ -2,6 +2,3 @@ en:
   document_images:
     crop:
       title: "Crop lead image for ‘%{title}’"
-      description: "Select the part of the image to use. Images on GOV.UK are a fixed shape."
-      no_js_description: "The image you selected has been automatically resized to fit on GOV.UK. If you have JavaScript enabled in your browser you will be able to manually crop and resize the image."
-      exact_dimensions_description: "The image you selected has exactly the required dimensions so it can not be cropped or resized."

--- a/config/locales/en/document_images/crop.yml
+++ b/config/locales/en/document_images/crop.yml
@@ -3,3 +3,4 @@ en:
     crop:
       title: "Crop lead image for ‘%{title}’"
       description: "Select the part of the image to use. Images on GOV.UK are a fixed shape."
+      no_js_description: "The image you selected has been automatically resized to fit on GOV.UK. If you have JavaScript enabled in your browser you will be able to manually crop and resize the image."

--- a/config/locales/en/document_images/crop.yml
+++ b/config/locales/en/document_images/crop.yml
@@ -4,3 +4,4 @@ en:
       title: "Crop lead image for ‘%{title}’"
       description: "Select the part of the image to use. Images on GOV.UK are a fixed shape."
       no_js_description: "The image you selected has been automatically resized to fit on GOV.UK. If you have JavaScript enabled in your browser you will be able to manually crop and resize the image."
+      exact_dimensions_description: "The image you selected has exactly the required dimensions so it can not be cropped or resized."


### PR DESCRIPTION
## Common experience
![screen shot 2018-10-11 at 11 20 27](https://user-images.githubusercontent.com/788096/46797814-1c3e8980-cd48-11e8-80e4-e027cffb80b5.png)

## No-javascript experience
The image is automatically resized and cropped center-based

![screen shot 2018-10-11 at 11 20 04](https://user-images.githubusercontent.com/788096/46797829-23fe2e00-cd48-11e8-8e5b-6e8d07fd1743.png)

## Fixed dimensions experience
The image is displayed as is without the cropping functionality

![screen shot 2018-10-11 at 11 25 19](https://user-images.githubusercontent.com/788096/46797944-6fb0d780-cd48-11e8-92ad-12d2c8ac61e8.png)

[Trello card](https://trello.com/c/Mx0dBCHb)