### PR TITLE
Publisher updates page 383 1

### DIFF
--- a/app/controllers/publisher_information_controller.rb
+++ b/app/controllers/publisher_information_controller.rb
@@ -1,0 +1,4 @@
+# frozen_string_literal: true
+
+class PublisherInformationController < ApplicationController
+end

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -101,18 +101,40 @@
   <%= render "govuk_publishing_components/components/layout_footer", {
     navigation: [
       {
-        title: "Support and feedback",
+        title: t("application.footer.support_and_feedback"),
         items: [
           {
-            href: "https://support.publishing.service.gov.uk/",
+            href: Plek.new.external_url_for("support") + "/technical_fault_report/new",
             text: "Raise a support request"
+          },
+          {
+            href: Plek.new.external_url_for("support") + "/general_request/new",
+            text: "Send us feedback"
           },
           {
             href: "https://www.gov.uk/government/content-publishing",
             text: "How to write, publish, and improve content"
           }
         ] + debug_links
-      }
+      },
+      {
+        title: t("application.footer.documentation"),
+        items: [
+          {
+            href: beta_capabilities_path,
+            text: "What the Beta can and cannot do"
+          },
+          {
+            href: how_to_use_publisher_path,
+            text: "How to use Content Publisher"
+          },
+          {
+            href: publisher_updates_path,
+            text: "What's new in Content Publisher"
+          }
+        ] + debug_links
+      },
+
     ]
   } %>
   <script src="https://cdn.ravenjs.com/3.26.4/raven.min.js" crossorigin="anonymous"></script>

--- a/app/views/publisher_information/_publication_info_nav.html.erb
+++ b/app/views/publisher_information/_publication_info_nav.html.erb
@@ -1,0 +1,25 @@
+<div class="govuk-grid-column-one-third">
+  <ul class="govuk-list">
+    <li>
+      <% if current_page == beta_capabilities_path %>
+        <strong>What the Beta can and cannot do</strong>
+      <% else %>
+        <a href="<%= beta_capabilities_path %>" class="govuk-link govuk-link--no-visited-state">What the Beta can and cannot do</a>
+      <% end %>
+    </li>
+    <li>
+      <% if current_page == how_to_use_publisher_path %>
+        <strong>How to use Content Publisher</strong>
+      <% else %>
+        <a href="<%= how_to_use_publisher_path %>" class="govuk-link govuk-link--no-visited-state ">How to use Content Publisher</a>
+      <% end %>
+    </li>
+    <li>
+      <% if current_page == publisher_updates_path %>
+        <strong>What's new in Content Publisher</strong>
+      <% else %>
+        <a href="<%= publisher_updates_path %>" class="govuk-link govuk-link--no-visited-state ">What's new in Content Publisher</a>
+      <% end %>
+    </li>
+  </ul>
+</div>

--- a/app/views/publisher_information/beta_capabilities.govspeak.md
+++ b/app/views/publisher_information/beta_capabilities.govspeak.md
@@ -1,0 +1,16 @@
+<span class="govuk-hint">Last updated: 9 November 2018</span>
+The Content publisher beta tool can be used to publish the following document types:
+
+* News stories
+* Press releases
+
+Content created in Content publisher cannot be edited in Whitehall publisher. Whitehall content cannot be edited in Content publisher.
+
+Some features are not yet available:
+
+* scheduling
+* access limiting
+* translations
+* contact embeds
+* unpublishing content (available on request)
+* withdrawing content (available on request)

--- a/app/views/publisher_information/beta_capabilities.html.erb
+++ b/app/views/publisher_information/beta_capabilities.html.erb
@@ -1,0 +1,13 @@
+<% content_for :browser_title, t("publisher_information.beta_capabilities.title") %>
+<div class="govuk-grid-row">
+  <%= render partial: "publication_info_nav", locals: {current_page: beta_capabilities_path } %>
+  <div class="govuk-grid-column-two-thirds">
+    <h1 class='govuk-heading-l page-title'><%= t("publisher_information.beta_capabilities.title") %></h1>
+    <%= render "govuk_publishing_components/components/govspeak" do %>
+        <%= govspeak_to_html File.read("app/views/publisher_information/beta_capabilities.govspeak.md") %>
+    <% end %>
+    <%= render "govuk_publishing_components/components/govspeak" do %>
+        <%= govspeak_to_html File.read("app/views/publisher_information/request_feature.govspeak.md") %>
+    <% end %>
+  </div>
+</div>

