### PR TITLE
Iterate publishing requirements to check presence

### DIFF
--- a/app/controllers/document_images_controller.rb
+++ b/app/controllers/document_images_controller.rb
@@ -22,7 +22,7 @@ class DocumentImagesController < ApplicationController
 
     unless image_uploader.valid?
       redirect_to document_images_path, alert: {
-        "alerts" => image_uploader.errors,
+        "items" => image_uploader.errors.map { |error| { text: error } },
         "title" => t("document_images.index.error_summary_title"),
       }
       return
@@ -80,7 +80,7 @@ class DocumentImagesController < ApplicationController
 
     if @errors.any?
       flash.now["alert"] = { "title" => I18n.t("document_images.edit.flashes.drafting_requirements.title"),
-                             "alerts" => @errors.values.flatten }
+                             "items" => @errors.values.flatten.map { |error| { text: error } } }
 
       render :edit
       return

--- a/app/controllers/publish_document_controller.rb
+++ b/app/controllers/publish_document_controller.rb
@@ -4,7 +4,7 @@ class PublishDocumentController < ApplicationController
   def confirmation
     @document = Document.find_by_param(params[:id])
 
-    unless PublishingRequirements.new(@document).ready_for_publishing?
+    if PublishingRequirements.new(@document).errors.any?
       redirect_to document_path(@document), tried_to_publish: true
       return
     end

--- a/app/controllers/review_controller.rb
+++ b/app/controllers/review_controller.rb
@@ -4,7 +4,7 @@ class ReviewController < ApplicationController
   def submit_for_2i
     document = Document.find_by_param(params[:id])
 
-    unless PublishingRequirements.new(document).ready_for_publishing?
+    if PublishingRequirements.new(document).errors.any?
       redirect_to document_path(document), tried_to_publish: true
       return
     end

--- a/app/formats/document_types.yml
+++ b/app/formats/document_types.yml
@@ -30,8 +30,6 @@
     - id: body
       label: Body
       type: govspeak
-      validations:
-        min_length: 10
   tags:
     - id: primary_publishing_organisation
       label: Primary organisation
@@ -89,8 +87,6 @@
     - id: body
       label: Body
       type: govspeak
-      validations:
-        min_length: 10
   tags:
     - id: primary_publishing_organisation
       label: Primary organisation

--- a/app/services/document_type_schema.rb
+++ b/app/services/document_type_schema.rb
@@ -61,6 +61,6 @@ class DocumentTypeSchema
 
   class Field
     include ActiveModel::Model
-    attr_accessor :id, :label, :type, :validations
+    attr_accessor :id, :label, :type
   end
 end

--- a/app/services/publishing_requirements.rb
+++ b/app/services/publishing_requirements.rb
@@ -8,48 +8,25 @@ class PublishingRequirements
     @document = document
   end
 
-  def ready_for_publishing?
-    unfulfilled_publishing_requirements.empty?
-  end
+  def errors
+    messages = Hash.new { |h, k| h[k] = [] }
 
-  def unfulfilled_publishing_requirements
-    @unfulfilled_publishing_requirements ||= begin
-      messages = []
-      perform_validations_that_apply_to_all_formats(messages)
-      perform_format_specific_validations(messages)
-      messages
-    end
-  end
-
-private
-
-  def perform_validations_that_apply_to_all_formats(messages)
-    if document.title.to_s.size < 10
-      messages << [I18n.t("publishing_requirements.title"), "#content"]
+    if @document.summary.blank?
+      messages["summary"] << {
+        text: I18n.t("publishing_requirements.presence", field: "summary"),
+        href: "#content",
+      }
     end
 
