### PR TITLE
Fix the review URL to be the one for this app

### DIFF
--- a/app/views/documents/show/_submitted_for_review.html.erb
+++ b/app/views/documents/show/_submitted_for_review.html.erb
@@ -1,7 +1,7 @@
 <% copy_to_clipboard = render(
   "govuk_publishing_components/components/copy_to_clipboard",
     label: t("documents.show.flashes.submitted_for_review.label"),
-    copyable_content: DocumentUrl.new(@document).public_url,
+    copyable_content: document_url(@document),
     button_text: "Copy link"
 ) %>
 

--- a/spec/features/workflow/submit_for_2i_spec.rb
+++ b/spec/features/workflow/submit_for_2i_spec.rb
@@ -6,8 +6,9 @@ RSpec.feature "2i" do
     when_i_visit_the_document
     and_i_click_submit_for_2i
     then_i_see_the_document_is_submitted
+    and_i_see_a_link_to_the_document
     when_i_edit_the_document
-    then_i_see_the_document_is_in_review
+    then_i_see_it_is_still_in_review
   end
 
   def given_there_is_a_document_in_draft
@@ -27,8 +28,13 @@ RSpec.feature "2i" do
     expect(page).to have_content I18n.t("user_facing_states.submitted_for_review.name")
   end
 
-  def then_i_see_the_document_is_in_review
+  def then_i_see_it_is_still_in_review
     expect(page).to have_content I18n.t("user_facing_states.submitted_for_review.name")
+  end
+
+  def and_i_see_a_link_to_the_document
+    review_url = find_field(I18n.t("documents.show.flashes.submitted_for_review.label")).value
+    expect(review_url).to eq(document_url(@document))
   end
 
   def when_i_edit_the_document


### PR DESCRIPTION
https://trello.com/c/nViNavOU/392-development-clean-up

This makes sure we're prompting the user to copy the document URL for
the app and not the one for GOV.UK, as the reviewers will want to come
to the app rather than the frontend.