### PR TITLE
Preview page opens on same tab with back button

### DIFF
--- a/app/views/documents/show/_actions.html.erb
+++ b/app/views/documents/show/_actions.html.erb
@@ -32,7 +32,7 @@
       <%= link_to "Remove", remove_document_path(@document), class: "govuk-link app-link--destructive app-link--right" %>
     <% elsif @document.user_facing_state == "submitted_for_review" %>
       <%= render "govuk_publishing_components/components/button", text: "Publish", href: publish_document_path(@document) %>
-      <%= render "govuk_publishing_components/components/button", text: "Preview", href: preview_document_path(@document), secondary: true, target: "_blank" %>
+      <%= render "govuk_publishing_components/components/button", text: "Preview", href: preview_document_path(@document), secondary: true %>
 
       <% unless @document.has_live_version_on_govuk %>
         <%= link_to "Delete draft", delete_draft_path(@document), class: "govuk-link app-link--destructive app-link--right" %>
@@ -42,7 +42,7 @@
         <%= render "govuk_publishing_components/components/button", text: "Submit for 2i review" %>
       <% end %>
 
-      <%= render "govuk_publishing_components/components/button", text: "Preview", href: preview_document_path(@document), secondary: true, target: "_blank" %>
+      <%= render "govuk_publishing_components/components/button", text: "Preview", href: preview_document_path(@document), secondary: true %>
 
       <%= link_to "Publish", publish_document_path(@document), class: "govuk-link" %>
 

--- a/app/views/preview/show.html.erb
+++ b/app/views/preview/show.html.erb
@@ -1,3 +1,4 @@
+<% content_for :back_link, document_path(@document) %>
 <% content_for :title, t("preview.show.title", title: @document.title_or_fallback) %>
 
 <%= render "components/page_preview",


### PR DESCRIPTION
https://trello.com/c/psIGjsfm/393-preview-page-to-open-in-same-tab-and-add-back-button-to-return-to-content-summary

As a publisher
I get confused when a preview window opens automatically in a new tab
and I am trying to go back to the summary screen but I can't find a
'back' button because I don't get a notification that it opened in a new
window