### PR TITLE
Added guidance links

### DIFF
--- a/app/formats/document_types.yml
+++ b/app/formats/document_types.yml
@@ -19,10 +19,14 @@
       body: The summary should explain the main point of the content. It's the first line of the content so don’t repeat it below and end with a full stop.
     - id: body
       title: Writing news
-      body: Tell the story in the first lines with the most important information at the top. Use short words, short sentences, and short paragraphs. Use subheadings in longer content.
-      [Guidance on news stories](https://www.gov.uk/guidance/content-design/content-types#news-story){:target="_blank"}
-      [Writing for GOV.UK](https://www.gov.uk/guidance/content-design/writing-for-gov-uk#writing-to-govuk-style){:target="_blank"}
-      [The style guide](https://www.gov.uk/guidance/style-guide){:target="_blank"}
+      body: |
+        Tell the story in the first lines with the most important information at the top. Use short words, short sentences, and short paragraphs. Use subheadings in longer content.
+
+        [Guidance on news stories](https://www.gov.uk/guidance/content-design/content-types#news-story){:target="_blank"}
+
+        [Writing for GOV.UK](https://www.gov.uk/guidance/content-design/writing-for-gov-uk#writing-to-govuk-style){:target="_blank"}
+
+        [The style guide](https://www.gov.uk/guidance/style-guide){:target="_blank"}
     - id: primary_publishing_organisation
       title: Primary organisation
       body: The organisation responsible for publishing and maintaining this content.
@@ -79,10 +83,14 @@
       body: The summary should explain the main point of the story. It is the first line of the story so don’t repeat it in the body and end with a full stop.
     - id: body
       title: Writing a press release
-      body: Use short words, short sentences, and short paragraphs. Use subheadings in longer content. Avoid 'notes to editors'.
-      [Guidance on press releases](https://www.gov.uk/guidance/content-design/content-types#press-release){:target="_blank"}
-      [Writing for GOV.UK](https://www.gov.uk/guidance/content-design/writing-for-gov-uk#writing-to-govuk-style){:target="_blank"}
-      [The style guide](https://www.gov.uk/guidance/style-guide){:target="_blank"}
+      body: |
+        Use short words, short sentences, and short paragraphs. Use subheadings in longer content. Avoid 'notes to editors'.
+
+        [Guidance on press releases](https://www.gov.uk/guidance/content-design/content-types#press-release){:target="_blank"}
+
+        [Writing for GOV.UK](https://www.gov.uk/guidance/content-design/writing-for-gov-uk#writing-to-govuk-style){:target="_blank"}
+
+        [The style guide](https://www.gov.uk/guidance/style-guide){:target="_blank"}
     - id: primary_publishing_organisation
       title: Primary organisation
       body: The organisation responsible for publishing and maintaining this content.

--- a/app/formats/document_types.yml
+++ b/app/formats/document_types.yml
@@ -20,6 +20,9 @@
     - id: body
       title: Writing news
       body: Tell the story in the first lines with the most important information at the top. Use short words, short sentences, and short paragraphs. Use subheadings in longer content.
+      [Guidance on news stories](https://www.gov.uk/guidance/content-design/content-types#news-story){:target="_blank"}
+      [Writing for GOV.UK](https://www.gov.uk/guidance/content-design/writing-for-gov-uk#writing-to-govuk-style){:target="_blank"}
+      [The style guide](https://www.gov.uk/guidance/style-guide){:target="_blank"}
     - id: primary_publishing_organisation
       title: Primary organisation
       body: The organisation responsible for publishing and maintaining this content.
@@ -75,8 +78,11 @@
       title: Summary
       body: The summary should explain the main point of the story. It is the first line of the story so don’t repeat it in the body and end with a full stop.
     - id: body
-      title: Writing a news story
-      body: Put the most important information at the top. Use short words, short sentences, and short paragraphs. Use subheadings in longer content.
+      title: Writing a press release
+      body: Use short words, short sentences, and short paragraphs. Use subheadings in longer content. Avoid 'notes to editors'.
+      [Guidance on press releases](https://www.gov.uk/guidance/content-design/content-types#press-release){:target="_blank"}
+      [Writing for GOV.UK](https://www.gov.uk/guidance/content-design/writing-for-gov-uk#writing-to-govuk-style){:target="_blank"}
+      [The style guide](https://www.gov.uk/guidance/style-guide){:target="_blank"}
     - id: primary_publishing_organisation
       title: Primary organisation
       body: The organisation responsible for publishing and maintaining this content.

--- a/app/views/documents/fields/_govspeak_input.html.erb
+++ b/app/views/documents/fields/_govspeak_input.html.erb
@@ -24,7 +24,9 @@
         id: "document-contents-guidance",
         title: document.document_type_schema.guidance_for(schema.id).title
       } do %>
-        <p class="govuk-body"><%= document.document_type_schema.guidance_for(schema.id).body %></p>
+        <%= render "govuk_publishing_components/components/govspeak" do %>
+          <%= govspeak_to_html document.document_type_schema.guidance_for(schema.id).body %>
+        <% end %>
 
         <h3 class="govuk-heading-s"><%= t("documents.edit.fields.govspeak.title") %></h3>
 


### PR DESCRIPTION
Added guidance links to markdown guidance section on right hand side of the Edit screen.
Links should open in a new tab or window.