### PR TITLE
MVP add contacts feature

### DIFF
--- a/app/controllers/document_contacts_controller.rb
+++ b/app/controllers/document_contacts_controller.rb
@@ -4,6 +4,9 @@ class DocumentContactsController < ApplicationController
   def search
     @document = Document.find_by_param(params[:id])
     @contacts_by_organisation = ContactsService.new.all_by_organisation
+  rescue GdsApi::BaseError => e
+    Rails.logger.error(e)
+    render "search_api_down", status: :service_unavailable
   end
 
   def insert

--- a/app/controllers/document_contacts_controller.rb
+++ b/app/controllers/document_contacts_controller.rb
@@ -1,0 +1,28 @@
+# frozen_string_literal: true
+
+class DocumentContactsController < ApplicationController
+  def search
+    @document = Document.find_by_param(params[:id])
+    @contacts_by_organisation = ContactsService.new.all_by_organisation
+  end
+
+  def insert
+    document = Document.find_by_param(params[:id])
+    contact_markdown = "[Contact:#{params.require(:contact_id)}]\n"
+
+    body = document.contents.fetch("body", "").chomp
+    document.contents["body"] = if body.present?
+                                  "#{body}\n\n#{contact_markdown}"
+                                else
+                                  contact_markdown
+                                end
+
+    DocumentDraftingService.update!(
+      document: document,
+      user: current_user,
+      type: "updated_content",
+    )
+
+    redirect_to edit_document_path(document) + "#body"
+  end
+end

--- a/app/controllers/documents_controller.rb
+++ b/app/controllers/documents_controller.rb
@@ -38,6 +38,7 @@ class DocumentsController < ApplicationController
   def update
     @document = Document.find_by_param(params[:id])
     @document.assign_attributes(update_params(@document))
+    add_contact_request = params[:submit] == "add_contact"
     @errors = DraftingRequirements.new(@document).errors
 
     if @errors.any?
@@ -56,7 +57,11 @@ class DocumentsController < ApplicationController
       type: "updated_content",
     )
 
-    redirect_to @document
+    if add_contact_request
+      redirect_to search_document_contacts_path(@document)
+    else
+      redirect_to @document
+    end
   rescue GdsApi::BaseError => e
     Rails.logger.error(e)
     redirect_to @document, alert_with_description: t("documents.show.flashes.draft_error")

--- a/app/services/contacts_service.rb
+++ b/app/services/contacts_service.rb
@@ -1,12 +1,58 @@
 # frozen_string_literal: true
 
 class ContactsService
+  CACHE_OPTIONS = { expires_in: 15.minutes, race_condition_ttl: 30.seconds }.freeze
+  EDITION_PARAMS = {
+    document_types: %w[contact].freeze,
+    fields: %w[content_id locale title description details links].freeze,
+    states: %w[published].freeze,
+    # This will need changing when this app supports more locales
+    locale: "en",
+    order: "id",
+    per_page: 1000,
+  }.freeze
+
   def by_content_id(content_id)
-    # FIXME: This might return a draft as this Publishing API method doesn't
-    # distinguish between these
-    document = GdsApi.publishing_api_v2.get_content(content_id)
-    document["schema_name"] == "contact" ? document.to_h : nil
-  rescue GdsApi::HTTPNotFound
-    nil
+    all_contacts.find { |contact| contact["content_id"] == content_id }
+  end
+
+  def all_by_organisation
+    @all_by_organisation ||= load_contacts_by_organisation
+  end
+
+private
+
+  def all_contacts
+    @all_contacts ||= Rails.cache.fetch("all_contacts", CACHE_OPTIONS) do
+      load_all_contacts
+    end
+  end
+
+  def load_all_contacts
+    GdsApi
+      .publishing_api_v2
+      .get_paged_editions(EDITION_PARAMS)
+      .inject([]) { |memo, page| memo + page["results"] }
+  end
+
+  def organisation_select_options
+    @organisation_select_options ||= LinkablesService.new("organisation").select_options
+  end
+
+  def load_contacts_by_organisation
+    contacts_by_org = all_contacts.each_with_object({}) do |contact, memo|
+      orgs = contact.dig("links", "organisations").to_a
+      orgs.each do |content_id|
+        memo[content_id] = memo[content_id].to_a + [contact]
+      end
+    end
+
+    organisation_select_options.map do |(name, content_id)|
+      {
+        "name" => name,
+        "content_id" => content_id,
+        "contacts" => contacts_by_org.fetch(content_id, []),
+      }
+    end
   end
 end

