### PR TITLE
Show topic on summary

### DIFF
--- a/app/controllers/document_topics_controller.rb
+++ b/app/controllers/document_topics_controller.rb
@@ -11,6 +11,6 @@ class DocumentTopicsController < ApplicationController
 
   def edit
     @document = Document.find_by_param(params[:document_id])
-    @topics = TopicsService.new.topics
+    @topic_index = TopicsService.new.topic_index
   end
 end

--- a/app/services/topics_service.rb
+++ b/app/services/topics_service.rb
@@ -5,31 +5,46 @@ require "gds_api/publishing_api_v2"
 class TopicsService
   GOVUK_HOMEPAGE_CONTENT_ID = "f3bbdec2-0e62-4520-a7fd-6ffd5d36e03a"
   CACHE_OPTIONS = { expires_in: 5.minutes, race_condition_ttl: 10.seconds }.freeze
-  TOPICS_TIMEOUT = 4.seconds
+  TOPIC_INDEX_TIMEOUT = 4.seconds
 
-  def topics
+  def topic_index
     Rails.cache.fetch("topics", CACHE_OPTIONS) do
-      all_topics = {}
+      index = {}
 
-      all_topics[GOVUK_HOMEPAGE_CONTENT_ID] = {
+      index[GOVUK_HOMEPAGE_CONTENT_ID] = {
         title: "GOV.UK Homepage",
         children: level_one_topics.map { |level_one_topic| level_one_topic["content_id"] },
       }
 
-      unroll(all_topics, level_one_topics)
-      all_topics
+      unroll(index, level_one_topics, GOVUK_HOMEPAGE_CONTENT_ID)
+      index
     end
+  end
+
+  def topics_for_document(content_id)
+    publishing_api.get_links(content_id)
+      .dig("links", "taxons").to_a
+      .map { |topic_content_id| topic_index[topic_content_id] }
+  end
+
+  def topic_breadcrumb(topic)
+    parent = topic_index[topic[:parent]]
+    parent ? [topic] + topic_breadcrumb(parent) : [topic]
   end
 
 private
 
-  def unroll(all_topics, topics)
+  def unroll(index, topics, parent_topic)
     topics.each do |topic|
       child_topics = topic.dig("links", "child_taxons").to_a
       child_topic_content_ids = child_topics.map { |child_topic| child_topic["content_id"] }
 
-      all_topics[topic["content_id"]] = { title: topic["title"], children: child_topic_content_ids }
-      unroll(all_topics, child_topics)
+      index[topic["content_id"]] = {
+        title: topic["title"],
+        children: child_topic_content_ids,
+        parent: parent_topic["content_id"],
+      }
+      unroll(index, child_topics, topic)
     end
   end
 
@@ -40,7 +55,7 @@ private
       .dig("expanded_links", "level_one_taxons")
 
     @level_one_topics.each do |level_one_topic|
-      raise GdsApi::TimedOutException.new if Time.zone.now - start_time > TOPICS_TIMEOUT
+      raise GdsApi::TimedOutException.new if Time.zone.now - start_time > TOPIC_INDEX_TIMEOUT
       level_one_topic_content_id = level_one_topic["content_id"]
 
       level_one_topic_links = publishing_api.get_expanded_links(level_one_topic_content_id)

--- a/app/views/document_topics/edit.html.erb
+++ b/app/views/document_topics/edit.html.erb
@@ -4,11 +4,11 @@
 <% def unroll(topic) %>
   <% capture do %>
     <li>
-      <%= @topics[topic][:title] %>
+      <%= @topic_index[topic][:title] %>
 
-      <% if @topics[topic][:children].any? %>
+      <% if @topic_index[topic][:children].any? %>
         <ul>
-          <% @topics[topic][:children].each do |child_topic| %>
+          <% @topic_index[topic][:children].each do |child_topic| %>
             <%= unroll(child_topic) %>
           <% end %>
         </ul>
@@ -18,7 +18,7 @@
 <% end %>
 
 <ul>
-  <% @topics[TopicsService::GOVUK_HOMEPAGE_CONTENT_ID][:children].each do |topic| %>
+  <% @topic_index[TopicsService::GOVUK_HOMEPAGE_CONTENT_ID][:children].each do |topic| %>
     <%= unroll(topic) %>
   <% end %>
 </ul>

--- a/app/views/documents/show/_tags.html.erb
+++ b/app/views/documents/show/_tags.html.erb
@@ -23,6 +23,7 @@
   <% Rails.logger.error(e) %>
 
   <%= render "components/summary", {
+    id: "tags",
     title: {
       text: t("documents.show.tags.title")
     },

--- a/app/views/documents/show/_topics.html.erb
+++ b/app/views/documents/show/_topics.html.erb
@@ -1,7 +1,27 @@
+<% service = TopicsService.new %>
+<% topics = service.topics_for_document(@document.content_id) %>
+
+<% breadcrumbs = capture do %>
+  <% if topics.any? %>
+    <div class="topic-breadcrumb">
+      <% topics.each do |topic| %>
+        <ol>
+          <% service.topic_breadcrumb(topic).reverse.each do |crumb| %>
+            <li><%= crumb[:title] %></li>
+          <% end %>
+        </ol>
+      <% end %>
+    </div>
+  <% else %>
+    <%= t("documents.show.topics.no_topics") %>
+  <% end %>
+<% end %>
+
 <%= render "components/summary", {
   id: "topics",
   title: {
     text: t("documents.show.topics.title"),
     change_url: document_topics_path(@document)
-  }
+  },
+  block: breadcrumbs
 } %>

--- a/app/views/documents/show/_topics.html.erb
+++ b/app/views/documents/show/_topics.html.erb
@@ -1,27 +1,38 @@
-<% service = TopicsService.new %>
-<% topics = service.topics_for_document(@document.content_id) %>
+<% begin %>
+  <% service = TopicsService.new %>
+  <% topics = service.topics_for_document(@document.content_id) %>
 
-<% breadcrumbs = capture do %>
-  <% if topics.any? %>
-    <div class="topic-breadcrumb">
-      <% topics.each do |topic| %>
-        <ol>
-          <% service.topic_breadcrumb(topic).reverse.each do |crumb| %>
-            <li><%= crumb[:title] %></li>
-          <% end %>
-        </ol>
-      <% end %>
-    </div>
-  <% else %>
-    <%= t("documents.show.topics.no_topics") %>
+  <% breadcrumbs = capture do %>
+    <% if topics.any? %>
+      <div class="topic-breadcrumb">
+        <% topics.each do |topic| %>
+          <ol>
+            <% service.topic_breadcrumb(topic).reverse.each do |crumb| %>
+              <li><%= crumb[:title] %></li>
+            <% end %>
+          </ol>
+        <% end %>
+      </div>
+    <% else %>
+      <%= t("documents.show.topics.no_topics") %>
+    <% end %>
   <% end %>
-<% end %>
 
-<%= render "components/summary", {
-  id: "topics",
-  title: {
-    text: t("documents.show.topics.title"),
-    change_url: document_topics_path(@document)
-  },
-  block: breadcrumbs
-} %>
+  <%= render "components/summary", {
+    title: {
+      text: t("documents.show.topics.title"),
+      change_url: document_topics_path(@document)
+    },
+    block: breadcrumbs
+  } %>
+<% rescue GdsApi::BaseError => e %>
+  <% Rails.logger.error(e) %>
+
+  <%= render "components/summary", {
+    id: "topics",
+    title: {
+      text: t("documents.show.topics.title")
+    },
+    block: t("documents.show.topics.api_down")
+  } %>
+<% end %>

--- a/config/locales/en/documents/show.yml
+++ b/config/locales/en/documents/show.yml
@@ -11,6 +11,7 @@ en:
       topics:
         title: Topics
         no_topics: No topics.
+        api_down: This content isn't available right now. We're having trouble getting the data we need to show you this content.
       tags:
         title: Tags
         api_down: This content isn't available right now. We're having trouble getting the data we need to show you this content.

--- a/config/locales/en/documents/show.yml
+++ b/config/locales/en/documents/show.yml
@@ -10,6 +10,7 @@ en:
         history: Document history
       topics:
         title: Topics
+        no_topics: No topics.
       tags:
         title: Tags
         api_down: This content isn't available right now. We're having trouble getting the data we need to show you this content.

--- a/spec/features/editing_images/upload_lead_image_drafting_requirements_spec.rb
+++ b/spec/features/editing_images/upload_lead_image_drafting_requirements_spec.rb
@@ -34,7 +34,6 @@ RSpec.feature "Upload a lead image drafting requirements" do
     asset_manager_delete_asset(@asset_id)
     stub_publishing_api_put_content(Document.last.content_id, {})
     click_on "Crop image"
-    WebMock.reset!
   end
 
   def and_i_skip_entering_alt_text

--- a/spec/features/editing_images/upload_lead_image_publishing_api_down_spec.rb
+++ b/spec/features/editing_images/upload_lead_image_publishing_api_down_spec.rb
@@ -33,7 +33,6 @@ RSpec.feature "Upload a lead image when Publishing API is down" do
     asset_manager_delete_asset(@asset_id)
     stub_publishing_api_put_content(Document.last.content_id, {})
     click_on "Crop image"
-    WebMock.reset!
   end
 
   def and_the_publishing_api_is_down

--- a/spec/features/editing_images/upload_lead_image_spec.rb
+++ b/spec/features/editing_images/upload_lead_image_spec.rb
@@ -32,6 +32,7 @@ RSpec.feature "Upload a lead image" do
     asset_manager_delete_asset(@asset_id)
     stub_publishing_api_put_content(Document.last.content_id, {})
     click_on "Crop image"
+    # TODO: Replace with https://github.com/bblimke/webmock/blob/d8686502442d9830dcccd24a1120ac08413d857a/lib/webmock/api.rb#L69 when it's released
     WebMock::RequestRegistry.instance.reset!
   end
 

--- a/spec/features/editing_images/upload_lead_image_spec.rb
+++ b/spec/features/editing_images/upload_lead_image_spec.rb
@@ -32,7 +32,7 @@ RSpec.feature "Upload a lead image" do
     asset_manager_delete_asset(@asset_id)
     stub_publishing_api_put_content(Document.last.content_id, {})
     click_on "Crop image"
-    WebMock.reset!
+    WebMock::RequestRegistry.instance.reset!
   end
 
   def and_i_fill_in_the_metadata

--- a/spec/features/editing_tags/show_tags_publishing_api_down_spec.rb
+++ b/spec/features/editing_tags/show_tags_publishing_api_down_spec.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-RSpec.feature "Showing a document when the Publishing API is down" do
+RSpec.feature "Showing tags when the Publishing API is down" do
   scenario do
     given_there_is_a_document_with_tags
     and_the_publishing_api_is_down
@@ -24,6 +24,8 @@ RSpec.feature "Showing a document when the Publishing API is down" do
   end
 
   def then_i_should_see_an_error_message
-    expect(page).to have_content(I18n.t("documents.show.tags.api_down"))
+    within("#tags") do
+      expect(page).to have_content(I18n.t("documents.show.tags.api_down"))
+    end
   end
 end

--- a/spec/features/editing_topics/edit_topics_publishing_api_down_spec.rb
+++ b/spec/features/editing_topics/edit_topics_publishing_api_down_spec.rb
@@ -3,8 +3,8 @@
 RSpec.feature "Show all the topics when the Publishing API is down" do
   scenario do
     given_there_is_a_document
-    and_the_publishing_api_is_down
     when_i_visit_the_document_page
+    and_the_publishing_api_is_down
     and_i_try_to_change_the_topics
     then_i_see_an_error_message
   end

--- a/spec/features/editing_topics/show_topics_publishing_api_down_spec.rb
+++ b/spec/features/editing_topics/show_topics_publishing_api_down_spec.rb
@@ -1,0 +1,28 @@
+# frozen_string_literal: true
+
+RSpec.feature "Showing topics when the Publishing API is down" do
+  scenario do
+    given_there_is_a_document
+    and_the_publishing_api_is_down
+    when_i_visit_the_document_page
+    then_i_should_see_an_error_message
+  end
+
+  def given_there_is_a_document
+    @document = create(:document)
+  end
+
+  def and_the_publishing_api_is_down
+    publishing_api_isnt_available
+  end
+
+  def when_i_visit_the_document_page
+    visit document_path(@document)
+  end
+
+  def then_i_should_see_an_error_message
+    within("#topics") do
+      expect(page).to have_content(I18n.t("documents.show.topics.api_down"))
+    end
+  end
+end

--- a/spec/features/editing_topics/show_topics_spec.rb
+++ b/spec/features/editing_topics/show_topics_spec.rb
@@ -1,22 +1,44 @@
 # frozen_string_literal: true
 
-RSpec.feature "Show all the topics" do
+RSpec.feature "Show the topics for a document" do
   scenario do
     given_there_is_a_document
-    when_i_visit_the_document_page
-    and_i_try_to_change_the_topics
-    then_i_see_all_of_the_topics
+    when_the_document_has_no_topics
+    and_i_visit_the_document_page
+    then_i_see_there_are_no_topics
+
+    when_the_document_has_a_topic
+    and_i_visit_the_document_page
+    then_i_see_the_topic_breadcrumb
   end
 
   def given_there_is_a_document
-    create :document
+    @document = create :document
   end
 
-  def when_i_visit_the_document_page
+  def when_the_document_has_no_topics
+    publishing_api_has_links(
+      "content_id" => @document.content_id,
+      "links" => {},
+    )
+  end
+
+  def and_i_visit_the_document_page
     visit document_path(Document.last)
   end
 
-  def and_i_try_to_change_the_topics
+  def then_i_see_there_are_no_topics
+    expect(page).to have_content(I18n.t("documents.show.topics.no_topics"))
+  end
+
+  def when_the_document_has_a_topic
+    publishing_api_has_links(
+      "content_id" => @document.content_id,
+      "links" => {
+        "taxons" => %w(level_three_topic),
+      },
+    )
+
     # GOV.UK homepage
     publishing_api_has_expanded_links(
       "content_id" => "f3bbdec2-0e62-4520-a7fd-6ffd5d36e03a",
@@ -50,13 +72,13 @@ RSpec.feature "Show all the topics" do
         ],
       },
     )