-    if document.summary.to_s.size < 10
-      messages << [I18n.t("publishing_requirements.summary"), "#content"]
-    end
-  end
-
-  def perform_format_specific_validations(messages)
-    schema = document.document_type_schema
-
-    schema.contents.each do |field|
-      # Validations come in pairs, like `min_length: 10`. They should use
-      # a underscored version of JSON Schema's validation system. For example,
-      # `max_length`, `one_of`.
-      #
-      # http://json-schema.org/latest/json-schema-validation.html
-      field.validations.each do |validation_name, value|
-        case validation_name
-        when "min_length"
-          if document.contents[field.id].to_s.size < value
-            messages << [I18n.t("publishing_requirements.min_length", field: field.label.downcase, min_length: value), "#content"]
-          end
-        end
+    @document.document_type_schema.contents.each do |field|
+      if @document.contents[field.id].blank?
+        messages[field.id] << {
+          text: I18n.t("publishing_requirements.field_presence", field: field.label.downcase),
+          href: "#content",
+        }
       end
     end
+
+    messages
   end
 end

--- a/app/views/components/_notice.html.erb
+++ b/app/views/components/_notice.html.erb
@@ -7,7 +7,7 @@
 
 <div class="app-c-notice" id="<%= id %>">
   <h2 class="app-c-notice__title">
-    <%= t("documents.show.publishing_requirements.before_publishing_attempt") %>
+    <%= title %>
   </h2>
 
   <div class="app-c-notice__body">

--- a/app/views/documents/show.html.erb
+++ b/app/views/documents/show.html.erb
@@ -7,12 +7,12 @@
   tabs: [
     {
       id: "edit-document",
-      label: "Edit document",
+      label: t("documents.show.tabs.summary"),
       content: render("documents/show/summary_tab"),
     },
     {
       id: "document-history",
-      label: "Document history",
+      label: t("documents.show.tabs.history"),
       content: render("documents/show/history_tab"),
     }
   ]