--- a/app/views/publisher_information/how_to_use_publisher.govspeak.md
+++ b/app/views/publisher_information/how_to_use_publisher.govspeak.md
@@ -1,0 +1,124 @@
+Content publisher is a new way of publishing content on GOV.UK. It is designed to make it 
+easier to publish useful content and to help you use data to manage that content.
+
+GDS are now beta testing Content publisher with government publishers. The beta version will have limited functionality at first. We are adding and improving features. 
+
+Read more about what Content publish can and cannot do.
+
+This document is for people who need to publish content to help them know what they should do with the new tool.
+
+
+##How to create content
+
+Content publisher can be used to create news stories and press releases. Other document types still need to be created in Whitehall publisher.
+
+You should always consider if content really needs to be published on GOV.UK. Unnecessary content makes it harder for users to find what the need.
+
+Read guidance on what to publish on GOV.UK.
+
+##Markdown
+
+The body text can be formatted using markdown. Markdown uses special characters to indicate what text needs styling. For example, adding ## at the start of a line makes that line a heading.
+
+Content publisher has a toolbar to make it easier to add common markdown. You can use the buttons to add headings, links, or lists. 
+
+More advanced markdown features can be used by following the guidance and examples in the interface. 
+
+Read full guidance on Markdown.
+
+##Lead image
+
+News content has a lead image which appears at the top of the page and is used as the thumbnail image on some links to the content. 
+
+Every page has a default lead image to represent your organisation. You should replace it with a picture that is more relevant to the content.
+
+You can upload any shape or size picture and crop it to the standard shape in Content publisher. Image files can be jpg, gif, or png files.
+
+You must add alt text for every image, but the caption is optional and the credit may not be required on all images.
+
+You can upload several images but must pick the one you want to be the lead image. 
+
+##Tags
+
+You should add tags that describe things the content is associated with. Tags help users find content on GOV.UK. 
+
+Tags available include the organisations and ministers involved, and the locations the content is relevant to.
+
+You only need to add any tags if they are relevant. If no minister is involved you don’t need to tag one.
+
+##Topics
+
+Topics describe what the content is about and group content on GOV.UK to make it easier to find. Topics used to be known as the Taxonomy.
+
+All content must be associated with at least one topic and can have as many as are relevant. Choose the most specific topics you can.
+
+You can select any relevant topics. No topics are restricted or owned by any department.
+
+Changes to topics are applied to a live page as soon as you save. If the content has already been published and you add new topics, then the last published edition will appear on those topic pages immediately, before you publish a new edition.
+
+Full guidance on topics.
+
+
+
+##How to update content
+
+You can search for existing content using the document search.
+
+To update published content you need to create a new edition. This new edition has the status ‘draft’ and can then be edited. When it is published it will replace the current edition live on GOV.UK.
+
+When you publish a new edition you need to indicate what type of change you have made. If the change is significant to users you must add a change note to explain the change. This change note will appear on GOV.UK and will be emailed to users.
+
+Full guidance on change notes.
+
+
+
+##How to publish content
+
+###Preview
+
+Before you publish content you must preview it. This shows you how the content will look on GOV.UK on a desktop screen and on a mobile screen. Half of our users are on a mobile device and so all content must be clear on small screens.
+
+Fact check or sign off
+
+Some content needs to be checked before it is published to make sure it is accurate. 
+
+You can share the content preview with others using the link provided so that they can see how it will look on GOV.UK.
+
+The person you share it with can then ask you to make any corrections or changes.
+
+###2i review
+
+All content should be reviewed by another person before it is published. This is to make sure the content is easy to understand and there are no mistakes.
+
+(2i is short for ‘2nd pair of eyes’, which means getting another person to review work.)
+
+When you think content is ready to publish you should select ‘Submit for 2i review’. This will mark it as being ready to be checked and it will have the status ‘Submitted for 2i review’.
+
+You then need to ask someone to do a 2i review. Send them the link to the page in Content publisher so that they can review it.
+
+If they find any mistakes in the content then they can edit it or ask you to edit it.
+
+When it has been reviewed and any improvements made then either you or they can go ahead and publish it. 
+
+Select the ‘Publish’ button, and then confirm that it has been reviewed. 
+
+###2i review before Content publisher
+
+The text may have been thoroughly reviewed before the document is created in Content publisher and the page prepared without any changes. If so it is possible to publish content without needing further review. 
+
+Select the ‘Publish’ button, and then confirm that it has been reviewed. 
+
+###Urgent publishing
+
+Some content needs to be published urgently before it can be reviewed. This used to be known as ‘Force publishing’.
+
+To publish urgently select the ‘Publish’ button, and then confirm that it should go live now but will still need review.
+
+The content will go live on GOV.UK but will be marked in Content publisher with the status ‘Published but needs 2i review’.
+
+You should send the Content publisher link to someone and ask them to review it.
+
+If they find mistakes then they or you can update the content to fix them.
+
+If there are no mistakes then they or you can select the ‘Approve’ button to confirm that the content has been reviewed. The content will then get the status ‘Published’.
+

