### PR TITLE
Add organisation as a custom dimension via dataLayer

### DIFF
--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -6,6 +6,9 @@
   <% end %>
 
   <% if ENV["GOOGLE_TAG_MANAGER_ID"] %>
+    <script>
+      dataLayer = [{ 'dimension1': <%= current_user.organisation_slug %> }];
+    </script>
     <%= render "govuk_publishing_components/components/google_tag_manager_script", {
       gtm_id: ENV["GOOGLE_TAG_MANAGER_ID"],
       gtm_auth: ENV["GOOGLE_TAG_MANAGER_AUTH"],


### PR DESCRIPTION
This PR adds current user's organisation to `dimension1` (which is configured to store organisations in GTM) via dataLayer.