### PR TITLE
Make image messages consistent

### DIFF
--- a/config/locales/en/document_images/index.yml
+++ b/config/locales/en/document_images/index.yml
@@ -2,7 +2,7 @@ en:
   document_images:
     index:
       title: "Images for ‘%{title}’"
-      description: Images can be jpg, png, gif, or svg files. [Full guidance on images](https://www.gov.uk/guidance/how-to-publish-on-gov-uk/images-and-videos)
+      description: Images can be jpg, png or gif files. [Full guidance on images](https://www.gov.uk/guidance/how-to-publish-on-gov-uk/images-and-videos)
       upload_image: Upload an image
       alt_text: Alt text
       caption: Image caption
@@ -13,7 +13,7 @@ en:
         upload_requirements:
           title: You need to
           no_file_selected: Select a file to upload
-          invalid_format: Select a a jpg, jpeg, png or gif image file
+          invalid_format: Select a a jpg, png or gif image file
           max_size: "Select an image file under %{max_size} in size"
           min_dimensions: "Select an image at least %{width} pixels wide by %{height} pixels high"
         cropped: "Image “%{file}” has been cropped"


### PR DESCRIPTION
This drops our mention of SVG as we don't support these yet
(unfortunately the guidance link may contradict that but then there's
various things in that document that currently don't accurate represent
Content Publisher.

It also drops the oxford comma and our use of jpg and jpeg.