### PR TITLE
Replace Contacts in Whitehall import process

### DIFF
--- a/lib/tasks/whitehall_news_importer.rb
+++ b/lib/tasks/whitehall_news_importer.rb
@@ -26,7 +26,7 @@ module Tasks
       doc.assign_attributes(
         base_path: translation["base_path"],
         contents: {
-          body: translation["body"],
+          body: embed_contacts(translation["body"], document.fetch("contacts", {})),
         },
         document_type: edition["news_article_type"]["key"],
         title: translation["title"],
@@ -80,6 +80,14 @@ module Tasks
 
     def has_live_version?(edition, document)
       document["editions"].count > 1 || edition["state"] == "published"
+    end
+
+    def embed_contacts(body, contacts)
+      body&.gsub(/\[Contact:\s*(\d*)\s*\]/) do
+        id = Regexp.last_match[1]
+        embed = contacts[id] || id
+        "[Contact:#{embed}]"
+      end
     end
   end
 end

--- a/spec/tasks/whitehall_news_importer_spec.rb
+++ b/spec/tasks/whitehall_news_importer_spec.rb
@@ -32,7 +32,6 @@ RSpec.describe Tasks::WhitehallNewsImporter do
     }
   end
 
-
   it "can import JSON data from Whitehall" do
     importer = Tasks::WhitehallNewsImporter.new
     parsed_json = JSON.parse(import_data.to_json)
@@ -121,6 +120,15 @@ RSpec.describe Tasks::WhitehallNewsImporter do
     parsed_json = JSON.parse(import_data.to_json)
     importer = Tasks::WhitehallNewsImporter.new
     expect { importer.import(parsed_json) }.not_to(change { Document.count })
+  end
+
+  it "changes the ids of embedded contacts" do
+    import_data[:editions][0][:translations][0][:body] = "[Contact:123]"
+    content_id = SecureRandom.uuid
+    import_data[:contacts] = { "123" => content_id }
+    Tasks::WhitehallNewsImporter.new.import(JSON.parse(import_data.to_json))
+
+    expect(Document.last.contents["body"]).to eq("[Contact:#{content_id}]")
   end
 
   context "when an imported document has more than one edition" do


### PR DESCRIPTION
Trello: https://trello.com/c/gEAMmD0g/386-ability-to-embed-a-contact-via-markdown

This changes the body field on imported documents from Whitehall so that
the values for [Contact:123] are instead represented by the content_id.

It expects the JSON for a document to have a hash of contacts which
has a mapping of whitehall id => content id (e.g. { "123" =>
"12345678-1234-1234..." } which covers all the contacts in all the
translations and all the editions of a document.

Pairs with this Whitehall PR: https://github.com/alphagov/whitehall/pull/4481