### PR TITLE
Use GOV.UK style when rendering govspeak alerts

### DIFF
--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -48,10 +48,13 @@
     <% if flash["alert_with_description"] %>
       <%= render "govuk_publishing_components/components/error_alert", {
         message: flash["alert_with_description"].fetch("title"),
-        description: govspeak_to_html(flash["alert_with_description"].fetch("description")),
+        description: capture do
+          render "govuk_publishing_components/components/govspeak" do
+            govspeak_to_html(flash["alert_with_description"].fetch("description"))
+          end
+        end
       } %>
     <% end %>
-
 
     <% if flash["alert"] %>
       <% if flash["alert"].is_a? Hash %>


### PR DESCRIPTION
https://trello.com/c/64Ljsaoi/394-error-link-colour-to-be-updated-to-be-consistent-with-govuk-styling