--- a/app/views/documents/show/_contents.html.erb
+++ b/app/views/documents/show/_contents.html.erb
@@ -1,6 +1,4 @@
-<% unless PublishingRequirements.new(@document).ready_for_publishing? %>
-  <%= render "documents/show/publishing_requirements" %>
-<% end %>
+<%= render "documents/show/publishing_requirements" %>
 
 <% contents = @document.document_type_schema.contents.map { |schema|
   {

--- a/app/views/documents/show/_publishing_requirements.html.erb
+++ b/app/views/documents/show/_publishing_requirements.html.erb
@@ -1,13 +1,17 @@
-<% if flash[:tried_to_publish] %>
-  <div class="govuk-!-margin-bottom-4">
-    <%= render "govuk_publishing_components/components/error_summary", {
-      title: t("documents.show.publishing_requirements.after_publishing_attempt"),
-      items: PublishingRequirements.new(@document).unfulfilled_publishing_requirements.map { |m, a| { text: m, href: a } }
+<% errors = PublishingRequirements.new(@document).errors.values.flatten %>
+
+<% if errors.any? %>
+  <% if flash[:tried_to_publish] %>
+    <div class="govuk-!-margin-bottom-4">
+      <%= render "govuk_publishing_components/components/error_summary", {
+        title: t("documents.show.flashes.after_publishing_attempt"),
+        items: errors
+      } %>
+    </div>
+  <% else %>
+    <%= render "/components/notice", {
+      title: t("documents.show.flashes.before_publishing_attempt"),
+      items: errors
     } %>
-  </div>
-<% else %>
-  <%= render "/components/notice", {
-    title: t("documents.show.publishing_requirements.after_publishing_attempt"),
-    items: PublishingRequirements.new(@document).unfulfilled_publishing_requirements.map { |m, a| { text: m, href: a } }
-  } %>
+  <% end %>
 <% end %>

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -49,11 +49,12 @@
       } %>
     <% end %>
 
+
     <% if flash["alert"] %>
       <% if flash["alert"].is_a? Hash %>
         <%= render "govuk_publishing_components/components/error_summary", {
           title: flash["alert"]["title"],
-          items: flash["alert"]["alerts"].map { |alert| {text: alert} }
+          items: flash["alert"]["items"].map(&:symbolize_keys)
         } %>
       <% else %>
         <%= render "components/error_alert", {

--- a/config/locales/en/documents/show.yml
+++ b/config/locales/en/documents/show.yml
@@ -5,13 +5,13 @@ en:
         title: Document type
         items:
           document_type: Document type
+      tabs:
+        summary: Document summary
+        history: Document history
       tags:
         title: Tags
         api_down: This content isn't available right now. We're having trouble getting the data we need to show you this content.
         none: None
-      publishing_requirements:
-        before_publishing_attempt: "Please meet these requirements before publishing"
-        after_publishing_attempt: "You can't publish before these requirements are met"
       contents:
         title: Content
         items:
@@ -44,6 +44,8 @@ en:
         unknown_user: Unknown
         last_edited_by: Last edited by
       flashes:
+        before_publishing_attempt: To publish this document you need to
+        after_publishing_attempt: Before you can publish this document you need to
         draft_error:
           title: Something has gone wrong
           description: Something went wrong when saving your draft. Please try again or [raise a support request](https://support.publishing.service.gov.uk/technical_fault_report/new).

--- a/config/locales/en/publishing_requirements.yml
+++ b/config/locales/en/publishing_requirements.yml
@@ -1,5 +1,4 @@
 en:
   publishing_requirements:
-    title: "Document needs a title before publishing (at least 10 characters)"
-    summary: "Document needs a summary before publishing (at least 10 characters)"
-    min_length: "The %{field} needs to be at least %{min_length} characters long"
+    presence: "Enter a %{field}"
+    field_presence: "Enter %{field} content"

--- a/spec/factories/field_schema_factory.rb
+++ b/spec/factories/field_schema_factory.rb
@@ -4,7 +4,6 @@ FactoryBot.define do
   factory :field_schema, class: Hash do
     id { SecureRandom.hex(4) }
     label { SecureRandom.alphanumeric(4) }
-    validations { {} }
     initialize_with { attributes.stringify_keys }
   end
 end

--- a/spec/features/workflow/publishing_requirements_spec.rb
+++ b/spec/features/workflow/publishing_requirements_spec.rb
@@ -2,63 +2,76 @@
 
 RSpec.feature "Publishing requirements" do
   scenario do
-    given_there_is_a_document_that_has_unfulfilled_requirements
-    when_i_visit_the_document_page
-    then_i_see_the_unfulfilled_publishing_requirements
+    given_there_is_a_document
+    when_the_document_has_no_summary
+    and_i_visit_the_document_page
+    then_i_see_a_hint_to_enter_a_summary
 
-    when_i_click_on_publish
-    then_i_am_on_the_document_page_with_extra_warning
-    and_when_i_click_on_submit_for_2i
-    then_i_am_on_the_document_page_with_extra_warning
+    when_the_document_has_a_blank_field
+    and_i_visit_the_document_page
+    then_i_see_a_hint_to_enter_the_field
 
-    when_i_fix_the_unfulfilled_publishing_requirements
-    then_i_see_no_unfulfilled_publishing_requirements
+    when_i_try_to_publish_the_document
+    then_i_see_an_error_to_enter_a_summary
+    and_i_see_an_error_to_enter_the_field
+
+    when_i_try_to_submit_the_document_for_2i
+    then_i_see_an_error_to_enter_a_summary
+    and_i_see_an_error_to_enter_the_field
   end
 
-  def given_there_is_a_document_that_has_unfulfilled_requirements
-    body_field_schema = build(:field_schema, id: "body", type: "govspeak", label: "Body", validations: { "min_length" => 10 })
-    document_type_schema = build(:document_type_schema, contents: [body_field_schema])
-    @document = create(:document, title: "Too small", summary: "Too small", document_type: document_type_schema.id)
+  def given_there_is_a_document
+    field_schema = build(:field_schema, id: "field", type: "govspeak", label: "Field")
+    document_type_schema = build(:document_type_schema, contents: [field_schema])
+    @document = create(:document, document_type: document_type_schema.id)
   end
 
-  def when_i_visit_the_document_page
-    visit document_path(@document)
-  end
-
-  def then_i_see_the_unfulfilled_publishing_requirements
-    expect(page).to have_content(I18n.t("documents.show.publishing_requirements.before_publishing_attempt"))
-
-    expect(page).to have_content(I18n.t("publishing_requirements.title"))
-    expect(page).to have_content(I18n.t("publishing_requirements.summary"))
-    expect(page).to have_content(I18n.t("publishing_requirements.min_length", field: "body", min_length: 10))
-  end
-
-  def when_i_click_on_publish
-    click_on "Publish"
-  end
-
-  def then_i_am_on_the_document_page_with_extra_warning
-    expect(page).to have_content(I18n.t("documents.show.publishing_requirements.after_publishing_attempt"))
-  end
-
-  def and_when_i_click_on_submit_for_2i
-    click_on "Submit for 2i"
-  end
-
-  def when_i_fix_the_unfulfilled_publishing_requirements
+  def and_i_visit_the_document_page
     stub_any_publishing_api_put_content
-
-    click_on "Change Content"
-
-    fill_in "document[title]", with: "A nice title of considerable length"
-    fill_in "document[summary]", with: "A nice summary of considerable length"
-    fill_in "document[contents][body]", with: "A very long body text."
     click_on "Save"
   end
 
-  def then_i_see_no_unfulfilled_publishing_requirements
-    expect(page).to_not have_content(I18n.t("publishing_requirements.title", min_length: 10))
-    expect(page).to_not have_content(I18n.t("publishing_requirements.summary", min_length: 10))
-    expect(page).to_not have_content(I18n.t("publishing_requirements.min_length", field: "Body", min_length: 10))
+  def when_the_document_has_no_summary
+    visit document_path(@document)
+    click_on "Change Content"
+    fill_in "document[summary]", with: ""
+  end
+
+  def when_the_document_has_a_blank_field
+    visit document_path(@document)
+    click_on "Change Content"
+    fill_in "document[contents][field]", with: ""
+  end
+
+  def then_i_see_a_hint_to_enter_a_summary
+    within(".app-c-notice") do
+      expect(page).to have_content(I18n.t("publishing_requirements.presence", field: "summary"))
+    end
+  end
+
+  def then_i_see_a_hint_to_enter_the_field
+    within(".app-c-notice") do
+      expect(page).to have_content(I18n.t("publishing_requirements.field_presence", field: "field"))
+    end
+  end
+
+  def when_i_try_to_publish_the_document
+    click_on "Publish"
+  end
+
+  def when_i_try_to_submit_the_document_for_2i
+    click_on "Submit for 2i review"
+  end
+
+  def then_i_see_an_error_to_enter_a_summary
+    within(".gem-c-error-summary") do
+      expect(page).to have_content(I18n.t("publishing_requirements.presence", field: "summary"))
+    end
+  end
+
+  def and_i_see_an_error_to_enter_the_field
+    within(".gem-c-error-summary") do
+      expect(page).to have_content(I18n.t("publishing_requirements.field_presence", field: "field"))
+    end
   end
 end


### PR DESCRIPTION
https://trello.com/c/yxeOlaA8/309-iterate-our-publishing-requirements

The previous publishing requirements are no longer applicable and we
want to iterate them to simply check for the presence of a summary and a
body. Instead of hard-coding the behaviour to the dynamic "body" field,
I've made it so that all dynamic field must be present on publish.

As all the requirements are now hard-coded, there's no need for the
'validations' hash for content fields. It's also good to remove this as
the new terminology of 'publishing requirements' and 'drafting
requirements' makes the lone term 'validations' pretty confusing.