### PR TITLE
Fix not checking for draft requirements on upload

### DIFF
--- a/app/controllers/document_lead_image_controller.rb
+++ b/app/controllers/document_lead_image_controller.rb
@@ -6,26 +6,6 @@ class DocumentLeadImageController < ApplicationController
     redirect_to document_images_path, alert_with_description: t("document_images.index.flashes.api_error")
   end
 
-  def index
-    @document = Document.find_by_param(params[:document_id])
-  end
-
-  def update
-    document = Document.find_by_param(params[:document_id])
-    image = document.images.find(params[:image_id])
-    image.update!(update_params)
-
-    document.assign_attributes(lead_image_id: image.id)
-
-    DocumentDraftingService.update!(
-      document: document,
-      user: current_user,
-      type: "lead_image_updated",
-    )
-
-    redirect_to document_path(document), notice: t("documents.show.flashes.lead_image.added", file: image.filename)
-  end
-
   def choose
     document = Document.find_by_param(params[:document_id])
     image = Image.find(params[:image_id])
@@ -53,41 +33,5 @@ class DocumentLeadImageController < ApplicationController
     )
 
     redirect_to document_path(document), notice: t("documents.show.flashes.lead_image.removed", file: image.filename)
-  end
-
-  def destroy
-    document = Document.find_by_param(params[:document_id])
-    image = document.images.find(params[:image_id])
-    raise "Trying to delete image for a live document" if document.has_live_version_on_govuk
-
-    document.assign_attributes(lead_image_id: nil)
-
-    DocumentDraftingService.update!(
-      document: document,
-      user: current_user,
-      type: "lead_image_removed",
-    )
-
-    AssetManagerService.new.delete(image)
-    image.destroy!
-    redirect_to document_path(document), notice: t("documents.show.flashes.lead_image.deleted", file: image.filename)
-  end
-
-private
-
-  def update_params
-    params.permit(:caption, :alt_text, :credit)
-  end
-
-  def upload_image_to_asset_manager(image)
-    AssetManagerService.new.upload_bytes(image, image.cropped_bytes)
-  end
-
-  def delete_image_from_asset_manager(image)
-    AssetManagerService.new.delete(image)
-  end
-
-  def update_crop_params
-    params.permit(:crop_x, :crop_y, :crop_width, :crop_height)
   end
 end

--- a/app/views/document_images/_image_list.html.erb
+++ b/app/views/document_images/_image_list.html.erb
@@ -23,7 +23,8 @@ end %>
   <% unless @document.has_live_version_on_govuk %>
     <% secondary_actions << capture do %>
       <% if image.id == @document.lead_image_id %>
-        <%= form_tag destroy_document_lead_image_path(@document, image), method: :delete, class: "app-inline-block" do %>
+        <%= form_tag destroy_document_image_path(@document, image), method: :delete, class: "app-inline-block" do %>
+          <%= hidden_field_tag :wizard, "lead_image" %>
           <button class="govuk-link app-link--destructive">Delete lead image</button>
         <% end %>
       <% else %>

--- a/app/views/document_images/edit.html.erb
+++ b/app/views/document_images/edit.html.erb
@@ -13,11 +13,9 @@
   no_border: true
 } %>
 
-<% submit_path = params[:wizard] == "lead_image" ?
-    choose_document_lead_image_path(@document, @image) :
-    update_document_image_path(@document, @image) %>
+<%= form_tag(update_document_image_path(@document, @image), method: :patch) do %>
+  <%= hidden_field_tag :wizard, params[:wizard] %>
 
