### PR TITLE
Add documentation on running Whitehall import

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,6 +33,29 @@ yarn install
 bundle exec rake
 ```
 
+### Importing Whitehall news documents
+
+To populate your local database with [Whitehall][whitehall-repo] content there
+is a task in Whitehall to export data and a task in Content Publisher to
+import that output.
+
+To export from Whitehall, you need to have a cloned copy of Whitehall with a
+populated database, cd into the whitehall directory and run:
+
+```
+bundle exec rake export:news_documents 2>&1 | grep created_at > /tmp/whitehall-export.json
+```
+
+This will take a while to run (~30 mins), this can be reduced by limiting the
+output with [filters][export-filters]
+
+To import this exported file into Content Publisher, you need to cd into the
+content publisher directory and run:
+
+```
+bundle exec rake import:whitehall_news INPUT=/tmp/whitehall-export.json
+```
+
 ## Licence
 
 [MIT License](LICENCE)
@@ -41,3 +64,5 @@ bundle exec rake
 [postgresql]: https://www.postgresql.org/
 [yarn]: https://yarnpkg.com/
 [imagemagick]: https://www.imagemagick.org/script/index.php
+[whitehall-repo]: https://github.com/alphagov/whitehall
+[export-filters]: https://github.com/alphagov/whitehall/blob/master/lib/tasks/export.rake#L153

--- a/lib/tasks/import.rake
+++ b/lib/tasks/import.rake
@@ -16,8 +16,9 @@ namespace :import do
 
       importer.import(JSON.parse(line))
       imported += 1
+      puts "Imported #{imported} documents" if (imported % 500).zero?
     end
 
-    puts "Imported #{imported} Whitehall news documents"
+    puts "Completed importing #{imported} Whitehall news documents"
   end
 end


### PR DESCRIPTION
This doesn't seem to be documented anywhere outside of commit messages,
so this adds this to the README.

I opted to go for the approach of creating a file rather than streaming
between tasks as since the streaming approach waits for STDIN it's easy
to get stuck waiting forever if there is nothing on STDIN and it
requires a delicate balance of being in the correct directories to run
the commands.