### PR TITLE
Update 'Edit tags' page to add YAML-editable hint text and remove unn…

### DIFF
--- a/app/formats/document_types.yml
+++ b/app/formats/document_types.yml
@@ -28,12 +28,6 @@
         [Writing for GOV.UK](https://www.gov.uk/guidance/content-design/writing-for-gov-uk#writing-to-govuk-style){:target="_blank"}
 
         [The style guide](https://www.gov.uk/guidance/style-guide){:target="_blank"}
-    - id: primary_publishing_organisation
-      title: Primary organisation
-      body: The organisation responsible for publishing and maintaining this content.
-    - id: organisations
-      title: Organisations
-      body: Any organisations who share responsibility for this content.
   contents:
     - id: body
       label: Body
@@ -43,26 +37,27 @@
       label: Primary organisation
       type: single_tag
       document_type: organisation
+      hint: The organisation responsible for publishing and maintaining this content.
     - id: organisations
       label: Organisations
       type: multi_tag
       document_type: organisation
+      hint: Tag organisations who share responsibility for this content.
     - id: role_appointments
       label: Ministers and government appointments
       type: multi_tag
       document_type: role_appointment
+      hint: Tag people who are directly involved.
     - id: topical_events
       label: Topical events
       type: multi_tag
       document_type: topical_event
+      hint: Tag major events this content is related to. For example, summits or budgets.
     - id: world_locations
       label: World locations
       type: multi_tag
       document_type: world_location
-    - id: worldwide_organisations
-      label: Worldwide organisations
-      type: multi_tag
-      document_type: worldwide_organisation
+      hint: Tag locations this content is about. If it only relates to the UK you don’t need to use this tag.
 
 - id: press_release
   label: Press release
@@ -93,12 +88,6 @@
         [Writing for GOV.UK](https://www.gov.uk/guidance/content-design/writing-for-gov-uk#writing-to-govuk-style){:target="_blank"}
 
         [The style guide](https://www.gov.uk/guidance/style-guide){:target="_blank"}
-    - id: primary_publishing_organisation
-      title: Primary organisation
-      body: The organisation responsible for publishing and maintaining this content.
-    - id: organisations
-      title: Organisations
-      body: Any organisations who share responsibility for this content.
   contents:
     - id: body
       label: Body
@@ -108,26 +97,27 @@
       label: Primary organisation
       type: single_tag
       document_type: organisation
+      hint: The organisation responsible for publishing and maintaining this content.
     - id: organisations
       label: Organisations
       type: multi_tag
       document_type: organisation
+      hint: Tag organisations who share responsibility for this content.
     - id: role_appointments
       label: Ministers and government appointments
       type: multi_tag
       document_type: role_appointment
+      hint: Tag people who are directly involved.
     - id: topical_events
       label: Topical events
       type: multi_tag
       document_type: topical_event
+      hint: Tag major events this content is related to. For example, summits or budgets.
     - id: world_locations
       label: World locations
       type: multi_tag
       document_type: world_location
-    - id: worldwide_organisations
-      label: Worldwide organisations
-      type: multi_tag
-      document_type: worldwide_organisation
+      hint: Tag locations this content is about. If it only relates to the UK you don’t need to use this tag.
 
 - id: fatality_notice
   label: Fatality notice

--- a/app/services/document_type_schema.rb
+++ b/app/services/document_type_schema.rb
@@ -47,7 +47,7 @@ class DocumentTypeSchema
 
   class Tag
     include ActiveModel::Model
-    attr_accessor :id, :label, :type, :document_type
+    attr_accessor :id, :label, :type, :document_type, :hint
   end
 
   class Guidance

--- a/app/views/components/_autocomplete.html.erb
+++ b/app/views/components/_autocomplete.html.erb
@@ -5,6 +5,7 @@
   multiple ||= nil
   size ||= nil
   data ||= nil
+  hint ||= nil
 %>
 
 <div class="app-c-autocomplete govuk-form-group">
@@ -15,6 +16,10 @@
   <% if options.any? %>
     <% if multiple %>
       <span class="govuk-hint app-c-autocomplete__multiselect-instructions">To select multiple items in a list, hold down Ctrl (PC) or Command (Mac) key.</span>
+    <% end %>
+
+    <% if hint %>
+      <span class="govuk-hint"><%= hint %></span>
     <% end %>
 
     <%= select_tag name,

--- a/app/views/document_tags/tags/_multi_tag_input.html.erb
+++ b/app/views/document_tags/tags/_multi_tag_input.html.erb
@@ -5,6 +5,7 @@
     text: schema.label,
     bold: true
   },
+  hint: schema.hint,
   options: LinkablesService.new(schema.document_type).select_options,
   selected_options: tags[schema.id],
   multiple: true,

--- a/app/views/document_tags/tags/_single_tag_input.html.erb
+++ b/app/views/document_tags/tags/_single_tag_input.html.erb
@@ -5,6 +5,7 @@
     text: schema.label,
     bold: true
   },
+  hint: schema.hint,
   options: LinkablesService.new(schema.document_type).select_options,
   selected_options: tags[schema.id],
   data: {

--- a/spec/formats/news_story_spec.rb
+++ b/spec/formats/news_story_spec.rb
@@ -36,9 +36,8 @@ RSpec.feature "Create a news story", format: true do
   def and_i_add_some_tags
     publishing_api_has_links(role_appointment_links)
 
-    expect(Document.last.document_type_schema.tags.count).to eq(6)
+    expect(Document.last.document_type_schema.tags.count).to eq(5)
     publishing_api_has_linkables([linkable], document_type: "topical_event")
-    publishing_api_has_linkables([linkable], document_type: "worldwide_organisation")
     publishing_api_has_linkables([linkable], document_type: "world_location")
     publishing_api_has_linkables([linkable], document_type: "organisation")
     publishing_api_has_linkables([linkable], document_type: "role_appointment")
@@ -46,7 +45,6 @@ RSpec.feature "Create a news story", format: true do
     click_on "Change Tags"
 
     select linkable["internal_name"], from: "tags[topical_events][]"
-    select linkable["internal_name"], from: "tags[worldwide_organisations][]"
     select linkable["internal_name"], from: "tags[world_locations][]"
     select linkable["internal_name"], from: "tags[organisations][]"
     select linkable["internal_name"], from: "tags[role_appointments][]"
@@ -65,7 +63,6 @@ RSpec.feature "Create a news story", format: true do
     {
       "links" => {
         "topical_events" => [linkable["content_id"]],
-        "worldwide_organisations" => [linkable["content_id"]],
         "world_locations" => [linkable["content_id"]],
         "organisations" => [linkable["content_id"]],
         "primary_publishing_organisation" => [linkable["content_id"]],

--- a/spec/formats/press_release_spec.rb
+++ b/spec/formats/press_release_spec.rb
@@ -36,9 +36,8 @@ RSpec.feature "Create a press release", format: true do
   def and_i_add_some_tags
     publishing_api_has_links(role_appointment_links)
 
-    expect(Document.last.document_type_schema.tags.count).to eq(6)
+    expect(Document.last.document_type_schema.tags.count).to eq(5)
     publishing_api_has_linkables([linkable], document_type: "topical_event")
-    publishing_api_has_linkables([linkable], document_type: "worldwide_organisation")
     publishing_api_has_linkables([linkable], document_type: "world_location")
     publishing_api_has_linkables([linkable], document_type: "organisation")
     publishing_api_has_linkables([linkable], document_type: "role_appointment")
@@ -46,7 +45,6 @@ RSpec.feature "Create a press release", format: true do
     click_on "Change Tags"
 
     select linkable["internal_name"], from: "tags[topical_events][]"
-    select linkable["internal_name"], from: "tags[worldwide_organisations][]"
     select linkable["internal_name"], from: "tags[world_locations][]"
     select linkable["internal_name"], from: "tags[organisations][]"
     select linkable["internal_name"], from: "tags[role_appointments][]"
@@ -65,7 +63,6 @@ RSpec.feature "Create a press release", format: true do
     {
       "links" => {
         "topical_events" => [linkable["content_id"]],
-        "worldwide_organisations" => [linkable["content_id"]],
         "world_locations" => [linkable["content_id"]],
         "organisations" => [linkable["content_id"]],
         "primary_publishing_organisation" => [linkable["content_id"]],


### PR DESCRIPTION
…ecessary tag fields

## What
Based on user reserach findings we need to clarify the 'Edit tags' page.

We need to
- Add hint text to the edit tags page
- Remove or hide 'Worldwide organisations' tag field for News Story and Press release (We will need it for other news schema document types later).

Hint text copy is here in the [Content improvement doc](https://docs.google.com/document/d/1LG9j1JbTyakGwv3qhPHBV6bmiQF8d7u9JxKQEc5cYOY/edit?ts=5be31510#bookmark=id.u57lo8njg61m).

https://trello.com/c/JH55nF2D/428-update-edit-tags-page-to-add-yaml-editable-hint-text-and-remove-unnecessary-tag-fields