-<%= form_tag(submit_path, method: :patch) do %>
   <div class="govuk-grid-row">
     <div class="govuk-grid-column-two-thirds">
       <%= render "govuk_publishing_components/components/input", {

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -42,8 +42,6 @@ Rails.application.routes.draw do
   delete "/documents/:document_id/images/:image_id" => "document_images#destroy", as: :destroy_document_image
 
   post "/documents/:document_id/lead-image/:image_id" => "document_lead_image#choose", as: :choose_document_lead_image
-  patch "/documents/:document_id/lead-image/:image_id" => "document_lead_image#update", as: :update_document_lead_image
-  delete "/documents/:document_id/lead-image/:image_id" => "document_lead_image#destroy", as: :destroy_document_lead_image
   delete "/documents/:document_id/lead-image" => "document_lead_image#remove", as: :remove_document_lead_image
 
   get "/healthcheck", to: proc { [200, {}, %w[OK]] }

--- a/spec/features/editing_images/image_drafting_requirements_spec.rb
+++ b/spec/features/editing_images/image_drafting_requirements_spec.rb
@@ -49,7 +49,6 @@ RSpec.feature "Image drafting requirements" do
     expect(find_field("alt_text").value).to eq(@alt_text)
 
     expect(page).to have_content(I18n.t("document_images.edit.flashes.drafting_requirements.alt_text_max_length",
-                                        field: "Alt text",
                                         max_length: ImageDraftingRequirements::ALT_TEXT_MAX_LENGTH))
   end
 
@@ -63,7 +62,6 @@ RSpec.feature "Image drafting requirements" do
     expect(find_field("caption").value).to eq(@caption)
 
     expect(page).to have_content(I18n.t("document_images.edit.flashes.drafting_requirements.caption_max_length",
-                                        field: "Caption",
                                         max_length: ImageDraftingRequirements::CAPTION_MAX_LENGTH))
   end
 end

--- a/spec/features/editing_images/upload_lead_image_drafting_requirements_spec.rb
+++ b/spec/features/editing_images/upload_lead_image_drafting_requirements_spec.rb
@@ -1,15 +1,16 @@
 # frozen_string_literal: true
 
-RSpec.feature "Upload a lead image when Publishing API is down" do
+RSpec.feature "Upload a lead image drafting requirements" do
   scenario do
     given_there_is_a_document
     when_i_visit_the_images_page
     and_i_upload_a_new_image
     and_i_crop_the_image
-    and_the_publishing_api_is_down
-    and_i_fill_in_the_metadata
+    and_i_skip_entering_alt_text
+    then_i_see_the_alt_text_is_needed
+
+    when_i_fill_in_the_metadata
     then_i_see_the_new_lead_image
-    and_the_preview_creation_failed
   end
 
   def given_there_is_a_document
@@ -36,22 +37,21 @@ RSpec.feature "Upload a lead image when Publishing API is down" do
     WebMock.reset!
   end
 
-  def and_the_publishing_api_is_down
-    publishing_api_isnt_available
+  def and_i_skip_entering_alt_text
+    click_on "Save and choose"
   end
 
-  def and_i_fill_in_the_metadata
+  def then_i_see_the_alt_text_is_needed
+    expect(page).to have_content(I18n.t("document_images.edit.flashes.drafting_requirements.alt_text_presence"))
+  end
+
+  def when_i_fill_in_the_metadata
     fill_in "alt_text", with: "Some alt text"
+    stub_any_publishing_api_put_content
     click_on "Save and choose"
   end
 
   def then_i_see_the_new_lead_image
-    within("#image-#{Image.last.id}") do
-      expect(page).to have_content(I18n.t("document_images.index.lead_image"))
-    end
-  end
-
-  def and_the_preview_creation_failed
-    expect(page).to have_content(I18n.t("document_images.index.flashes.api_error.title"))
+    expect(page).to have_content(I18n.t("documents.show.flashes.lead_image.added", file: Image.last.filename))
   end
 end


### PR DESCRIPTION
https://trello.com/c/iecyxRBY/272-add-validations-for-image-details

Checking for draft requirements for images had only been applied when
editing the image. Attempting to add the requirements checking to the
lead images controller failed because "render 'document_images/edit"
looses track of the lead_image wizard param. So this commit pulls some
of the lead-image-specific functionality back into the document images
controller, which actually seems to make the flow a bit clearer.