### PR TITLE
Update label for search

### DIFF
--- a/config/locales/en/documents/index.yml
+++ b/config/locales/en/documents/index.yml
@@ -27,7 +27,7 @@ en:
             * double-checking your spelling
         unknown_user: Unknown
       filter:
-        title_or_url: Search for a title or URL slug
+        title_or_url: Title or URL
         document_type: Document type
         state: Status
         organisation: Organisation

--- a/spec/features/finding/index_filtering_spec.rb
+++ b/spec/features/finding/index_filtering_spec.rb
@@ -51,7 +51,7 @@ RSpec.feature "User filters documents" do
   end
 
   def and_i_filter_by_title
-    fill_in "title", with: "super"
+    fill_in "title_or_url", with: "super"
     click_on "Filter"
   end
 
@@ -89,7 +89,7 @@ RSpec.feature "User filters documents" do
   end
 
   def when_i_filter_too_much
-    fill_in "title", with: SecureRandom.uuid
+    fill_in "title_or_url", with: SecureRandom.uuid
     click_on "Filter"
   end
 

--- a/spec/features/finding/index_ordering_spec.rb
+++ b/spec/features/finding/index_ordering_spec.rb
@@ -41,7 +41,7 @@ RSpec.feature "User orders documents" do
   end
 
   def when_i_apply_a_filter
-    fill_in "title", with: "recent"
+    fill_in "title_or_url", with: "recent"
     click_on "Filter"
   end
 


### PR DESCRIPTION
Slug isn’t widely understood by users. 
Content Data use "Title or URL", we should be consistent. 

Approved by @paola-roccuzzo