### PR TITLE
Publisher information changes

### DIFF
--- a/app/views/publisher_information/publisher_updates.govspeak.md
+++ b/app/views/publisher_information/publisher_updates.govspeak.md
@@ -1,3 +1,2 @@
-
-
-
+### Content Publisher is available in beta <span class="govuk-caption-m">29 November 2018</span>
+Beta partners can now access Content Publisher to publish news stories and press releases. Most features are available, [some will be released later](https://content-publisher.integration.publishing.service.gov.uk/beta-capabilities).

--- a/app/views/publisher_information/publisher_updates.govspeak.md
+++ b/app/views/publisher_information/publisher_updates.govspeak.md
@@ -1,9 +1,3 @@
-### Scheduling <span class="govuk-caption-m">22 October 2018</span>
-You can now schedule documents in to publish in the future
 
-
-
-### Inline images <span class="govuk-caption-m">16 September 2018</span>
-Inline images are now available for News stories
 
 

--- a/app/views/publisher_information/publisher_updates.govspeak.md
+++ b/app/views/publisher_information/publisher_updates.govspeak.md
@@ -1,2 +1,2 @@
 ### Content Publisher is available in beta <span class="govuk-caption-m">29 November 2018</span>
-Beta partners can now access Content Publisher to publish news stories and press releases. Most features are available, [some will be released later](https://content-publisher.integration.publishing.service.gov.uk/beta-capabilities).
+Beta partners can now access Content Publisher to publish news stories and press releases. Most features are available, [some will be released later](/beta-capabilities).


### PR DESCRIPTION

Remove dummy content from What's new page and replace with first release note

https://trello.com/c/JN04xUyt/458-update-publisher-information-in-whats-new-section