### PR TITLE
Extract image upload validations as requirements

### DIFF
--- a/app/controllers/document_lead_image_controller.rb
+++ b/app/controllers/document_lead_image_controller.rb
@@ -22,7 +22,7 @@ class DocumentLeadImageController < ApplicationController
       attributes_to_update: { lead_image_id: image.id },
     )
 
-    redirect_to document_path(document), notice: t("documents.show.flashes.lead_image.added", filename: image.filename)
+    redirect_to document_path(document), notice: t("documents.show.flashes.lead_image.added", file: image.filename)
   end
 
   def choose
@@ -36,11 +36,12 @@ class DocumentLeadImageController < ApplicationController
       attributes_to_update: { lead_image_id: params[:image_id] },
     )
 
-    redirect_to document_path(document), notice: t("documents.show.flashes.lead_image.chosen", filename: image.filename)
+    redirect_to document_path(document), notice: t("documents.show.flashes.lead_image.chosen", file: image.filename)
   end
 
   def remove
     document = Document.find_by_param(params[:document_id])
+    image = document.lead_image
 
     DocumentUpdateService.update!(
       document: document,
@@ -49,7 +50,7 @@ class DocumentLeadImageController < ApplicationController
       attributes_to_update: { lead_image_id: nil },
     )
 
-    redirect_to document_path(document), notice: t("documents.show.flashes.lead_image.removed")
+    redirect_to document_path(document), notice: t("documents.show.flashes.lead_image.removed", file: image.filename)
   end
 
   def destroy
@@ -66,7 +67,7 @@ class DocumentLeadImageController < ApplicationController
 
     AssetManagerService.new.delete(image)
     image.destroy!
-    redirect_to document_path(document), notice: t("documents.show.flashes.lead_image.deleted")
+    redirect_to document_path(document), notice: t("documents.show.flashes.lead_image.deleted", file: image.filename)
   end
 
 private

--- a/app/services/image_drafting_requirements.rb
+++ b/app/services/image_drafting_requirements.rb
@@ -14,18 +14,17 @@ class ImageDraftingRequirements
     messages = Hash.new { |h, k| h[k] = [] }
 
     if @image.alt_text.blank?
-      messages["alt_text"] << I18n.t("document_images.edit.flashes.drafting_requirements.presence",
-                                     field: "alt text")
+      messages["alt_text"] << I18n.t("document_images.edit.flashes.drafting_requirements.alt_text_presence")
     end
 
     if @image.alt_text.length > ALT_TEXT_MAX_LENGTH
