### PR TITLE
Edit topics

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -443,4 +443,4 @@ RUBY VERSION
    ruby 2.5.3p105
 
 BUNDLED WITH
-   1.16.3
+   1.17.1

--- a/app/controllers/document_topics_controller.rb
+++ b/app/controllers/document_topics_controller.rb
@@ -21,7 +21,7 @@ class DocumentTopicsController < ApplicationController
     redirect_to document_path(document), notice: t("documents.show.flashes.topics_updated")
   rescue GdsApi::HTTPConflict => e
     Rails.logger.error(e)
-    redirect_to document, alert_with_description: t("documents.show.flashes.topic_update_conflict")
+    redirect_to document_topics_path, alert_with_description: t("document_topics.edit.flashes.topic_update_conflict")
   rescue GdsApi::BaseError => e
     Rails.logger.error(e)
     redirect_to document, alert_with_description: t("documents.show.flashes.topic_update_error")

--- a/app/controllers/document_topics_controller.rb
+++ b/app/controllers/document_topics_controller.rb
@@ -17,7 +17,10 @@ class DocumentTopicsController < ApplicationController
 
   def update
     document = Document.find_by_param(params[:document_id])
-    TopicsService.new.patch_topics(document, params.require(:topics))
+    TopicsService.new.patch_topics(document, params.fetch(:topics, {}))
     redirect_to document_path(document), notice: t("documents.show.flashes.topics_updated")
+  rescue GdsApi::BaseError => e
+    Rails.logger.error(e)
+    redirect_to document, alert_with_description: t("documents.show.flashes.topic_update_error")
   end
 end

--- a/app/controllers/document_topics_controller.rb
+++ b/app/controllers/document_topics_controller.rb
@@ -12,5 +12,12 @@ class DocumentTopicsController < ApplicationController
   def edit
     @document = Document.find_by_param(params[:document_id])
     @topic_index = TopicsService.new.topic_index
+    @topic_content_ids = TopicsService.new.topics_for_document(@document)
+  end
+
+  def update
+    document = Document.find_by_param(params[:document_id])
+    TopicsService.new.patch_topics(document, params.require(:topics))
+    redirect_to document_path(document), notice: t("documents.show.flashes.topics_updated")
   end
 end

--- a/app/controllers/document_topics_controller.rb
+++ b/app/controllers/document_topics_controller.rb
@@ -17,7 +17,7 @@ class DocumentTopicsController < ApplicationController
 
   def update
     document = Document.find_by_param(params[:document_id])
-    TopicsService.new.patch_topics(document, params.fetch(:topics, []), params[:version])
+    TopicsService.new.patch_topics(document, params.fetch(:topics, []), params[:version].to_i)
     redirect_to document_path(document), notice: t("documents.show.flashes.topics_updated")
   rescue GdsApi::HTTPConflict => e
     Rails.logger.error(e)

--- a/app/services/topics_service.rb
+++ b/app/services/topics_service.rb
@@ -13,7 +13,7 @@ class TopicsService
 
       index[GOVUK_HOMEPAGE_CONTENT_ID] = {
         title: "GOV.UK Homepage",
-        children: level_one_topics.map { |level_one_topic| level_one_topic["content_id"] },
+        child_topic_content_ids: level_one_topics.map { |level_one_topic| level_one_topic["content_id"] },
       }
 
       unroll(index, level_one_topics, GOVUK_HOMEPAGE_CONTENT_ID)
@@ -33,7 +33,7 @@ class TopicsService
 
   def topic_breadcrumb(topic_content_id)
     topic = topic_index[topic_content_id]
-    parent = topic[:parent]
+    parent = topic[:parent_topic_content_id]
     parent ? [topic] + topic_breadcrumb(parent) : [topic]
   end
 
@@ -46,8 +46,8 @@ private
 
       index[topic["content_id"]] = {
         title: topic["title"],
-        children: child_topic_content_ids,
-        parent: parent_topic["content_id"],
+        child_topic_content_ids: child_topic_content_ids,
+        parent_topic_content_id: parent_topic["content_id"],
       }
       unroll(index, child_topics, topic)
     end

--- a/app/services/topics_service.rb
+++ b/app/services/topics_service.rb
@@ -34,7 +34,7 @@ class TopicsService
   def topic_breadcrumb(topic_content_id)
     topic = topic_index[topic_content_id]
     parent = topic[:parent_topic_content_id]
-    parent ? [topic] + topic_breadcrumb(parent) : [topic]
+    parent ? topic_breadcrumb(parent) + [topic] : [topic]
   end
 
 private

--- a/app/services/topics_service.rb
+++ b/app/services/topics_service.rb
@@ -21,12 +21,14 @@ class TopicsService
     end
   end
 
-  def patch_topics(document, topics)
-    publishing_api.patch_links(document.content_id, links: { taxons: topics })
+  def patch_topics(document, topics, version)
+    publishing_api.patch_links(document.content_id, links: { taxons: topics }, previous_version: version)
   end
 
   def topics_for_document(document)
-    publishing_api.get_links(document.content_id).dig("links", "taxons").to_a
+    links = publishing_api.get_links(document.content_id)
+    topic_content_ids = links.dig("links", "taxons").to_a
+    [topic_content_ids, links["version"]]
   end
 
   def topic_breadcrumb(topic_content_id)

