### PR TITLE
Restrict access to managing topics to pre-release features

### DIFF
--- a/app/controllers/document_topics_controller.rb
+++ b/app/controllers/document_topics_controller.rb
@@ -1,6 +1,9 @@
 # frozen_string_literal: true
 
 class DocumentTopicsController < ApplicationController
+  include GDS::SSO::ControllerMethods
+  before_action { authorise_user!(User::PRE_RELEASE_FEATURES_PERMISSION) }
+
   rescue_from GdsApi::BaseError do |e|
     Rails.logger.error(e)
     render "#{action_name}_api_down", status: :service_unavailable

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -6,4 +6,6 @@ class User < ApplicationRecord
   include GDS::SSO::User
   has_many :documents, foreign_key: :creator_id, inverse_of: :creator, dependent: :restrict_with_exception
   serialize :permissions, Array
+
+  PRE_RELEASE_FEATURES_PERMISSION = "pre_release_features"
 end

--- a/app/views/documents/show/_summary_tab.html.erb
+++ b/app/views/documents/show/_summary_tab.html.erb
@@ -10,7 +10,9 @@
       <%= render "documents/show/lead_image" %>
     <% end %>
 
-    <%= render "documents/show/topics" %>
+    <% if current_user.has_permission?(User::PRE_RELEASE_FEATURES_PERMISSION) %>
+      <%= render "documents/show/topics" %>
+    <% end %>
     <%= render "documents/show/tags" %>
 
   </div>

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -1,3 +1,4 @@
 # frozen_string_literal: true
 
-User.find_or_create_by! name: "publisher"
+user = User.find_or_create_by!(name: "publisher")
+user.update_attribute(:permissions, [User::PRE_RELEASE_FEATURES_PERMISSION])

--- a/spec/features/editing_topics/access_topics_without_pre_release_features_permission_spec.rb
+++ b/spec/features/editing_topics/access_topics_without_pre_release_features_permission_spec.rb
@@ -1,0 +1,40 @@
+# frozen_string_literal: true
+
+RSpec.feature "Access topics without the pre-release features permission" do
+  scenario do
+    given_there_is_a_document
+    and_i_dont_have_pre_release_features_permission
+    when_i_visit_the_document_page
+    then_i_cant_see_the_change_topics_section
+    when_i_visit_the_topics_page
+    then_i_see_a_no_permission_message
+  end
+
+  def given_there_is_a_document
+    create :document
+  end
+
+  def and_i_dont_have_pre_release_features_permission
+    user = User.first
+    user.update_attribute(:permissions,
+                          user.permissions - [User::PRE_RELEASE_FEATURES_PERMISSION])
+  end
+
+  def when_i_visit_the_document_page
+    visit document_path(Document.last)
+  end
+
+  def then_i_cant_see_the_change_topics_section
+    expect(page).not_to have_link("Change Topics")
+  end
+
+  def when_i_visit_the_topics_page
+    visit document_topics_path(Document.last)
+  end
+
+  def then_i_see_a_no_permission_message
+    expect(page).to have_content(
+      "Sorry, you don't seem to have the #{User::PRE_RELEASE_FEATURES_PERMISSION} permission for this app",
+    )
+  end
+end


### PR DESCRIPTION
Trello: https://trello.com/c/pt9c438U/361-feature-flag-for-upcoming-user-research

This PR is to merge into https://github.com/alphagov/content-publisher/pull/392 so that can move from DO NOT MERGE. I intend to then update https://github.com/alphagov/content-publisher/pull/411 to be consistent with approaches in this.

See commits for details.