### PR TITLE
Debug permission flag

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,6 +33,22 @@ yarn install
 bundle exec rake
 ```
 
+### Permissions
+
+Functionality of this application is enabled with permissions. There is a
+`pre_release_features` permission, for using functionality not yet available to
+users, and there is a `debug` permission, to access debug and documentation in
+app.
+
+To enable these permissions in a development environment run:
+
+```
+bundle exec rake developer_permissions
+```
+
+To enable them for your GOV.UK account add them to your account in
+[signon](https://github.com/alphagov/signon).
+
 ### Importing Whitehall news documents
 
 To populate your local database with [Whitehall][whitehall-repo] content there

--- a/README.md
+++ b/README.md
@@ -22,8 +22,20 @@ This is a Ruby on Rails application.
 
 ### Running the application
 
+The first time you run this application you'll want to set you
+[permissions](#permissions).
+
+Then, if you are running on the [GOV.UK development VM][dev-vm]:
+
 ```
+cd /var/govuk/govuk-puppet/development-vm
 bowl content-publisher
+```
+
+Otherwise, on your machine:
+
+```
+./startup.sh
 ```
 
 ### Running the test suite
@@ -80,5 +92,6 @@ bundle exec rake import:whitehall_news INPUT=/tmp/whitehall-export.json
 [postgresql]: https://www.postgresql.org/
 [yarn]: https://yarnpkg.com/
 [imagemagick]: https://www.imagemagick.org/script/index.php
+[dev-vm]: https://github.com/alphagov/govuk-puppet/tree/master/development-vm
 [whitehall-repo]: https://github.com/alphagov/whitehall
 [export-filters]: https://github.com/alphagov/whitehall/blob/master/lib/tasks/export.rake#L153

--- a/app/controllers/documentation_controller.rb
+++ b/app/controllers/documentation_controller.rb
@@ -1,5 +1,6 @@
 # frozen_string_literal: true
 
 class DocumentationController < ApplicationController
-  # TODO: restrict to GDS staff.
+  include GDS::SSO::ControllerMethods
+  before_action { authorise_user!(User::DEBUG_PERMISSION) }
 end

--- a/app/controllers/documents_controller.rb
+++ b/app/controllers/documents_controller.rb
@@ -1,6 +1,8 @@
 # frozen_string_literal: true
 
 class DocumentsController < ApplicationController
+  include GDS::SSO::ControllerMethods
+
   def index
     filter = DocumentFilter.new(filter_params)
     @documents = filter.documents
@@ -76,6 +78,7 @@ class DocumentsController < ApplicationController
   end
 
   def debug
+    authorise_user!(User::DEBUG_PERMISSION)
     @document = Document.find_by_param(params[:id])
     @papertrail_users = User.where(id: @document.versions.pluck(:whodunnit))
   end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -8,4 +8,5 @@ class User < ApplicationRecord
   serialize :permissions, Array
 
   PRE_RELEASE_FEATURES_PERMISSION = "pre_release_features"
+  DEBUG_PERMISSION = "debug"
 end

--- a/app/views/documentation/index.html.erb
+++ b/app/views/documentation/index.html.erb
@@ -19,12 +19,12 @@
         <td class='govuk-table__cell'><%= schema.id %></td>
 
         <% if schema.managed_elsewhere %>
-          <td class='govuk-table__cell'><%= link_to(t("documentation.index.formats.table.link_name"), schema.managed_elsewhere_url) %></td>
+          <td class='govuk-table__cell'><%= link_to(t("documentation.index.formats.table.link_name"), schema.managed_elsewhere_url, class: "govuk-link") %></td>
         <% else %>
           <td class='govuk-table__cell'></td>
         <% end %>
 
-        <td class='govuk-table__cell'><%= link_to 'Tech docs', "https://docs.publishing.service.gov.uk/document-types/#{schema.id}.html" %></td>
+        <td class='govuk-table__cell'><%= link_to 'Tech docs', "https://docs.publishing.service.gov.uk/document-types/#{schema.id}.html", class: "govuk-link"%></td>
       </tr>
     <% end %>
   </body>
@@ -32,7 +32,7 @@
 
 <h2 class='govuk-heading-m'><%= t("documentation.index.states.title") %></h2>
 
-<p><%= t("documentation.index.states.body") %></p>
+<p class='govuk-body'><%= t("documentation.index.states.body") %></p>
 
 <table class='govuk-table'>
   <thead class='govuk-table__head'>

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -81,12 +81,19 @@
   </div>
 
   <%
-    internal_metadata = {}
+    debug_links = []
+
+    if current_user.has_permission?(User::DEBUG_PERMISSION)
+      debug_links << {
+        href: documentation_path,
+        text: "App documentation",
+      }
+    end
 
     if @document && current_user.has_permission?(User::DEBUG_PERMISSION)
-      internal_metadata = {
+      debug_links << {
         href: debug_document_path(@document),
-        text: "Document internal metadata"
+        text: "Document internal metadata",
       }
     end
   %>
@@ -104,7 +111,7 @@
             href: "https://www.gov.uk/government/content-publishing",
             text: "How to write, publish, and improve content"
           }
-        ].push(internal_metadata)
+        ] + debug_links
       }
     ]
   } %>

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -83,7 +83,7 @@
   <%
     internal_metadata = {}
 
-    if @document && debug_document_path(@document)
+    if @document && current_user.has_permission?(User::DEBUG_PERMISSION)
       internal_metadata = {
         href: debug_document_path(@document),
         text: "Internal metadata (not shown to publishers)"

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -86,7 +86,7 @@
     if @document && current_user.has_permission?(User::DEBUG_PERMISSION)
       internal_metadata = {
         href: debug_document_path(@document),
-        text: "Internal metadata (not shown to publishers)"
+        text: "Document internal metadata"
       }
     end
   %>

--- a/lib/tasks/development_permissions.rake
+++ b/lib/tasks/development_permissions.rake
@@ -1,0 +1,10 @@
+# frozen_string_literal: true
+
+desc "Set development permissions on the mock User GDS-SSO uses"
+task development_permissions: :environment do
+  raise "Setting development permissions outside dev environment" unless Rails.env.development?
+  user = User.first || User.create!(name: "publisher")
+  permissions = (user.permissions + [User::PRE_RELEASE_FEATURES_PERMISSION, User::DEBUG_PERMISSION]).uniq
+  user.update_attribute(:permissions, permissions)
+  puts "User permissions are now #{permissions.to_sentence}"
+end

--- a/spec/features/debug_spec.rb
+++ b/spec/features/debug_spec.rb
@@ -1,0 +1,45 @@
+# frozen_string_literal: true
+
+RSpec.feature "Viewing debug information" do
+  scenario do
+    given_there_is_a_document
+    when_i_dont_have_the_debug_permission
+    and_i_visit_the_debug_page
+    then_i_see_an_error_page
+    when_im_given_debug_permission
+    and_i_visit_the_debug_page
+    then_i_see_the_debug_page
+  end
+
+  def given_there_is_a_document
+    create :document
+  end
+
+  def and_i_visit_the_debug_page
+    visit debug_document_path(Document.last)
+  end
+
+  def when_i_dont_have_the_debug_permission
+    user = User.first
+    user.update_attribute(:permissions,
+                          user.permissions - [User::DEBUG_PERMISSION])
+  end
+
+  def then_i_see_an_error_page
+    expect(page).to have_content(
+      "Sorry, you don't seem to have the #{User::DEBUG_PERMISSION} permission for this app",
+    )
+  end
+
+  def when_im_given_debug_permission
+    user = User.first
+    user.update_attribute(:permissions,
+                          user.permissions + [User::DEBUG_PERMISSION])
+  end
+
+  def then_i_see_the_debug_page
+    expect(page).to have_content(
+      "Internal metadata for ‘#{Document.last.title_or_fallback}’",
+    )
+  end
+end

--- a/spec/features/documentation_spec.rb
+++ b/spec/features/documentation_spec.rb
@@ -1,13 +1,35 @@
 # frozen_string_literal: true
 
-RSpec.feature "GDS Documentation" do
+RSpec.feature "Viewing documentation" do
   scenario do
-    when_i_visit_the_documentation_page
+    when_i_dont_have_the_debug_permission
+    and_i_visit_the_documentation_page
+    then_i_see_an_error_page
+    when_im_given_debug_permission
+    and_i_visit_the_documentation_page
     then_i_see_the_documentation_page
   end
 
-  def when_i_visit_the_documentation_page
+  def when_i_dont_have_the_debug_permission
+    user = User.first
+    user.update_attribute(:permissions,
+                          user.permissions - [User::DEBUG_PERMISSION])
+  end
+
+  def and_i_visit_the_documentation_page
     visit "/documentation"
+  end
+
+  def then_i_see_an_error_page
+    expect(page).to have_content(
+      "Sorry, you don't seem to have the #{User::DEBUG_PERMISSION} permission for this app",
+    )
+  end
+
+  def when_im_given_debug_permission
+    user = User.first
+    user.update_attribute(:permissions,
+                          user.permissions + [User::DEBUG_PERMISSION])
   end
 
   def then_i_see_the_documentation_page

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -54,12 +54,4 @@ RSpec.configure do |config|
   config.after :each, type: :feature, js: true do
     Capybara::Chromedriver::Logger::TestHooks.after_example!
   end
-
-  config.before :each, type: :controller do
-    request.env["warden"] = double(
-      authenticate!: true,
-      authenticated?: true,
-      user: User.first,
-    )
-  end
 end


### PR DESCRIPTION
Trello: https://trello.com/c/pt9c438U/361-feature-flag-for-upcoming-user-research

This adds a "debug" permission which can be used by signon for features that provide information that shouldn't be available to normal users of the app and just to provide functionality for someone learning more about the app and how it works.