### PR TITLE
Maintain 'in review' state when the doc is edited

### DIFF
--- a/app/services/document_update_service.rb
+++ b/app/services/document_update_service.rb
@@ -7,9 +7,8 @@ class DocumentUpdateService
     end
 
     document.publication_state = "changes_not_sent_to_draft"
-    document.review_state = "unreviewed"
     document.last_editor = user if document_edited?(type)
-
+    document.review_state = "unreviewed" unless in_review?(document)
     document.assign_attributes(attributes_to_update)
 
     Document.transaction do
@@ -22,5 +21,9 @@ class DocumentUpdateService
 
   def self.document_edited?(type)
     %w(updated_content updated_tags).include?(type)
+  end
+
+  def self.in_review?(document)
+    document.review_state == "submitted_for_review"
   end
 end

--- a/spec/features/workflow/submit_for_2i_spec.rb
+++ b/spec/features/workflow/submit_for_2i_spec.rb
@@ -5,7 +5,9 @@ RSpec.feature "2i" do
     given_there_is_a_document_in_draft
     when_i_visit_the_document
     and_i_click_submit_for_2i
-    then_i_see_that_the_content_has_been_submitted
+    then_i_see_the_document_is_submitted
+    when_i_edit_the_document
+    then_i_see_the_document_is_in_review
   end
 
   def given_there_is_a_document_in_draft
@@ -20,7 +22,19 @@ RSpec.feature "2i" do
     click_on "Submit for 2i review"
   end
 
-  def then_i_see_that_the_content_has_been_submitted
-    expect(page).to have_content "Content has been submitted for 2i review"
+  def then_i_see_the_document_is_submitted
+    expect(page).to have_content I18n.t("documents.show.flashes.submitted_for_review.title")
+    expect(page).to have_content I18n.t("user_facing_states.submitted_for_review.name")
+  end
+
+  def then_i_see_the_document_is_in_review
+    expect(page).to have_content I18n.t("user_facing_states.submitted_for_review.name")
+  end
+
+  def when_i_edit_the_document
+    stub_any_publishing_api_put_content
+    click_on "Change Content"
+    fill_in "document[title]", with: "a new title"
+    click_on "Save"
   end
 end


### PR DESCRIPTION
https://trello.com/c/7EQhBAvi/323-editing-content-shouldnt-reset-the-user-facing-state-back-to-draft

When a user edits a document that is submitted for review, we should
preserve this state and not set the review state back to 'unreviewed'.
Otherwise, the user has to re-submit the document every time they make a
change.