### PR TITLE
Fix target for markdown guidance so it opens a tab

### DIFF
--- a/app/views/documents/fields/_govspeak_input.html.erb
+++ b/app/views/documents/fields/_govspeak_input.html.erb
@@ -27,8 +27,9 @@
         <p class="govuk-body"><%= document.document_type_schema.guidance_for(schema.id).body %></p>
 
         <h3 class="govuk-heading-s"><%= t("documents.edit.fields.govspeak.title") %></h3>
+
         <p class="govuk-body">
-          <a href="https://www.gov.uk/guidance/how-to-publish-on-gov-uk/markdown" class="govuk-link"><%= t("documents.edit.fields.govspeak.guidance") %></a>
+          <%= link_to t("documents.edit.fields.govspeak.guidance"), "https://www.gov.uk/guidance/how-to-publish-on-gov-uk/markdown", class: "govuk-link", target: "_blank" %>
         </p>
 
         <%= render "components/markdown_guidance" %>

--- a/app/views/documents/index.html.erb
+++ b/app/views/documents/index.html.erb
@@ -11,7 +11,7 @@
     <hr class="govuk-section-break govuk-section-break--visible govuk-section-break--l">
 
     <p class="govuk-heading-s"> <%= t("documents.index.guidance.title") %></p>
-    <p class="govuk-body"><%= link_to "Planning, writing and managing content", "https://www.gov.uk/topic/government-digital-guidance/content-publishing", class: "govuk-link", target: "blank" %></p>
+    <p class="govuk-body"><%= link_to "Planning, writing and managing content", "https://www.gov.uk/topic/government-digital-guidance/content-publishing", class: "govuk-link", target: "_blank" %></p>
   </div>
 
   <div class="govuk-grid-column-two-thirds">


### PR DESCRIPTION
https://trello.com/c/flWT8HIe/408-external-guidance-for-supertypes-should-open-a-new-tab

Also make the use of 'target=_blank' consistent.