### PR TITLE
Trim body on summary screen using character limit

### DIFF
--- a/app/views/components/_formatted_text.html.erb
+++ b/app/views/components/_formatted_text.html.erb
@@ -1,3 +1,3 @@
 <pre class="app-c-formatted-text">
-<%= text.lines[0..lines].join.strip %> <% if text.lines.count > lines %>…<% end %>
+<%= text[0..chars] %> <% if text.length > chars %>…<% end %>
 </pre>

--- a/app/views/documents/fields/_govspeak.html.erb
+++ b/app/views/documents/fields/_govspeak.html.erb
@@ -1,4 +1,4 @@
 <%= render "components/formatted_text", {
   text: @document.contents[schema.id].to_s,
-  lines: 3
+  chars: 150
 } %>


### PR DESCRIPTION
https://trello.com/c/nViNavOU/347-development-clean-up-for-user-research

The previous line-based approach made the summary screen too long when
publishers create content with long initial paragraphs.