-
-    click_on "Change Topics"
   end
 
-  def then_i_see_all_of_the_topics
-    expect(page).to have_content("Level One Topic")
-    expect(page).to have_content("Level Two Topic")
-    expect(page).to have_content("Level Three Topic")
+  def then_i_see_the_topic_breadcrumb
+    within(".topic-breadcrumb") do
+      expect(page).to have_content("Level One Topic")
+      expect(page).to have_content("Level Two Topic")
+      expect(page).to have_content("Level Three Topic")
+    end
   end
 end

--- a/spec/formats/news_story_spec.rb
+++ b/spec/formats/news_story_spec.rb
@@ -22,6 +22,7 @@ RSpec.feature "Create a news story", format: true do
     fill_in "document[title]", with: "A great title"
     fill_in "document[summary]", with: "A great summary"
     click_on "Save"
+    # TODO: Replace with https://github.com/bblimke/webmock/blob/d8686502442d9830dcccd24a1120ac08413d857a/lib/webmock/api.rb#L69 when it's released
     WebMock::RequestRegistry.instance.reset!
   end
 

--- a/spec/formats/news_story_spec.rb
+++ b/spec/formats/news_story_spec.rb
@@ -22,7 +22,7 @@ RSpec.feature "Create a news story", format: true do
     fill_in "document[title]", with: "A great title"
     fill_in "document[summary]", with: "A great summary"
     click_on "Save"