--- a/app/views/publisher_information/how_to_use_publisher.html.erb
+++ b/app/views/publisher_information/how_to_use_publisher.html.erb
@@ -1,0 +1,14 @@
+<% content_for :browser_title, t("publisher_information.how_to_use_publisher.title") %>
+<div class="govuk-grid-row">
+  <%= render partial: "publication_info_nav", locals: {current_page: how_to_use_publisher_path } %>
+  <div class="govuk-grid-column-two-thirds">
+    <h1 class="govuk-heading-l page-title"><%= t("publisher_information.how_to_use_publisher.title") %></h1>
+
+    <%= render "govuk_publishing_components/components/govspeak" do %>
+        <%= govspeak_to_html File.read("app/views/publisher_information/how_to_use_publisher.govspeak.md") %>
+    <% end %>
+    <%= render "govuk_publishing_components/components/govspeak" do %>
+        <%= govspeak_to_html File.read("app/views/publisher_information/request_feature.govspeak.md") %>
+    <% end %>
+  </div>
+</div>

--- a/app/views/publisher_information/publisher_updates.govspeak.md
+++ b/app/views/publisher_information/publisher_updates.govspeak.md
@@ -1,0 +1,9 @@
+###Scheduling
+<span class="govuk-hint">22 October 2018</span>
+
+You can now schedule documents in to publish in the future
+
+###Inline images
+<span class="govuk-hint">16 September 2018</span>
+
+Inline images are now available for News stories

--- a/app/views/publisher_information/publisher_updates.html.erb
+++ b/app/views/publisher_information/publisher_updates.html.erb
@@ -1,0 +1,17 @@
+<% content_for :browser_title, t("publisher_information.publisher_updates.title") %>
+<div class="govuk-grid-row">
+  <%= render partial: "publication_info_nav", locals: {current_page: publisher_updates_path } %>
+  <div class="govuk-grid-column-two-thirds">
+    <h1 class='govuk-heading-l page-title'><%= t("publisher_information.publisher_updates.title") %></h1>
+
+    <%= render "govuk_publishing_components/components/govspeak" do %>
+        <%= govspeak_to_html t("publisher_information.publisher_updates.summary") %>
+    <% end %>
+    <%= render "govuk_publishing_components/components/govspeak" do %>
+        <%= govspeak_to_html File.read("app/views/publisher_information/publisher_updates.govspeak.md") %>
+    <% end %>
+    <%= render "govuk_publishing_components/components/govspeak" do %>
+        <%= govspeak_to_html File.read("app/views/publisher_information/request_feature.govspeak.md") %>
+    <% end %>
+  </div>
+</div>

