### PR TITLE
Fix links in markdown preview

### DIFF
--- a/app/assets/javascripts/components/markdown-editor.js
+++ b/app/assets/javascripts/components/markdown-editor.js
@@ -54,6 +54,7 @@ MarkdownEditor.prototype.handlePreviewButton = function (event) {
   this.fetchGovspeakPreview(this.$input.value)
     .then(function (text) {
       $preview.innerHTML = text
+      MarkdownEditor.prototype.setTargetBlank($preview)
     })
     .catch(function () {
       $preview.innerHTML = 'Error previewing content'
@@ -62,7 +63,6 @@ MarkdownEditor.prototype.handlePreviewButton = function (event) {
       $preview.classList.add('app-c-markdown-editor__govspeak--rendered')
     })
 
-  this.setTargetBlank(this.$preview)
   this.toggleElements()
 }
 


### PR DESCRIPTION
This PR fixes the 'open in a new tab' for the preview markdown container.

The script was erroneously trying to set the `target` as `_blank` on an empty container as the `fetchGovspeakPreview` is starting a new thread of events

[Trello card](https://trello.com/c/h4YtRSCW)