### PR TITLE
Improvements to styling of toolbar

### DIFF
--- a/app/assets/stylesheets/components/_markdown-editor.scss
+++ b/app/assets/stylesheets/components/_markdown-editor.scss
@@ -4,7 +4,7 @@
 
 .app-c-markdown-editor {
   .govuk-textarea {
-    padding-top: (govuk-spacing(8) + 50px);
+    padding-top: (govuk-spacing(9) + govuk-spacing(6));
     resize: vertical;
   }
 }
@@ -35,13 +35,12 @@
   @include govuk-font(19);
   display: inline-block;
   margin-bottom: -$govuk-border-width-form-element;
-  padding: (govuk-spacing(1) + $govuk-border-width-form-element) govuk-spacing(4);
+  padding: (govuk-spacing(1) + $govuk-border-width-form-element);
   border: $govuk-border-width-form-element solid transparent;
   border-top: 0;
   border-bottom: 0;
   color: $govuk-link-colour;
   background-color: transparent;
-  text-decoration: underline;
   cursor: pointer;
 
   &:focus {
@@ -83,46 +82,54 @@
 
 .app-c-markdown-editor__toolbar {
   background-color: govuk-colour("grey-4");
-  padding-left: 7px;
-  padding-top: 7px;
+  line-height: 0;
 }
 
-.app-c-markdown-editor-toolbar__button {
-  @include govuk-focusable;
+.app-c-markdown-editor__toolbar-group {
+  display: table;
+  width: 100%;
+}
+
+.app-c-markdown-editor__toolbar-button {
+  @include govuk-focusable-fill;
   display: inline-block;
+
+  &:focus {
+    outline: 0;
+  }
 
   &:hover {
     cursor: pointer;
-    background-color: govuk-colour("white");
+    background-color: govuk-colour("grey-3");
   }
 }
 
-.app-c-markdown-editor-toolbar__icon {
+.app-c-markdown-editor__toolbar-icon {
   display: block;
-  width: 35px;
-  height: 35px;
+  width: 40px;
+  height: 40px;
 }
 
-.app-c-markdown-editor-toolbar__icon--heading-2 {
+.app-c-markdown-editor__toolbar-icon--heading-2 {
   background-image: image-url("components/markdown-editor/headline_two.svg");
 }
 
-.app-c-markdown-editor-toolbar__icon--heading-3 {
+.app-c-markdown-editor__toolbar-icon--heading-3 {
   background-image: image-url("components/markdown-editor/headline_three.svg");
 }
 
-.app-c-markdown-editor-toolbar__icon--link {
+.app-c-markdown-editor__toolbar-icon--link {
   background-image: image-url("components/markdown-editor/link.svg");
 }
 
-.app-c-markdown-editor-toolbar__icon--blockquote {
+.app-c-markdown-editor__toolbar-icon--blockquote {
   background-image: image-url("components/markdown-editor/blockquote.svg");
 }
 
-.app-c-markdown-editor-toolbar__icon--numbered-list {
+.app-c-markdown-editor__toolbar-icon--numbered-list {
   background-image: image-url("components/markdown-editor/number_list.svg");
 }
 
-.app-c-markdown-editor-toolbar__icon--bullets {
+.app-c-markdown-editor__toolbar-icon--bullets {
   background-image: image-url("components/markdown-editor/bullet_point.svg");
 }

--- a/app/views/components/_markdown_editor.html.erb
+++ b/app/views/components/_markdown_editor.html.erb
@@ -14,29 +14,29 @@
         <button type="button" class="app-c-markdown-editor__button js-markdown-preview-button"><%= preview_button_text %></button>
       </div>
       <div class="app-c-markdown-editor__toolbar">
-        <markdown-toolbar class="app-c-markdown-toolbar" for="<%= textarea[:id] %>">
-          <md-header-2 class="app-c-markdown-editor-toolbar__button">
-            <i class="app-c-markdown-editor-toolbar__icon app-c-markdown-editor-toolbar__icon--heading-2" title="Heading level 2" aria-hidden="true"></i>
+        <markdown-toolbar class="app-c-markdown-editor__toolbar-group" for="<%= textarea[:id] %>">
+          <md-header-2 class="app-c-markdown-editor__toolbar-button">
+            <i class="app-c-markdown-editor__toolbar-icon app-c-markdown-editor__toolbar-icon--heading-2" title="Heading level 2" aria-hidden="true"></i>
             <span class="govuk-visually-hidden">Heading level 2</span>
           </md-header-2>
-          <md-header-3 class="app-c-markdown-editor-toolbar__button">
-            <i class="app-c-markdown-editor-toolbar__icon app-c-markdown-editor-toolbar__icon--heading-3" title="Heading level 3" aria-hidden="true"></i>
+          <md-header-3 class="app-c-markdown-editor__toolbar-button">
+            <i class="app-c-markdown-editor__toolbar-icon app-c-markdown-editor__toolbar-icon--heading-3" title="Heading level 3" aria-hidden="true"></i>
             <span class="govuk-visually-hidden">Heading level 3</span>
           </md-header-3>
-          <md-link class="app-c-markdown-editor-toolbar__button">
-            <i class="app-c-markdown-editor-toolbar__icon app-c-markdown-editor-toolbar__icon--link" title="Link" aria-hidden="true"></i>
+          <md-link class="app-c-markdown-editor__toolbar-button">
+            <i class="app-c-markdown-editor__toolbar-icon app-c-markdown-editor__toolbar-icon--link" title="Link" aria-hidden="true"></i>
             <span class="govuk-visually-hidden">Link</span>
           </md-link>
-          <md-quote class="app-c-markdown-editor-toolbar__button">
-            <i class="app-c-markdown-editor-toolbar__icon app-c-markdown-editor-toolbar__icon--blockquote" title="Blockquote" aria-hidden="true"></i>
+          <md-quote class="app-c-markdown-editor__toolbar-button">
+            <i class="app-c-markdown-editor__toolbar-icon app-c-markdown-editor__toolbar-icon--blockquote" title="Blockquote" aria-hidden="true"></i>
             <span class="govuk-visually-hidden">Blockquote</span>
           </md-quote>
-          <md-ordered-list class="app-c-markdown-editor-toolbar__button">
-            <i class="app-c-markdown-editor-toolbar__icon app-c-markdown-editor-toolbar__icon--numbered-list" title="Numbered list" aria-hidden="true"></i>
+          <md-ordered-list class="app-c-markdown-editor__toolbar-button">
+            <i class="app-c-markdown-editor__toolbar-icon app-c-markdown-editor__toolbar-icon--numbered-list" title="Numbered list" aria-hidden="true"></i>
             <span class="govuk-visually-hidden">Numbered list</span>
           </md-ordered-list>
-          <md-unordered-list class="app-c-markdown-editor-toolbar__button">
-            <i class="app-c-markdown-editor-toolbar__icon app-c-markdown-editor-toolbar__icon--bullets" title="Bullets" aria-hidden="true"></i>
+          <md-unordered-list class="app-c-markdown-editor__toolbar-button">
+            <i class="app-c-markdown-editor__toolbar-icon app-c-markdown-editor__toolbar-icon--bullets" title="Bullets" aria-hidden="true"></i>
             <span class="govuk-visually-hidden">Bullets</span>
           </md-unordered-list>
         </markdown-toolbar>


### PR DESCRIPTION
Changes requested:
- Hover state #dee0e2
- Focus state filled rather than outline
- Size of icons to be increased by 40px
- Remove padding - 40px height
- Remove underline on links
- Reduce padding on toggle to 10px (so left side aligns)

### Preview
![oct-19-2018 11-08-31](https://user-images.githubusercontent.com/4599889/47212589-8e3e5080-d390-11e8-8a1b-a40a68edc218.gif)

Ticket: https://trello.com/c/TvmLqnxi/332-add-toolbar-to-markdown-editor