--- a/app/views/publisher_information/request_feature.govspeak.md
+++ b/app/views/publisher_information/request_feature.govspeak.md
@@ -1,0 +1,4 @@
+##Request Feature
+You can help us prioritise features by [sending us feedback](https://support.publishing.service.gov.uk/general_request/new).
+
+You can also talk to us and other Beta users on the [Content Publisher Basecamp forum](https://basecamp.com/2308334/projects/15740446).

--- a/config/locales/en/application.yml
+++ b/config/locales/en/application.yml
@@ -1,0 +1,6 @@
+en:
+  application:
+    footer:
+      support_and_feedback: Support and feedback
+      documentation: Documentation
+      how_to_write_publish_improve: How to write, publish, and improve content

--- a/config/locales/en/publisher_information/beta_capabilities.yml
+++ b/config/locales/en/publisher_information/beta_capabilities.yml
@@ -1,0 +1,4 @@
+en:
+  publisher_information:
+    beta_capabilities:
+      title: What the Beta can and cannot do

--- a/config/locales/en/publisher_information/how_to_use_publisher.yml
+++ b/config/locales/en/publisher_information/how_to_use_publisher.yml
@@ -1,0 +1,4 @@
+en:
+  publisher_information:
+    how_to_use_publisher:
+      title: How to use Content Publisher

--- a/config/locales/en/publisher_information/publisher_updates.yml
+++ b/config/locales/en/publisher_information/publisher_updates.yml
@@ -1,0 +1,5 @@
+en:
+  publisher_information:
+    publisher_updates:
+      title: What's new in Content Publisher
+      summary: Summary of updates to Content Publisher, content design guidance, or the design of GOV.UK.

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -50,6 +50,10 @@ Rails.application.routes.draw do
 
   get "/documentation" => "documentation#index"
 
+  get "/how-to-use-publisher" => "publisher_information#how_to_use_publisher", as: :how_to_use_publisher
+  get "/beta-capabilities" => "publisher_information#beta_capabilities", as: :beta_capabilities
+  get "/publisher-updates" => "publisher_information#publisher_updates", as: :publisher_updates
+
   post "/govspeak-preview" => "govspeak_preview#to_html"
 
   mount GovukPublishingComponents::Engine, at: "/component-guide"

--- a/spec/features/publisher_information/visit_publisher_information_pages_spec.rb
+++ b/spec/features/publisher_information/visit_publisher_information_pages_spec.rb
@@ -1,0 +1,53 @@
+# frozen_string_literal: true
+
+RSpec.feature "User is on the home page and can visit the publisher information pages" do
+  scenario do
+    given_im_on_the_home_page
+    when_i_click_on_the_publisher_updates_link_in_footer
+    then_i_can_see_publisher_updates_page
+    when_i_click_on_the_beta_capabilities_link_in_footer
+    then_i_can_see_beta_capabilities_page
+    when_i_click_on_the_how_to_use_publisher_link_in_footer
+    then_i_can_see_how_to_use_publisher_page
+  end
+
+  def given_im_on_the_home_page
+    visit root_path
+  end
+
+  def when_i_click_on_the_publisher_updates_link_in_footer
+    within(".govuk-footer") do
+      click_on "What's new in Content Publisher"
+    end
+  end
+
+  def then_i_can_see_publisher_updates_page
+    within(".page-title") do
+      expect(page).to have_content(I18n.t("publisher_information.publisher_updates.title"))
+    end
+  end
+
+  def when_i_click_on_the_beta_capabilities_link_in_footer
+    within(".govuk-footer") do
+      click_on "What the Beta can and cannot do"
+    end
+  end
+
+  def then_i_can_see_beta_capabilities_page
+    within(".page-title") do
+      expect(page).to have_content(I18n.t("publisher_information.beta_capabilities.title"))
+    end
+  end
+
+  def when_i_click_on_the_how_to_use_publisher_link_in_footer
+    within(".govuk-footer") do
+      click_on "How to use Content Publisher"
+    end
+  end
+
+  def then_i_can_see_how_to_use_publisher_page
+    within(".page-title") do
+      expect(page).to have_content(I18n.t("publisher_information.how_to_use_publisher.title"))
+    end
+  end
+end


### PR DESCRIPTION
Supporting epic: https://trello.com/c/f7iCiQMB/338-publishers-can-find-what-beta-features-are-included-and-have-a-feedback-option-in-content-publisher

These changes allow the application to show user more information about the content publisher through three views: 
(1) publisher updates, which shows the latest changes.
(2) beta capabilities, which indicates what users should expect from the beta version of the application
(3) a how to page that describes how to use the content publisher application.

There is some repetition in the views but I plan to develop a layout which can better support all three pages. This request does not include adding in back link navigation and it does not include the header that should contain a link to get to the views that are developed here.

The main changes are:
(1) publisher_information_controller, which will not likely do much because most of the linking activities is handled by the routes.rb facility
(2) three views, each of which draws most of their contents from corresponding mark down files.
(3) a 'request_feature.govspeak.md' markdown file, whose contents will appear at the bottom of each of the three views.
(4) new translation files to support each of the main views.
(5) enhancements to the views/layouts/application.html.erb so that the footer can let users
reach the main page for this feature (app/views/publisher_information/index.html.erb) 
(6) Modified footer so that it can publish two columns of links, the second of which shows the three main publisher information links.
(7) Moved the left hand list of publisher information links into a partial view (e.g.: publisher updates, beta-capabilities, how-to-use-publisher pages)
(8) The main applications.rb layout has been modified so that href links used to refer to publisher information views now use Ruby route paths rather than URL paths.  So using ‘beta_capabilities_path’ instead of ‘/publisher-information/beta-capabilities’ in an href tag.
(9) Minor changes to what the titles of the publisher information view pages are called
(10) Adding support for making selection of publisher information links bold the currently selected view.
(11) Eliminated use of 'index' to refer to the publisher updates view of the publisher information pages.  It now has 'publisher-updates' in the routes.
(12) Adding support for Send us feedback footer link

Testing
I've limited testing to just checking whether from the home page of the Content publisher application we can click on the "Publisher updates" footer link and get to a page that shows the 
views we've been developing.  

Future design discussions
Are we still happy having one YML file for each view? They're a bit 'bitty' but maybe retaining the convention makes it easier for future developers to add new pages.



