### PR TITLE
Add image requirements for alt text / caption

### DIFF
--- a/app/services/image_drafting_requirements.rb
+++ b/app/services/image_drafting_requirements.rb
@@ -1,0 +1,35 @@
+# frozen_string_literal: true
+
+class ImageDraftingRequirements
+  ALT_TEXT_MAX_LENGTH = 125
+  CAPTION_MAX_LENGTH = 160
+
+  attr_reader :image
+
+  def initialize(image)
+    @image = image
+  end
+
+  def errors
+    messages = Hash.new { |h, k| h[k] = [] }
+
+    if @image.alt_text.blank?
+      messages["alt_text"] << I18n.t("document_images.edit.flashes.drafting_requirements.presence",
+                                     field: "alt text")
+    end
+
+    if @image.alt_text.length > ALT_TEXT_MAX_LENGTH
+      messages["alt_text"] << I18n.t("document_images.edit.flashes.drafting_requirements.max_length",
+                                     field: "Alt text",
+                                     max_length: ALT_TEXT_MAX_LENGTH)
+    end
+
+    if @image.caption.length > CAPTION_MAX_LENGTH
+      messages["caption"] << I18n.t("document_images.edit.flashes.drafting_requirements.max_length",
+                                    field: "Caption",
+                                    max_length: CAPTION_MAX_LENGTH)
+    end
+
+    messages
+  end
+end

--- a/app/views/document_images/edit.html.erb
+++ b/app/views/document_images/edit.html.erb
@@ -27,6 +27,7 @@
         },
         name: "alt_text",
         value: @image.alt_text,
+        error_message: @errors&.fetch("alt_text", nil)&.join("<br/>"),
         data: {
           "contextual-guidance": "alt-text-guidance"
         }
@@ -54,6 +55,7 @@
         },
         name: "caption",
         value: @image.caption,
+        error_message: @errors&.fetch("caption", nil)&.join("<br/>"),
         data: {
           "contextual-guidance": "caption-guidance"
         }

--- a/config/locales/en/document_images/edit.yml
+++ b/config/locales/en/document_images/edit.yml
@@ -6,6 +6,11 @@ en:
         alt_text: Alt text
         caption: Image caption
         credit: Image credit
+      flashes:
+        drafting_requirements:
+          title: You need to
+          presence: "Enter %{field}"
+          max_length: "%{field} must be less than %{max_length} characters"
       guidance:
         alt_text: A simple and specific description of what the image shows. This helps screen-readers and search engines.
         caption: This text appears on the page under the image.

--- a/spec/features/editing_images/image_drafting_requirements_spec.rb
+++ b/spec/features/editing_images/image_drafting_requirements_spec.rb
@@ -1,0 +1,70 @@
+# frozen_string_literal: true
+
+RSpec.feature "Image drafting requirements" do
+  scenario do
+    given_there_is_a_document_with_images
+    when_i_visit_the_images_page
+    and_i_edit_the_image_metadata
+    and_the_image_has_no_alt_text
+    then_i_see_the_alt_text_is_needed
+
+    when_i_enter_too_much_alt_text
+    then_i_see_the_alt_text_is_too_long
+
+    when_i_enter_too_much_caption_text
+    then_i_see_the_caption_is_too_long
+  end
+
+  def given_there_is_a_document_with_images
+    document_type_schema = build(:document_type_schema, lead_image: true)
+    document = create(:document, document_type: document_type_schema.id)
+    create(:image, document: document)
+  end
+
+  def when_i_visit_the_images_page
+    visit document_images_path(Document.last)
+  end
+
+  def and_i_edit_the_image_metadata
+    @request = stub_publishing_api_put_content(Document.last.content_id, {})
+    click_on "Edit details"
+  end
+
+  def and_the_image_has_no_alt_text
+    fill_in "alt_text", with: ""
+    click_on "Save details"
+  end
+
+  def then_i_see_the_alt_text_is_needed
+    expect(page).to have_content(I18n.t("document_images.edit.flashes.drafting_requirements.presence",
+                                        field: "alt text"))
+  end
+
+  def when_i_enter_too_much_alt_text
+    @alt_text = "a" * (ImageDraftingRequirements::ALT_TEXT_MAX_LENGTH + 1)
+    fill_in "alt_text", with: @alt_text
+    click_on "Save details"
+  end
+
+  def then_i_see_the_alt_text_is_too_long
+    expect(find_field("alt_text").value).to eq(@alt_text)
+
+    expect(page).to have_content(I18n.t("document_images.edit.flashes.drafting_requirements.max_length",
+                                        field: "Alt text",
+                                        max_length: ImageDraftingRequirements::ALT_TEXT_MAX_LENGTH))
+  end
+
+  def when_i_enter_too_much_caption_text
+    @caption = "a" * (ImageDraftingRequirements::CAPTION_MAX_LENGTH + 1)
+    fill_in "caption", with: @caption
+    click_on "Save details"
+  end
+
+  def then_i_see_the_caption_is_too_long
+    expect(find_field("caption").value).to eq(@caption)
+
+    expect(page).to have_content(I18n.t("document_images.edit.flashes.drafting_requirements.max_length",
+                                        field: "Caption",
+                                        max_length: ImageDraftingRequirements::CAPTION_MAX_LENGTH))
+  end
+end


### PR DESCRIPTION
https://trello.com/c/iecyxRBY/272-add-validations-for-image-details

This ensures we enter alt text for an image, as well as putting some
sensible limits on the maximum length of the text in these fields.

Although it's not possible to have multiple errors for each field in
this particular case, we'd like to adopt the pattern used here to
support it in other cases and maintain consistency.