### PR TITLE
Make the crop handles bigger

### DIFF
--- a/app/assets/stylesheets/components/_image-cropper.scss
+++ b/app/assets/stylesheets/components/_image-cropper.scss
@@ -2,7 +2,7 @@
 @import "govuk-frontend/helpers/all";
 @import "vendor/cropperjs/dist/cropper";
 
-$cropper-point-size: 10px;
+$cropper-point-size: 20px;
 
 .app-c-image-cropper {
   @include govuk-font($size: 19);


### PR DESCRIPTION
If they uploaded an image to the exact dimensions, some publishers didn't realise their images could be cropped. 

Making the crop handles bigger might help alleviate this.

https://trello.com/c/Yu5DjMk3/398-iterate-lead-image-workflow-based-on-user-research