### PR TITLE
Update share link content

### DIFF
--- a/app/views/components/_page_preview.html.erb
+++ b/app/views/components/_page_preview.html.erb
@@ -1,8 +1,8 @@
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
-    <%= render "govuk_publishing_components/components/details", title: "Share" do %>
+    <%= render "govuk_publishing_components/components/details", title: "Share document preview for fact check or approval" do %>
       <%= render "govuk_publishing_components/components/copy_to_clipboard",
-        label: "Copy and send this link to someone and they’ll be able to preview your draft on GOV.UK.",
+        label: "Send this link to someone so they can see a preview of how the document will appear on GOV.UK.",
         copyable_content: url,
         button_text: "Copy link" %>
     <% end %>

--- a/app/views/components/_page_preview.html.erb
+++ b/app/views/components/_page_preview.html.erb
@@ -2,7 +2,7 @@
   <div class="govuk-grid-column-two-thirds">
     <%= render "govuk_publishing_components/components/details", title: "Share document preview for fact check or approval" do %>
       <%= render "govuk_publishing_components/components/copy_to_clipboard",
-        label: "Send this link to someone so they can see a preview of how the document will appear on GOV.UK.",
+        label: "Send this link to someone so they can see a preview of how the document will appear on GOV.UK. No password is needed.",
         copyable_content: url,
         button_text: "Copy link" %>
     <% end %>


### PR DESCRIPTION
Publishers did not see the option to share preview
Publishers did not know what they could use it for

https://trello.com/c/NJ4v3YFb/397-iterate-preview-page-sharing-based-on-user-research-insights