### PR TITLE
Make upload_lead_image_asset_manager_down_spec more robust

### DIFF
--- a/spec/features/editing_images/upload_lead_image_asset_manager_down_spec.rb
+++ b/spec/features/editing_images/upload_lead_image_asset_manager_down_spec.rb
@@ -33,6 +33,7 @@ RSpec.feature "Upload a lead image when Asset Manager is down" do
   end
 
   def and_the_image_does_not_exist
-    expect(page).to_not have_content(I18n.t("document_images.index.existing_image"))
+    expect(page).to_not have_css("img[class='app-c-image-meta__image']")
+    expect(Image.count).to eq(0)
   end
 end


### PR DESCRIPTION
This test now checks that an image is not displayed on the page via the
css and that an image has not been created in the db. Previously, this
test only looked for some text that may or may not change in the future.