### PR TITLE
Enhance ability to detect live publications with imported whitehall d…

### DIFF
--- a/lib/tasks/whitehall_news_importer.rb
+++ b/lib/tasks/whitehall_news_importer.rb
@@ -36,6 +36,7 @@ module Tasks
         tags: tags(edition),
         current_edition_number: document["editions"].count,
         has_live_version_on_govuk: is_live?(edition, document),
+        update_type: edition["minor_change"] ? "minor" : "major",
       )
 
       doc.save!

--- a/lib/tasks/whitehall_news_importer.rb
+++ b/lib/tasks/whitehall_news_importer.rb
@@ -30,12 +30,12 @@ module Tasks
         },
         document_type: edition["news_article_type"]["key"],
         title: translation["title"],
-        publication_state: publication_state(edition, document),
+        publication_state: publication_state(edition),
         review_state: review_state(edition),
         summary: translation["summary"],
         tags: tags(edition),
         current_edition_number: document["editions"].count,
-        has_live_version_on_govuk: is_live?(edition, document),
+        has_live_version_on_govuk: has_live_version?(edition, document),
         update_type: edition["minor_change"] ? "minor" : "major",
       )
 
@@ -66,8 +66,8 @@ module Tasks
       edition["lead_organisations"]
     end
 
-    def publication_state(edition, document)
-      return "sent_to_live" if is_live?(edition, document)
+    def publication_state(edition)
+      return "sent_to_live" if edition["state"] == "published"
       "sent_to_draft"
     end
 
@@ -78,7 +78,7 @@ module Tasks
       "submitted_for_review"
     end
 
-    def is_live?(edition, document)
+    def has_live_version?(edition, document)
       document["editions"].count > 1 || edition["state"] == "published"
     end
   end

--- a/lib/tasks/whitehall_news_importer.rb
+++ b/lib/tasks/whitehall_news_importer.rb
@@ -31,7 +31,7 @@ module Tasks
         document_type: edition["news_article_type"]["key"],
         title: translation["title"],
         publication_state: publication_state(edition, document),
-        review_state: review_state(edition, document),
+        review_state: review_state(edition),
         summary: translation["summary"],
         tags: tags(edition),
         current_edition_number: document["editions"].count,
@@ -71,9 +71,9 @@ module Tasks
       "sent_to_draft"
     end
 
-    def review_state(edition, document)
+    def review_state(edition)
       return "published_without_review" if edition["force_published"]
-      return "reviewed" if is_live?(edition, document)
+      return "reviewed" if edition["state"] == "published"
       return "unreviewed" if edition["state"] == "draft"
       "submitted_for_review"
     end

--- a/spec/tasks/whitehall_news_importer_spec.rb
+++ b/spec/tasks/whitehall_news_importer_spec.rb
@@ -123,7 +123,7 @@ RSpec.describe Tasks::WhitehallNewsImporter do
     expect { importer.import(parsed_json) }.not_to(change { Document.count })
   end
 
