### PR TITLE
Enforce entering a change note when we publish

### DIFF
--- a/app/services/publishing_requirements.rb
+++ b/app/services/publishing_requirements.rb
@@ -13,7 +13,7 @@ class PublishingRequirements
 
     if @document.summary.blank?
       messages["summary"] << {
-        text: I18n.t("publishing_requirements.presence", field: "summary"),
+        text: I18n.t("publishing_requirements.summary_presence"),
         href: "#content",
       }
     end
@@ -21,10 +21,19 @@ class PublishingRequirements
     @document.document_type_schema.contents.each do |field|
       if @document.contents[field.id].blank?
         messages[field.id] << {
-          text: I18n.t("publishing_requirements.field_presence", field: field.label.downcase),
+          text: I18n.t("publishing_requirements.#{field.id}_presence"),
           href: "#content",
         }
       end
+    end
+
+    if @document.has_live_version_on_govuk &&
+        @document.update_type == "major" &&
+        @document.change_note.blank?
+      messages["summary"] << {
+        text: I18n.t("publishing_requirements.change_note_presence"),
+        href: "#content",
+      }
     end
 
     messages

--- a/config/locales/en/publishing_requirements.yml
+++ b/config/locales/en/publishing_requirements.yml
@@ -1,4 +1,5 @@
 en:
   publishing_requirements:
-    presence: "Enter a %{field}"
-    field_presence: "Enter %{field} content"
+    summary_presence: Enter a summary
+    body_presence: Enter a body
+    change_note_presence: Enter a change note

--- a/spec/factories/document_factory.rb
+++ b/spec/factories/document_factory.rb
@@ -10,9 +10,11 @@ FactoryBot.define do
     publication_state { "changes_not_sent_to_draft" }
     review_state { "unreviewed" }
     current_edition_number { (rand * 100).to_i }
+    update_type { "major" }
 
     trait :with_required_content_for_publishing do
       summary { SecureRandom.alphanumeric(10) }
+      update_type { "minor" }
     end
   end
 end

--- a/spec/features/workflow/publishing_requirements_spec.rb
+++ b/spec/features/workflow/publishing_requirements_spec.rb
@@ -3,55 +3,54 @@
 RSpec.feature "Publishing requirements" do
   scenario do
     given_there_is_a_document
-    when_the_document_has_no_summary
-    and_i_visit_the_document_page
-    then_i_see_a_hint_to_enter_a_summary
+    when_the_document_has_missing_contents
+    then_i_see_a_hint_to_enter_the_contents
 
-    when_the_document_has_a_blank_field
-    and_i_visit_the_document_page
-    then_i_see_a_hint_to_enter_the_field
+    when_the_document_needs_a_change_note
+    then_i_see_a_hint_to_enter_a_change_note
 
     when_i_try_to_publish_the_document
-    then_i_see_an_error_to_enter_a_summary
-    and_i_see_an_error_to_enter_the_field
+    then_i_see_an_error_to_enter_the_contents
+    and_i_see_an_error_to_enter_a_change_note
 
     when_i_try_to_submit_the_document_for_2i
-    then_i_see_an_error_to_enter_a_summary
-    and_i_see_an_error_to_enter_the_field
+    then_i_see_an_error_to_enter_the_contents
+    and_i_see_an_error_to_enter_a_change_note
   end
 
   def given_there_is_a_document
-    field_schema = build(:field_schema, id: "field", type: "govspeak", label: "Field")
+    field_schema = build(:field_schema, id: "body", type: "govspeak")
     document_type_schema = build(:document_type_schema, contents: [field_schema])
     @document = create(:document, document_type: document_type_schema.id)
   end
 
-  def and_i_visit_the_document_page
+  def when_the_document_has_missing_contents
+    visit document_path(@document)
+    click_on "Change Content"
+    fill_in "document[summary]", with: ""
+    fill_in "document[contents][body]", with: ""
     stub_any_publishing_api_put_content
     click_on "Save"
   end
 
-  def when_the_document_has_no_summary
-    visit document_path(@document)
+  def when_the_document_needs_a_change_note
+    @document.update!(has_live_version_on_govuk: true)
     click_on "Change Content"
-    fill_in "document[summary]", with: ""
+    fill_in "document[change_note]", with: ""
+    stub_any_publishing_api_put_content
+    click_on "Save"
   end
 
-  def when_the_document_has_a_blank_field
-    visit document_path(@document)
-    click_on "Change Content"
-    fill_in "document[contents][field]", with: ""
-  end
-
-  def then_i_see_a_hint_to_enter_a_summary
+  def then_i_see_a_hint_to_enter_the_contents
     within(".app-c-notice") do
-      expect(page).to have_content(I18n.t("publishing_requirements.presence", field: "summary"))
+      expect(page).to have_content(I18n.t("publishing_requirements.summary_presence"))
+      expect(page).to have_content(I18n.t("publishing_requirements.body_presence"))
     end
   end
 
-  def then_i_see_a_hint_to_enter_the_field
+  def then_i_see_a_hint_to_enter_a_change_note
     within(".app-c-notice") do
-      expect(page).to have_content(I18n.t("publishing_requirements.field_presence", field: "field"))
+      expect(page).to have_content(I18n.t("publishing_requirements.change_note_presence"))
     end
   end
 
@@ -63,15 +62,16 @@ RSpec.feature "Publishing requirements" do
     click_on "Submit for 2i review"
   end
 
-  def then_i_see_an_error_to_enter_a_summary
+  def then_i_see_an_error_to_enter_the_contents
     within(".gem-c-error-summary") do
-      expect(page).to have_content(I18n.t("publishing_requirements.presence", field: "summary"))
+      expect(page).to have_content(I18n.t("publishing_requirements.summary_presence"))
+      expect(page).to have_content(I18n.t("publishing_requirements.body_presence"))
     end
   end
 
-  def and_i_see_an_error_to_enter_the_field
+  def and_i_see_an_error_to_enter_a_change_note
     within(".gem-c-error-summary") do
-      expect(page).to have_content(I18n.t("publishing_requirements.field_presence", field: "field"))
+      expect(page).to have_content(I18n.t("publishing_requirements.change_note_presence"))
     end
   end
 end


### PR DESCRIPTION
https://trello.com/c/IjE24eFh/415-update-publishing-requirements-for-creating-an-edition-of-a-document

This isn't in-play right now, but I had a few spare minutes...

When the user sets the "major" update type for a live document, we
should ensure they enter a change note before they publish.

We currently auto-select the "major" update type each time a user
creates a new edition, so this updates the document factory to match.

Using interpolated values for locale keys leads to grammatical
problems (e.g. Enter a alt text) and we should avoid it.