--- a/app/services/topics_service.rb
+++ b/app/services/topics_service.rb
@@ -21,14 +21,17 @@ class TopicsService
     end
   end
 
-  def topics_for_document(content_id)
-    publishing_api.get_links(content_id)
-      .dig("links", "taxons").to_a
-      .map { |topic_content_id| topic_index[topic_content_id] }
+  def patch_topics(document, topics)
+    publishing_api.patch_links(document.content_id, links: { taxons: topics })
   end
 
-  def topic_breadcrumb(topic)
-    parent = topic_index[topic[:parent]]
+  def topics_for_document(document)
+    publishing_api.get_links(document.content_id).dig("links", "taxons").to_a
+  end
+
+  def topic_breadcrumb(topic_content_id)
+    topic = topic_index[topic_content_id]
+    parent = topic[:parent]
     parent ? [topic] + topic_breadcrumb(parent) : [topic]
   end
 

--- a/app/views/document_topics/edit.html.erb
+++ b/app/views/document_topics/edit.html.erb
@@ -30,6 +30,8 @@
     <% end %>
   </ul>
 
+  <%= hidden_field_tag :version, @version %>
+
   <%= render "govuk_publishing_components/components/button", {
     text: "Save", margin_bottom: true
   } %>

--- a/app/views/document_topics/edit.html.erb
+++ b/app/views/document_topics/edit.html.erb
@@ -1,15 +1,21 @@
 <% content_for :back_link, document_path(@document) %>
 <% content_for :title, t("document_topics.edit.title", title: @document.title_or_fallback) %>
 
-<% def unroll(topic) %>
+<% def unroll(topic_content_id) %>
   <% capture do %>
     <li>
-      <%= @topic_index[topic][:title] %>
+      <%= tag.input type: "checkbox",
+        id: topic_content_id,
+        name: "topics[]",
+        value: topic_content_id,
+        checked: @topic_content_ids.include?(topic_content_id) %>
 
-      <% if @topic_index[topic][:children].any? %>
+      <%= @topic_index[topic_content_id][:title] %>
+
+      <% if @topic_index[topic_content_id][:children].any? %>
         <ul>
-          <% @topic_index[topic][:children].each do |child_topic| %>
-            <%= unroll(child_topic) %>
+          <% @topic_index[topic_content_id][:children].each do |child_topic_content_id| %>
+            <%= unroll(child_topic_content_id) %>
           <% end %>
         </ul>
       <% end %>
@@ -17,8 +23,14 @@
   <% end %>
 <% end %>
 
-<ul>
-  <% @topic_index[TopicsService::GOVUK_HOMEPAGE_CONTENT_ID][:children].each do |topic| %>
-    <%= unroll(topic) %>
-  <% end %>
-</ul>
+<%= form_tag update_document_topics_path(@document), method: :patch do %>
+  <ul>
+    <% @topic_index[TopicsService::GOVUK_HOMEPAGE_CONTENT_ID][:children].each do |topic_content_id| %>
+      <%= unroll(topic_content_id) %>
+    <% end %>
+  </ul>
+
+  <%= render "govuk_publishing_components/components/button", {
+    text: "Save", margin_bottom: true
+  } %>
+<% end %>

--- a/app/views/document_topics/edit.html.erb
+++ b/app/views/document_topics/edit.html.erb
@@ -12,9 +12,9 @@
 
       <%= @topic_index[topic_content_id][:title] %>
 
-      <% if @topic_index[topic_content_id][:children].any? %>
+      <% if @topic_index[topic_content_id][:child_topic_content_ids].any? %>
         <ul>
-          <% @topic_index[topic_content_id][:children].each do |child_topic_content_id| %>
+          <% @topic_index[topic_content_id][:child_topic_content_ids].each do |child_topic_content_id| %>
             <%= unroll(child_topic_content_id) %>
           <% end %>
         </ul>
@@ -24,8 +24,9 @@
 <% end %>
 
 <%= form_tag update_document_topics_path(@document), method: :patch do %>
+  <% root_topic = @topic_index[TopicsService::GOVUK_HOMEPAGE_CONTENT_ID] %>
   <ul>
-    <% @topic_index[TopicsService::GOVUK_HOMEPAGE_CONTENT_ID][:children].each do |topic_content_id| %>
+    <% root_topic[:child_topic_content_ids].each do |topic_content_id| %>
       <%= unroll(topic_content_id) %>
     <% end %>
   </ul>

--- a/app/views/document_topics/edit.html.erb
+++ b/app/views/document_topics/edit.html.erb
@@ -4,12 +4,14 @@
 <% def unroll(topic_content_id) %>
   <li>
     <%= tag.input type: "checkbox",
-      id: topic_content_id,
+      id: "topic-#{topic_content_id}",
       name: "topics[]",
       value: topic_content_id,
       checked: @topic_content_ids.include?(topic_content_id) %>
 
-    <%= @topic_index[topic_content_id][:title] %>
+    <%= tag.label for: "topic-#{topic_content_id}" do %>
+      <%= @topic_index[topic_content_id][:title] %>
+    <% end %>
 
     <% if @topic_index[topic_content_id][:child_topic_content_ids].any? %>
       <ul>