-  context "when an imported document has more than on edition" do
+  context "when an imported document has more than one edition" do
     let(:import_published_then_drafted_data) do
       {
         content_id: SecureRandom.uuid,
@@ -178,7 +178,7 @@ RSpec.describe Tasks::WhitehallNewsImporter do
       Tasks::WhitehallNewsImporter.new.import(parsed_json)
 
       expect(Document.last.publication_state).to eq("sent_to_live")
-      expect(Document.last.review_state).to eq("reviewed")
+      expect(Document.last.review_state).to eq("unreviewed")
       expect(Document.last.has_live_version_on_govuk).to eq(true)
     end
   end

--- a/spec/tasks/whitehall_news_importer_spec.rb
+++ b/spec/tasks/whitehall_news_importer_spec.rb
@@ -126,48 +126,48 @@ RSpec.describe Tasks::WhitehallNewsImporter do
   context "when an imported document has more than on edition" do
     let(:import_published_then_drafted_data) do
       {
-          content_id: SecureRandom.uuid,
-          editions: [
+        content_id: SecureRandom.uuid,
+        editions: [
+          {
+            created_at: Time.zone.now,
+            news_article_type: { key: "news_story" },
+            translations: [
               {
-                  created_at: Time.zone.now,
-                  news_article_type: { key: "news_story" },
-                  translations: [
-                      {
-                          locale: "en",
-                          title: "Title",
-                          summary: "Summary",
-                          body: "Body",
-                          base_path: "/government/news/title",
-                      },
-                  ],
-                  lead_organisations: [SecureRandom.uuid, SecureRandom.uuid],
-                  supporting_organisations: [SecureRandom.uuid, SecureRandom.uuid],
-                  worldwide_organisations: [SecureRandom.uuid, SecureRandom.uuid],
-                  topical_events: [SecureRandom.uuid, SecureRandom.uuid],
-                  world_locations: [SecureRandom.uuid, SecureRandom.uuid],
-                  state: "draft",
-                  force_published: false,
+                locale: "en",
+                title: "Title",
+                summary: "Summary",
+                body: "Body",
+                base_path: "/government/news/title",
               },
+            ],
+            lead_organisations: [SecureRandom.uuid, SecureRandom.uuid],
+            supporting_organisations: [SecureRandom.uuid, SecureRandom.uuid],
+            worldwide_organisations: [SecureRandom.uuid, SecureRandom.uuid],
+            topical_events: [SecureRandom.uuid, SecureRandom.uuid],
+            world_locations: [SecureRandom.uuid, SecureRandom.uuid],
+            state: "draft",
+            force_published: false,
+          },
+          {
+            created_at: Time.zone.now - 1.day,
+            news_article_type: { key: "news_story" },
+            translations: [
               {
-                  created_at: Time.zone.now - 1.day,
-                  news_article_type: { key: "news_story" },
-                  translations: [
-                      {
-                          locale: "en",
-                          title: "Title",
-                          summary: "Summary",
-                          body: "Body",
-                          base_path: "/government/news/title",
-                      },
-                  ],
-                  lead_organisations: [SecureRandom.uuid, SecureRandom.uuid],
-                  supporting_organisations: [SecureRandom.uuid, SecureRandom.uuid],
-                  worldwide_organisations: [SecureRandom.uuid, SecureRandom.uuid],
-                  topical_events: [SecureRandom.uuid, SecureRandom.uuid],
-                  world_locations: [SecureRandom.uuid, SecureRandom.uuid],
-                  state: "published",
-                  force_published: false,
+                locale: "en",
+                title: "Title",
+                summary: "Summary",
+                body: "Body",
+                base_path: "/government/news/title",
               },
+            ],
+            lead_organisations: [SecureRandom.uuid, SecureRandom.uuid],
+            supporting_organisations: [SecureRandom.uuid, SecureRandom.uuid],
+            worldwide_organisations: [SecureRandom.uuid, SecureRandom.uuid],
+            topical_events: [SecureRandom.uuid, SecureRandom.uuid],
+            world_locations: [SecureRandom.uuid, SecureRandom.uuid],
+            state: "published",
+            force_published: false,
+            },
           ],
       }
     end

--- a/spec/tasks/whitehall_news_importer_spec.rb
+++ b/spec/tasks/whitehall_news_importer_spec.rb
@@ -177,7 +177,7 @@ RSpec.describe Tasks::WhitehallNewsImporter do
       parsed_json = JSON.parse(import_published_then_drafted_data.to_json)
       Tasks::WhitehallNewsImporter.new.import(parsed_json)
 
-      expect(Document.last.publication_state).to eq("sent_to_live")
+      expect(Document.last.publication_state).to eq("sent_to_draft")
       expect(Document.last.review_state).to eq("unreviewed")
       expect(Document.last.has_live_version_on_govuk).to eq(true)
     end


### PR DESCRIPTION

Trello: https://trello.com/c/vAsVUGzV/245-import-hasliveversionongovuk-from-whitehall

These changes are about enhancing the importing task for whitehall records to they are better able to determine if a document has any edition that is already live.

A document will have a live edition of some kind if it meets one of two
criteria:
(1) the publication state of the imported document record is 'published'
(2) it has at least two editions.

If it has a live edition, these flags must be set properly:
- publication_state must be set to 'sent-to-live'
- has_live_version_on_govuk must be set to true
- review state must be set to 'reviewed'

Previously the code was only checking for criterion (1).

Main changes:
- add document as parameter to methods that determine flag states and
  use the edition count method to support criterion (2)
- modify tests to accommodate criterion (2)
- modify most tests so they also check for has_live_version_on_govuk state
- change wording of test case descriptions because now we have three
  states to check which seem linked