### PR TITLE
Remove hard-coded government/political payload

### DIFF
--- a/app/services/publishing_api_payload.rb
+++ b/app/services/publishing_api_payload.rb
@@ -56,26 +56,17 @@ private
   end
 
   def details
-    details_hash = temporary_defaults_in_details
+    details = {}
 
     document_type_schema.contents.each do |field|
-      details_hash[field.id] = perform_input_type_specific_transformations(field)
+      details[field.id] = perform_input_type_specific_transformations(field)
     end
 
     if document_type_schema.lead_image && document.lead_image.present?
-      details_hash["image"] = image
+      details["image"] = image
     end
 
-    details_hash
-  end
-
-  def temporary_defaults_in_details
-    {
-      "government" => {
-        "title" => "Hey", "slug" => "what", "current" => true
-      },
-      "political" => false,
-    }
+    details
   end
 
   def roles_and_people(role_appointments)


### PR DESCRIPTION
https://trello.com/c/msxsnIdE/415-stop-sending-political-government-fields-to-publishing-api

See https://github.com/alphagov/govuk-content-schemas/commit/ec2cb5a6b83c5a71bfa4f1853d12e420724d57e8