### PR TITLE
Update copy link in force publish screen to content summary

### DIFF
--- a/app/views/publish_document/published.html.erb
+++ b/app/views/publish_document/published.html.erb
@@ -27,7 +27,7 @@
 
         <%= render "govuk_publishing_components/components/copy_to_clipboard",
           label: t("publish_document.published.published_without_review.send_label"),
-          copyable_content: DocumentUrl.new(@document).public_url,
+          copyable_content: document_url(@document),
           button_text: "Copy link" %>
       <% end %>
     <% end %>


### PR DESCRIPTION
https://trello.com/c/sHwyBYZl/392-update-copy-link-in-force-publish-screen-to-content-summary

When the user publishes a document without review, we currently show a confirmation screen with a link to the live document on GOV.UK. This should be replaced with a link to the document summary, as we want publishers to direct the people reviewing their content to a screen where they can achieve this.