--- a/app/views/document_topics/edit.html.erb
+++ b/app/views/document_topics/edit.html.erb
@@ -2,32 +2,30 @@
 <% content_for :title, t("document_topics.edit.title", title: @document.title_or_fallback) %>
 
 <% def unroll(topic_content_id) %>
-  <% capture do %>
-    <li>
-      <%= tag.input type: "checkbox",
-        id: topic_content_id,
-        name: "topics[]",
-        value: topic_content_id,
-        checked: @topic_content_ids.include?(topic_content_id) %>
+  <li>
+    <%= tag.input type: "checkbox",
+      id: topic_content_id,
+      name: "topics[]",
+      value: topic_content_id,
+      checked: @topic_content_ids.include?(topic_content_id) %>
 
-      <%= @topic_index[topic_content_id][:title] %>
+    <%= @topic_index[topic_content_id][:title] %>
 
-      <% if @topic_index[topic_content_id][:child_topic_content_ids].any? %>
-        <ul>
-          <% @topic_index[topic_content_id][:child_topic_content_ids].each do |child_topic_content_id| %>
-            <%= unroll(child_topic_content_id) %>
-          <% end %>
-        </ul>
-      <% end %>
-    </li>
-  <% end %>
+    <% if @topic_index[topic_content_id][:child_topic_content_ids].any? %>
+      <ul>
+        <% @topic_index[topic_content_id][:child_topic_content_ids].each do |child_topic_content_id| %>
+          <% unroll(child_topic_content_id) %>
+        <% end %>
+      </ul>
+    <% end %>
+  </li>
 <% end %>
 
 <%= form_tag update_document_topics_path(@document), method: :patch do %>
   <% root_topic = @topic_index[TopicsService::GOVUK_HOMEPAGE_CONTENT_ID] %>
   <ul>
     <% root_topic[:child_topic_content_ids].each do |topic_content_id| %>
-      <%= unroll(topic_content_id) %>
+      <% unroll(topic_content_id) %>
     <% end %>
   </ul>
 

