### PR TITLE
Fix back link for lead image wizard edit page

### DIFF
--- a/app/views/document_images/edit.html.erb
+++ b/app/views/document_images/edit.html.erb
@@ -1,5 +1,10 @@
 <% content_for :title, t("document_images.edit.title", title: @document.title_or_fallback) %>
-<% content_for :back_link, document_images_path(@document) %>
+
+<% if params[:wizard] == "lead_image" %>
+  <% content_for :back_link, crop_document_image_path(@document, @image, wizard: params[:wizard]) %>
+<% else %>
+  <% content_for :back_link, document_images_path(@document) %>
+<% end %>
 
 <%= render "components/image_meta", {
   id: "selected-image",


### PR DESCRIPTION
https://trello.com/c/EUgQ9ZQd/338-fix-back-link-for-lead-image-wizard

When editing an existing image's attributes, this should go back to the
images index page. But when the user is working through the lead image
wizard, it makes more sense to take them back to the crop screen, as
this is the previous screen they should have been on.