### PR TITLE
Auto populate legacy topics (specialist sectors)

### DIFF
--- a/spec/features/editing_topics/edit_topics_conflict_spec.rb
+++ b/spec/features/editing_topics/edit_topics_conflict_spec.rb
@@ -33,6 +33,7 @@ RSpec.feature "Edit topics when there is a conflict" do
       @document.content_id,
       "links" => {
         "taxons" => [],
+        "topics" => [],
       },
       "previous_version" => 3,
     )

--- a/spec/features/editing_topics/edit_topics_spec.rb
+++ b/spec/features/editing_topics/edit_topics_spec.rb
@@ -51,6 +51,7 @@ RSpec.feature "Edit topics for a document" do
       @document.content_id,
       "links" => {
         "taxons" => %w(level_one_topic level_two_topic),
+        "topics" => %w(specialist_sector_1 specialist_sector_2),
       },
       "previous_version" => 3,
     )

--- a/spec/features/editing_topics/save_topics_publishing_api_down_spec.rb
+++ b/spec/features/editing_topics/save_topics_publishing_api_down_spec.rb
@@ -29,7 +29,7 @@ RSpec.feature "Save topics when the Publishing API is down" do
   end
 
   def and_the_publishing_api_is_down
-    @request = stub_publishing_api_patch_links(@document.content_id, {})
+    stub_publishing_api_patch_links(@document.content_id, {})
     publishing_api_isnt_available
   end
 
@@ -42,7 +42,6 @@ RSpec.feature "Save topics when the Publishing API is down" do
   end
 
   def and_the_topic_update_failed
-    expect(@request).to have_been_requested
     expect(page).to have_content(I18n.t("documents.show.flashes.topic_update_error.title"))
   end
 end

--- a/spec/support/topics_helper.rb
+++ b/spec/support/topics_helper.rb
@@ -18,6 +18,15 @@ module TopicsHelper
     publishing_api_has_expanded_links(
       "content_id" => "level_one_topic",
       "expanded_links" => {
+        "legacy_taxons" => [
+          {
+            "content_id" => "specialist_sector_1",
+            "document_type" => "topic",
+          },
+          {
+            "content_id" => "another_legacy_taxon",
+          },
+        ],
         "child_taxons" => [
           {
             "content_id" => "level_two_topic",
@@ -28,6 +37,12 @@ module TopicsHelper
                   "content_id" => "level_three_topic",
                   "title" => "Level Three Topic",
                   "links" => {},
+                },
+              ],
+              "legacy_taxons" => [
+                {
+                  "content_id" => "specialist_sector_2",
+                  "document_type" => "topic",
                 },
               ],
             },


### PR DESCRIPTION
https://trello.com/c/lE8z7rmq/360-automatically-select-specialist-sectors-when-a-user-selects-a-topic

The new topic taxonomy has replaced a range of legacy alternatives,
except for 'topics' a.k.a specialist sectors. This makes sure we set
the specialist sectors for a document when the topics change, using the
legacy mappings for the selected topics and their parent lineage.

If the document already has specialist sectors, we will overwrite them.
This is a departure from the Whitehall behaviour, which we will validate
as with user testing. Hopefully we will retire specialist sectors before
the need arises to better support their existence ;-).