### PR TITLE
Add flash messages to image workflows

### DIFF
--- a/app/controllers/document_images_controller.rb
+++ b/app/controllers/document_images_controller.rb
@@ -64,7 +64,7 @@ class DocumentImagesController < ApplicationController
       return
     end
 
-    redirect_to document_images_path(document)
+    redirect_to document_images_path(document), notice: t("document_images.index.flashes.cropped", filename: image.filename)
   end
 
   def edit
@@ -84,7 +84,7 @@ class DocumentImagesController < ApplicationController
       attributes_to_update: {},
     )
 
-    redirect_to document_images_path(document)
+    redirect_to document_images_path(document), notice: t("document_images.index.flashes.details_edited", filename: image.filename)
   end
 
   def destroy
@@ -101,7 +101,7 @@ class DocumentImagesController < ApplicationController
 
     AssetManagerService.new.delete(image)
     image.destroy!
-    redirect_to document_images_path(document), notice: t("document_images.index.flashes.image_deleted")
+    redirect_to document_images_path(document), notice: t("document_images.index.flashes.deleted")
   end
 
 private

--- a/app/controllers/document_lead_image_controller.rb
+++ b/app/controllers/document_lead_image_controller.rb
@@ -22,11 +22,12 @@ class DocumentLeadImageController < ApplicationController
       attributes_to_update: { lead_image_id: image.id },
     )
 
-    redirect_to document_path(document)
+    redirect_to document_path(document), notice: t("documents.show.flashes.lead_image.added", filename: image.filename)
   end
 
   def choose
     document = Document.find_by_param(params[:document_id])
+    image = Image.find(params[:image_id])
 
     DocumentUpdateService.update!(
       document: document,
@@ -35,7 +36,7 @@ class DocumentLeadImageController < ApplicationController
       attributes_to_update: { lead_image_id: params[:image_id] },
     )
 
-    redirect_to document_path(document)
+    redirect_to document_path(document), notice: t("documents.show.flashes.lead_image.chosen", filename: image.filename)
   end
 
   def remove
@@ -48,7 +49,7 @@ class DocumentLeadImageController < ApplicationController
       attributes_to_update: { lead_image_id: nil },
     )
 
-    redirect_to document_path(document)
+    redirect_to document_path(document), notice: t("documents.show.flashes.lead_image.removed")
   end
 
   def destroy
@@ -65,7 +66,7 @@ class DocumentLeadImageController < ApplicationController
 
     AssetManagerService.new.delete(image)
     image.destroy!
-    redirect_to document_path(document)
+    redirect_to document_path(document), notice: t("documents.show.flashes.lead_image.deleted")
   end
 
 private

--- a/config/locales/en/document_images/edit.yml
+++ b/config/locales/en/document_images/edit.yml
@@ -1,7 +1,7 @@
 en:
   document_images:
     edit:
-      title: "Edit lead image for ‘%{title}’"
+      title: "Edit image for ‘%{title}’"
       form_labels:
         alt_text: Alt text
         caption: Image caption

--- a/config/locales/en/document_images/index.yml
+++ b/config/locales/en/document_images/index.yml
@@ -12,7 +12,9 @@ en:
       error_summary_title: You need to
       lead_image: Lead image
       flashes:
