### PR TITLE
Remove footer link repetition

### DIFF
--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -144,9 +144,8 @@
             href: publisher_updates_path,
             text: "What's new in Content Publisher"
           }
-        ] + debug_links
+        ]
       },
-
     ]
   } %>
   <script src="https://cdn.ravenjs.com/3.26.4/raven.min.js" crossorigin="anonymous"></script>


### PR DESCRIPTION
The debug links only need to be appended to one list of links.

Before:
<img width="987" alt="screen shot 2018-11-19 at 10 42 23" src="https://user-images.githubusercontent.com/282717/48702160-232ea680-ebe8-11e8-8a4d-2a25bbc7edf1.png">

After:
<img width="982" alt="screen shot 2018-11-19 at 10 43 45" src="https://user-images.githubusercontent.com/282717/48702167-25910080-ebe8-11e8-85c3-b07f6f1f19c9.png">

