### PR TITLE
Embed contacts via markdown

### DIFF
--- a/app/controllers/govspeak_preview_controller.rb
+++ b/app/controllers/govspeak_preview_controller.rb
@@ -4,6 +4,6 @@ class GovspeakPreviewController < ApplicationController
   skip_before_action :verify_authenticity_token
 
   def to_html
-    render plain: GovspeakService.new.to_html(params[:govspeak])
+    render plain: GovspeakService.new(params[:govspeak]).to_html
   end
 end

--- a/app/controllers/govspeak_preview_controller.rb
+++ b/app/controllers/govspeak_preview_controller.rb
@@ -4,6 +4,6 @@ class GovspeakPreviewController < ApplicationController
   skip_before_action :verify_authenticity_token
 
   def to_html
-    render plain: GovspeakService.new(params[:govspeak]).to_html
+    render plain: GovspeakDocument.new(params[:govspeak]).to_html
   end
 end

--- a/app/services/contacts_service.rb
+++ b/app/services/contacts_service.rb
@@ -1,0 +1,12 @@
+# frozen_string_literal: true
+
+class ContactsService
+  def by_content_id(content_id)
+    # FIXME: This might return a draft as this Publishing API method doesn't
+    # distinguish between these
+    document = GdsApi.publishing_api_v2.get_content(content_id)
+    document["schema_name"] == "contact" ? document.to_h : nil
+  rescue GdsApi::HTTPNotFound
+    nil
+  end
+end

--- a/app/services/govspeak_document.rb
+++ b/app/services/govspeak_document.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-class GovspeakService
+class GovspeakDocument
   attr_reader :text
 
   def initialize(text)

--- a/app/services/govspeak_service.rb
+++ b/app/services/govspeak_service.rb
@@ -1,7 +1,25 @@
 # frozen_string_literal: true
 
 class GovspeakService
-  def to_html(text)
-    Govspeak::Document.new(text).to_html
+  attr_reader :text
+
+  def initialize(text)
+    @text = text
+  end
+
+  def to_html
+    Govspeak::Document.new(text, contacts: contacts).to_html
+  end
+
+private
+
+  def contacts
+    @contacts ||= begin
+                    contact_content_ids = Govspeak::Document.new(text).extract_contact_content_ids
+                    contacts = contact_content_ids.map do |id|
+                      ContactsService.new.by_content_id(id)
+                    end
+                    contacts.compact
+                  end
   end
 end

--- a/app/services/publishing_api_payload.rb
+++ b/app/services/publishing_api_payload.rb
@@ -97,7 +97,7 @@ private
   # or class system.
   def perform_input_type_specific_transformations(field)
     if field.type == "govspeak"
-      GovspeakService.new.to_html(document.contents[field.id])
+      GovspeakService.new(document.contents[field.id]).to_html
     else
       document.contents[field.id]
     end

--- a/app/services/publishing_api_payload.rb
+++ b/app/services/publishing_api_payload.rb
@@ -97,7 +97,7 @@ private
   # or class system.
   def perform_input_type_specific_transformations(field)
     if field.type == "govspeak"
-      GovspeakService.new(document.contents[field.id]).to_html
+      GovspeakDocument.new(document.contents[field.id]).to_html
     else
       document.contents[field.id]
     end

--- a/spec/services/contacts_service_spec.rb
+++ b/spec/services/contacts_service_spec.rb
@@ -1,0 +1,45 @@
+# frozen_string_literal: true
+
+RSpec.describe ContactsService do
+  describe "#by_content_id" do
+    context "when a contact is found" do
+      it "returns the contact" do
+        content_id = SecureRandom.uuid
+        contact = {
+          "content_id" => content_id,
+          "locale" => "en",
+          "title" => "Clark Kent",
+          "schema_name" => "contact",
+          "document_type" => "contact",
+        }
+        publishing_api_has_item(contact)
+
+        expect(ContactsService.new.by_content_id(content_id)).to eq(contact)
+      end
+    end
+
+    context "when a contact is not found" do
+      it "returns nil" do
+        content_id = SecureRandom.uuid
+        publishing_api_does_not_have_item(content_id)
+        expect(ContactsService.new.by_content_id(content_id)).to be_nil
+      end
+    end
+
+    context "when the returned result is not a contact" do
+      it "returns nil" do
+        content_id = SecureRandom.uuid
+        news = {
+          content_id: content_id,
+          locale: "en",
+          title: "Breaking news",
+          schema_name: "news_article",
+          document_type: "news_story",
+        }
+        publishing_api_has_item(news)
+
+        expect(ContactsService.new.by_content_id(content_id)).to be_nil
+      end
+    end
+  end
+end