-        image_deleted: Image deleted
+        cropped: "Cropped image for ‘%{filename}’"
+        details_edited: "Image details have been edited for ‘%{filename}’"
+        deleted: Image deleted
         api_error:
           title: Something has gone wrong
           description: Something went wrong when uploading your file. Please try again or [raise a support request](https://support.publishing.service.gov.uk/technical_fault_report/new).

--- a/config/locales/en/documents/show.yml
+++ b/config/locales/en/documents/show.yml
@@ -44,7 +44,6 @@ en:
         unknown_user: Unknown
         last_edited_by: Last edited by
       flashes:
-        image_deleted: Image deleted
         draft_error:
           title: Something has gone wrong
           description: Something went wrong when saving your draft. Please try again or [raise a support request](https://support.publishing.service.gov.uk/technical_fault_report/new).
@@ -59,3 +58,9 @@ en:
         delete_draft_error:
           title: Something has gone wrong
           description: Something went wrong when deleting your draft. Please try again or [raise a support request](https://support.publishing.service.gov.uk/technical_fault_report/new).
+        lead_image:
+          added: "Lead image added for ‘%{filename}’"
+          chosen: "Lead image has been set with ‘%{filename}’"
+          removed: Lead image removed
+          deleted: Lead image deleted
+

--- a/spec/features/editing_images/choose_lead_image_spec.rb
+++ b/spec/features/editing_images/choose_lead_image_spec.rb
@@ -37,6 +37,7 @@ RSpec.feature "Choose a lead image" do
   end
 
   def and_the_preview_creation_succeeded
+    expect(page).to have_content(I18n.t("documents.show.flashes.lead_image.chosen", filename: Image.last.filename))
     expect(@request).to have_been_requested
     expect(page).to have_content(I18n.t("user_facing_states.draft.name"))
 

--- a/spec/features/editing_images/delete_image_spec.rb
+++ b/spec/features/editing_images/delete_image_spec.rb
@@ -27,7 +27,7 @@ RSpec.feature "Delete an image" do
 
   def then_i_see_the_image_is_gone
     expect(all("#image-#{@image.id}").count).to be_zero
-    expect(page).to have_content(I18n.t("document_images.index.flashes.image_deleted"))
+    expect(page).to have_content(I18n.t("document_images.index.flashes.deleted"))
 
     expect(@image_request).to have_been_requested
     expect(ActiveStorage::Blob.service.exist?(@image.blob.key)).to be_falsey

--- a/spec/features/editing_images/delete_lead_image_spec.rb
+++ b/spec/features/editing_images/delete_lead_image_spec.rb
@@ -27,6 +27,7 @@ RSpec.feature "Delete an image" do
   end
 
   def then_i_see_the_document_has_no_lead_image
+    expect(page).to have_content(I18n.t("documents.show.flashes.lead_image.deleted"))
     expect(page).to have_content(I18n.t("documents.show.lead_image.no_lead_image"))
     expect(page).to have_content(I18n.t("documents.history.entry_types.lead_image_removed"))
     expect(@image_request).to have_been_requested

--- a/spec/features/editing_images/edit_image_crop_spec.rb
+++ b/spec/features/editing_images/edit_image_crop_spec.rb
@@ -51,6 +51,7 @@ RSpec.feature "Edit image crop", js: true do
     expect(Image.last.crop_x).to eq(0)
     expect(Image.last.crop_width).to eq(960)
     expect(Image.last.crop_height).to eq(640)
+    expect(page).to have_content(I18n.t("document_images.index.flashes.cropped", filename: Image.last.filename))
   end
 
   def and_the_preview_creation_succeeded

--- a/spec/features/editing_images/edit_image_metadata_spec.rb
+++ b/spec/features/editing_images/edit_image_metadata_spec.rb
@@ -30,6 +30,7 @@ RSpec.feature "Edit image metadata" do
 
   def then_i_see_the_image_is_updated
     expect(@request).to have_been_requested
+    expect(page).to have_content(I18n.t("document_images.index.flashes.details_edited", filename: Image.last.filename))
     expect(page).to have_content("Some alt text")
     expect(page).to have_content("A caption")
     expect(page).to have_content("A credit")

--- a/spec/features/editing_images/remove_lead_image_spec.rb
+++ b/spec/features/editing_images/remove_lead_image_spec.rb
@@ -25,6 +25,7 @@ RSpec.feature "Remove a lead image" do
   end
 
   def then_the_document_has_no_lead_image
+    expect(page).to have_content(I18n.t("documents.show.flashes.lead_image.removed"))
     expect(@request).to have_been_requested
     expect(page).to have_content(I18n.t("user_facing_states.draft.name"))
 

--- a/spec/features/editing_images/upload_lead_image_spec.rb
+++ b/spec/features/editing_images/upload_lead_image_spec.rb
@@ -44,6 +44,7 @@ RSpec.feature "Upload a lead image" do
   end
 
   def then_i_see_the_new_lead_image
+    expect(page).to have_content(I18n.t("documents.show.flashes.lead_image.added", filename: Image.last.filename))
     expect(page).to have_content("A caption")
     expect(page).to have_content("A credit")
     expect(find("#lead-image img")["src"]).to include("1000x1000.jpg")


### PR DESCRIPTION
Adds flash messages to the image management section of the workflow.

Provide a flash message when a user:
## Chooses lead image
<img width="1042" alt="screen shot 2018-10-17 at 13 04 37" src="https://user-images.githubusercontent.com/24479188/47085024-37f4d480-d20d-11e8-846a-5db5cb36b375.png">



## Removes lead image
<img width="1041" alt="screen shot 2018-10-17 at 13 03 28" src="https://user-images.githubusercontent.com/24479188/47084965-1267cb00-d20d-11e8-9846-c211c22ca4e7.png">



## Edits a crop (in edit context)
<img width="1038" alt="screen shot 2018-10-17 at 12 17 01" src="https://user-images.githubusercontent.com/24479188/47084826-a7b68f80-d20c-11e8-8460-04b49ceea582.png">



## Edits details (in edit context)
<img width="1031" alt="screen shot 2018-10-17 at 12 17 10" src="https://user-images.githubusercontent.com/24479188/47084800-940b2900-d20c-11e8-9ec1-d762eec8c7b8.png">



## Completes the add lead image workflow
<img width="1035" alt="screen shot 2018-10-17 at 13 01 44" src="https://user-images.githubusercontent.com/24479188/47084897-d3d21080-d20c-11e8-9a92-541b635d2003.png">

Trello:
https://trello.com/c/66Zaa8e0/304-add-flash-messages-for-image-actions
