### PR TITLE
Revert "Bump govuk_test from 0.2.1 to 0.3.0"

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -36,7 +36,7 @@ group :development, :test do
   gem "factory_bot_rails", "~> 4"
   gem "govuk-lint", "~> 3"
   gem "govuk_schemas", "~> 3.2"
-  gem "govuk_test", "~> 0.3"
+  gem "govuk_test", "~> 0.2"
   gem "jasmine", "~> 2.4"
   gem "rspec-rails", "~> 3"
   gem "webmock", "~> 3"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -70,20 +70,19 @@ GEM
     brakeman (4.3.1)
     builder (3.2.3)
     byebug (10.0.2)
-    capybara (3.10.1)
+    capybara (3.7.2)
       addressable
       mini_mime (>= 0.1.3)
       nokogiri (~> 1.8)
       rack (>= 1.6.0)
       rack-test (>= 0.6.3)
-      regexp_parser (~> 1.2)
-      xpath (~> 3.2)
+      xpath (~> 3.1)
     capybara-chromedriver-logger (0.2.1)
       capybara
       colorize
     childprocess (0.9.0)
       ffi (~> 1.0, >= 1.0.11)
-    chromedriver-helper (2.1.0)
+    chromedriver-helper (2.0.1)
       archive-zip (~> 0.10)
       nokogiri (~> 1.8)
     colorize (0.8.1)
@@ -160,10 +159,9 @@ GEM
       sass-rails (>= 5.0.4)
     govuk_schemas (3.2.0)
       json-schema (~> 2.8.0)
-    govuk_test (0.3.0)
+    govuk_test (0.2.1)
       capybara
       chromedriver-helper
-      ptools
       puma
       selenium-webdriver
     hashdiff (0.3.7)
@@ -269,7 +267,6 @@ GEM
     phantomjs (2.1.1.0)
     plek (2.1.1)
     powerpack (0.1.2)
-    ptools (1.3.5)
     public_suffix (3.0.3)
     puma (3.12.0)
     rack (2.0.6)
@@ -307,7 +304,6 @@ GEM
     rb-fsevent (0.10.3)
     rb-inotify (0.9.10)
       ffi (>= 0.5.0, < 2)
-    regexp_parser (1.2.0)
     request_store (1.4.1)
       rack (>= 1.4)
     rest-client (2.0.2)
@@ -367,9 +363,9 @@ GEM
     scss_lint (0.57.0)
       rake (>= 0.9, < 13)
       sass (~> 3.5.5)
-    selenium-webdriver (3.141.0)
+    selenium-webdriver (3.14.0)
       childprocess (~> 0.5)
-      rubyzip (~> 1.2, >= 1.2.2)
+      rubyzip (~> 1.2)
     sentry-raven (2.7.4)
       faraday (>= 0.7.6, < 1.0)
     simplecov (0.16.1)
@@ -410,7 +406,7 @@ GEM
     websocket-driver (0.7.0)
       websocket-extensions (>= 0.1.0)
     websocket-extensions (0.1.3)
-    xpath (3.2.0)
+    xpath (3.1.0)
       nokogiri (~> 1.8)
 
 PLATFORMS
@@ -431,7 +427,7 @@ DEPENDENCIES
   govuk_app_config (~> 1)
   govuk_publishing_components (~> 12.7)
   govuk_schemas (~> 3.2)
-  govuk_test (~> 0.3)
+  govuk_test (~> 0.2)
   image_processing (~> 1)
   jasmine (~> 2.4)
   kaminari (~> 1)


### PR DESCRIPTION
Reverts alphagov/content-publisher#445

This breaks because another app is installing an old version of the chromedriver-helper on staging, which creates a broken, global binary that overrides the working system one.