### PR TITLE
Remove default image content

### DIFF
--- a/config/locales/en/documents/show.yml
+++ b/config/locales/en/documents/show.yml
@@ -35,7 +35,7 @@ en:
           Something went wrong when deleting your draft. Please try again or [raise a support request](https://support.publishing.service.gov.uk/technical_fault_report/new).
       lead_image:
         title: Lead image
-        no_lead_image: No image selected. The default image for your department will be used.
+        no_lead_image: No image selected.
         upload_image: Upload an image
         fields:
           alt_text: Alt text


### PR DESCRIPTION
We don’t have this yet. 

Let’s remove now in case we don’t by the time we launch. We can add the line back once the feature is built.

https://trello.com/c/WOEm2VQ2/452-review-the-entire-app-for-design-fixes