### PR TITLE
Refactor GdsApi usage for helper methods

### DIFF
--- a/app/services/asset_manager_service.rb
+++ b/app/services/asset_manager_service.rb
@@ -1,20 +1,18 @@
 # frozen_string_literal: true
 
-require "gds_api/asset_manager"
-
 class AssetManagerService
   def upload_bytes(asset, content)
     file = AssetManagerFile.from_bytes(asset, content)
-    upload = asset_manager.create_asset(file: file, draft: true)
+    upload = GdsApi.asset_manager.create_asset(file: file, draft: true)
     upload["file_url"]
   end
 
   def publish(asset)
-    asset_manager.update_asset(asset.asset_manager_id, draft: false)
+    GdsApi.asset_manager.update_asset(asset.asset_manager_id, draft: false)
   end
 
   def delete(asset)
-    asset_manager.delete_asset(asset.asset_manager_id)
+    GdsApi.asset_manager.delete_asset(asset.asset_manager_id)
   end
 
   # Used as a stand-in for a File / Rack::Multipart::UploadedFile object when
@@ -52,14 +50,5 @@ class AssetManagerService
     def filename
       File.basename(asset.filename)
     end
-  end
-
-private
-
-  def asset_manager
-    @asset_manager ||= GdsApi::AssetManager.new(
-      Plek.new.find("asset-manager"),
-      bearer_token: ENV.fetch("ASSET_MANAGER_BEARER_TOKEN", "example"),
-    )
   end
 end

--- a/app/services/linkables_service.rb
+++ b/app/services/linkables_service.rb
@@ -1,7 +1,5 @@
 # frozen_string_literal: true
 
-require "gds_api/publishing_api_v2"
-
 class LinkablesService
   CACHE_OPTIONS = { expires_in: 5.minutes, race_condition_ttl: 10.seconds }.freeze
 
@@ -26,16 +24,7 @@ private
     # Maybe we'll need to go further with this a la:
     # https://github.com/alphagov/whitehall/blob/fc62edcd5a9b1ba8bfb22911f69f128083535127/app/models/policy.rb#L45-L58
     @linkables ||= Rails.cache.fetch("linkables.#{document_type}", CACHE_OPTIONS) do
-      publishing_api.get_linkables(document_type: document_type).to_hash
+      GdsApi.publishing_api_v2(timeout: 1).get_linkables(document_type: document_type).to_hash
     end
-  end
-
-  def publishing_api
-    GdsApi::PublishingApiV2.new(
-      Plek.new.find("publishing-api"),
-      disable_cache: true,
-      timeout: 1,
-      bearer_token: ENV["PUBLISHING_API_BEARER_TOKEN"] || "example",
-    )
   end
 end

--- a/app/services/path_generator_service.rb
+++ b/app/services/path_generator_service.rb
@@ -1,7 +1,5 @@
 # frozen_string_literal: true
 
-require "gds_api/publishing_api_v2"
-
 class PathGeneratorService
   class ErrorGeneratingPath < RuntimeError
   end

--- a/app/services/publishing_api_payload.rb
+++ b/app/services/publishing_api_payload.rb
@@ -1,7 +1,5 @@
 # frozen_string_literal: true
 
-require "gds_api/publishing_api_v2"
-
 class PublishingApiPayload
   PUBLISHING_APP = "content-publisher"
 
@@ -85,7 +83,7 @@ private
 
     role_appointments
       .each_with_object("roles" => [], "people" => []) do |appointment_id, memo|
-        response = publishing_api.get_links(appointment_id).to_hash
+        response = GdsApi.publishing_api_v2.get_links(appointment_id).to_hash
 
         roles = response.dig("links", "role") || []
         people = response.dig("links", "person") || []
@@ -103,12 +101,5 @@ private
     else
       document.contents[field.id]
     end
-  end
-
-  def publishing_api
-    @publishing_api ||= GdsApi::PublishingApiV2.new(
-      Plek.new.find("publishing-api"),
-      bearer_token: ENV["PUBLISHING_API_BEARER_TOKEN"] || "example",
-    )
   end
 end


### PR DESCRIPTION
Since the helper methods arrived in 53.2 of gds-api-adapters [1] we can
now shorten the code used for initialising them. I didn't see any
particular benefits for memoization of the adapters.

[1]: https://github.com/alphagov/gds-api-adapters/blob/master/CHANGELOG.md#5320