### PR TITLE
Fix markdown buttons break line of content after first word

### DIFF
--- a/app/assets/javascripts/vendor/@github/markdown-toolbar-element/dist/index.umd.js
+++ b/app/assets/javascripts/vendor/@github/markdown-toolbar-element/dist/index.umd.js
@@ -158,17 +158,77 @@
     window.customElements.define('md-header', MarkdownHeaderButtonElement);
   }
 
-  var MarkdownBoldButtonElement = function (_MarkdownButtonElemen2) {
-    _inherits(MarkdownBoldButtonElement, _MarkdownButtonElemen2);
+  var MarkdownHeading2ButtonElement = function (_MarkdownButtonElemen2) {
+    _inherits(MarkdownHeading2ButtonElement, _MarkdownButtonElemen2);
+
+    function MarkdownHeading2ButtonElement() {
+      _classCallCheck(this, MarkdownHeading2ButtonElement);
+
+      var _this3 = _possibleConstructorReturn(this, (MarkdownHeading2ButtonElement.__proto__ || Object.getPrototypeOf(MarkdownHeading2ButtonElement)).call(this));
+
+      styles.set(_this3, { prefix: '## ' });
+      return _this3;
+    }
+
+    return MarkdownHeading2ButtonElement;
+  }(MarkdownButtonElement);
+
+  if (!window.customElements.get('md-header-2')) {
+    window.MarkdownHeading2ButtonElement = MarkdownHeading2ButtonElement;
+    window.customElements.define('md-header-2', MarkdownHeading2ButtonElement);
+  }
+
+  var MarkdownHeading3ButtonElement = function (_MarkdownButtonElemen3) {
+    _inherits(MarkdownHeading3ButtonElement, _MarkdownButtonElemen3);
+
+    function MarkdownHeading3ButtonElement() {
+      _classCallCheck(this, MarkdownHeading3ButtonElement);
+
+      var _this4 = _possibleConstructorReturn(this, (MarkdownHeading3ButtonElement.__proto__ || Object.getPrototypeOf(MarkdownHeading3ButtonElement)).call(this));
+
+      styles.set(_this4, { prefix: '### ' });
+      return _this4;
+    }
+
+    return MarkdownHeading3ButtonElement;
+  }(MarkdownButtonElement);
+
+  if (!window.customElements.get('md-header-3')) {
+    window.MarkdownHeading3ButtonElement = MarkdownHeading3ButtonElement;
+    window.customElements.define('md-header-3', MarkdownHeading3ButtonElement);
+  }
+
+  var MarkdownHeading4ButtonElement = function (_MarkdownButtonElemen4) {
+    _inherits(MarkdownHeading4ButtonElement, _MarkdownButtonElemen4);
+
+    function MarkdownHeading4ButtonElement() {
+      _classCallCheck(this, MarkdownHeading4ButtonElement);
+
+      var _this5 = _possibleConstructorReturn(this, (MarkdownHeading4ButtonElement.__proto__ || Object.getPrototypeOf(MarkdownHeading4ButtonElement)).call(this));
+
+      styles.set(_this5, { prefix: '#### ' });
+      return _this5;
+    }
+
+    return MarkdownHeading4ButtonElement;
+  }(MarkdownButtonElement);
+
+  if (!window.customElements.get('md-header-4')) {
+    window.MarkdownHeading4ButtonElement = MarkdownHeading4ButtonElement;
+    window.customElements.define('md-header-4', MarkdownHeading4ButtonElement);
+  }
+
+  var MarkdownBoldButtonElement = function (_MarkdownButtonElemen5) {
+    _inherits(MarkdownBoldButtonElement, _MarkdownButtonElemen5);
 
     function MarkdownBoldButtonElement() {
       _classCallCheck(this, MarkdownBoldButtonElement);
 
-      var _this3 = _possibleConstructorReturn(this, (MarkdownBoldButtonElement.__proto__ || Object.getPrototypeOf(MarkdownBoldButtonElement)).call(this));
+      var _this6 = _possibleConstructorReturn(this, (MarkdownBoldButtonElement.__proto__ || Object.getPrototypeOf(MarkdownBoldButtonElement)).call(this));
 
-      _this3.setAttribute('hotkey', 'b');
-      styles.set(_this3, { prefix: '**', suffix: '**', trimFirst: true });
-      return _this3;
+      _this6.setAttribute('hotkey', 'b');
+      styles.set(_this6, { prefix: '**', suffix: '**', trimFirst: true });
+      return _this6;
     }
 
     return MarkdownBoldButtonElement;
@@ -179,17 +239,17 @@
     window.customElements.define('md-bold', MarkdownBoldButtonElement);
   }
 
-  var MarkdownItalicButtonElement = function (_MarkdownButtonElemen3) {
-    _inherits(MarkdownItalicButtonElement, _MarkdownButtonElemen3);
+  var MarkdownItalicButtonElement = function (_MarkdownButtonElemen6) {
+    _inherits(MarkdownItalicButtonElement, _MarkdownButtonElemen6);
 
     function MarkdownItalicButtonElement() {
       _classCallCheck(this, MarkdownItalicButtonElement);
 
-      var _this4 = _possibleConstructorReturn(this, (MarkdownItalicButtonElement.__proto__ || Object.getPrototypeOf(MarkdownItalicButtonElement)).call(this));
+      var _this7 = _possibleConstructorReturn(this, (MarkdownItalicButtonElement.__proto__ || Object.getPrototypeOf(MarkdownItalicButtonElement)).call(this));
 
-      _this4.setAttribute('hotkey', 'i');
-      styles.set(_this4, { prefix: '_', suffix: '_', trimFirst: true });
-      return _this4;
+      _this7.setAttribute('hotkey', 'i');
+      styles.set(_this7, { prefix: '_', suffix: '_', trimFirst: true });
+      return _this7;
     }
 
     return MarkdownItalicButtonElement;
@@ -200,16 +260,16 @@
     window.customElements.define('md-italic', MarkdownItalicButtonElement);
   }
 
-  var MarkdownQuoteButtonElement = function (_MarkdownButtonElemen4) {
-    _inherits(MarkdownQuoteButtonElement, _MarkdownButtonElemen4);
+  var MarkdownQuoteButtonElement = function (_MarkdownButtonElemen7) {
+    _inherits(MarkdownQuoteButtonElement, _MarkdownButtonElemen7);
 
     function MarkdownQuoteButtonElement() {
       _classCallCheck(this, MarkdownQuoteButtonElement);
 
-      var _this5 = _possibleConstructorReturn(this, (MarkdownQuoteButtonElement.__proto__ || Object.getPrototypeOf(MarkdownQuoteButtonElement)).call(this));
+      var _this8 = _possibleConstructorReturn(this, (MarkdownQuoteButtonElement.__proto__ || Object.getPrototypeOf(MarkdownQuoteButtonElement)).call(this));
 
-      styles.set(_this5, { prefix: '> ', multiline: true, surroundWithNewlines: true });
-      return _this5;
+      styles.set(_this8, { prefix: '> ', multiline: true });
+      return _this8;
     }
 
     return MarkdownQuoteButtonElement;
@@ -220,16 +280,16 @@
     window.customElements.define('md-quote', MarkdownQuoteButtonElement);
   }
 
-  var MarkdownCodeButtonElement = function (_MarkdownButtonElemen5) {
-    _inherits(MarkdownCodeButtonElement, _MarkdownButtonElemen5);
+  var MarkdownCodeButtonElement = function (_MarkdownButtonElemen8) {
+    _inherits(MarkdownCodeButtonElement, _MarkdownButtonElemen8);
 
     function MarkdownCodeButtonElement() {
       _classCallCheck(this, MarkdownCodeButtonElement);
 
-      var _this6 = _possibleConstructorReturn(this, (MarkdownCodeButtonElement.__proto__ || Object.getPrototypeOf(MarkdownCodeButtonElement)).call(this));
+      var _this9 = _possibleConstructorReturn(this, (MarkdownCodeButtonElement.__proto__ || Object.getPrototypeOf(MarkdownCodeButtonElement)).call(this));
 
-      styles.set(_this6, { prefix: '`', suffix: '`', blockPrefix: '```', blockSuffix: '```' });
-      return _this6;
+      styles.set(_this9, { prefix: '`', suffix: '`', blockPrefix: '```', blockSuffix: '```' });
+      return _this9;
     }
 
     return MarkdownCodeButtonElement;
@@ -240,17 +300,17 @@
     window.customElements.define('md-code', MarkdownCodeButtonElement);
   }
 
-  var MarkdownLinkButtonElement = function (_MarkdownButtonElemen6) {
-    _inherits(MarkdownLinkButtonElement, _MarkdownButtonElemen6);
+  var MarkdownLinkButtonElement = function (_MarkdownButtonElemen9) {
+    _inherits(MarkdownLinkButtonElement, _MarkdownButtonElemen9);
 
     function MarkdownLinkButtonElement() {
       _classCallCheck(this, MarkdownLinkButtonElement);
 
-      var _this7 = _possibleConstructorReturn(this, (MarkdownLinkButtonElement.__proto__ || Object.getPrototypeOf(MarkdownLinkButtonElement)).call(this));
+      var _this10 = _possibleConstructorReturn(this, (MarkdownLinkButtonElement.__proto__ || Object.getPrototypeOf(MarkdownLinkButtonElement)).call(this));
 
-      _this7.setAttribute('hotkey', 'k');
-      styles.set(_this7, { prefix: '[', suffix: '](url)', replaceNext: 'url', scanFor: 'https?://' });
-      return _this7;
+      _this10.setAttribute('hotkey', 'k');
+      styles.set(_this10, { prefix: '[', suffix: '](url)', replaceNext: 'url', scanFor: 'https?://' });
+      return _this10;
     }
 
     return MarkdownLinkButtonElement;
@@ -261,16 +321,61 @@
     window.customElements.define('md-link', MarkdownLinkButtonElement);
   }
 
-  var MarkdownUnorderedListButtonElement = function (_MarkdownButtonElemen7) {
-    _inherits(MarkdownUnorderedListButtonElement, _MarkdownButtonElemen7);
+  var MarkdownCallToActionButtonElement = function (_MarkdownButtonElemen10) {
+    _inherits(MarkdownCallToActionButtonElement, _MarkdownButtonElemen10);
+
+    function MarkdownCallToActionButtonElement() {
+      _classCallCheck(this, MarkdownCallToActionButtonElement);
+
+      var _this11 = _possibleConstructorReturn(this, (MarkdownCallToActionButtonElement.__proto__ || Object.getPrototypeOf(MarkdownCallToActionButtonElement)).call(this));
+
+      styles.set(_this11, {
+        prefix: '$CTA [',
+        suffix: '](url) $CTA',
+        replaceNext: 'url',
+        scanFor: 'https?://'
+      });
+      return _this11;
+    }
+
+    return MarkdownCallToActionButtonElement;
+  }(MarkdownButtonElement);
+
+  if (!window.customElements.get('md-link-cta')) {
+    window.MarkdownCallToActionButtonElement = MarkdownCallToActionButtonElement;
+    window.customElements.define('md-link-cta', MarkdownCallToActionButtonElement);
+  }
+
+  var MarkdownEmailLinkButtonElement = function (_MarkdownButtonElemen11) {
+    _inherits(MarkdownEmailLinkButtonElement, _MarkdownButtonElemen11);
+
+    function MarkdownEmailLinkButtonElement() {
+      _classCallCheck(this, MarkdownEmailLinkButtonElement);
+
+      var _this12 = _possibleConstructorReturn(this, (MarkdownEmailLinkButtonElement.__proto__ || Object.getPrototypeOf(MarkdownEmailLinkButtonElement)).call(this));
+
+      styles.set(_this12, { prefix: '<', suffix: '>' });
+      return _this12;
+    }
+
+    return MarkdownEmailLinkButtonElement;
+  }(MarkdownButtonElement);
+
+  if (!window.customElements.get('md-link-email')) {
+    window.MarkdownEmailLinkButtonElement = MarkdownEmailLinkButtonElement;
+    window.customElements.define('md-link-email', MarkdownEmailLinkButtonElement);
+  }
+
+  var MarkdownUnorderedListButtonElement = function (_MarkdownButtonElemen12) {
+    _inherits(MarkdownUnorderedListButtonElement, _MarkdownButtonElemen12);
 
     function MarkdownUnorderedListButtonElement() {
       _classCallCheck(this, MarkdownUnorderedListButtonElement);
 
-      var _this8 = _possibleConstructorReturn(this, (MarkdownUnorderedListButtonElement.__proto__ || Object.getPrototypeOf(MarkdownUnorderedListButtonElement)).call(this));
+      var _this13 = _possibleConstructorReturn(this, (MarkdownUnorderedListButtonElement.__proto__ || Object.getPrototypeOf(MarkdownUnorderedListButtonElement)).call(this));
 
-      styles.set(_this8, { prefix: '- ', multiline: true, surroundWithNewlines: true });
-      return _this8;
+      styles.set(_this13, { prefix: '- ', multiline: true });
+      return _this13;
     }
 
     return MarkdownUnorderedListButtonElement;
@@ -281,16 +386,16 @@
     window.customElements.define('md-unordered-list', MarkdownUnorderedListButtonElement);
   }
 
-  var MarkdownOrderedListButtonElement = function (_MarkdownButtonElemen8) {
-    _inherits(MarkdownOrderedListButtonElement, _MarkdownButtonElemen8);
+  var MarkdownOrderedListButtonElement = function (_MarkdownButtonElemen13) {
+    _inherits(MarkdownOrderedListButtonElement, _MarkdownButtonElemen13);
 
     function MarkdownOrderedListButtonElement() {
       _classCallCheck(this, MarkdownOrderedListButtonElement);
 
-      var _this9 = _possibleConstructorReturn(this, (MarkdownOrderedListButtonElement.__proto__ || Object.getPrototypeOf(MarkdownOrderedListButtonElement)).call(this));
+      var _this14 = _possibleConstructorReturn(this, (MarkdownOrderedListButtonElement.__proto__ || Object.getPrototypeOf(MarkdownOrderedListButtonElement)).call(this));
 
-      styles.set(_this9, { prefix: '1. ', multiline: true, orderedList: true });
-      return _this9;
+      styles.set(_this14, { prefix: '1. ', multiline: true, orderedList: true });
+      return _this14;
     }
 
     return MarkdownOrderedListButtonElement;
@@ -301,17 +406,17 @@
     window.customElements.define('md-ordered-list', MarkdownOrderedListButtonElement);
   }
 
-  var MarkdownTaskListButtonElement = function (_MarkdownButtonElemen9) {
-    _inherits(MarkdownTaskListButtonElement, _MarkdownButtonElemen9);
+  var MarkdownTaskListButtonElement = function (_MarkdownButtonElemen14) {
+    _inherits(MarkdownTaskListButtonElement, _MarkdownButtonElemen14);
 
     function MarkdownTaskListButtonElement() {
       _classCallCheck(this, MarkdownTaskListButtonElement);
 
-      var _this10 = _possibleConstructorReturn(this, (MarkdownTaskListButtonElement.__proto__ || Object.getPrototypeOf(MarkdownTaskListButtonElement)).call(this));
+      var _this15 = _possibleConstructorReturn(this, (MarkdownTaskListButtonElement.__proto__ || Object.getPrototypeOf(MarkdownTaskListButtonElement)).call(this));
 
-      _this10.setAttribute('hotkey', 'L');
-      styles.set(_this10, { prefix: '- [ ] ', multiline: true, surroundWithNewlines: true });
-      return _this10;
+      _this15.setAttribute('hotkey', 'L');
+      styles.set(_this15, { prefix: '- [ ] ', multiline: true, surroundWithNewlines: true });
+      return _this15;
     }
 
     return MarkdownTaskListButtonElement;
@@ -322,16 +427,16 @@
     window.customElements.define('md-task-list', MarkdownTaskListButtonElement);
   }
 
-  var MarkdownMentionButtonElement = function (_MarkdownButtonElemen10) {
-    _inherits(MarkdownMentionButtonElement, _MarkdownButtonElemen10);
+  var MarkdownMentionButtonElement = function (_MarkdownButtonElemen15) {
+    _inherits(MarkdownMentionButtonElement, _MarkdownButtonElemen15);
 
     function MarkdownMentionButtonElement() {
       _classCallCheck(this, MarkdownMentionButtonElement);
 
-      var _this11 = _possibleConstructorReturn(this, (MarkdownMentionButtonElement.__proto__ || Object.getPrototypeOf(MarkdownMentionButtonElement)).call(this));
+      var _this16 = _possibleConstructorReturn(this, (MarkdownMentionButtonElement.__proto__ || Object.getPrototypeOf(MarkdownMentionButtonElement)).call(this));
 
-      styles.set(_this11, { prefix: '@', prefixSpace: true });
-      return _this11;
+      styles.set(_this16, { prefix: '@', prefixSpace: true });
+      return _this16;
     }
 
     return MarkdownMentionButtonElement;
@@ -342,16 +447,16 @@
     window.customElements.define('md-mention', MarkdownMentionButtonElement);
   }
 
-  var MarkdownRefButtonElement = function (_MarkdownButtonElemen11) {
-    _inherits(MarkdownRefButtonElement, _MarkdownButtonElemen11);
+  var MarkdownRefButtonElement = function (_MarkdownButtonElemen16) {
+    _inherits(MarkdownRefButtonElement, _MarkdownButtonElemen16);
 
     function MarkdownRefButtonElement() {
       _classCallCheck(this, MarkdownRefButtonElement);
 
-      var _this12 = _possibleConstructorReturn(this, (MarkdownRefButtonElement.__proto__ || Object.getPrototypeOf(MarkdownRefButtonElement)).call(this));
+      var _this17 = _possibleConstructorReturn(this, (MarkdownRefButtonElement.__proto__ || Object.getPrototypeOf(MarkdownRefButtonElement)).call(this));
 
-      styles.set(_this12, { prefix: '#', prefixSpace: true });
-      return _this12;
+      styles.set(_this17, { prefix: '#', prefixSpace: true });
+      return _this17;
     }
 
     return MarkdownRefButtonElement;
@@ -360,6 +465,26 @@
   if (!window.customElements.get('md-ref')) {
     window.MarkdownRefButtonElement = MarkdownRefButtonElement;
     window.customElements.define('md-ref', MarkdownRefButtonElement);
+  }
+
+  var MarkdownAddressButtonElement = function (_MarkdownButtonElemen17) {
+    _inherits(MarkdownAddressButtonElement, _MarkdownButtonElemen17);
+
+    function MarkdownAddressButtonElement() {
+      _classCallCheck(this, MarkdownAddressButtonElement);
+
+      var _this18 = _possibleConstructorReturn(this, (MarkdownAddressButtonElement.__proto__ || Object.getPrototypeOf(MarkdownAddressButtonElement)).call(this));
+
+      styles.set(_this18, { prefix: '$A\n', suffix: '\n$A', multiline: true });
+      return _this18;
+    }
+
+    return MarkdownAddressButtonElement;
+  }(MarkdownButtonElement);
+
+  if (!window.customElements.get('md-address')) {
+    window.MarkdownAddressButtonElement = MarkdownAddressButtonElement;
+    window.customElements.define('md-address', MarkdownAddressButtonElement);
   }
 
   var modifierKey = navigator.userAgent.match(/Macintosh/) ? 'Meta' : 'Control';


### PR DESCRIPTION
We found in user research that publishers don't select the item they want to style, but rather position the cursor at the beginning of a line. With this approach, after pressing a markdown toolbar button (i.e. list) it currently makes the content break with a new line after the first word.

This PR fixes the issue by removing the new inserted line and applies to all the current items (h2, h3, blockquote and lists) except for for link which is an inline wrapper injector.

The updated code comes from https://github.com/alphagov/markdown-toolbar-element. Plan to do releases and changelog soon, so I can point to those for changes instead.

[Trello card](https://trello.com/c/oVHHFHWJ)

### Before
<img width="639" alt="screen shot 2018-10-26 at 10 03 04" src="https://user-images.githubusercontent.com/788096/47556535-7a519c00-d906-11e8-80fb-aa57ea92c9fc.png">


### After
<img width="638" alt="screen shot 2018-10-26 at 10 03 42" src="https://user-images.githubusercontent.com/788096/47556542-7c1b5f80-d906-11e8-901c-d07aa52707d9.png">