-      messages["alt_text"] << I18n.t("document_images.edit.flashes.drafting_requirements.max_length",
+      messages["alt_text"] << I18n.t("document_images.edit.flashes.drafting_requirements.alt_text_max_length",
                                      field: "Alt text",
                                      max_length: ALT_TEXT_MAX_LENGTH)
     end
 
     if @image.caption.length > CAPTION_MAX_LENGTH
-      messages["caption"] << I18n.t("document_images.edit.flashes.drafting_requirements.max_length",
+      messages["caption"] << I18n.t("document_images.edit.flashes.drafting_requirements.caption_max_length",
                                     field: "Caption",
                                     max_length: CAPTION_MAX_LENGTH)
     end

--- a/app/services/image_normaliser.rb
+++ b/app/services/image_normaliser.rb
@@ -2,7 +2,7 @@
 
 require "mini_magick"
 
-class ImageUploader::ImageNormaliser
+class ImageNormaliser
   def initialize(image_path)
     @image = MiniMagick::Image.open(image_path)
     @output = Tempfile.new

--- a/app/services/image_upload_requirements.rb
+++ b/app/services/image_upload_requirements.rb
@@ -1,0 +1,41 @@
+# frozen_string_literal: true
+
+class ImageUploadRequirements
+  include ActionView::Helpers::NumberHelper
+
+  SUPPORTED_FORMATS = %w(image/jpeg image/png image/gif).freeze
+  MAX_FILE_SIZE = 20.megabytes
+
+  attr_reader :file
+
+  def initialize(file)
+    @file = file
+  end
+
+  def errors
+    messages = []
+
+    unless file
+      return [I18n.t("document_images.index.flashes.upload_requirements.no_file_selected")]
+    end
+
+    if SUPPORTED_FORMATS.exclude?(Marcel::MimeType.for(file))
+      return [I18n.t("document_images.index.flashes.upload_requirements.invalid_format")]
+    end
+
+    if file.size >= MAX_FILE_SIZE
+      messages << I18n.t("document_images.index.flashes.upload_requirements.max_size",
+                         max_size: number_to_human_size(MAX_FILE_SIZE))
+    end
+
+    dimensions = ImageNormaliser.new(file.path).dimensions
+
+    if dimensions[:width] < Image::WIDTH || dimensions[:height] < Image::HEIGHT
+      messages << I18n.t("document_images.index.flashes.upload_requirements.min_dimensions",
+                         width: Image::WIDTH,
+                         height: Image::HEIGHT)
+    end
+
+    messages
+  end
+end

--- a/app/services/image_uploader.rb
+++ b/app/services/image_uploader.rb
@@ -3,20 +3,8 @@
 require "mini_magick"
 
 class ImageUploader
-  include ActionView::Helpers::NumberHelper
-
-  MAX_FILE_SIZE = 20.megabytes
-
   def initialize(file)
     @file = file
-  end
-
-  def valid?
-    errors.empty?
-  end
-
-  def errors
-    @errors ||= validate
   end
 
   def upload(document)
@@ -61,28 +49,5 @@ private
       crop_width: cropper.dimensions[:width],
       crop_height: cropper.dimensions[:height],
     }
-  end
-
-  def validate
-    if %w(image/jpeg image/png image/gif).exclude?(mime_type)
-      return [I18n.t("validations.images.invalid_format")]
-    end
-
-    errors = []
-
-    if file.size >= MAX_FILE_SIZE
-      errors << I18n.t("validations.images.max_size",
-                       max_size: number_to_human_size(MAX_FILE_SIZE))
-    end
-
-    dimensions = image_normaliser.dimensions
-
-    if dimensions[:width] < Image::WIDTH || dimensions[:height] < Image::HEIGHT
-      errors << I18n.t("validations.images.min_dimensions",
-                       width: Image::WIDTH,
-                       height: Image::HEIGHT)
-    end
-
-    errors
   end
 end

--- a/config/locales/en/document_images/edit.yml
+++ b/config/locales/en/document_images/edit.yml
@@ -9,8 +9,9 @@ en:
       flashes:
         drafting_requirements:
           title: You need to
-          presence: "Enter %{field}"
-          max_length: "%{field} must be less than %{max_length} characters"
+          alt_text_presence: Enter alt text
+          alt_text_max_length: "Enter alt text that is fewer than %{max_length} characters long"
+          caption_max_length: "Enter an image caption that is fewer than %{max_length} characters long"
       guidance:
         alt_text: A simple and specific description of what the image shows. This helps screen-readers and search engines.
         caption: This text appears on the page under the image.

--- a/config/locales/en/document_images/index.yml
+++ b/config/locales/en/document_images/index.yml
@@ -8,13 +8,17 @@ en:
       alt_text: Alt text
       caption: Image caption
       credit: Image credit
-      no_file_selected: You must select a file
-      error_summary_title: You need to
       lead_image: Lead image
       flashes:
-        cropped: "Cropped image for ‘%{filename}’"
-        details_edited: "Image details have been edited for ‘%{filename}’"
-        deleted: Image deleted
+        upload_requirements:
+          title: You need to
+          no_file_selected: Select a file to upload
+          invalid_format: Select a a jpg, jpeg, png or gif image file
+          max_size: "Select an image file under %{max_size} in size"
+          min_dimensions: "Select an image at least %{width} pixels wide by %{height} pixels high"
+        cropped: "Image “%{file}” has been cropped"
+        details_edited: "Image details for “%{file}” have been updated"
+        deleted: "Image “%{file}” has been deleted"
         api_error:
           title: Something has gone wrong
           description: Something went wrong when uploading your file. Please try again or [raise a support request](https://support.publishing.service.gov.uk/technical_fault_report/new).

--- a/config/locales/en/documents/show.yml
+++ b/config/locales/en/documents/show.yml
@@ -54,15 +54,14 @@ en:
           description: Something went wrong when publishing. Please try again or [raise a support request](https://support.publishing.service.gov.uk/technical_fault_report/new).
         approved: Content has been reviewed and approved
         submitted_for_review:
-          title: Content has been submitted for 2i review
+          title: Content has been marked as ready for 2i review
           label: Send this document to another publisher for them to review. When content is ready you or they can publish it.
         delete_draft: Are you sure you want to delete this draft
         delete_draft_error:
           title: Something has gone wrong
           description: Something went wrong when deleting your draft. Please try again or [raise a support request](https://support.publishing.service.gov.uk/technical_fault_report/new).
         lead_image:
-          added: "Lead image added for ‘%{filename}’"
-          chosen: "Lead image has been set with ‘%{filename}’"
-          removed: Lead image removed
-          deleted: Lead image deleted
-
+          added: "Image “%{file}” has been uploaded and selected as the lead image"
+          chosen: "Image “%{file}” has been selected as the lead image"
+          removed: "Image “%{file}” has been deselected. Document will now use the default lead image"
+          deleted: "Image “%{file}” has been deleted. Document wil now use the default lead image"

--- a/config/locales/en/validations.yml
+++ b/config/locales/en/validations.yml
@@ -1,6 +1,0 @@
-en:
-  validations:
-    images:
-      invalid_format: "Expected a jpg, png or gif image"
-      max_size: "Image uploads must be less than %{max_size} in filesize"
-      min_dimensions: "Images must have dimensions of at least %{width} x %{height} pixels"

--- a/spec/features/editing_images/choose_lead_image_spec.rb
+++ b/spec/features/editing_images/choose_lead_image_spec.rb
@@ -37,7 +37,7 @@ RSpec.feature "Choose a lead image" do
   end
 
   def and_the_preview_creation_succeeded
-    expect(page).to have_content(I18n.t("documents.show.flashes.lead_image.chosen", filename: Image.last.filename))
+    expect(page).to have_content(I18n.t("documents.show.flashes.lead_image.chosen", file: @image.filename))
     expect(@request).to have_been_requested
     expect(page).to have_content(I18n.t("user_facing_states.draft.name"))
 

--- a/spec/features/editing_images/delete_image_spec.rb
+++ b/spec/features/editing_images/delete_image_spec.rb
@@ -27,7 +27,7 @@ RSpec.feature "Delete an image" do
 
   def then_i_see_the_image_is_gone
     expect(all("#image-#{@image.id}").count).to be_zero
-    expect(page).to have_content(I18n.t("document_images.index.flashes.deleted"))
+    expect(page).to have_content(I18n.t("document_images.index.flashes.deleted", file: @image.filename))
 
     expect(@image_request).to have_been_requested
     expect(ActiveStorage::Blob.service.exist?(@image.blob.key)).to be_falsey

--- a/spec/features/editing_images/delete_lead_image_spec.rb
+++ b/spec/features/editing_images/delete_lead_image_spec.rb
@@ -27,7 +27,7 @@ RSpec.feature "Delete an image" do
   end
 
   def then_i_see_the_document_has_no_lead_image
-    expect(page).to have_content(I18n.t("documents.show.flashes.lead_image.deleted"))
+    expect(page).to have_content(I18n.t("documents.show.flashes.lead_image.deleted", file: @image.filename))
     expect(page).to have_content(I18n.t("documents.show.lead_image.no_lead_image"))
     expect(page).to have_content(I18n.t("documents.history.entry_types.lead_image_removed"))
     expect(@image_request).to have_been_requested

--- a/spec/features/editing_images/edit_image_crop_spec.rb
+++ b/spec/features/editing_images/edit_image_crop_spec.rb
@@ -51,7 +51,7 @@ RSpec.feature "Edit image crop", js: true do
     expect(Image.last.crop_x).to eq(0)
     expect(Image.last.crop_width).to eq(960)
     expect(Image.last.crop_height).to eq(640)
-    expect(page).to have_content(I18n.t("document_images.index.flashes.cropped", filename: Image.last.filename))
+    expect(page).to have_content(I18n.t("document_images.index.flashes.cropped", file: Image.last.filename))
   end
 
   def and_the_preview_creation_succeeded

--- a/spec/features/editing_images/edit_image_metadata_spec.rb
+++ b/spec/features/editing_images/edit_image_metadata_spec.rb
@@ -12,7 +12,7 @@ RSpec.feature "Edit image metadata" do
   def given_there_is_a_document_with_images
     document_type_schema = build(:document_type_schema, lead_image: true)
     document = create(:document, document_type: document_type_schema.id)
-    create(:image, document: document)
+    @image = create(:image, document: document)
   end
 
   def when_i_visit_the_images_page
@@ -30,7 +30,7 @@ RSpec.feature "Edit image metadata" do
 
   def then_i_see_the_image_is_updated
     expect(@request).to have_been_requested
-    expect(page).to have_content(I18n.t("document_images.index.flashes.details_edited", filename: Image.last.filename))
+    expect(page).to have_content(I18n.t("document_images.index.flashes.details_edited", file: @image.filename))
     expect(page).to have_content("Some alt text")
     expect(page).to have_content("A caption")
     expect(page).to have_content("A credit")

--- a/spec/features/editing_images/image_drafting_requirements_spec.rb
+++ b/spec/features/editing_images/image_drafting_requirements_spec.rb
@@ -36,8 +36,7 @@ RSpec.feature "Image drafting requirements" do
   end
 
   def then_i_see_the_alt_text_is_needed
-    expect(page).to have_content(I18n.t("document_images.edit.flashes.drafting_requirements.presence",
-                                        field: "alt text"))
+    expect(page).to have_content(I18n.t("document_images.edit.flashes.drafting_requirements.alt_text_presence"))
   end
 
   def when_i_enter_too_much_alt_text
@@ -49,7 +48,7 @@ RSpec.feature "Image drafting requirements" do
   def then_i_see_the_alt_text_is_too_long
     expect(find_field("alt_text").value).to eq(@alt_text)
 
-    expect(page).to have_content(I18n.t("document_images.edit.flashes.drafting_requirements.max_length",
+    expect(page).to have_content(I18n.t("document_images.edit.flashes.drafting_requirements.alt_text_max_length",
                                         field: "Alt text",
                                         max_length: ImageDraftingRequirements::ALT_TEXT_MAX_LENGTH))
   end
@@ -63,7 +62,7 @@ RSpec.feature "Image drafting requirements" do
   def then_i_see_the_caption_is_too_long
     expect(find_field("caption").value).to eq(@caption)
 
-    expect(page).to have_content(I18n.t("document_images.edit.flashes.drafting_requirements.max_length",
+    expect(page).to have_content(I18n.t("document_images.edit.flashes.drafting_requirements.caption_max_length",
                                         field: "Caption",
                                         max_length: ImageDraftingRequirements::CAPTION_MAX_LENGTH))
   end

--- a/spec/features/editing_images/remove_lead_image_spec.rb
+++ b/spec/features/editing_images/remove_lead_image_spec.rb
@@ -25,7 +25,7 @@ RSpec.feature "Remove a lead image" do
   end
 
   def then_the_document_has_no_lead_image
-    expect(page).to have_content(I18n.t("documents.show.flashes.lead_image.removed"))
+    expect(page).to have_content(I18n.t("documents.show.flashes.lead_image.removed", file: @image.filename))
     expect(@request).to have_been_requested
     expect(page).to have_content(I18n.t("user_facing_states.draft.name"))
 

--- a/spec/features/editing_images/upload_invalid_lead_image_spec.rb
+++ b/spec/features/editing_images/upload_invalid_lead_image_spec.rb
@@ -24,6 +24,6 @@ RSpec.feature "Edit a lead image" do
   end
 
   def then_i_should_see_an_error
-    expect(page).to have_content(I18n.t("validations.images.invalid_format"))
+    expect(page).to have_content(I18n.t("document_images.index.flashes.upload_requirements.invalid_format"))
   end
 end

--- a/spec/features/editing_images/upload_lead_image_spec.rb
+++ b/spec/features/editing_images/upload_lead_image_spec.rb
@@ -44,7 +44,7 @@ RSpec.feature "Upload a lead image" do
   end
 
   def then_i_see_the_new_lead_image
-    expect(page).to have_content(I18n.t("documents.show.flashes.lead_image.added", filename: Image.last.filename))
+    expect(page).to have_content(I18n.t("documents.show.flashes.lead_image.added", file: Image.last.filename))
     expect(page).to have_content("A caption")
     expect(page).to have_content("A credit")
     expect(find("#lead-image img")["src"]).to include("1000x1000.jpg")

--- a/spec/features/editing_images/upload_no_file_as_lead_image_spec.rb
+++ b/spec/features/editing_images/upload_no_file_as_lead_image_spec.rb
@@ -22,6 +22,6 @@ RSpec.feature "Upload no file as a lead image" do
   end
 
   def then_i_should_see_an_error
-    expect(page).to have_content(I18n.t("document_images.index.no_file_selected"))
+    expect(page).to have_content(I18n.t("document_images.index.flashes.upload_requirements.no_file_selected"))
   end
 end

--- a/spec/services/image_normaliser_spec.rb
+++ b/spec/services/image_normaliser_spec.rb
@@ -3,13 +3,13 @@
 require "mini_magick"
 require "digest"
 
-RSpec.describe ImageUploader::ImageNormaliser do
+RSpec.describe ImageNormaliser do
   describe "#dimensions" do
     context "when given an image without an orientation" do
       it "returns the dimensions" do
         path = file_fixture("960x640.jpg")
 
-        normaliser = ImageUploader::ImageNormaliser.new(path)
+        normaliser = ImageNormaliser.new(path)
         expect(normaliser.dimensions).to eql(width: 960, height: 640)
       end
     end
@@ -18,7 +18,7 @@ RSpec.describe ImageUploader::ImageNormaliser do
       it "returns the normalised dimensions" do
         path = file_fixture("640x960-rotated.jpg")
 
-        normaliser = ImageUploader::ImageNormaliser.new(path)
+        normaliser = ImageNormaliser.new(path)
         expect(normaliser.dimensions).to eql(width: 960, height: 640)
       end
     end
@@ -26,13 +26,13 @@ RSpec.describe ImageUploader::ImageNormaliser do
 
   describe "#normalised_file" do
     it "returns a tempfile" do
-      normaliser = ImageUploader::ImageNormaliser.new(file_fixture("960x640.jpg"))
+      normaliser = ImageNormaliser.new(file_fixture("960x640.jpg"))
       expect(normaliser.normalised_file).to be_a(Tempfile)
     end
 
     it "does not modify the source file" do
       path = file_fixture("640x960-rotated.jpg")
-      normaliser = ImageUploader::ImageNormaliser.new(path)
+      normaliser = ImageNormaliser.new(path)
       expect { normaliser.normalised_file }
         .not_to(change { Digest::SHA256.file(path).hexdigest })
     end
@@ -43,7 +43,7 @@ RSpec.describe ImageUploader::ImageNormaliser do
       # orientation 6 means rotated 90 degrees clockwise
       expect(source_image.exif).to match(hash_including("Orientation" => "6"))
 
-      normaliser = ImageUploader::ImageNormaliser.new(source_path)
+      normaliser = ImageNormaliser.new(source_path)
       image = MiniMagick::Image.open(normaliser.normalised_file.path)
 
       expect(image.width).to eql(960)

--- a/spec/services/image_upload_requirements_spec.rb
+++ b/spec/services/image_upload_requirements_spec.rb
@@ -1,0 +1,48 @@
+# frozen_string_literal: true
+
+RSpec.describe ImageUploadRequirements do
+  describe "#errors" do
+    it "returns an empty array when a valid image is uploaded" do
+      uploaded_file = fixture_file_upload("files/960x640.jpg", "image/jpeg")
+      errors = ImageUploadRequirements.new(uploaded_file).errors
+      expect(errors).to be_empty
+    end
+
+    it "returns an error when no image is specified" do
+      errors = ImageUploadRequirements.new(nil).errors
+      error = I18n.t("document_images.index.flashes.upload_requirements.no_file_selected")
+      expect(errors).to eq([error])
+    end
+
+
+    it "returns an error when an incorrect file type is provided" do
+      uploaded_file = fixture_file_upload("files/text-file.txt", "text/plain")
+      errors = ImageUploadRequirements.new(uploaded_file).errors
+
+      error = I18n.t("document_images.index.flashes.upload_requirements.invalid_format")
+      expect(errors).to eq([error])
+    end
+
+    it "has an error when a file bigger than the max size is provided" do
+      uploaded_file = fixture_file_upload("files/960x640.jpg", "image/jpeg")
+      allow(uploaded_file).to receive(:size).and_return(30.megabytes)
+      errors = ImageUploadRequirements.new(uploaded_file).errors
+
+      error = I18n.t("document_images.index.flashes.upload_requirements.max_size",
+                     max_size: "20 MB")
+
+      expect(errors).to eq([error])
+    end
+
+    it "has an error when a file smaller than the minimum dimensions is provided" do
+      uploaded_file = fixture_file_upload("files/100x100.jpg", "image/jpeg")
+      errors = ImageUploadRequirements.new(uploaded_file).errors
+
+      error = I18n.t("document_images.index.flashes.upload_requirements.min_dimensions",
+                     width: Image::WIDTH,
+                     height: Image::HEIGHT)
+
+      expect(errors).to eq([error])
+    end
+  end
+end

--- a/spec/services/image_uploader_spec.rb
+++ b/spec/services/image_uploader_spec.rb
@@ -3,45 +3,6 @@
 require "mini_magick"
 
 RSpec.describe ImageUploader do
-  describe "#valid?" do
-    it "returns false when an invalid image is uploaded" do
-      uploaded_file = fixture_file_upload("files/text-file.txt", "text/plain")
-      uploader = ImageUploader.new(uploaded_file)
-      expect(uploader.valid?).to be(false)
-    end
-
-    it "returns true when a valid image is uploaded" do
-      uploaded_file = fixture_file_upload("files/960x640.jpg", "image/jpeg")
-      uploader = ImageUploader.new(uploaded_file)
-      expect(uploader.valid?).to be(true)
-    end
-  end
-
-  describe "#errors" do
-    it "has an error when an incorrect file type is provided" do
-      uploaded_file = fixture_file_upload("files/text-file.txt", "text/plain")
-      uploader = ImageUploader.new(uploaded_file)
-      expect(uploader.errors).to match([I18n.t("validations.images.invalid_format")])
-    end
-
-    it "has an error when a file bigger than the max size is provided" do
-      uploaded_file = fixture_file_upload("files/960x640.jpg", "image/jpeg")
-      allow(uploaded_file).to receive(:size).and_return(30.megabytes)
-      uploader = ImageUploader.new(uploaded_file)
-
-      error = I18n.t("validations.images.max_size", max_size: "20 MB")
-      expect(uploader.errors).to match([error])
-    end
-
-    it "has an error when a file smaller than the minimum dimensions is provided" do
-      uploaded_file = fixture_file_upload("files/100x100.jpg", "image/jpeg")
-      uploader = ImageUploader.new(uploaded_file)
-
-      error = I18n.t("validations.images.min_dimensions", width: Image::WIDTH, height: Image::HEIGHT)
-      expect(uploader.errors).to match([error])
-    end
-  end
-
   describe "#upload" do
     it "creates an image model for a document" do
       uploaded_file = fixture_file_upload("files/960x640.jpg", "image/jpeg")


### PR DESCRIPTION
https://trello.com/c/yxeOlaA8/309-iterate-our-publishing-requirements

This extracts the validation logic from the image uploader class to be
consistent with the 'requirements' pattern we've developed for document
drafting/publishing and image drafting. As the error messages won't be
shown away from the images index page, we no longer need the top level
locale file.