### PR TITLE
Cleanup superfluous topics before patching links

### DIFF
--- a/spec/features/editing_topics/edit_topics_spec.rb
+++ b/spec/features/editing_topics/edit_topics_spec.rb
@@ -50,7 +50,7 @@ RSpec.feature "Edit topics for a document" do
     @request = stub_publishing_api_patch_links(
       @document.content_id,
       "links" => {
-        "taxons" => %w(level_one_topic level_two_topic),
+        "taxons" => %w(level_two_topic),
         "topics" => %w(specialist_sector_1 specialist_sector_2),
       },
       "previous_version" => 3,


### PR DESCRIPTION
https://trello.com/c/fiIF8jNV/405-cleanup-superfluous-topics-on-save

Previously we assumed the frontend would ensure only leaf topics were
submitted on the edit page for topics; this assumption was false.

This changes the patch_links method to remove superfluous topics that
are an ancestor of another selected topic. To avoid implementing
multiple recursive methods, I extracted the recursive part of the
topic_breadcrumb method so that we can re-use it for ancestor cleanup.