### PR TITLE
Implement styling improvements to the Summary page

### DIFF
--- a/app/assets/stylesheets/components/_summary.scss
+++ b/app/assets/stylesheets/components/_summary.scss
@@ -9,6 +9,16 @@
 .app-c-summary {
   @include govuk-font(19);
   position: relative;
+  border-bottom: 1px solid $govuk-border-colour;
+  @include govuk-responsive-margin(7, "top");
+
+  &:nth-of-type(1) {
+    margin-top: govuk-spacing(0);
+  }
+
+  &:nth-last-of-type(1) {
+    border-bottom: none;
+  }
 }
 
 .app-c-summary__change-link {
@@ -24,16 +34,12 @@
 }
 
 .app-c-summary__block {
-  @include govuk-responsive-margin(9, "bottom");
+  @include govuk-responsive-margin(7, "bottom");
 }
 
 .app-c-summary__list {
   @include govuk-font(19);
-
-  margin-top: 0;
-
-  @include govuk-responsive-margin(9, "bottom");
-
+  @include govuk-responsive-margin(7, "bottom");
   @include govuk-media-query($from: desktop) {
     display: table;
   }
@@ -65,7 +71,6 @@
 
 .app-c-summary__contents {
   position: relative;
-  border-bottom: 1px solid $govuk-border-colour;
 
   @include govuk-media-query($from: desktop) {
     display: table-row;
@@ -90,7 +95,6 @@
   @include govuk-media-query($from: desktop) {
     display: table-cell;
     padding: govuk-em(12, 19) govuk-em(20, 19) govuk-em(9, 19) 0;
-    border-bottom: 1px solid $govuk-border-colour;
   }
 }
 

--- a/app/views/documents/tags/_multi_tag.html.erb
+++ b/app/views/documents/tags/_multi_tag.html.erb
@@ -1,5 +1,5 @@
 <% if values.any? %>
-  <ul class="govuk-list govuk-list--bullet">
+  <ul class="govuk-list">
     <% values.each do |value| %>
       <li><%= value["internal_name"] %></li>
     <% end %>


### PR DESCRIPTION
The different sections seem to blend together, spacing + lines between content blocks and individual items is a bit haphazard

Meta data block currently shows lots of stuff that may not all be necessary, and it's not grouped very logically.

**1. Remove base path field**
 [More info in this section of Content improvement doc](https://docs.google.com/document/d/1LG9j1JbTyakGwv3qhPHBV6bmiQF8d7u9JxKQEc5cYOY/edit?ts=5be31510#bookmark=id.w04bw5q8ktz3)

Ticket: https://trello.com/c/OcxRWyd0/340-implement-styling-improvements-to-the-summary-page