-    WebMock.reset!
+    WebMock::RequestRegistry.instance.reset!
   end
 
   def and_i_add_some_tags

--- a/spec/formats/press_release_spec.rb
+++ b/spec/formats/press_release_spec.rb
@@ -22,6 +22,7 @@ RSpec.feature "Create a press release", format: true do
     fill_in "document[title]", with: "A great title"
     fill_in "document[summary]", with: "A great summary"
     click_on "Save"
+    # TODO: Replace with https://github.com/bblimke/webmock/blob/d8686502442d9830dcccd24a1120ac08413d857a/lib/webmock/api.rb#L69 when it's released
     WebMock::RequestRegistry.instance.reset!
   end
 

--- a/spec/formats/press_release_spec.rb
+++ b/spec/formats/press_release_spec.rb
@@ -22,7 +22,7 @@ RSpec.feature "Create a press release", format: true do
     fill_in "document[title]", with: "A great title"
     fill_in "document[summary]", with: "A great summary"
     click_on "Save"
-    WebMock.reset!
+    WebMock::RequestRegistry.instance.reset!
   end
 
   def and_i_add_some_tags

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -44,6 +44,11 @@ RSpec.configure do |config|
   config.before :each, type: :feature do
     # This is required by lots of specs when visiting the index page
     publishing_api_has_linkables([], document_type: "organisation")
+
+    # This is required by lots of specs when visiting the show page
+    endpoint = GdsApi::TestHelpers::PublishingApiV2::PUBLISHING_API_V2_ENDPOINT
+    stub_request(:get, %r(\A#{endpoint}/links/[a-z0-9\-]+\Z))
+      .to_return(status: 200, body: { "links": {} }.to_json)
   end
 
   config.after :each, type: :feature, js: true do


### PR DESCRIPTION
https://trello.com/c/5tAUflyY/331-show-current-taxons-for-a-document

This adds the ability to see the current topics for a document on the summary page. We extended the TopicsService to allow us to get the current topics, which meant doing some renaming to keep the purpose of the methods clear. We also cope with the Publishing API being down or slow.

We have some duplication of stubs in the tests, but I don't think it's enough to get a clear refactoring out of it. I'm expecting the final piece of work - to enable editing of topics - will involve revisiting these specs, rather than creating new ones, so it seems unlikely the duplication will spread.