--- a/spec/services/govspeak_document_spec.rb
+++ b/spec/services/govspeak_document_spec.rb
@@ -1,9 +1,9 @@
 # frozen_string_literal: true
 
-RSpec.describe GovspeakService do
+RSpec.describe GovspeakDocument do
   describe "#to_html" do
     it "converts the provided text to HTML" do
-      expect(GovspeakService.new("## Hullo").to_html)
+      expect(GovspeakDocument.new("## Hullo").to_html)
         .to match(%{<h2 id="hullo">Hullo</h2>})
     end
 
@@ -12,7 +12,7 @@ RSpec.describe GovspeakService do
         content_id = SecureRandom.uuid
         govspeak = "[Contact:#{content_id}]"
         publishing_api_does_not_have_item(content_id)
-        expect(GovspeakService.new(govspeak).to_html).to eql("\n")
+        expect(GovspeakDocument.new(govspeak).to_html).to eql("\n")
       end
     end
 
@@ -36,7 +36,7 @@ RSpec.describe GovspeakService do
         )
 
         govspeak = "[Contact:#{content_id}]"
-        expect(GovspeakService.new(govspeak).to_html)
+        expect(GovspeakDocument.new(govspeak).to_html)
           .to match(%{<a href="mailto:clark@dailyplanet.com" class="email">Mail Clark</a>})
       end
     end

--- a/spec/services/govspeak_service_spec.rb
+++ b/spec/services/govspeak_service_spec.rb
@@ -1,0 +1,44 @@
+# frozen_string_literal: true
+
+RSpec.describe GovspeakService do
+  describe "#to_html" do
+    it "converts the provided text to HTML" do
+      expect(GovspeakService.new("## Hullo").to_html)
+        .to match(%{<h2 id="hullo">Hullo</h2>})
+    end
+
+    context "when an unknown contact is referenced" do
+      it "renders an empty string" do
+        content_id = SecureRandom.uuid
+        govspeak = "[Contact:#{content_id}]"
+        publishing_api_does_not_have_item(content_id)
+        expect(GovspeakService.new(govspeak).to_html).to eql("\n")
+      end
+    end
+
+    context "when a known contact that is referenced" do
+      it "renders the contact" do
+        content_id = SecureRandom.uuid
+
+        publishing_api_has_item(
+          content_id: content_id,
+          locale: "en",
+          title: "Clark Kent",
+          description: "Prone to lengthy work absences",
+          details: {
+            email_addresses: [
+              email: "clark@dailyplanet.com",
+              title: "Mail Clark",
+            ],
+          },
+          schema_name: "contact",
+          document_type: "contact",
+        )
+
+        govspeak = "[Contact:#{content_id}]"
+        expect(GovspeakService.new(govspeak).to_html)
+          .to match(%{<a href="mailto:clark@dailyplanet.com" class="email">Mail Clark</a>})
+      end
+    end
+  end
+end


### PR DESCRIPTION
Trello: https://trello.com/c/gEAMmD0g/386-ability-to-embed-a-contact-via-markdown

This is marked as DNM as https://github.com/alphagov/govspeak/pull/130 needs to be released first

![nov-07-2018 09-42-07](https://user-images.githubusercontent.com/282717/48123299-77916800-e271-11e8-8ac5-a99965c5271f.gif)

This PR introduces the ability to convert markdown such as `[Contact:e3dd86ba-508c-4e4c-9cba-1b98208d4de0]` and then insert the HTML of a contact. 

It does this by looking up all contact content_ids in the govspeak and then for each of them [looking them up](https://github.com/alphagov/publishing-api/blob/master/doc/api.md#get-v2contentcontent_id) in the Publishing API.

The means to look up in the Publishing API isn't perfect, it's as many calls as there are contacts embedded and may indadvertedly embed draft contact information. The expectation though is that the UI work to embed contacts may offer an opportunity to review those issues.