--- a/app/views/documents/show/_tags.html.erb
+++ b/app/views/documents/show/_tags.html.erb
@@ -12,6 +12,7 @@
   } %>
 
   <%= render "components/summary", {
+    id: "tags",
     title: {
       text: t("documents.show.tags.title"),
       change_url: document_tags_path(@document)

--- a/app/views/documents/show/_topics.html.erb
+++ b/app/views/documents/show/_topics.html.erb
@@ -7,7 +7,7 @@
       <div class="topic-breadcrumb">
         <% topic_content_ids.each do |topic_content_id| %>
           <ol>
-            <% service.topic_breadcrumb(topic_content_id).reverse.each do |crumb| %>
+            <% service.topic_breadcrumb(topic_content_id).each do |crumb| %>
               <li><%= crumb[:title] %></li>
             <% end %>
           </ol>

--- a/app/views/documents/show/_topics.html.erb
+++ b/app/views/documents/show/_topics.html.erb
@@ -19,6 +19,7 @@
   <% end %>
 
   <%= render "components/summary", {
+    id: "topics",
     title: {
       text: t("documents.show.topics.title"),
       change_url: document_topics_path(@document)

--- a/app/views/documents/show/_topics.html.erb
+++ b/app/views/documents/show/_topics.html.erb
@@ -1,6 +1,6 @@
 <% begin %>
   <% service = TopicsService.new %>
-  <% topic_content_ids = service.topics_for_document(@document) %>
+  <% topic_content_ids, _version = service.topics_for_document(@document) %>
 
   <% breadcrumbs = capture do %>
     <% if topic_content_ids.any? %>

--- a/app/views/documents/show/_topics.html.erb
+++ b/app/views/documents/show/_topics.html.erb
@@ -1,13 +1,13 @@
 <% begin %>
   <% service = TopicsService.new %>
-  <% topics = service.topics_for_document(@document.content_id) %>
+  <% topic_content_ids = service.topics_for_document(@document) %>
 
   <% breadcrumbs = capture do %>
-    <% if topics.any? %>
+    <% if topic_content_ids.any? %>
       <div class="topic-breadcrumb">
-        <% topics.each do |topic| %>
+        <% topic_content_ids.each do |topic_content_id| %>
           <ol>
-            <% service.topic_breadcrumb(topic).reverse.each do |crumb| %>
+            <% service.topic_breadcrumb(topic_content_id).reverse.each do |crumb| %>
               <li><%= crumb[:title] %></li>
             <% end %>
           </ol>

--- a/config/locales/en/document_topics/edit.yml
+++ b/config/locales/en/document_topics/edit.yml
@@ -3,3 +3,7 @@ en:
     edit:
       title: "Topics for ‘%{title}’"
       api_down: This content can't be edited right now. We're having trouble getting the data we need for you to make changes on this page.
+      flashes:
+        topic_update_conflict:
+          title: Somebody else changed the topics before you could
+          description:  Your changes have not been saved. Please try again.

--- a/config/locales/en/documents/show.yml
+++ b/config/locales/en/documents/show.yml
@@ -70,3 +70,6 @@ en:
           removed: "Image “%{file}” has been deselected. Document will now use the default lead image"
           deleted: "Image “%{file}” has been deleted. Document wil now use the default lead image"
         topics_updated: Topics updated on all editions
+        topic_update_error:
+          title: Something has gone wrong
+          description: Something went wrong when saving your changes. Please try again or [raise a support request](https://support.publishing.service.gov.uk/technical_fault_report/new).

--- a/config/locales/en/documents/show.yml
+++ b/config/locales/en/documents/show.yml
@@ -69,3 +69,4 @@ en:
           chosen: "Image “%{file}” has been selected as the lead image"
           removed: "Image “%{file}” has been deselected. Document will now use the default lead image"
           deleted: "Image “%{file}” has been deleted. Document wil now use the default lead image"
+        topics_updated: Topics updated on all editions

--- a/config/locales/en/documents/show.yml
+++ b/config/locales/en/documents/show.yml
@@ -74,5 +74,5 @@ en:
           title: Something has gone wrong
           description: Something went wrong when saving your changes. Please try again or [raise a support request](https://support.publishing.service.gov.uk/technical_fault_report/new).
         topic_update_conflict:
-          title: Somebody changed the topics before you could
-          description:  Your changes have not been saved. Please try again or [raise a support request](https://support.publishing.service.gov.uk/technical_fault_report/new).
+          title: Somebody else changed the topics before you could
+          description:  Your changes have not been saved. Please try again.

--- a/config/locales/en/documents/show.yml
+++ b/config/locales/en/documents/show.yml
@@ -73,3 +73,6 @@ en:
         topic_update_error:
           title: Something has gone wrong
           description: Something went wrong when saving your changes. Please try again or [raise a support request](https://support.publishing.service.gov.uk/technical_fault_report/new).
+        topic_update_conflict:
+          title: Somebody changed the topics before you could
+          description:  Your changes have not been saved. Please try again or [raise a support request](https://support.publishing.service.gov.uk/technical_fault_report/new).

--- a/config/locales/en/documents/show.yml
+++ b/config/locales/en/documents/show.yml
@@ -73,6 +73,3 @@ en:
         topic_update_error:
           title: Something has gone wrong
           description: Something went wrong when saving your changes. Please try again or [raise a support request](https://support.publishing.service.gov.uk/technical_fault_report/new).
-        topic_update_conflict:
-          title: Somebody else changed the topics before you could
-          description:  Your changes have not been saved. Please try again.

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -45,6 +45,7 @@ Rails.application.routes.draw do
   delete "/documents/:document_id/lead-image" => "document_lead_image#remove", as: :remove_document_lead_image
 
   get "/documents/:document_id/topics" => "document_topics#edit", as: :document_topics
+  patch "/documents/:document_id/topics" => "document_topics#update", as: :update_document_topics
 
   get "/healthcheck", to: proc { [200, {}, %w[OK]] }
 

--- a/spec/features/editing_tags/edit_tags_publishing_api_down_spec.rb
+++ b/spec/features/editing_tags/edit_tags_publishing_api_down_spec.rb
@@ -5,7 +5,7 @@ RSpec.feature "Edit tags when the API is down" do
     given_there_is_a_document
     when_i_visit_the_document_page
     and_the_publishing_api_is_down
-    and_i_try_to_change_the_topics
+    and_i_try_to_change_the_tags
     then_i_should_see_an_error_message
   end
 
@@ -24,7 +24,7 @@ RSpec.feature "Edit tags when the API is down" do
     visit document_path(@document)
   end
 
-  def and_i_try_to_change_the_topics
+  def and_i_try_to_change_the_tags
     click_on "Change Tags"
   end
 

--- a/spec/features/editing_tags/edit_tags_publishing_api_down_spec.rb
+++ b/spec/features/editing_tags/edit_tags_publishing_api_down_spec.rb
@@ -1,11 +1,11 @@
 # frozen_string_literal: true
 
-RSpec.feature "Edit document tags when the API is down" do
+RSpec.feature "Edit tags when the API is down" do
   scenario do
     given_there_is_a_document
-    and_the_publishing_api_is_down
     when_i_visit_the_document_page
-    and_i_click_on_edit_tags
+    and_the_publishing_api_is_down
+    and_i_try_to_change_the_topics
     then_i_should_see_an_error_message
   end
 
@@ -24,7 +24,7 @@ RSpec.feature "Edit document tags when the API is down" do
     visit document_path(@document)
   end
 
-  def and_i_click_on_edit_tags
+  def and_i_try_to_change_the_topics
     click_on "Change Tags"
   end
 

--- a/spec/features/editing_tags/edit_tags_spec.rb
+++ b/spec/features/editing_tags/edit_tags_spec.rb
@@ -11,7 +11,7 @@ RSpec.feature "Edit document tags" do
     and_i_click_on_edit_tags
     then_i_can_see_the_current_selections
     when_i_edit_the_tags
-    then_i_can_view_the_tags
+    then_i_can_see_the_tags
     and_the_preview_creation_succeeded
   end
 
@@ -54,7 +54,7 @@ RSpec.feature "Edit document tags" do
     click_on "Save"
   end
 
-  def then_i_can_view_the_tags
+  def then_i_can_see_the_tags
     expect(page).to have_content("Tag to select 1")
     expect(page).to have_content("Tag to select 2")
     expect(page).not_to have_content("Initial tag")

--- a/spec/features/editing_tags/edit_tags_spec.rb
+++ b/spec/features/editing_tags/edit_tags_spec.rb
@@ -9,7 +9,7 @@ RSpec.feature "Edit document tags" do
     given_there_is_a_document
     when_i_visit_the_document_page
     and_i_click_on_edit_tags
-    then_i_can_see_the_current_selections
+    then_i_see_the_current_selections
     when_i_edit_the_tags
     then_i_can_see_the_tags
     and_the_preview_creation_succeeded
@@ -19,13 +19,16 @@ RSpec.feature "Edit document tags" do
     multi_tag_schema = build(:tag_schema, type: "multi_tag", id: "multi_tag_id")
     single_tag_schema = build(:tag_schema, type: "single_tag", id: "single_tag_id")
     document_type_schema = build(:document_type_schema, tags: [multi_tag_schema, single_tag_schema])
+
     tag_linkables = [initial_tag, tag_to_select_1, tag_to_select_2]
     publishing_api_has_linkables(tag_linkables, document_type: multi_tag_schema["document_type"])
     publishing_api_has_linkables(tag_linkables, document_type: single_tag_schema["document_type"])
+
     initial_tags = {
       multi_tag_schema["id"] => [initial_tag["content_id"]],
       single_tag_schema["id"] => [initial_tag["content_id"]],
     }
+
     @document = create(:document, document_type: document_type_schema.id, tags: initial_tags)
   end
 
@@ -37,27 +40,26 @@ RSpec.feature "Edit document tags" do
     click_on "Change Tags"
   end
 
-  def then_i_can_see_the_current_selections
+  def then_i_see_the_current_selections
     @request = stub_publishing_api_put_content(Document.last.content_id, {})
-    expect(page).to have_select("tags[multi_tag_id][]",
-                                 selected: "Initial tag")
-    expect(page).to have_select("tags[single_tag_id][]",
-                                selected: "Initial tag")
+    expect(page).to have_select("tags[multi_tag_id][]", selected: "Initial tag")
+    expect(page).to have_select("tags[single_tag_id][]", selected: "Initial tag")
   end
 
   def when_i_edit_the_tags
     select "Tag to select 1", from: "tags[multi_tag_id][]"
     select "Tag to select 2", from: "tags[multi_tag_id][]"
     unselect "Initial tag", from: "tags[multi_tag_id][]"
-
     select "Tag to select 1", from: "tags[single_tag_id][]"
     click_on "Save"
   end
 
   def then_i_can_see_the_tags
-    expect(page).to have_content("Tag to select 1")
-    expect(page).to have_content("Tag to select 2")
-    expect(page).not_to have_content("Initial tag")
+    within("#tags") do
+      expect(page).to have_content("Tag to select 1")
+      expect(page).to have_content("Tag to select 2")
+      expect(page).not_to have_content("Initial tag")
+    end
   end
 
   def and_the_preview_creation_succeeded

--- a/spec/features/editing_tags/save_tags_publishing_api_down_spec.rb
+++ b/spec/features/editing_tags/save_tags_publishing_api_down_spec.rb
@@ -1,13 +1,11 @@
 # frozen_string_literal: true
 
-require "spec_helper"
-
 RSpec.feature "Save document tags when the API is down" do
   scenario do
     given_there_is_a_document_with_tags
-    and_i_am_editing_the_tags
+    and_i_am_on_the_tags_page
     and_the_publishing_api_is_down
-    when_i_finish_editing_the_tags
+    when_i_click_the_save_button
     then_i_see_the_document_page
     and_the_preview_creation_failed
   end
@@ -20,7 +18,7 @@ RSpec.feature "Save document tags when the API is down" do
     @document = create(:document, document_type: document_type_schema.id, tags: tag)
   end
 
-  def and_i_am_editing_the_tags
+  def and_i_am_on_the_tags_page
     visit document_tags_path(@document)
   end
 
@@ -29,12 +27,12 @@ RSpec.feature "Save document tags when the API is down" do
     publishing_api_isnt_available
   end
 
-  def when_i_finish_editing_the_tags
+  def when_i_click_the_save_button
     click_on "Save"
   end
 
   def then_i_see_the_document_page
-    expect(page).to have_content(@document.title)
+    expect(current_path).to eq document_path(@document)
   end
 
   def and_the_preview_creation_failed

--- a/spec/features/editing_topics/edit_topics_conflict_spec.rb
+++ b/spec/features/editing_topics/edit_topics_conflict_spec.rb
@@ -1,0 +1,56 @@
+# frozen_string_literal: true
+
+RSpec.feature "Edit topics when there is a conflict" do
+  scenario do
+    given_there_is_a_document
+    when_i_visit_the_topics_page
+    given_the_remote_has_changed
+    when_i_click_save
+    then_i_see_an_error_message
+  end
+
+  def given_there_is_a_document
+    @document = create :document
+  end
+
+  def when_i_visit_the_topics_page
+    publishing_api_has_links(
+      "content_id" => @document.content_id,
+      "links" => {
+        "taxons" => [],
+      },
+      "version" => 3,
+    )
+
+    # GOV.UK homepage
+    publishing_api_has_expanded_links(
+      "content_id" => "f3bbdec2-0e62-4520-a7fd-6ffd5d36e03a",
+      "expanded_links" => {
+        "level_one_taxons" => [],
+      },
+    )
+
+    visit document_topics_path(Document.last)
+  end
+
+  def given_the_remote_has_changed
+    #TODO: This should be moved to the gds-api-adapters
+    endpoint = GdsApi::TestHelpers::PublishingApiV2::PUBLISHING_API_V2_ENDPOINT
+    stub_request(:patch, "#{endpoint}/links/#{@document.content_id}")
+      .with(body: {
+        "links" => {
+          "taxons" => [],
+        },
+        "previous_version" => "3",
+      })
+      .to_return(status: 409)
+  end
+
+  def when_i_click_save
+    click_on "Save"
+  end
+
+  def then_i_see_an_error_message
+    expect(page).to have_content(I18n.t("documents.show.flashes.topic_update_conflict.title"))
+  end
+end

--- a/spec/features/editing_topics/edit_topics_conflict_spec.rb
+++ b/spec/features/editing_topics/edit_topics_conflict_spec.rb
@@ -1,6 +1,8 @@
 # frozen_string_literal: true
 
 RSpec.feature "Edit topics when there is a conflict" do
+  include TopicsHelper
+
   scenario do
     given_there_is_a_document
     when_i_visit_the_topics_page
@@ -22,14 +24,7 @@ RSpec.feature "Edit topics when there is a conflict" do
       "version" => 3,
     )
 
-    # GOV.UK homepage
-    publishing_api_has_expanded_links(
-      "content_id" => "f3bbdec2-0e62-4520-a7fd-6ffd5d36e03a",
-      "expanded_links" => {
-        "level_one_taxons" => [],
-      },
-    )
-
+    publishing_api_has_taxonomy
     visit document_topics_path(Document.last)
   end
 

--- a/spec/features/editing_topics/edit_topics_conflict_spec.rb
+++ b/spec/features/editing_topics/edit_topics_conflict_spec.rb
@@ -29,16 +29,13 @@ RSpec.feature "Edit topics when there is a conflict" do
   end
 
   def given_the_remote_has_changed
-    #TODO: This should be moved to the gds-api-adapters
-    endpoint = GdsApi::TestHelpers::PublishingApiV2::PUBLISHING_API_V2_ENDPOINT
-    stub_request(:patch, "#{endpoint}/links/#{@document.content_id}")
-      .with(body: {
-        "links" => {
-          "taxons" => [],
-        },
-        "previous_version" => "3",
-      })
-      .to_return(status: 409)
+    stub_publishing_api_patch_links_conflict(
+      @document.content_id,
+      "links" => {
+        "taxons" => [],
+      },
+      "previous_version" => 3,
+    )
   end
 
   def when_i_click_save

--- a/spec/features/editing_topics/edit_topics_conflict_spec.rb
+++ b/spec/features/editing_topics/edit_topics_conflict_spec.rb
@@ -43,6 +43,7 @@ RSpec.feature "Edit topics when there is a conflict" do
   end
 
   def then_i_see_an_error_message
-    expect(page).to have_content(I18n.t("documents.show.flashes.topic_update_conflict.title"))
+    expect(page).to have_content(I18n.t("document_topics.edit.flashes.topic_update_conflict.title"))
+    expect(current_path).to eq(document_topics_path(@document))
   end
 end

--- a/spec/features/editing_topics/edit_topics_publishing_api_down_spec.rb
+++ b/spec/features/editing_topics/edit_topics_publishing_api_down_spec.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-RSpec.feature "Show all the topics when the Publishing API is down" do
+RSpec.feature "Edit tags when the Publishing API is down" do
   scenario do
     given_there_is_a_document
     when_i_visit_the_document_page

--- a/spec/features/editing_topics/edit_topics_spec.rb
+++ b/spec/features/editing_topics/edit_topics_spec.rb
@@ -24,6 +24,7 @@ RSpec.feature "Edit topics for a document" do
       "links" => {
         "taxons" => %w(level_three_topic),
       },
+      "version" => 3,
     )
 
     # GOV.UK homepage
@@ -67,6 +68,8 @@ RSpec.feature "Edit topics for a document" do
     expect(page).to have_content("Level One Topic")
     expect(page).to have_content("Level Two Topic")
     expect(page).to have_content("Level Three Topic")
+    expect(find("#level_one_topic")).to_not be_checked
+    expect(find("#level_two_topic")).to_not be_checked
     expect(find("#level_three_topic")).to be_checked
   end
 
@@ -80,6 +83,7 @@ RSpec.feature "Edit topics for a document" do
       "links" => {
         "taxons" => %w(level_one_topic level_two_topic),
       },
+      "previous_version" => "3",
     )
 
     click_on "Save"

--- a/spec/features/editing_topics/edit_topics_spec.rb
+++ b/spec/features/editing_topics/edit_topics_spec.rb
@@ -1,6 +1,8 @@
 # frozen_string_literal: true
 
 RSpec.feature "Edit topics for a document" do
+  include TopicsHelper
+
   scenario do
     given_there_is_a_document
     when_i_visit_the_document_page
@@ -27,40 +29,7 @@ RSpec.feature "Edit topics for a document" do
       "version" => 3,
     )
 
-    # GOV.UK homepage
-    publishing_api_has_expanded_links(
-      "content_id" => "f3bbdec2-0e62-4520-a7fd-6ffd5d36e03a",
-      "expanded_links" => {
-        "level_one_taxons" => [
-          {
-            "title" => "Level One Topic",
-            "content_id" => "level_one_topic",
-          },
-        ],
-      },
-    )
-
-    publishing_api_has_expanded_links(
-      "content_id" => "level_one_topic",
-      "expanded_links" => {
-        "child_taxons" => [
-          {
-            "content_id" => "level_two_topic",
-            "title" => "Level Two Topic",
-            "links" => {
-              "child_taxons" => [
-                {
-                  "content_id" => "level_three_topic",
-                  "title" => "Level Three Topic",
-                  "links" => {},
-                },
-              ],
-            },
-          },
-        ],
-      },
-    )
-
+    publishing_api_has_taxonomy
     click_on "Change Topics"
   end
 

--- a/spec/features/editing_topics/edit_topics_spec.rb
+++ b/spec/features/editing_topics/edit_topics_spec.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-RSpec.feature "Show all the topics" do
+RSpec.feature "Edit topics for a document" do
   scenario do
     given_there_is_a_document
     when_i_visit_the_document_page
@@ -78,8 +78,8 @@ RSpec.feature "Show all the topics" do
     @request = stub_publishing_api_patch_links(
       @document.content_id,
       "links" => {
-        "taxons" => %w(level_one_topic level_two_topic)
-      }
+        "taxons" => %w(level_one_topic level_two_topic),
+      },
     )
 
     click_on "Save"

--- a/spec/features/editing_topics/edit_topics_spec.rb
+++ b/spec/features/editing_topics/edit_topics_spec.rb
@@ -37,15 +37,15 @@ RSpec.feature "Edit topics for a document" do
     expect(page).to have_content("Level One Topic")
     expect(page).to have_content("Level Two Topic")
     expect(page).to have_content("Level Three Topic")
-    expect(find("#level_one_topic")).to_not be_checked
-    expect(find("#level_two_topic")).to_not be_checked
-    expect(find("#level_three_topic")).to be_checked
+    expect(find("#topic-level_one_topic")).to_not be_checked
+    expect(find("#topic-level_two_topic")).to_not be_checked
+    expect(find("#topic-level_three_topic")).to be_checked
   end
 
   def when_i_edit_the_topics
-    uncheck("level_three_topic")
-    check("level_two_topic")
-    check("level_one_topic")
+    uncheck("Level Three Topic")
+    check("Level Two Topic")
+    check("Level One Topic")
 
     @request = stub_publishing_api_patch_links(
       @document.content_id,

--- a/spec/features/editing_topics/edit_topics_spec.rb
+++ b/spec/features/editing_topics/edit_topics_spec.rb
@@ -52,7 +52,7 @@ RSpec.feature "Edit topics for a document" do
       "links" => {
         "taxons" => %w(level_one_topic level_two_topic),
       },
-      "previous_version" => "3",
+      "previous_version" => 3,
     )
 
     click_on "Save"

--- a/spec/features/editing_topics/edit_topics_without_permission_spec.rb
+++ b/spec/features/editing_topics/edit_topics_without_permission_spec.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-RSpec.feature "Access topics without the pre-release features permission" do
+RSpec.feature "Edit topics without the pre-release features permission" do
   scenario do
     given_there_is_a_document
     and_i_dont_have_pre_release_features_permission

--- a/spec/features/editing_topics/save_topics_publishing_api_down_spec.rb
+++ b/spec/features/editing_topics/save_topics_publishing_api_down_spec.rb
@@ -1,0 +1,65 @@
+# frozen_string_literal: true
+
+RSpec.feature "Save topics when the Publishing API is down" do
+  scenario do
+    given_there_is_a_document
+    and_i_am_on_the_topics_page
+    and_the_publishing_api_is_down
+    when_i_click_the_save_button
+    then_i_see_the_document_page
+    and_the_topic_update_failed
+  end
+
+  def given_there_is_a_document
+    @document = create :document
+  end
+
+  def and_i_am_on_the_topics_page
+    publishing_api_has_links(
+      "content_id" => @document.content_id,
+      "links" => {
+        "taxons" => %w(level_one_topic),
+      },
+    )
+
+    # GOV.UK homepage
+    publishing_api_has_expanded_links(
+      "content_id" => "f3bbdec2-0e62-4520-a7fd-6ffd5d36e03a",
+      "expanded_links" => {
+        "level_one_taxons" => [
+          {
+            "title" => "Level One Topic",
+            "content_id" => "level_one_topic",
+          },
+        ],
+      },
+    )
+
+    publishing_api_has_expanded_links(
+      "content_id" => "level_one_topic",
+      "expanded_links" => {
+        "child_taxons" => [],
+      },
+    )
+
+    visit document_topics_path(@document)
+  end
+
+  def and_the_publishing_api_is_down
+    @request = stub_publishing_api_patch_links(@document.content_id, {})
+    publishing_api_isnt_available
+  end
+
+  def when_i_click_the_save_button
+    click_on "Save"
+  end
+
+  def then_i_see_the_document_page
+    expect(current_path).to eq document_path(@document)
+  end
+
+  def and_the_topic_update_failed
+    expect(@request).to have_been_requested
+    expect(page).to have_content(I18n.t("documents.show.flashes.topic_update_error.title"))
+  end
+end

--- a/spec/features/editing_topics/save_topics_publishing_api_down_spec.rb
+++ b/spec/features/editing_topics/save_topics_publishing_api_down_spec.rb
@@ -1,6 +1,8 @@
 # frozen_string_literal: true
 
 RSpec.feature "Save topics when the Publishing API is down" do
+  include TopicsHelper
+
   scenario do
     given_there_is_a_document
     and_i_am_on_the_topics_page
@@ -22,26 +24,7 @@ RSpec.feature "Save topics when the Publishing API is down" do
       },
     )
 
-    # GOV.UK homepage
-    publishing_api_has_expanded_links(
-      "content_id" => "f3bbdec2-0e62-4520-a7fd-6ffd5d36e03a",
-      "expanded_links" => {
-        "level_one_taxons" => [
-          {
-            "title" => "Level One Topic",
-            "content_id" => "level_one_topic",
-          },
-        ],
-      },
-    )
-
-    publishing_api_has_expanded_links(
-      "content_id" => "level_one_topic",
-      "expanded_links" => {
-        "child_taxons" => [],
-      },
-    )
-
+    publishing_api_has_taxonomy
     visit document_topics_path(@document)
   end
 

--- a/spec/features/editing_topics/show_topics_spec.rb
+++ b/spec/features/editing_topics/show_topics_spec.rb
@@ -1,6 +1,8 @@
 # frozen_string_literal: true
 
 RSpec.feature "Show the topics for a document" do
+  include TopicsHelper
+
   scenario do
     given_there_is_a_document
     when_the_document_has_no_topics
@@ -39,39 +41,7 @@ RSpec.feature "Show the topics for a document" do
       },
     )
 
-    # GOV.UK homepage
-    publishing_api_has_expanded_links(
-      "content_id" => "f3bbdec2-0e62-4520-a7fd-6ffd5d36e03a",
-      "expanded_links" => {
-        "level_one_taxons" => [
-          {
-            "title" => "Level One Topic",
-            "content_id" => "level_one_topic",
-          },
-        ],
-      },
-    )
-
-    publishing_api_has_expanded_links(
-      "content_id" => "level_one_topic",
-      "expanded_links" => {
-        "child_taxons" => [
-          {
-            "content_id" => "level_two_topic",
-            "title" => "Level Two Topic",
-            "links" => {
-              "child_taxons" => [
-                {
-                  "content_id" => "level_three_topic",
-                  "title" => "Level Three Topic",
-                  "links" => {},
-                },
-              ],
-            },
-          },
-        ],
-      },
-    )
+    publishing_api_has_taxonomy
   end
 
   def then_i_see_the_topic_breadcrumb

--- a/spec/features/editing_topics/show_topics_spec.rb
+++ b/spec/features/editing_topics/show_topics_spec.rb
@@ -75,7 +75,7 @@ RSpec.feature "Show the topics for a document" do
   end
 
   def then_i_see_the_topic_breadcrumb
-    within(".topic-breadcrumb") do
+    within("#topics .topic-breadcrumb") do
       expect(page).to have_content("Level One Topic")
       expect(page).to have_content("Level Two Topic")
       expect(page).to have_content("Level Three Topic")

--- a/spec/support/topics_helper.rb
+++ b/spec/support/topics_helper.rb
@@ -1,0 +1,39 @@
+# frozen_string_literal: true
+
+module TopicsHelper
+  def publishing_api_has_taxonomy
+    # GOV.UK homepage
+    publishing_api_has_expanded_links(
+      "content_id" => "f3bbdec2-0e62-4520-a7fd-6ffd5d36e03a",
+      "expanded_links" => {
+        "level_one_taxons" => [
+          {
+            "title" => "Level One Topic",
+            "content_id" => "level_one_topic",
+          },
+        ],
+      },
+    )
+
+    publishing_api_has_expanded_links(
+      "content_id" => "level_one_topic",
+      "expanded_links" => {
+        "child_taxons" => [
+          {
+            "content_id" => "level_two_topic",
+            "title" => "Level Two Topic",
+            "links" => {
+              "child_taxons" => [
+                {
+                  "content_id" => "level_three_topic",
+                  "title" => "Level Three Topic",
+                  "links" => {},
+                },
+              ],
+            },
+          },
+        ],
+      },
+    )
+  end
+end


### PR DESCRIPTION
https://trello.com/c/82J6eESL/356-allow-the-user-to-modify-the-topics-for-a-document

This enables a user to edit the topics for a document:

   * The user can see which topics are currently selected and change the selections (https://github.com/alphagov/content-publisher/commit/b0dadb13e92a9a8bb7273fb9d6e8a3c983da29ee)
   * We cope when the Publishing API is down (https://github.com/alphagov/content-publisher/commit/3eb253272cbe78c2f0b8cdd61b115ad3ca1a7c61)
   * We abort when the topics have been changed externally (https://github.com/alphagov/content-publisher/commit/ee9d022078bd7a1e5390d620b847dd4ecd8d22e8)

Because we don't store the topic taxonomy locally, we need to repeatedly stub parts of the tree, up to three levels deep. To avoid duplicate code, we've refactored this into our first helper, which is included explicitly in the necessary specs. (https://github.com/alphagov/content-publisher/commit/917f165e89506efcdb298b4465042f199ac2d7a5)