### PR TITLE
Add character count to edit document page

### DIFF
--- a/app/views/documents/edit.html.erb
+++ b/app/views/documents/edit.html.erb
@@ -51,20 +51,17 @@
 
   <div class="govuk-grid-row">
     <div class="govuk-grid-column-two-thirds">
-      <%= render "govuk_publishing_components/components/character_count", {
-        textarea: {
-          label: {
-            text: t("documents.edit.form_labels.summary"),
-            bold: true
-          },
-          name: "document[summary]",
-          value: @document.summary,
-          rows: 4,
-          data: {
-            "contextual-guidance": "document-summary-guidance"
-          }
+      <%= render "govuk_publishing_components/components/textarea", {
+        label: {
+          text: t("documents.edit.form_labels.summary"),
+          bold: true
         },
-        maxlength: 600
+        name: "document[summary]",
+        value: @document.summary,
+        rows: 4,
+        data: {
+          "contextual-guidance": "document-summary-guidance"
+        }
       } %>
     </div>
 

--- a/app/views/documents/edit.html.erb
+++ b/app/views/documents/edit.html.erb
@@ -23,7 +23,7 @@
             "contextual-guidance": "document-title-guidance"
           }
         },
-        maxlength: 65
+        maxlength: 150
       } %>
 
       <%= render "components/url_preview", {
@@ -64,7 +64,7 @@
             "contextual-guidance": "document-summary-guidance"
           }
         },
-        maxlength: 160
+        maxlength: 600
       } %>
     </div>
 

--- a/app/views/documents/edit.html.erb
+++ b/app/views/documents/edit.html.erb
@@ -9,19 +9,21 @@
   <%= form_for(@document, html: {'autocomplete': 'off'}, data: {'module': 'edit-document-form', 'url-preview-path': generate_path_path}) do |f| %>
   <div class="govuk-grid-row">
     <div class="govuk-grid-column-two-thirds">
-      <%= render "govuk_publishing_components/components/textarea", {
-        label: {
-          text: t("documents.edit.form_labels.title"),
-          bold: true
+      <%= render "govuk_publishing_components/components/character_count", {
+        textarea: {
+          label: {
+            text: t("documents.edit.form_labels.title"),
+            bold: true
+          },
+          name: "document[title]",
+          value: @document.title,
+          rows: 2,
+          data: {
+            "url-preview": "input",
+            "contextual-guidance": "document-title-guidance"
+          }
         },
-        id: "document-title-id",
-        name: "document[title]",
-        value: @document.title,
-        rows: 2,
-        data: {
-          "url-preview": "input",
-          "contextual-guidance": "document-title-guidance"
-        }
+        maxlength: 65
       } %>
 
       <%= render "components/url_preview", {
@@ -49,17 +51,20 @@
 
   <div class="govuk-grid-row">
     <div class="govuk-grid-column-two-thirds">
-      <%= render "govuk_publishing_components/components/textarea", {
-        label: {
-          text: t("documents.edit.form_labels.summary"),
-          bold: true
+      <%= render "govuk_publishing_components/components/character_count", {
+        textarea: {
+          label: {
+            text: t("documents.edit.form_labels.summary"),
+            bold: true
+          },
+          name: "document[summary]",
+          value: @document.summary,
+          rows: 4,
+          data: {
+            "contextual-guidance": "document-summary-guidance"
+          }
         },
-        name: "document[summary]",
-        value: @document.summary,
-        rows: 4,
-        data: {
-          "contextual-guidance": "document-summary-guidance"
-        }
+        maxlength: 160
       } %>
     </div>
 

--- a/spec/features/editing_content/url_preview_spec.rb
+++ b/spec/features/editing_content/url_preview_spec.rb
@@ -29,7 +29,7 @@ RSpec.feature "Shows a preview of the URL", js: true do
   end
 
   def and_i_interact_with_the_title_but_leave_it_unedited
-    page.find("#document-title-id").click
+    page.find("textarea[name='document[title]']").click
     page.find("body").click
   end
 


### PR DESCRIPTION
This PR: 
- replaces the textarea component with a character-count component for title and summary on edit document page and sets the limit to 65 and 160 respectively
- updates a test to use a consistent selector throughout the test and removes a redundant id attribute

[Trello card](https://trello.com/c/28Ol82Ky)

## JavaScript enabled
<img width="1440" alt="screen shot 2018-10-19 at 11 17 09" src="https://user-images.githubusercontent.com/788096/47214494-022f2780-d396-11e8-8685-aecb94b05f81.png">

## JavaScript disabled
<img width="1440" alt="screen shot 2018-10-19 at 11 16 38" src="https://user-images.githubusercontent.com/788096/47214521-183ce800-d396-11e8-8db4-a28e42e25bc7.png">
