### PR TITLE
Add link to raise support request

### DIFF
--- a/app/views/layouts/_phase_banner_elements.html.erb
+++ b/app/views/layouts/_phase_banner_elements.html.erb
@@ -1,4 +1,7 @@
 <span class="gem-c-phase-banner__banner-item">
+  <a class="govuk-link govuk-link--no-visited-state" href="<%= Plek.new.external_url_for("support") + "/technical_fault_report/new" %>"><%= t("application.phase_banner.raise_a_support_request") %></a>
+</span>
+<span class="gem-c-phase-banner__banner-item">
   <a class="govuk-link govuk-link--no-visited-state" href="<%= Plek.new.external_url_for("support") + "/general_request/new" %>"><%= t("application.phase_banner.send_us_feedback") %></a>
 </span>
 <span class="gem-c-phase-banner__banner-item">

--- a/config/locales/en/application.yml
+++ b/config/locales/en/application.yml
@@ -1,6 +1,7 @@
 en:
   application:
     phase_banner:
+      raise_a_support_request: Raise a support request
       send_us_feedback: Send us feedback
       whats_new: What's new
     footer:


### PR DESCRIPTION
In research, users thought they should use the feedback form for technical support. In private beta, we should be super clear about where they should go when they need help.

https://trello.com/c/WOEm2VQ2/452-review-the-entire-app-for-design-fixes