--- a/app/views/document_contacts/search.html.erb
+++ b/app/views/document_contacts/search.html.erb
@@ -1,0 +1,28 @@
+<% content_for :back_link, edit_document_path(@document) %>
+<% content_for :browser_title, t("document_contacts.search.title") %>
+
+<%
+  contact_options = @contacts_by_organisation.flat_map do |org|
+    org["contacts"].map do |contact|
+      ["#{contact['title']} - #{org['name']}", contact["content_id"]]
+    end
+  end
+%>
+
+<%= form_tag(insert_document_contact_path(@document)) do %>
+  <%= render "components/autocomplete", {
+    name: "contact_id",
+    label: {
+      text: %{<h1 class="govuk-heading-l">#{t("document_contacts.search.title")}</h1>}.html_safe,
+    },
+    options: ["", ""] + contact_options,
+    data: {
+      module: "autocomplete",
+    }
+  } %>
+
+  <%= render "govuk_publishing_components/components/button", {
+    text: "Insert contact", margin_bottom: true
+  } %>
+<% end %>
+

--- a/app/views/document_contacts/search_api_down.html.erb
+++ b/app/views/document_contacts/search_api_down.html.erb
@@ -1,0 +1,7 @@
+<% content_for :back_link, document_path(@document) %>
+<% content_for :title, t("document_contacts.search.title") %>
+
+<p class="govuk-body">
+  <%= t("document_contacts.search.api_down") %>
+</p>
+

--- a/app/views/documents/fields/_govspeak_input.html.erb
+++ b/app/views/documents/fields/_govspeak_input.html.erb
@@ -9,7 +9,7 @@
         data: {
           "contextual-guidance": "document-contents-guidance"
         },
-        id: "govspeak-editor",
+        id: schema.id,
         name: "document[contents][#{schema.id}]",
         value: document.contents[schema.id],
         rows: 25,
@@ -39,3 +39,6 @@
     </div>
   <% end %>
 </div>
+
+<button name="submit" type="submit" value="add_contact" class="govuk-button">Add contact</button>
+<br>

--- a/config/locales/en/document_contacts/search.yml
+++ b/config/locales/en/document_contacts/search.yml
@@ -1,0 +1,5 @@
+en:
+  document_contacts:
+    search:
+      title: Search contacts
+      api_down: Contacts can't be selected right now. We're having trouble getting the data we need for you to make changes on this page.

--- a/config/locales/en/document_contacts/select.yml
+++ b/config/locales/en/document_contacts/select.yml
@@ -1,4 +1,0 @@
-en:
-  document_contacts:
-    search:
-      title: Search contacts

--- a/config/locales/en/document_contacts/select.yml
+++ b/config/locales/en/document_contacts/select.yml
@@ -1,0 +1,4 @@
+en:
+  document_contacts:
+    search:
+      title: Search contacts

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -22,6 +22,9 @@ Rails.application.routes.draw do
   get "/documents/:id/delete-draft" => "documents#confirm_delete_draft", as: :delete_draft
   delete "/documents/:id" => "documents#destroy"
 
+  get "/documents/:id/search-contacts" => "document_contacts#search", as: :search_document_contacts
+  post "/documents/:id/search-contacts" => "document_contacts#insert", as: :insert_document_contact
+
   post "/documents/:id/submit-for-2i" => "review#submit_for_2i", as: :submit_document_for_2i
   post "/documents/:id/approve" => "review#approve", as: :approve_document
 

--- a/spec/features/editing_content/insert_contact_publishing_api_down_spec.rb
+++ b/spec/features/editing_content/insert_contact_publishing_api_down_spec.rb
@@ -1,0 +1,34 @@
+# frozen_string_literal: true
+
+RSpec.feature "Insert contact when the Publishing API down" do
+  scenario do
+    given_there_is_a_document
+    when_i_go_to_edit_the_document
+    and_i_go_to_add_a_contact_with_the_publishing_api_down
+    then_i_should_see_an_error_message
+  end
+
+  def given_there_is_a_document
+    body_field_schema = build(:field_schema, id: "body", type: "govspeak")
+    document_type_schema = build(:document_type_schema, contents: [body_field_schema])
+    @document = create(:document, document_type: document_type_schema.id)
+  end
+
+  def when_i_go_to_edit_the_document
+    visit document_path(@document)
+    click_on "Change Content"
+  end
+
+  def and_i_go_to_add_a_contact_with_the_publishing_api_down
+    publishing_api_isnt_available
+    # Add contact will submit the form and update the content before redirecting
+    # thus we want the put content API call to succeed before contacts being
+    # unavailable
+    stub_publishing_api_put_content(@document.content_id, {})
+    click_on "Add contact"
+  end
+
+  def then_i_should_see_an_error_message
+    expect(page).to have_content(I18n.t("document_contacts.search.api_down"))
+  end
+end

--- a/spec/features/editing_content/insert_contact_spec.rb
+++ b/spec/features/editing_content/insert_contact_spec.rb
@@ -1,0 +1,51 @@
+# frozen_string_literal: true
+
+RSpec.feature "Insert contact" do
+  scenario do
+    given_there_is_a_document
+    when_i_go_to_edit_the_document
+    and_i_go_to_add_a_contact
+    when_i_select_a_contact
+    then_i_can_see_the_contact_in_the_body
+  end
+
+  let(:organisation) { { "content_id" => SecureRandom.uuid, "internal_name" => "Organisation" } }
+  let(:contact) do
+    {
+      "content_id" => SecureRandom.uuid,
+      "title" => "Contact",
+      "links" => { "organisations" => [organisation["content_id"]] },
+    }
+  end
+
+  before do
+    publishing_api_has_linkables([organisation], document_type: "organisation")
+    publishing_api_get_editions([contact], ContactsService::EDITION_PARAMS)
+  end
+
+  def given_there_is_a_document
+    body_field_schema = build(:field_schema, id: "body", type: "govspeak")
+    document_type_schema = build(:document_type_schema, contents: [body_field_schema])
+    @document = create(:document, document_type: document_type_schema.id)
+  end
+
+  def when_i_go_to_edit_the_document
+    visit document_path(@document)
+    click_on "Change Content"
+  end
+
+  def and_i_go_to_add_a_contact
+    @request = stub_publishing_api_put_content(@document.content_id, {})
+    click_on "Add contact"
+  end
+
+  def when_i_select_a_contact
+    select "Contact - Organisation", from: "contact_id"
+    click_on "Insert contact"
+  end
+
+  def then_i_can_see_the_contact_in_the_body
+    expect(find_field("document[contents][body]").value)
+      .to match(/\[Contact:#{contact['content_id']}\]/)
+  end
+end

--- a/spec/services/contacts_service_spec.rb
+++ b/spec/services/contacts_service_spec.rb
@@ -5,40 +5,62 @@ RSpec.describe ContactsService do
     context "when a contact is found" do
       it "returns the contact" do
         content_id = SecureRandom.uuid
-        contact = {
-          "content_id" => content_id,
-          "locale" => "en",
-          "title" => "Clark Kent",
-          "schema_name" => "contact",
-          "document_type" => "contact",
-        }
-        publishing_api_has_item(contact)
+        editions = [{ "content_id" => content_id, "locale" => "en", "title" => "Clark Kent" }]
+        publishing_api_get_editions(editions, ContactsService::EDITION_PARAMS)
 
-        expect(ContactsService.new.by_content_id(content_id)).to eq(contact)
+        expect(ContactsService.new.by_content_id(content_id)).to eq(editions.first)
       end
     end
 
     context "when a contact is not found" do
       it "returns nil" do
-        content_id = SecureRandom.uuid
-        publishing_api_does_not_have_item(content_id)
-        expect(ContactsService.new.by_content_id(content_id)).to be_nil
+        publishing_api_get_editions([], ContactsService::EDITION_PARAMS)
+        expect(ContactsService.new.by_content_id(SecureRandom.uuid)).to be_nil
+      end
+    end
+  end
+
+  describe "#all_by_organisation" do
+    context "when there are organisations with contacts" do
+      it "returns each organisation with their contacts" do
+        org1 = { "content_id" => SecureRandom.uuid, "internal_name" => "Org 1" }
+        org2 = { "content_id" => SecureRandom.uuid, "internal_name" => "Org 2" }
+        publishing_api_has_linkables([org1, org2], document_type: "organisation")
+
+        org1_contacts = [
+          { "content_id" => SecureRandom.uuid, "locale" => "en", "title" => "Contact 1", "links" => { "organisations" => [org1["content_id"]] } },
+          { "content_id" => SecureRandom.uuid, "locale" => "en", "title" => "Contact 2", "links" => { "organisations" => [org1["content_id"]] } },
+        ]
+        org2_contacts = [
+          { "content_id" => SecureRandom.uuid, "locale" => "en", "title" => "Contact 3", "links" => { "organisations" => [org2["content_id"]] } },
+        ]
+        publishing_api_get_editions(org1_contacts + org2_contacts, ContactsService::EDITION_PARAMS)
+
+        expect(ContactsService.new.all_by_organisation).to match([
+          { "name" => org1["internal_name"], "content_id" => org1["content_id"], "contacts" => org1_contacts },
+          { "name" => org2["internal_name"], "content_id" => org2["content_id"], "contacts" => org2_contacts },
+        ])
       end
     end
 
-    context "when the returned result is not a contact" do
-      it "returns nil" do
-        content_id = SecureRandom.uuid
-        news = {
-          content_id: content_id,
-          locale: "en",
-          title: "Breaking news",
-          schema_name: "news_article",
-          document_type: "news_story",
-        }
-        publishing_api_has_item(news)
+    context "when there are organisations without contacts" do
+      it "returns them despite their lack of contacts" do
+        org1 = { "content_id" => SecureRandom.uuid, "internal_name" => "Org 1" }
+        publishing_api_has_linkables([org1], document_type: "organisation")
 
-        expect(ContactsService.new.by_content_id(content_id)).to be_nil
+        publishing_api_get_editions([], ContactsService::EDITION_PARAMS)
+
+        expect(ContactsService.new.all_by_organisation).to match([
+          { "name" => org1["internal_name"], "content_id" => org1["content_id"], "contacts" => [] },
+        ])
+      end
+    end
+
+    context "when there are no organisations" do
+      it "returns an empty array" do
+        publishing_api_has_linkables([], document_type: "organisation")
+        publishing_api_get_editions([], ContactsService::EDITION_PARAMS)
+        expect(ContactsService.new.all_by_organisation).to eql([])
       end
     end
   end

--- a/spec/services/govspeak_document_spec.rb
+++ b/spec/services/govspeak_document_spec.rb
@@ -11,7 +11,7 @@ RSpec.describe GovspeakDocument do
       it "renders an empty string" do
         content_id = SecureRandom.uuid
         govspeak = "[Contact:#{content_id}]"
-        publishing_api_does_not_have_item(content_id)
+        publishing_api_get_editions([], ContactsService::EDITION_PARAMS)
         expect(GovspeakDocument.new(govspeak).to_html).to eql("\n")
       end
     end
@@ -19,20 +19,21 @@ RSpec.describe GovspeakDocument do
     context "when a known contact that is referenced" do
       it "renders the contact" do
         content_id = SecureRandom.uuid
-
-        publishing_api_has_item(
-          content_id: content_id,
-          locale: "en",
-          title: "Clark Kent",
-          description: "Prone to lengthy work absences",
-          details: {
-            email_addresses: [
-              email: "clark@dailyplanet.com",
-              title: "Mail Clark",
-            ],
-          },
-          schema_name: "contact",
-          document_type: "contact",
+        publishing_api_get_editions(
+          [
+            {
+              "content_id" => content_id,
+              "title" => "Clark Kent",
+              "description" => "Prone to lengthy work absences",
+              "details" => {
+                "email_addresses" => [
+                  "email" => "clark@dailyplanet.com",
+                  "title" => "Mail Clark",
+                ],
+              },
+            },
+          ],
+          ContactsService::EDITION_PARAMS,
         )
 
         govspeak = "[Contact:#{content_id}]"


### PR DESCRIPTION
Trello: https://trello.com/c/a80pDKyV/412-browse-and-insert-a-contact-into-markdown

![nov-15-2018 13-40-06](https://user-images.githubusercontent.com/282717/48556513-11918a00-e8dc-11e8-8992-2446a07bec46.gif)

This card will be followed up with some design tweaks. More info in commits, main commit info below: 

This implements the design to insert contacts into a document that
involved loading a new page - with the intention of avoiding a modal
window and having an identical JS and No JS experience.

It involves allowing a user to submit the edit content with a different
button and because of that button changing the behaviour of the update
action to redirect the user to a select contact view. When this form is
submitted it then redirects the user back to the edit content form.

This approach is hopefully not something we will keep long term or use
again as it suffers from a number of issues:

- User can be prevented from getting to the insert contact screen by a
  validation error
- A new entry in the document history will be created each time the user
  submits either form
- We can't insert at a particular point in the textarea field easily and
  thus append to the end of the string
- We have to closely embed which field will be amended with the
  DocumentContactsController which doesn't make it particularly friendly
  to the format system

There are a number of approaches that could solve one or more of these
issues but will likely cause the complications and exceptions for this
to increase - whereas it probably makes sense to be entirely in the
concern of the govspeak editor.