### PR TITLE
Replace autocompletes with selects for filters

### DIFF
--- a/app/assets/stylesheets/utilities/_overwrites.scss
+++ b/app/assets/stylesheets/utilities/_overwrites.scss
@@ -52,3 +52,7 @@
 .govuk-footer__heading {
   @include govuk-visually-hidden;
 }
+
+.govuk-select {
+  width: 100%;
+}

--- a/app/views/documents/index/_filters.html.erb
+++ b/app/views/documents/index/_filters.html.erb
@@ -9,67 +9,66 @@
     type: "search"
   } %>
 
-  <% document_type_select = DocumentTypeSchema.all
-    .reject(&:managed_elsewhere)
-    .map { |d| [d.label, d.id] }
-  %>
+  <div class="govuk-form-group">
+    <% document_type_select = DocumentTypeSchema.all
+      .reject(&:managed_elsewhere)
+      .map { |d| [d.label, d.id] }
+    %>
 
-  <%= render "components/autocomplete", {
-    name: "document_type",
-    label: {
+    <%= render "govuk_publishing_components/components/label", {
       text: t("documents.index.filter.document_type"),
+      html_for: "document-type-filter",
       bold: true
-    },
-    # TODO: implement allow_blank so we don't have to add a blank option
-    options: [["", ""]] + document_type_select,
-    selected_options: [params[:document_type]],
-    size: 10,
-    data: {
-      module: "autocomplete"
-    }
-  } %>
+    } %>
 
-  <% state_select = UserFacingState::STATES
-    .map { |state| [t("user_facing_states.#{state}.name"), state] }
-  %>
+    <%= select_tag "document_type",
+      options_for_select(document_type_select, [params[:document_type]]),
+      include_blank: true,
+      id: "document-type-filter",
+      class: "govuk-select"
+    %>
+  </div>
 
-  <%= render "components/autocomplete", {
-    name: "state",
-    label: {
+  <div class="govuk-form-group">
+    <% state_select = UserFacingState::STATES
+      .map { |state| [t("user_facing_states.#{state}.name"), state] }
+    %>
+
+    <%= render "govuk_publishing_components/components/label", {
       text: t("documents.index.filter.state"),
+      html_for: "document-state-filter",
       bold: true
-    },
-    # TODO: implement allow_blank so we don't have to add a blank option
-    options: [["", ""]] + state_select,
-    selected_options: [params[:state]],
-    size: 10,
-    data: {
-      module: "autocomplete"
-    }
-  } %>
+    } %>
 
-  <% organisation_select = begin
-    LinkablesService.new("organisation").select_options
-  rescue GdsApi::BaseError => e
-    GovukError.notify(e)
-    []
-  end %>
+    <%= select_tag "state",
+      options_for_select(state_select, [params[:state]]),
+      include_blank: true,
+      id: "document-state-filter",
+      class: "govuk-select"
+    %>
+  </div>
 
-  <%= render "components/autocomplete", {
-    id: "organisation",
-    name: "organisation",
-    label: {
+  <div class="govuk-form-group">
+    <% organisation_select = begin
+      LinkablesService.new("organisation").select_options
+    rescue GdsApi::BaseError => e
+      GovukError.notify(e)
+      []
+    end %>
+
+    <%= render "govuk_publishing_components/components/label", {
       text: t("documents.index.filter.organisation"),
+      html_for: "document-organisation-filter",
       bold: true
-    },
-    # TODO: implement allow_blank so we don't have to add a blank option
-    options: [["", ""]] + organisation_select,
-    selected_options: [params[:organisation]],
-    size: 10,
-    data: {
-      module: "autocomplete"
-    }
-  } %>
+    } %>
+
+    <%= select_tag "organisation",
+      options_for_select(organisation_select, [params[:organisation]]),
+      include_blank: true,
+      id: "document-organisation-filter",
+      class: "govuk-select"
+    %>
+  </div>
 
   <%= hidden_field_tag "sort", @sort %>
 

--- a/spec/features/finding/index_filtering_api_down_spec.rb
+++ b/spec/features/finding/index_filtering_api_down_spec.rb
@@ -21,6 +21,6 @@ RSpec.feature "User filters documents without Publishing API" do
   end
 
   def then_i_cannot_filter_by_organisation
-    expect(all("#organisation option").count).to eq 1
+    expect(all("#document-organisation-filter option").count).to eq 1
   end
 end


### PR DESCRIPTION
This PR replaces the autocomplete components with selects for filters in the index page.

The reason we're not using the select component is that the data doesn't come in a form that's usable for the component. It currently comes as two arrays one with for the options values and another with the selected items. The component takes a single array with a boolean flag (`selected: true`) for the selected options.

[Trello card](https://trello.com/c/DjDrH3lY)