### PR TITLE
Allow documents to be "removed" or "retired"

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -33,6 +33,7 @@ end
 group :development, :test do
   gem "byebug", "~> 10"
   gem "capybara-chromedriver-logger"
+  gem "climate_control"
   gem "factory_bot_rails", "~> 4"
   gem "govuk-lint", "~> 3"
   gem "govuk_schemas", "~> 3.2"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -86,6 +86,7 @@ GEM
     chromedriver-helper (2.1.0)
       archive-zip (~> 0.10)
       nokogiri (~> 1.8)
+    climate_control (0.2.0)
     colorize (0.8.1)
     commander (4.4.7)
       highline (~> 2.0.0)
@@ -420,6 +421,7 @@ DEPENDENCIES
   brakeman (~> 4)
   byebug (~> 10)
   capybara-chromedriver-logger
+  climate_control
   factory_bot_rails (~> 4)
   foreman (~> 0.85)
   gds-api-adapters (~> 54)

--- a/README.md
+++ b/README.md
@@ -86,6 +86,35 @@ content publisher directory and run:
 bundle exec rake import:whitehall_news INPUT=/tmp/whitehall-export.json
 ```
 
+### Retiring and removing documents
+
+We need to allow users to unpublish content from GOV.UK. In Content Publisher we are replacing
+unpublish terminology with "retired" and "removed".
+
+Retired content is still displayed on GOV.UK, but there is an explanation box on the page that describes
+why the content is out of date.
+
+Removed content no longer displayed on GOV.UK. The user is either served a "Gone" page, or the removed
+content can be redirected to another page on GOV.UK
+
+#### Retiring documents
+
+```
+rake unpublish:retire_document["/full/base-path","Reason the document is being retired"]
+```
+
+#### Removing documents
+
+```
+rake unpublish:remove_document["/full/base-path"]
+```
+
+##### Redirect removed documents to another page on GOV.UK
+
+```
+rake unpublish:remove_document["/full/base-path","/full/redirect/base-path"]
+```
+
 ## Licence
 
 [MIT License](LICENCE)

--- a/README.md
+++ b/README.md
@@ -86,34 +86,9 @@ content publisher directory and run:
 bundle exec rake import:whitehall_news INPUT=/tmp/whitehall-export.json
 ```
 
-### Retiring and removing documents
+### User support
 
-We need to allow users to unpublish content from GOV.UK. In Content Publisher we are replacing
-unpublish terminology with "retired" and "removed".
-
-Retired content is still displayed on GOV.UK, but there is an explanation box on the page that describes
-why the content is out of date.
-
-Removed content no longer displayed on GOV.UK. The user is either served a "Gone" page, or the removed
-content can be redirected to another page on GOV.UK
-
-#### Retiring documents
-
-```
-rake unpublish:retire_document["/full/base-path","Reason the document is being retired"]
-```
-
-#### Removing documents
-
-```
-rake unpublish:remove_document["/full/base-path"]
-```
-
-##### Redirect removed documents to another page on GOV.UK
-
-```
-rake unpublish:remove_document["/full/base-path","/full/redirect/base-path"]
-```
+- [Retiring and removing documents](docs/retiring-and-removing-documents.md)
 
 ## Licence
 

--- a/app/services/document_unpublishing_service.rb
+++ b/app/services/document_unpublishing_service.rb
@@ -5,9 +5,15 @@ class DocumentUnpublishingService
     GdsApi.publishing_api_v2.unpublish(document.content_id, type: "withdrawal", explanation: explanatory_note, locale: locale)
   end
 
-  def remove(document, explanatory_note: nil, alternative_path: nil)
+  def remove(document, explanatory_note: nil, alternative_path: nil, locale: "en")
     delete_assets(document.images)
-    GdsApi.publishing_api_v2.unpublish(document.content_id, type: "gone", explanation: explanatory_note, alternative_path: alternative_path)
+    GdsApi.publishing_api_v2.unpublish(
+      document.content_id,
+      type: "gone",
+      explanation: explanatory_note,
+      alternative_path: alternative_path,
+      locale: locale,
+    )
   end
 
   def remove_and_redirect(document, redirect_path)

--- a/app/services/document_unpublishing_service.rb
+++ b/app/services/document_unpublishing_service.rb
@@ -5,9 +5,9 @@ class DocumentUnpublishingService
     GdsApi.publishing_api_v2.unpublish(document.content_id, type: "withdrawal", explanation: explanatory_note, locale: locale)
   end
 
-  def remove(document)
+  def remove(document, explanatory_note: nil)
     delete_assets(document.images)
-    GdsApi.publishing_api_v2.unpublish(document.content_id, type: "gone")
+    GdsApi.publishing_api_v2.unpublish(document.content_id, type: "gone", explanation: explanatory_note)
   end
 
   def remove_and_redirect(document, redirect_path)

--- a/app/services/document_unpublishing_service.rb
+++ b/app/services/document_unpublishing_service.rb
@@ -4,4 +4,8 @@ class DocumentUnpublishingService
   def retire(document, explanatory_note)
     GdsApi.publishing_api_v2.unpublish(document.content_id, type: "withdrawal", explanation: explanatory_note)
   end
+
+  def remove(document)
+    GdsApi.publishing_api_v2.unpublish(document.content_id, type: "gone")
+  end
 end

--- a/app/services/document_unpublishing_service.rb
+++ b/app/services/document_unpublishing_service.rb
@@ -1,8 +1,8 @@
 # frozen_string_literal: true
 
 class DocumentUnpublishingService
-  def retire(document, explanatory_note)
-    GdsApi.publishing_api_v2.unpublish(document.content_id, type: "withdrawal", explanation: explanatory_note)
+  def retire(document, explanatory_note, locale: "en")
+    GdsApi.publishing_api_v2.unpublish(document.content_id, type: "withdrawal", explanation: explanatory_note, locale: locale)
   end
 
   def remove(document, redirect_path: nil)

--- a/app/services/document_unpublishing_service.rb
+++ b/app/services/document_unpublishing_service.rb
@@ -5,11 +5,14 @@ class DocumentUnpublishingService
     GdsApi.publishing_api_v2.unpublish(document.content_id, type: "withdrawal", explanation: explanatory_note, locale: locale)
   end
 
-  def remove(document, redirect_path: nil)
+  def remove(document)
     delete_assets(document.images)
-
-    return GdsApi.publishing_api_v2.unpublish(document.content_id, type: "redirect", alternative_path: redirect_path) if redirect_path.present?
     GdsApi.publishing_api_v2.unpublish(document.content_id, type: "gone")
+  end
+
+  def remove_and_redirect(document, redirect_path)
+    delete_assets(document.images)
+    GdsApi.publishing_api_v2.unpublish(document.content_id, type: "redirect", alternative_path: redirect_path)
   end
 
 private

--- a/app/services/document_unpublishing_service.rb
+++ b/app/services/document_unpublishing_service.rb
@@ -5,9 +5,9 @@ class DocumentUnpublishingService
     GdsApi.publishing_api_v2.unpublish(document.content_id, type: "withdrawal", explanation: explanatory_note, locale: locale)
   end
 
-  def remove(document, explanatory_note: nil)
+  def remove(document, explanatory_note: nil, alternative_path: nil)
     delete_assets(document.images)
-    GdsApi.publishing_api_v2.unpublish(document.content_id, type: "gone", explanation: explanatory_note)
+    GdsApi.publishing_api_v2.unpublish(document.content_id, type: "gone", explanation: explanatory_note, alternative_path: alternative_path)
   end
 
   def remove_and_redirect(document, redirect_path)

--- a/app/services/document_unpublishing_service.rb
+++ b/app/services/document_unpublishing_service.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+class DocumentUnpublishingService
+  def retire(document, explanatory_note)
+    GdsApi.publishing_api_v2.unpublish(document.content_id, type: "withdrawal", explanation: explanatory_note)
+  end
+end

--- a/app/services/document_unpublishing_service.rb
+++ b/app/services/document_unpublishing_service.rb
@@ -16,9 +16,15 @@ class DocumentUnpublishingService
     )
   end
 
-  def remove_and_redirect(document, redirect_path, explanatory_note: nil)
+  def remove_and_redirect(document, redirect_path, explanatory_note: nil, locale: "en")
     delete_assets(document.images)
-    GdsApi.publishing_api_v2.unpublish(document.content_id, type: "redirect", alternative_path: redirect_path, explanation: explanatory_note)
+    GdsApi.publishing_api_v2.unpublish(
+      document.content_id,
+      type: "redirect",
+      alternative_path: redirect_path,
+      explanation: explanatory_note,
+      locale: locale,
+    )
   end
 
 private

--- a/app/services/document_unpublishing_service.rb
+++ b/app/services/document_unpublishing_service.rb
@@ -5,7 +5,8 @@ class DocumentUnpublishingService
     GdsApi.publishing_api_v2.unpublish(document.content_id, type: "withdrawal", explanation: explanatory_note)
   end
 
-  def remove(document)
+  def remove(document, redirect_path: nil)
+    return GdsApi.publishing_api_v2.unpublish(document.content_id, type: "redirect", alternative_path: redirect_path) if redirect_path.present?
     GdsApi.publishing_api_v2.unpublish(document.content_id, type: "gone")
   end
 end

--- a/app/services/document_unpublishing_service.rb
+++ b/app/services/document_unpublishing_service.rb
@@ -16,9 +16,9 @@ class DocumentUnpublishingService
     )
   end
 
-  def remove_and_redirect(document, redirect_path)
+  def remove_and_redirect(document, redirect_path, explanatory_note: nil)
     delete_assets(document.images)
-    GdsApi.publishing_api_v2.unpublish(document.content_id, type: "redirect", alternative_path: redirect_path)
+    GdsApi.publishing_api_v2.unpublish(document.content_id, type: "redirect", alternative_path: redirect_path, explanation: explanatory_note)
   end
 
 private

--- a/app/services/document_unpublishing_service.rb
+++ b/app/services/document_unpublishing_service.rb
@@ -6,7 +6,17 @@ class DocumentUnpublishingService
   end
 
   def remove(document, redirect_path: nil)
+    delete_assets(document.images)
+
     return GdsApi.publishing_api_v2.unpublish(document.content_id, type: "redirect", alternative_path: redirect_path) if redirect_path.present?
     GdsApi.publishing_api_v2.unpublish(document.content_id, type: "gone")
+  end
+
+private
+
+  def delete_assets(assets)
+    assets.each do |asset|
+      AssetManagerService.new.delete(asset)
+    end
   end
 end

--- a/app/views/remove_document/remove.govspeak.md
+++ b/app/views/remove_document/remove.govspeak.md
@@ -1,4 +1,4 @@
-If you need to remove this content please [raise a support request and we’ll do it for you](https://support.publishing.service.gov.uk/).
+If you need to remove this content please [raise a support request and we’ll do it for you](https://support.publishing.service.gov.uk/unpublish_content_request/new).
 
 You must include any public explanation or new web address required.
 

--- a/app/views/retire_document/retire.govspeak.md
+++ b/app/views/retire_document/retire.govspeak.md
@@ -1,4 +1,4 @@
-If you need to retire this content please [raise a support request and we’ll do it for you](https://support.publishing.service.gov.uk/).
+If you need to retire this content please [raise a support request and we’ll do it for you](https://support.publishing.service.gov.uk/unpublish_content_request/new).
 
 You must include any public explanation or new web address required.
 

--- a/docs/retiring-and-removing-documents.md
+++ b/docs/retiring-and-removing-documents.md
@@ -1,0 +1,61 @@
+# Retiring and removing documents
+
+We need to allow users to unpublish content from GOV.UK. In Content Publisher we are replacing
+unpublish terminology with "retired" and "removed".
+
+Retired content is still displayed on GOV.UK, but there is an explanation box on the page that describes
+why the content is out of date.
+
+Removed content returns a 410 gone page to the user. If an explanatory note or a alternative path have been provided,
+they will be displayed in the body of the page.
+
+Removed and redirected content redirects users to another page on GOV.UK
+
+Environment variables are being used to pass parameters to the rake tasks.
+
+## Retiring documents
+
+Required parameters:
+
+- CONTENT_ID
+- NOTE
+
+Optional parameters:
+
+- LOCALE (set to "en" by default)
+
+```
+rake unpublish:retire_document CONTENT_ID='a-content-id' NOTE='A note'
+```
+
+## Removing documents
+
+Required parameters:
+
+- CONTENT_ID
+
+Optional parameters:
+
+- LOCALE (set to "en" by default)
+- NOTE
+- NEW_PATH
+
+```
+rake unpublish:remove_document CONTENT_ID='a-content-id'
+```
+
+## Redirect removed documents to another page on GOV.UK
+
+Required parameters:
+
+- CONTENT_ID
+- NEW_PATH
+
+Optional parameters:
+
+- LOCALE (set to "en" by default)
+- NOTE
+
+```
+rake unpublish:remove_document CONTENT_ID='a-content-id' NEW_PATH='/redirect-to-here'
+```

--- a/lib/tasks/unpublish.rake
+++ b/lib/tasks/unpublish.rake
@@ -14,17 +14,21 @@ namespace :unpublish do
   end
 
   desc "Remove a document"
-  task :remove_document, %I(base_path redirect_path) => :environment do |_, args|
+  task :remove_document, [:base_path] => :environment do |_, args|
     raise "Missing base_path parameter" unless args.base_path
 
     document = Document.find_by(base_path: args.base_path)
 
-    if document.present?
-      if args.redirect_path.present?
-        DocumentUnpublishingService.new.remove(document, redirect_path: args.redirect_path)
-      else
-        DocumentUnpublishingService.new.remove(document)
-      end
-    end
+    DocumentUnpublishingService.new.remove(document) if document.present?
+  end
+
+  desc "Remove and redirect a document"
+  task :remove_and_redirect_document, %I(base_path redirect_path) => :environment do |_, args|
+    raise "Missing base_path parameter" unless args.base_path
+    raise "Missing redirect_path parameter" unless args.redirect_path
+
+    document = Document.find_by(base_path: args.base_path)
+
+    DocumentUnpublishingService.new.remove_and_redirect(document, args.redirect_path) if document.present?
   end
 end

--- a/lib/tasks/unpublish.rake
+++ b/lib/tasks/unpublish.rake
@@ -13,11 +13,12 @@ namespace :unpublish do
     DocumentUnpublishingService.new.retire(document, explanatory_note) if document.present?
   end
 
-  desc "Remove a document"
-  task :remove_document, [:base_path] => :environment do |_, args|
-    raise "Missing base_path parameter" unless args.base_path
+  desc "Remove a document from GOV.UK e.g. unpublish:remove_document BASE_PATH='/base-path'"
+  task remove_document: :environment do
+    raise "Missing BASE_PATH value" if ENV["BASE_PATH"].nil?
 
-    document = Document.find_by(base_path: args.base_path)
+    base_path = ENV["BASE_PATH"]
+    document = Document.find_by(base_path: base_path)
 
     DocumentUnpublishingService.new.remove(document) if document.present?
   end

--- a/lib/tasks/unpublish.rake
+++ b/lib/tasks/unpublish.rake
@@ -11,6 +11,8 @@ namespace :unpublish do
     locale = ENV["LOCALE"] || "en"
 
     document = Document.find_by(content_id: content_id, locale: locale)
+    raise "Document must have a published version before it can be retired" unless document.has_live_version_on_govuk
+
     DocumentUnpublishingService.new.retire(document, explanatory_note, locale: locale) if document.present?
   end
 

--- a/lib/tasks/unpublish.rake
+++ b/lib/tasks/unpublish.rake
@@ -1,14 +1,16 @@
 # frozen_string_literal: true
 
 namespace :unpublish do
-  desc "Retire a document"
-  task :retire_document, %I(base_path explanatory_note) => :environment do |_, args|
-    raise "Missing base_path parameter" unless args.base_path
-    raise "Missing explanatory_note parameter" unless args.explanatory_note
+  desc "Retire a document on GOV.UK e.g. unpublish:retire_document BASE_PATH='/base-path' NOTE='A note'"
+  task retire_document: :environment do
+    raise "Missing BASE_PATH value" if ENV["BASE_PATH"].nil?
+    raise "Missing NOTE value" if ENV["NOTE"].nil?
 
-    document = Document.find_by(base_path: args.base_path)
+    base_path = ENV["BASE_PATH"]
+    explanatory_note = ENV["NOTE"]
 
-    DocumentUnpublishingService.new.retire(document, args.explanatory_note) if document.present?
+    document = Document.find_by(base_path: base_path)
+    DocumentUnpublishingService.new.retire(document, explanatory_note) if document.present?
   end
 
   desc "Remove a document"

--- a/lib/tasks/unpublish.rake
+++ b/lib/tasks/unpublish.rake
@@ -26,6 +26,7 @@ namespace :unpublish do
     locale = ENV["LOCALE"] || "en"
 
     document = Document.find_by(content_id: content_id, locale: locale)
+    raise "Document must have a published version before it can be removed" unless document.has_live_version_on_govuk
 
     if document.present?
       DocumentUnpublishingService.new.remove(

--- a/lib/tasks/unpublish.rake
+++ b/lib/tasks/unpublish.rake
@@ -20,10 +20,11 @@ namespace :unpublish do
 
     content_id = ENV["CONTENT_ID"]
     locale = ENV["LOCALE"] || "en"
+    explanatory_note = ENV["NOTE"]
 
     document = Document.find_by_param("#{content_id}:#{locale}")
 
-    DocumentUnpublishingService.new.remove(document) if document.present?
+    DocumentUnpublishingService.new.remove(document, explanatory_note: explanatory_note) if document.present?
   end
 
   desc "Remove and redirect a document on GOV.UK e.g. unpublish:remove_and_redirect_document CONTENT_ID='a-content-id' REDIRECT='/redirect-to-here'"

--- a/lib/tasks/unpublish.rake
+++ b/lib/tasks/unpublish.rake
@@ -10,4 +10,13 @@ namespace :unpublish do
 
     DocumentUnpublishingService.new.retire(document, args.explanatory_note) if document.present?
   end
+
+  desc "Remove a document"
+  task :remove_document, [:base_path] => :environment do |_, args|
+    raise "Missing base_path parameter" unless args.base_path
+
+    document = Document.find_by(base_path: args.base_path)
+
+    DocumentUnpublishingService.new.remove(document) if document.present?
+  end
 end

--- a/lib/tasks/unpublish.rake
+++ b/lib/tasks/unpublish.rake
@@ -10,7 +10,7 @@ namespace :unpublish do
     explanatory_note = ENV["NOTE"]
     locale = ENV["LOCALE"] || "en"
 
-    document = Document.find_by_param("#{content_id}:#{locale}")
+    document = Document.find_by(content_id: content_id, locale: locale)
     DocumentUnpublishingService.new.retire(document, explanatory_note, locale: locale) if document.present?
   end
 
@@ -23,7 +23,7 @@ namespace :unpublish do
     alternative_path = ENV["NEW_PATH"]
     locale = ENV["LOCALE"] || "en"
 
-    document = Document.find_by_param("#{content_id}:#{locale}")
+    document = Document.find_by(content_id: content_id, locale: locale)
 
     if document.present?
       DocumentUnpublishingService.new.remove(
@@ -45,7 +45,7 @@ namespace :unpublish do
     redirect_path = ENV["NEW_PATH"]
     locale = ENV["LOCALE"] || "en"
 
-    document = Document.find_by_param("#{content_id}:#{locale}")
+    document = Document.find_by(content_id: content_id, locale: locale)
 
     if document.present?
       DocumentUnpublishingService.new.remove_and_redirect(

--- a/lib/tasks/unpublish.rake
+++ b/lib/tasks/unpublish.rake
@@ -12,11 +12,17 @@ namespace :unpublish do
   end
 
   desc "Remove a document"
-  task :remove_document, [:base_path] => :environment do |_, args|
+  task :remove_document, %I(base_path redirect_path) => :environment do |_, args|
     raise "Missing base_path parameter" unless args.base_path
 
     document = Document.find_by(base_path: args.base_path)
 
-    DocumentUnpublishingService.new.remove(document) if document.present?
+    if document.present?
+      if args.redirect_path.present?
+        DocumentUnpublishingService.new.remove(document, redirect_path: args.redirect_path)
+      else
+        DocumentUnpublishingService.new.remove(document)
+      end
+    end
   end
 end

--- a/lib/tasks/unpublish.rake
+++ b/lib/tasks/unpublish.rake
@@ -36,9 +36,10 @@ namespace :unpublish do
     content_id = ENV["CONTENT_ID"]
     redirect_path = ENV["REDIRECT"]
     locale = ENV["LOCALE"] || "en"
+    explanatory_note = ENV["NOTE"]
 
     document = Document.find_by_param("#{content_id}:#{locale}")
 
-    DocumentUnpublishingService.new.remove_and_redirect(document, redirect_path) if document.present?
+    DocumentUnpublishingService.new.remove_and_redirect(document, redirect_path, explanatory_note: explanatory_note) if document.present?
   end
 end

--- a/lib/tasks/unpublish.rake
+++ b/lib/tasks/unpublish.rake
@@ -11,7 +11,7 @@ namespace :unpublish do
     locale = ENV["LOCALE"] || "en"
 
     document = Document.find_by_param("#{content_id}:#{locale}")
-    DocumentUnpublishingService.new.retire(document, explanatory_note) if document.present?
+    DocumentUnpublishingService.new.retire(document, explanatory_note, locale: locale) if document.present?
   end
 
   desc "Remove a document from GOV.UK e.g. unpublish:remove_document CONTENT_ID='a-content-id'"
@@ -25,7 +25,14 @@ namespace :unpublish do
 
     document = Document.find_by_param("#{content_id}:#{locale}")
 
-    DocumentUnpublishingService.new.remove(document, explanatory_note: explanatory_note, alternative_path: alternative_path) if document.present?
+    if document.present?
+      DocumentUnpublishingService.new.remove(
+        document,
+        explanatory_note: explanatory_note,
+        alternative_path: alternative_path,
+        locale: locale,
+      )
+    end
   end
 
   desc "Remove and redirect a document on GOV.UK e.g. unpublish:remove_and_redirect_document CONTENT_ID='a-content-id' REDIRECT='/redirect-to-here'"
@@ -40,6 +47,13 @@ namespace :unpublish do
 
     document = Document.find_by_param("#{content_id}:#{locale}")
 
-    DocumentUnpublishingService.new.remove_and_redirect(document, redirect_path, explanatory_note: explanatory_note) if document.present?
+    if document.present?
+      DocumentUnpublishingService.new.remove_and_redirect(
+        document,
+        redirect_path,
+        explanatory_note: explanatory_note,
+        locale: locale,
+      )
+    end
   end
 end

--- a/lib/tasks/unpublish.rake
+++ b/lib/tasks/unpublish.rake
@@ -1,24 +1,24 @@
 # frozen_string_literal: true
 
 namespace :unpublish do
-  desc "Retire a document on GOV.UK e.g. unpublish:retire_document BASE_PATH='/base-path' NOTE='A note'"
+  desc "Retire a document on GOV.UK e.g. unpublish:retire_document CONTENT_ID='a-content-id' NOTE='A note'"
   task retire_document: :environment do
-    raise "Missing BASE_PATH value" if ENV["BASE_PATH"].nil?
+    raise "Missing CONTENT_ID value" if ENV["CONTENT_ID"].nil?
     raise "Missing NOTE value" if ENV["NOTE"].nil?
 
-    base_path = ENV["BASE_PATH"]
+    content_id = ENV["CONTENT_ID"]
     explanatory_note = ENV["NOTE"]
 
-    document = Document.find_by(base_path: base_path)
+    document = Document.find_by(content_id: content_id)
     DocumentUnpublishingService.new.retire(document, explanatory_note) if document.present?
   end
 
-  desc "Remove a document from GOV.UK e.g. unpublish:remove_document BASE_PATH='/base-path'"
+  desc "Remove a document from GOV.UK e.g. unpublish:remove_document CONTENT_ID='a-content-id'"
   task remove_document: :environment do
-    raise "Missing BASE_PATH value" if ENV["BASE_PATH"].nil?
+    raise "Missing CONTENT_ID value" if ENV["CONTENT_ID"].nil?
 
-    base_path = ENV["BASE_PATH"]
-    document = Document.find_by(base_path: base_path)
+    content_id = ENV["CONTENT_ID"]
+    document = Document.find_by(content_id: content_id)
 
     DocumentUnpublishingService.new.remove(document) if document.present?
   end
@@ -28,10 +28,10 @@ namespace :unpublish do
     raise "Missing CONTENT_ID value" if ENV["CONTENT_ID"].nil?
     raise "Missing REDIRECT value" if ENV["REDIRECT"].nil?
 
-    base_path = ENV["BASE_PATH"]
+    content_id = ENV["CONTENT_ID"]
     redirect_path = ENV["REDIRECT"]
 
-    document = Document.find_by(base_path: base_path)
+    document = Document.find_by(content_id: content_id)
 
     DocumentUnpublishingService.new.remove_and_redirect(document, redirect_path) if document.present?
   end

--- a/lib/tasks/unpublish.rake
+++ b/lib/tasks/unpublish.rake
@@ -49,6 +49,7 @@ namespace :unpublish do
     locale = ENV["LOCALE"] || "en"
 
     document = Document.find_by(content_id: content_id, locale: locale)
+    raise "Document must have a published version before it can be redirected" unless document.has_live_version_on_govuk
 
     if document.present?
       DocumentUnpublishingService.new.remove_and_redirect(

--- a/lib/tasks/unpublish.rake
+++ b/lib/tasks/unpublish.rake
@@ -23,13 +23,16 @@ namespace :unpublish do
     DocumentUnpublishingService.new.remove(document) if document.present?
   end
 
-  desc "Remove and redirect a document"
-  task :remove_and_redirect_document, %I(base_path redirect_path) => :environment do |_, args|
-    raise "Missing base_path parameter" unless args.base_path
-    raise "Missing redirect_path parameter" unless args.redirect_path
+  desc "Remove and redirect a document on GOV.UK e.g. unpublish:remove_and_redirect_document CONTENT_ID='a-content-id' REDIRECT='/redirect-to-here'"
+  task remove_and_redirect_document: :environment do
+    raise "Missing CONTENT_ID value" if ENV["CONTENT_ID"].nil?
+    raise "Missing REDIRECT value" if ENV["REDIRECT"].nil?
 
-    document = Document.find_by(base_path: args.base_path)
+    base_path = ENV["BASE_PATH"]
+    redirect_path = ENV["REDIRECT"]
 
-    DocumentUnpublishingService.new.remove_and_redirect(document, args.redirect_path) if document.present?
+    document = Document.find_by(base_path: base_path)
+
+    DocumentUnpublishingService.new.remove_and_redirect(document, redirect_path) if document.present?
   end
 end

--- a/lib/tasks/unpublish.rake
+++ b/lib/tasks/unpublish.rake
@@ -1,0 +1,13 @@
+# frozen_string_literal: true
+
+namespace :unpublish do
+  desc "Retire a document"
+  task :retire_document, %I(base_path explanatory_note) => :environment do |_, args|
+    raise "Missing base_path parameter" unless args.base_path
+    raise "Missing explanatory_note parameter" unless args.explanatory_note
+
+    document = Document.find_by(base_path: args.base_path)
+
+    DocumentUnpublishingService.new.retire(document, args.explanatory_note) if document.present?
+  end
+end

--- a/lib/tasks/unpublish.rake
+++ b/lib/tasks/unpublish.rake
@@ -8,8 +8,9 @@ namespace :unpublish do
 
     content_id = ENV["CONTENT_ID"]
     explanatory_note = ENV["NOTE"]
+    locale = ENV["LOCALE"] || "en"
 
-    document = Document.find_by(content_id: content_id)
+    document = Document.find_by_param("#{content_id}:#{locale}")
     DocumentUnpublishingService.new.retire(document, explanatory_note) if document.present?
   end
 
@@ -18,7 +19,9 @@ namespace :unpublish do
     raise "Missing CONTENT_ID value" if ENV["CONTENT_ID"].nil?
 
     content_id = ENV["CONTENT_ID"]
-    document = Document.find_by(content_id: content_id)
+    locale = ENV["LOCALE"] || "en"
+
+    document = Document.find_by_param("#{content_id}:#{locale}")
 
     DocumentUnpublishingService.new.remove(document) if document.present?
   end
@@ -30,8 +33,9 @@ namespace :unpublish do
 
     content_id = ENV["CONTENT_ID"]
     redirect_path = ENV["REDIRECT"]
+    locale = ENV["LOCALE"] || "en"
 
-    document = Document.find_by(content_id: content_id)
+    document = Document.find_by_param("#{content_id}:#{locale}")
 
     DocumentUnpublishingService.new.remove_and_redirect(document, redirect_path) if document.present?
   end

--- a/lib/tasks/unpublish.rake
+++ b/lib/tasks/unpublish.rake
@@ -19,9 +19,9 @@ namespace :unpublish do
     raise "Missing CONTENT_ID value" if ENV["CONTENT_ID"].nil?
 
     content_id = ENV["CONTENT_ID"]
-    locale = ENV["LOCALE"] || "en"
     explanatory_note = ENV["NOTE"]
     alternative_path = ENV["NEW_PATH"]
+    locale = ENV["LOCALE"] || "en"
 
     document = Document.find_by_param("#{content_id}:#{locale}")
 
@@ -35,15 +35,15 @@ namespace :unpublish do
     end
   end
 
-  desc "Remove and redirect a document on GOV.UK e.g. unpublish:remove_and_redirect_document CONTENT_ID='a-content-id' REDIRECT='/redirect-to-here'"
+  desc "Remove and redirect a document on GOV.UK e.g. unpublish:remove_and_redirect_document CONTENT_ID='a-content-id' NEW_PATH='/redirect-to-here'"
   task remove_and_redirect_document: :environment do
     raise "Missing CONTENT_ID value" if ENV["CONTENT_ID"].nil?
-    raise "Missing REDIRECT value" if ENV["REDIRECT"].nil?
+    raise "Missing NEW_PATH value" if ENV["NEW_PATH"].nil?
 
     content_id = ENV["CONTENT_ID"]
-    redirect_path = ENV["REDIRECT"]
-    locale = ENV["LOCALE"] || "en"
     explanatory_note = ENV["NOTE"]
+    redirect_path = ENV["NEW_PATH"]
+    locale = ENV["LOCALE"] || "en"
 
     document = Document.find_by_param("#{content_id}:#{locale}")
 

--- a/lib/tasks/unpublish.rake
+++ b/lib/tasks/unpublish.rake
@@ -21,10 +21,11 @@ namespace :unpublish do
     content_id = ENV["CONTENT_ID"]
     locale = ENV["LOCALE"] || "en"
     explanatory_note = ENV["NOTE"]
+    alternative_path = ENV["NEW_PATH"]
 
     document = Document.find_by_param("#{content_id}:#{locale}")
 
-    DocumentUnpublishingService.new.remove(document, explanatory_note: explanatory_note) if document.present?
+    DocumentUnpublishingService.new.remove(document, explanatory_note: explanatory_note, alternative_path: alternative_path) if document.present?
   end
 
   desc "Remove and redirect a document on GOV.UK e.g. unpublish:remove_and_redirect_document CONTENT_ID='a-content-id' REDIRECT='/redirect-to-here'"

--- a/spec/features/workflow/unpublishing_spec.rb
+++ b/spec/features/workflow/unpublishing_spec.rb
@@ -149,7 +149,7 @@ RSpec.feature "Unpublish documents rake tasks" do
     end
 
     it "runs the rake task to remove a document with a redirect" do
-      document = create(:document, locale: "en")
+      document = create(:document, :published, locale: "en")
       redirect_path = "/redirect-path"
       stub_publishing_api_unpublish(document.content_id, body: { type: "redirect", alternative_path: redirect_path })
 
@@ -177,7 +177,7 @@ RSpec.feature "Unpublish documents rake tasks" do
     end
 
     it "sets an optional explanatory note" do
-      document = create(:document, locale: "en")
+      document = create(:document, :published, locale: "en")
       redirect_path = "/redirect-path"
       explanatory_note = "The reason the document is being removed"
       stub_publishing_api_unpublish(document.content_id, body: { type: "redirect", alternative_path: redirect_path, explanatory_note: explanatory_note })
@@ -196,7 +196,7 @@ RSpec.feature "Unpublish documents rake tasks" do
     end
 
     it "copes with commas in the explanatory note" do
-      document = create(:document, locale: "en")
+      document = create(:document, :published, locale: "en")
       redirect_path = "/redirect-path"
       explanatory_note = "The reason the document is being removed, firstly, secondly and so forth"
       stub_publishing_api_unpublish(document.content_id, body: { type: "redirect", alternative_path: redirect_path, explanatory_note: explanatory_note })
@@ -212,6 +212,15 @@ RSpec.feature "Unpublish documents rake tasks" do
       ENV["NEW_PATH"] = redirect_path
       ENV["NOTE"] = explanatory_note
       Rake::Task["unpublish:remove_and_redirect_document"].invoke
+    end
+
+    it "raises an error if the document does not have a live version on GOV.uk" do
+      document = create(:document, locale: "en")
+      redirect_path = "/redirect-path"
+
+      ENV["CONTENT_ID"] = document.content_id
+      ENV["NEW_PATH"] = redirect_path
+      expect { Rake::Task["unpublish:remove_and_redirect_document"].invoke }.to raise_error("Document must have a published version before it can be redirected")
     end
   end
 end

--- a/spec/features/workflow/unpublishing_spec.rb
+++ b/spec/features/workflow/unpublishing_spec.rb
@@ -41,7 +41,7 @@ RSpec.feature "Unpublish documents rake tasks" do
       document = create(:document, locale: "en")
       stub_publishing_api_unpublish(document.content_id, body: { type: "gone" })
 
-      expect_any_instance_of(DocumentUnpublishingService).to receive(:remove).with(document)
+      expect_any_instance_of(DocumentUnpublishingService).to receive(:remove).with(document, explanatory_note: nil)
 
       ENV["CONTENT_ID"] = document.content_id
       Rake::Task["unpublish:remove_document"].invoke
@@ -50,6 +50,17 @@ RSpec.feature "Unpublish documents rake tasks" do
     it "raises an error if a BASE_PATH is not present" do
       ENV["CONTENT_ID"] = nil
       expect { Rake::Task["unpublish:remove_document"].invoke }.to raise_error("Missing CONTENT_ID value")
+    end
+
+    it "sets an optional explanatory note" do
+      document = create(:document, locale: "en")
+      explanatory_note = "The reason the document is being removed"
+      stub_publishing_api_unpublish(document.content_id, body: { type: "gone", explanation: explanatory_note })
+
+      expect_any_instance_of(DocumentUnpublishingService).to receive(:remove).with(document, explanatory_note: explanatory_note)
+      ENV["CONTENT_ID"] = document.content_id
+      ENV["NOTE"] = explanatory_note
+      Rake::Task["unpublish:remove_document"].invoke
     end
   end
 

--- a/spec/features/workflow/unpublishing_spec.rb
+++ b/spec/features/workflow/unpublishing_spec.rb
@@ -26,4 +26,23 @@ RSpec.feature "Unpublish documents rake tasks" do
       expect { Rake::Task["unpublish:retire_document"].invoke("/a-base-path") }.to raise_error("Missing explanatory_note parameter")
     end
   end
+
+  describe "unpublish:remove_document" do
+    before do
+      Rake::Task["unpublish:remove_document"].reenable
+    end
+
+    it "runs the rake task to remove a document" do
+      document = create(:document, base_path: "/a-base-path")
+      stub_publishing_api_unpublish(document.content_id, body: { type: "gone" })
+
+      expect_any_instance_of(DocumentUnpublishingService).to receive(:remove).with(document)
+
+      Rake::Task["unpublish:remove_document"].invoke("/a-base-path")
+    end
+
+    it "raises an error if a base_path is not present" do
+      expect { Rake::Task["unpublish:remove_document"].invoke }.to raise_error("Missing base_path parameter")
+    end
+  end
 end

--- a/spec/features/workflow/unpublishing_spec.rb
+++ b/spec/features/workflow/unpublishing_spec.rb
@@ -112,7 +112,7 @@ RSpec.feature "Unpublish documents rake tasks" do
       )
 
       ENV["CONTENT_ID"] = document.content_id
-      ENV["REDIRECT"] = redirect_path
+      ENV["NEW_PATH"] = redirect_path
       Rake::Task["unpublish:remove_and_redirect_document"].invoke
     end
 
@@ -121,10 +121,10 @@ RSpec.feature "Unpublish documents rake tasks" do
       expect { Rake::Task["unpublish:remove_and_redirect_document"].invoke }.to raise_error("Missing CONTENT_ID value")
     end
 
-    it "raises an error if a REDIRECT is not present" do
+    it "raises an error if a NEW_PATH is not present" do
       ENV["CONTENT_ID"] = "a-content-id"
-      ENV["REDIRECT"] = nil
-      expect { Rake::Task["unpublish:remove_and_redirect_document"].invoke }.to raise_error("Missing REDIRECT value")
+      ENV["NEW_PATH"] = nil
+      expect { Rake::Task["unpublish:remove_and_redirect_document"].invoke }.to raise_error("Missing NEW_PATH value")
     end
 
     it "sets an optional explanatory note" do
@@ -141,7 +141,7 @@ RSpec.feature "Unpublish documents rake tasks" do
       )
 
       ENV["CONTENT_ID"] = document.content_id
-      ENV["REDIRECT"] = redirect_path
+      ENV["NEW_PATH"] = redirect_path
       ENV["NOTE"] = explanatory_note
       Rake::Task["unpublish:remove_and_redirect_document"].invoke
     end

--- a/spec/features/workflow/unpublishing_spec.rb
+++ b/spec/features/workflow/unpublishing_spec.rb
@@ -59,7 +59,7 @@ RSpec.feature "Unpublish documents rake tasks" do
     end
 
     it "runs the rake task to remove a document" do
-      document = create(:document, locale: "en")
+      document = create(:document, :published, locale: "en")
       stub_publishing_api_unpublish(document.content_id, body: { type: "gone" })
 
       expect_any_instance_of(DocumentUnpublishingService).to receive(:remove).with(
@@ -80,7 +80,7 @@ RSpec.feature "Unpublish documents rake tasks" do
     end
 
     it "sets an optional explanatory note" do
-      document = create(:document, locale: "en")
+      document = create(:document, :published, locale: "en")
       explanatory_note = "The reason the document is being removed"
       stub_publishing_api_unpublish(document.content_id, body: { type: "gone", explanation: explanatory_note })
 
@@ -98,7 +98,7 @@ RSpec.feature "Unpublish documents rake tasks" do
     end
 
     it "copes with commas in the explanatory note" do
-      document = create(:document, locale: "en")
+      document = create(:document, :published, locale: "en")
       explanatory_note = "The reason the document is being removed, firstly, secondly and so forth"
       stub_publishing_api_unpublish(document.content_id, body: { type: "gone", explanation: explanatory_note })
 
@@ -116,7 +116,7 @@ RSpec.feature "Unpublish documents rake tasks" do
     end
 
     it "sets an optional alternative path" do
-      document = create(:document, locale: "en")
+      document = create(:document, :published, locale: "en")
       alternative_path = "/go-here-instead"
       stub_publishing_api_unpublish(document.content_id, body: { type: "gone" })
 
@@ -131,6 +131,15 @@ RSpec.feature "Unpublish documents rake tasks" do
       ENV["NOTE"] = nil
       ENV["NEW_PATH"] = alternative_path
       Rake::Task["unpublish:remove_document"].invoke
+    end
+
+    it "raises an error if the document does not have a live version on GOV.uk" do
+      document = create(:document, locale: "en")
+
+      ENV["CONTENT_ID"] = document.content_id
+      ENV["NOTE"] = nil
+      ENV["NEW_PATH"] = nil
+      expect { Rake::Task["unpublish:remove_document"].invoke }.to raise_error("Document must have a published version before it can be removed")
     end
   end
 

--- a/spec/features/workflow/unpublishing_spec.rb
+++ b/spec/features/workflow/unpublishing_spec.rb
@@ -13,7 +13,7 @@ RSpec.feature "Unpublish documents rake tasks" do
       explanatory_note = "The reason the document is being retired"
 
       stub_publishing_api_unpublish(document.content_id, body: { type: "withdrawal", explanation: explanatory_note })
-      expect_any_instance_of(DocumentUnpublishingService).to receive(:retire).with(document, explanatory_note)
+      expect_any_instance_of(DocumentUnpublishingService).to receive(:retire).with(document, explanatory_note, locale: "en")
 
       ENV["CONTENT_ID"] = document.content_id
       ENV["NOTE"] = explanatory_note
@@ -45,6 +45,7 @@ RSpec.feature "Unpublish documents rake tasks" do
         document,
         explanatory_note: nil,
         alternative_path: nil,
+        locale: "en",
       )
 
       ENV["CONTENT_ID"] = document.content_id
@@ -65,6 +66,7 @@ RSpec.feature "Unpublish documents rake tasks" do
         document,
         explanatory_note: explanatory_note,
         alternative_path: nil,
+        locale: "en",
       )
 
       ENV["CONTENT_ID"] = document.content_id
@@ -82,6 +84,7 @@ RSpec.feature "Unpublish documents rake tasks" do
         document,
         explanatory_note: nil,
         alternative_path: alternative_path,
+        locale: "en",
       )
 
       ENV["CONTENT_ID"] = document.content_id
@@ -105,6 +108,7 @@ RSpec.feature "Unpublish documents rake tasks" do
         document,
         redirect_path,
         explanatory_note: nil,
+        locale: "en",
       )
 
       ENV["CONTENT_ID"] = document.content_id
@@ -133,6 +137,7 @@ RSpec.feature "Unpublish documents rake tasks" do
         document,
         redirect_path,
         explanatory_note: explanatory_note,
+        locale: "en",
       )
 
       ENV["CONTENT_ID"] = document.content_id

--- a/spec/features/workflow/unpublishing_spec.rb
+++ b/spec/features/workflow/unpublishing_spec.rb
@@ -15,20 +15,20 @@ RSpec.feature "Unpublish documents rake tasks" do
       stub_publishing_api_unpublish(document.content_id, body: { type: "withdrawal", explanation: explanatory_note })
       expect_any_instance_of(DocumentUnpublishingService).to receive(:retire).with(document, explanatory_note, locale: "en")
 
-      ENV["CONTENT_ID"] = document.content_id
-      ENV["NOTE"] = explanatory_note
-      Rake::Task["unpublish:retire_document"].invoke
+
+      ClimateControl.modify CONTENT_ID: document.content_id, NOTE: explanatory_note do
+        Rake::Task["unpublish:retire_document"].invoke
+      end
     end
 
     it "raises an error if a BASE_PATH is not present" do
-      ENV["CONTENT_ID"] = nil
       expect { Rake::Task["unpublish:retire_document"].invoke }.to raise_error("Missing CONTENT_ID value")
     end
 
     it "raises an error if a NOTE is not present" do
-      ENV["CONTENT_ID"] = "a-content-id"
-      ENV["NOTE"] = nil
-      expect { Rake::Task["unpublish:retire_document"].invoke }.to raise_error("Missing NOTE value")
+      ClimateControl.modify CONTENT_ID: "a-content-id" do
+        expect { Rake::Task["unpublish:retire_document"].invoke }.to raise_error("Missing NOTE value")
+      end
     end
 
     it "copes with commas in the explanatory note" do
@@ -38,18 +38,18 @@ RSpec.feature "Unpublish documents rake tasks" do
       stub_publishing_api_unpublish(document.content_id, body: { type: "withdrawal", explanation: explanatory_note })
       expect_any_instance_of(DocumentUnpublishingService).to receive(:retire).with(document, explanatory_note, locale: "en")
 
-      ENV["CONTENT_ID"] = document.content_id
-      ENV["NOTE"] = explanatory_note
-      Rake::Task["unpublish:retire_document"].invoke
+      ClimateControl.modify CONTENT_ID: document.content_id, NOTE: explanatory_note do
+        Rake::Task["unpublish:retire_document"].invoke
+      end
     end
 
     it "raises an error if the document does not have a live version on GOV.uk" do
       document = create(:document, locale: "en")
       explanatory_note = "The reason the document is being retired"
 
-      ENV["CONTENT_ID"] = document.content_id
-      ENV["NOTE"] = explanatory_note
-      expect { Rake::Task["unpublish:retire_document"].invoke }.to raise_error("Document must have a published version before it can be retired")
+      ClimateControl.modify CONTENT_ID: document.content_id, NOTE: explanatory_note do
+        expect { Rake::Task["unpublish:retire_document"].invoke }.to raise_error("Document must have a published version before it can be retired")
+      end
     end
   end
 
@@ -69,13 +69,12 @@ RSpec.feature "Unpublish documents rake tasks" do
         locale: "en",
       )
 
-      ENV["CONTENT_ID"] = document.content_id
-      ENV["NOTE"] = nil
-      Rake::Task["unpublish:remove_document"].invoke
+      ClimateControl.modify CONTENT_ID: document.content_id do
+        Rake::Task["unpublish:remove_document"].invoke
+      end
     end
 
     it "raises an error if a BASE_PATH is not present" do
-      ENV["CONTENT_ID"] = nil
       expect { Rake::Task["unpublish:remove_document"].invoke }.to raise_error("Missing CONTENT_ID value")
     end
 
@@ -91,10 +90,9 @@ RSpec.feature "Unpublish documents rake tasks" do
         locale: "en",
       )
 
-      ENV["CONTENT_ID"] = document.content_id
-      ENV["NOTE"] = explanatory_note
-      ENV["NEW_PATH"] = nil
-      Rake::Task["unpublish:remove_document"].invoke
+      ClimateControl.modify CONTENT_ID: document.content_id, NOTE: explanatory_note do
+        Rake::Task["unpublish:remove_document"].invoke
+      end
     end
 
     it "copes with commas in the explanatory note" do
@@ -109,10 +107,9 @@ RSpec.feature "Unpublish documents rake tasks" do
         locale: "en",
       )
 
-      ENV["CONTENT_ID"] = document.content_id
-      ENV["NOTE"] = explanatory_note
-      ENV["NEW_PATH"] = nil
-      Rake::Task["unpublish:remove_document"].invoke
+      ClimateControl.modify CONTENT_ID: document.content_id, NOTE: explanatory_note do
+        Rake::Task["unpublish:remove_document"].invoke
+      end
     end
 
     it "sets an optional alternative path" do
@@ -127,19 +124,17 @@ RSpec.feature "Unpublish documents rake tasks" do
         locale: "en",
       )
 
-      ENV["CONTENT_ID"] = document.content_id
-      ENV["NOTE"] = nil
-      ENV["NEW_PATH"] = alternative_path
-      Rake::Task["unpublish:remove_document"].invoke
+      ClimateControl.modify CONTENT_ID: document.content_id, NEW_PATH: alternative_path do
+        Rake::Task["unpublish:remove_document"].invoke
+      end
     end
 
     it "raises an error if the document does not have a live version on GOV.uk" do
       document = create(:document, locale: "en")
 
-      ENV["CONTENT_ID"] = document.content_id
-      ENV["NOTE"] = nil
-      ENV["NEW_PATH"] = nil
-      expect { Rake::Task["unpublish:remove_document"].invoke }.to raise_error("Document must have a published version before it can be removed")
+      ClimateControl.modify CONTENT_ID: document.content_id do
+        expect { Rake::Task["unpublish:remove_document"].invoke }.to raise_error("Document must have a published version before it can be removed")
+      end
     end
   end
 
@@ -160,20 +155,19 @@ RSpec.feature "Unpublish documents rake tasks" do
         locale: "en",
       )
 
-      ENV["CONTENT_ID"] = document.content_id
-      ENV["NEW_PATH"] = redirect_path
-      Rake::Task["unpublish:remove_and_redirect_document"].invoke
+      ClimateControl.modify CONTENT_ID: document.content_id, NEW_PATH: redirect_path do
+        Rake::Task["unpublish:remove_and_redirect_document"].invoke
+      end
     end
 
     it "raises an error if a BASE_PATH is not present" do
-      ENV["CONTENT_ID"] = nil
       expect { Rake::Task["unpublish:remove_and_redirect_document"].invoke }.to raise_error("Missing CONTENT_ID value")
     end
 
     it "raises an error if a NEW_PATH is not present" do
-      ENV["CONTENT_ID"] = "a-content-id"
-      ENV["NEW_PATH"] = nil
-      expect { Rake::Task["unpublish:remove_and_redirect_document"].invoke }.to raise_error("Missing NEW_PATH value")
+      ClimateControl.modify CONTENT_ID: "a-content-id" do
+        expect { Rake::Task["unpublish:remove_and_redirect_document"].invoke }.to raise_error("Missing NEW_PATH value")
+      end
     end
 
     it "sets an optional explanatory note" do
@@ -189,10 +183,9 @@ RSpec.feature "Unpublish documents rake tasks" do
         locale: "en",
       )
 
-      ENV["CONTENT_ID"] = document.content_id
-      ENV["NEW_PATH"] = redirect_path
-      ENV["NOTE"] = explanatory_note
-      Rake::Task["unpublish:remove_and_redirect_document"].invoke
+      ClimateControl.modify CONTENT_ID: document.content_id, NEW_PATH: redirect_path, NOTE: explanatory_note do
+        Rake::Task["unpublish:remove_and_redirect_document"].invoke
+      end
     end
 
     it "copes with commas in the explanatory note" do
@@ -208,19 +201,18 @@ RSpec.feature "Unpublish documents rake tasks" do
         locale: "en",
       )
 
-      ENV["CONTENT_ID"] = document.content_id
-      ENV["NEW_PATH"] = redirect_path
-      ENV["NOTE"] = explanatory_note
-      Rake::Task["unpublish:remove_and_redirect_document"].invoke
+      ClimateControl.modify CONTENT_ID: document.content_id, NEW_PATH: redirect_path, NOTE: explanatory_note do
+        Rake::Task["unpublish:remove_and_redirect_document"].invoke
+      end
     end
 
     it "raises an error if the document does not have a live version on GOV.uk" do
       document = create(:document, locale: "en")
       redirect_path = "/redirect-path"
 
-      ENV["CONTENT_ID"] = document.content_id
-      ENV["NEW_PATH"] = redirect_path
-      expect { Rake::Task["unpublish:remove_and_redirect_document"].invoke }.to raise_error("Document must have a published version before it can be redirected")
+      ClimateControl.modify CONTENT_ID: document.content_id, NEW_PATH: redirect_path do
+        expect { Rake::Task["unpublish:remove_and_redirect_document"].invoke }.to raise_error("Document must have a published version before it can be redirected")
+      end
     end
   end
 end

--- a/spec/features/workflow/unpublishing_spec.rb
+++ b/spec/features/workflow/unpublishing_spec.rb
@@ -9,7 +9,7 @@ RSpec.feature "Unpublish documents rake tasks" do
     end
 
     it "runs the task to retire a document" do
-      document = create(:document, locale: "en")
+      document = create(:document, :published, locale: "en")
       explanatory_note = "The reason the document is being retired"
 
       stub_publishing_api_unpublish(document.content_id, body: { type: "withdrawal", explanation: explanatory_note })
@@ -32,7 +32,7 @@ RSpec.feature "Unpublish documents rake tasks" do
     end
 
     it "copes with commas in the explanatory note" do
-      document = create(:document, locale: "en")
+      document = create(:document, :published, locale: "en")
       explanatory_note = "The reason the document is being retired, firstly, secondly and so forth"
 
       stub_publishing_api_unpublish(document.content_id, body: { type: "withdrawal", explanation: explanatory_note })
@@ -41,6 +41,15 @@ RSpec.feature "Unpublish documents rake tasks" do
       ENV["CONTENT_ID"] = document.content_id
       ENV["NOTE"] = explanatory_note
       Rake::Task["unpublish:retire_document"].invoke
+    end
+
+    it "raises an error if the document does not have a live version on GOV.uk" do
+      document = create(:document, locale: "en")
+      explanatory_note = "The reason the document is being retired"
+
+      ENV["CONTENT_ID"] = document.content_id
+      ENV["NOTE"] = explanatory_note
+      expect { Rake::Task["unpublish:retire_document"].invoke }.to raise_error("Document must have a published version before it can be retired")
     end
   end
 

--- a/spec/features/workflow/unpublishing_spec.rb
+++ b/spec/features/workflow/unpublishing_spec.rb
@@ -15,15 +15,20 @@ RSpec.feature "Unpublish documents rake tasks" do
       stub_publishing_api_unpublish(document.content_id, body: { type: "withdrawal", explanation: explanatory_note })
       expect_any_instance_of(DocumentUnpublishingService).to receive(:retire).with(document, explanatory_note)
 
-      Rake::Task["unpublish:retire_document"].invoke("/a-base-path", explanatory_note)
+      ENV["BASE_PATH"] = "/a-base-path"
+      ENV["NOTE"] = explanatory_note
+      Rake::Task["unpublish:retire_document"].invoke
     end
 
-    it "raises an error if a base_path is not present" do
-      expect { Rake::Task["unpublish:retire_document"].invoke }.to raise_error("Missing base_path parameter")
+    it "raises an error if a BASE_PATH is not present" do
+      ENV["BASE_PATH"] = nil
+      expect { Rake::Task["unpublish:retire_document"].invoke }.to raise_error("Missing BASE_PATH value")
     end
 
-    it "raises an error if an explanatory_note is not present" do
-      expect { Rake::Task["unpublish:retire_document"].invoke("/a-base-path") }.to raise_error("Missing explanatory_note parameter")
+    it "raises an error if a NOTE is not present" do
+      ENV["BASE_PATH"] = "/a-base-path"
+      ENV["NOTE"] = nil
+      expect { Rake::Task["unpublish:retire_document"].invoke }.to raise_error("Missing NOTE value")
     end
   end
 

--- a/spec/features/workflow/unpublishing_spec.rb
+++ b/spec/features/workflow/unpublishing_spec.rb
@@ -46,18 +46,32 @@ RSpec.feature "Unpublish documents rake tasks" do
       Rake::Task["unpublish:remove_document"].invoke("/a-base-path")
     end
 
+    it "raises an error if a base_path is not present" do
+      expect { Rake::Task["unpublish:remove_document"].invoke }.to raise_error("Missing base_path parameter")
+    end
+  end
+
+  describe "unpublish:remove_and_redirect_document" do
+    before do
+      Rake::Task["unpublish:remove_and_redirect_document"].reenable
+    end
+
     it "runs the rake task to remove a document with a redirect" do
       document = create(:document, base_path: "/a-base-path")
       redirect_path = "/redirect-path"
       stub_publishing_api_unpublish(document.content_id, body: { type: "redirect", alternative_path: redirect_path })
 
-      expect_any_instance_of(DocumentUnpublishingService).to receive(:remove).with(document, redirect_path: redirect_path)
+      expect_any_instance_of(DocumentUnpublishingService).to receive(:remove_and_redirect).with(document, redirect_path)
 
-      Rake::Task["unpublish:remove_document"].invoke("/a-base-path", redirect_path)
+      Rake::Task["unpublish:remove_and_redirect_document"].invoke("/a-base-path", redirect_path)
     end
 
-    it "raises an error if a base_path is not present" do
-      expect { Rake::Task["unpublish:remove_document"].invoke }.to raise_error("Missing base_path parameter")
+    it "raises an error if a redirect_path is not present" do
+      expect { Rake::Task["unpublish:remove_and_redirect_document"].invoke }.to raise_error("Missing base_path parameter")
+    end
+
+    it "raises an error if a redirect_path is not present" do
+      expect { Rake::Task["unpublish:remove_and_redirect_document"].invoke("/a-base-path") }.to raise_error("Missing redirect_path parameter")
     end
   end
 end

--- a/spec/features/workflow/unpublishing_spec.rb
+++ b/spec/features/workflow/unpublishing_spec.rb
@@ -41,7 +41,11 @@ RSpec.feature "Unpublish documents rake tasks" do
       document = create(:document, locale: "en")
       stub_publishing_api_unpublish(document.content_id, body: { type: "gone" })
 
-      expect_any_instance_of(DocumentUnpublishingService).to receive(:remove).with(document, explanatory_note: nil)
+      expect_any_instance_of(DocumentUnpublishingService).to receive(:remove).with(
+        document,
+        explanatory_note: nil,
+        alternative_path: nil,
+      )
 
       ENV["CONTENT_ID"] = document.content_id
       Rake::Task["unpublish:remove_document"].invoke
@@ -57,9 +61,32 @@ RSpec.feature "Unpublish documents rake tasks" do
       explanatory_note = "The reason the document is being removed"
       stub_publishing_api_unpublish(document.content_id, body: { type: "gone", explanation: explanatory_note })
 
-      expect_any_instance_of(DocumentUnpublishingService).to receive(:remove).with(document, explanatory_note: explanatory_note)
+      expect_any_instance_of(DocumentUnpublishingService).to receive(:remove).with(
+        document,
+        explanatory_note: explanatory_note,
+        alternative_path: nil,
+      )
+
       ENV["CONTENT_ID"] = document.content_id
       ENV["NOTE"] = explanatory_note
+      ENV["NEW_PATH"] = nil
+      Rake::Task["unpublish:remove_document"].invoke
+    end
+
+    it "sets an optional alternative path" do
+      document = create(:document, locale: "en")
+      alternative_path = "/go-here-instead"
+      stub_publishing_api_unpublish(document.content_id, body: { type: "gone" })
+
+      expect_any_instance_of(DocumentUnpublishingService).to receive(:remove).with(
+        document,
+        explanatory_note: nil,
+        alternative_path: alternative_path,
+      )
+
+      ENV["CONTENT_ID"] = document.content_id
+      ENV["NOTE"] = nil
+      ENV["NEW_PATH"] = alternative_path
       Rake::Task["unpublish:remove_document"].invoke
     end
   end

--- a/spec/features/workflow/unpublishing_spec.rb
+++ b/spec/features/workflow/unpublishing_spec.rb
@@ -41,6 +41,16 @@ RSpec.feature "Unpublish documents rake tasks" do
       Rake::Task["unpublish:remove_document"].invoke("/a-base-path")
     end
 
+    it "runs the rake task to remove a document with a redirect" do
+      document = create(:document, base_path: "/a-base-path")
+      redirect_path = "/redirect-path"
+      stub_publishing_api_unpublish(document.content_id, body: { type: "redirect", alternative_path: redirect_path })
+
+      expect_any_instance_of(DocumentUnpublishingService).to receive(:remove).with(document, redirect_path: redirect_path)
+
+      Rake::Task["unpublish:remove_document"].invoke("/a-base-path", redirect_path)
+    end
+
     it "raises an error if a base_path is not present" do
       expect { Rake::Task["unpublish:remove_document"].invoke }.to raise_error("Missing base_path parameter")
     end

--- a/spec/features/workflow/unpublishing_spec.rb
+++ b/spec/features/workflow/unpublishing_spec.rb
@@ -1,0 +1,29 @@
+# frozen_string_literal: true
+
+require "rake"
+
+RSpec.feature "Unpublish documents rake tasks" do
+  describe "unpublish:retire_document" do
+    before do
+      Rake::Task["unpublish:retire_document"].reenable
+    end
+
+    it "runs the task to retire a document" do
+      document = create(:document, base_path: "/a-base-path")
+      explanatory_note = "The reason the document is being retired"
+
+      stub_publishing_api_unpublish(document.content_id, body: { type: "withdrawal", explanation: explanatory_note })
+      expect_any_instance_of(DocumentUnpublishingService).to receive(:retire).with(document, explanatory_note)
+
+      Rake::Task["unpublish:retire_document"].invoke("/a-base-path", explanatory_note)
+    end
+
+    it "raises an error if a base_path is not present" do
+      expect { Rake::Task["unpublish:retire_document"].invoke }.to raise_error("Missing base_path parameter")
+    end
+
+    it "raises an error if an explanatory_note is not present" do
+      expect { Rake::Task["unpublish:retire_document"].invoke("/a-base-path") }.to raise_error("Missing explanatory_note parameter")
+    end
+  end
+end

--- a/spec/features/workflow/unpublishing_spec.rb
+++ b/spec/features/workflow/unpublishing_spec.rb
@@ -43,11 +43,13 @@ RSpec.feature "Unpublish documents rake tasks" do
 
       expect_any_instance_of(DocumentUnpublishingService).to receive(:remove).with(document)
 
-      Rake::Task["unpublish:remove_document"].invoke("/a-base-path")
+      ENV["BASE_PATH"] = "/a-base-path"
+      Rake::Task["unpublish:remove_document"].invoke
     end
 
-    it "raises an error if a base_path is not present" do
-      expect { Rake::Task["unpublish:remove_document"].invoke }.to raise_error("Missing base_path parameter")
+    it "raises an error if a BASE_PATH is not present" do
+      ENV["BASE_PATH"] = nil
+      expect { Rake::Task["unpublish:remove_document"].invoke }.to raise_error("Missing BASE_PATH value")
     end
   end
 

--- a/spec/features/workflow/unpublishing_spec.rb
+++ b/spec/features/workflow/unpublishing_spec.rb
@@ -9,7 +9,7 @@ RSpec.feature "Unpublish documents rake tasks" do
     end
 
     it "runs the task to retire a document" do
-      document = create(:document)
+      document = create(:document, locale: "en")
       explanatory_note = "The reason the document is being retired"
 
       stub_publishing_api_unpublish(document.content_id, body: { type: "withdrawal", explanation: explanatory_note })
@@ -38,7 +38,7 @@ RSpec.feature "Unpublish documents rake tasks" do
     end
 
     it "runs the rake task to remove a document" do
-      document = create(:document)
+      document = create(:document, locale: "en")
       stub_publishing_api_unpublish(document.content_id, body: { type: "gone" })
 
       expect_any_instance_of(DocumentUnpublishingService).to receive(:remove).with(document)
@@ -59,7 +59,7 @@ RSpec.feature "Unpublish documents rake tasks" do
     end
 
     it "runs the rake task to remove a document with a redirect" do
-      document = create(:document)
+      document = create(:document, locale: "en")
       redirect_path = "/redirect-path"
       stub_publishing_api_unpublish(document.content_id, body: { type: "redirect", alternative_path: redirect_path })
 

--- a/spec/features/workflow/unpublishing_spec.rb
+++ b/spec/features/workflow/unpublishing_spec.rb
@@ -65,15 +65,20 @@ RSpec.feature "Unpublish documents rake tasks" do
 
       expect_any_instance_of(DocumentUnpublishingService).to receive(:remove_and_redirect).with(document, redirect_path)
 
-      Rake::Task["unpublish:remove_and_redirect_document"].invoke("/a-base-path", redirect_path)
+      ENV["BASE_PATH"] = "/a-base-path"
+      ENV["REDIRECT"] = redirect_path
+      Rake::Task["unpublish:remove_and_redirect_document"].invoke
     end
 
-    it "raises an error if a redirect_path is not present" do
-      expect { Rake::Task["unpublish:remove_and_redirect_document"].invoke }.to raise_error("Missing base_path parameter")
+    it "raises an error if a BASE_PATH is not present" do
+      ENV["BASE_PATH"] = nil
+      expect { Rake::Task["unpublish:remove_and_redirect_document"].invoke }.to raise_error("Missing BASE_PATH value")
     end
 
-    it "raises an error if a redirect_path is not present" do
-      expect { Rake::Task["unpublish:remove_and_redirect_document"].invoke("/a-base-path") }.to raise_error("Missing redirect_path parameter")
+    it "raises an error if a REDIRECT is not present" do
+      ENV["BASE_PATH"] = "/a-base-path"
+      ENV["REDIRECT"] = nil
+      expect { Rake::Task["unpublish:remove_and_redirect_document"].invoke("/a-base-path") }.to raise_error("Missing REDIRECT value")
     end
   end
 end

--- a/spec/features/workflow/unpublishing_spec.rb
+++ b/spec/features/workflow/unpublishing_spec.rb
@@ -9,24 +9,24 @@ RSpec.feature "Unpublish documents rake tasks" do
     end
 
     it "runs the task to retire a document" do
-      document = create(:document, base_path: "/a-base-path")
+      document = create(:document)
       explanatory_note = "The reason the document is being retired"
 
       stub_publishing_api_unpublish(document.content_id, body: { type: "withdrawal", explanation: explanatory_note })
       expect_any_instance_of(DocumentUnpublishingService).to receive(:retire).with(document, explanatory_note)
 
-      ENV["BASE_PATH"] = "/a-base-path"
+      ENV["CONTENT_ID"] = document.content_id
       ENV["NOTE"] = explanatory_note
       Rake::Task["unpublish:retire_document"].invoke
     end
 
     it "raises an error if a BASE_PATH is not present" do
-      ENV["BASE_PATH"] = nil
-      expect { Rake::Task["unpublish:retire_document"].invoke }.to raise_error("Missing BASE_PATH value")
+      ENV["CONTENT_ID"] = nil
+      expect { Rake::Task["unpublish:retire_document"].invoke }.to raise_error("Missing CONTENT_ID value")
     end
 
     it "raises an error if a NOTE is not present" do
-      ENV["BASE_PATH"] = "/a-base-path"
+      ENV["CONTENT_ID"] = "a-content-id"
       ENV["NOTE"] = nil
       expect { Rake::Task["unpublish:retire_document"].invoke }.to raise_error("Missing NOTE value")
     end
@@ -38,18 +38,18 @@ RSpec.feature "Unpublish documents rake tasks" do
     end
 
     it "runs the rake task to remove a document" do
-      document = create(:document, base_path: "/a-base-path")
+      document = create(:document)
       stub_publishing_api_unpublish(document.content_id, body: { type: "gone" })
 
       expect_any_instance_of(DocumentUnpublishingService).to receive(:remove).with(document)
 
-      ENV["BASE_PATH"] = "/a-base-path"
+      ENV["CONTENT_ID"] = document.content_id
       Rake::Task["unpublish:remove_document"].invoke
     end
 
     it "raises an error if a BASE_PATH is not present" do
-      ENV["BASE_PATH"] = nil
-      expect { Rake::Task["unpublish:remove_document"].invoke }.to raise_error("Missing BASE_PATH value")
+      ENV["CONTENT_ID"] = nil
+      expect { Rake::Task["unpublish:remove_document"].invoke }.to raise_error("Missing CONTENT_ID value")
     end
   end
 
@@ -59,24 +59,24 @@ RSpec.feature "Unpublish documents rake tasks" do
     end
 
     it "runs the rake task to remove a document with a redirect" do
-      document = create(:document, base_path: "/a-base-path")
+      document = create(:document)
       redirect_path = "/redirect-path"
       stub_publishing_api_unpublish(document.content_id, body: { type: "redirect", alternative_path: redirect_path })
 
       expect_any_instance_of(DocumentUnpublishingService).to receive(:remove_and_redirect).with(document, redirect_path)
 
-      ENV["BASE_PATH"] = "/a-base-path"
+      ENV["CONTENT_ID"] = document.content_id
       ENV["REDIRECT"] = redirect_path
       Rake::Task["unpublish:remove_and_redirect_document"].invoke
     end
 
     it "raises an error if a BASE_PATH is not present" do
-      ENV["BASE_PATH"] = nil
-      expect { Rake::Task["unpublish:remove_and_redirect_document"].invoke }.to raise_error("Missing BASE_PATH value")
+      ENV["CONTENT_ID"] = nil
+      expect { Rake::Task["unpublish:remove_and_redirect_document"].invoke }.to raise_error("Missing CONTENT_ID value")
     end
 
     it "raises an error if a REDIRECT is not present" do
-      ENV["BASE_PATH"] = "/a-base-path"
+      ENV["CONTENT_ID"] = "a-content-id"
       ENV["REDIRECT"] = nil
       expect { Rake::Task["unpublish:remove_and_redirect_document"].invoke("/a-base-path") }.to raise_error("Missing REDIRECT value")
     end

--- a/spec/services/asset_manager_service_spec.rb
+++ b/spec/services/asset_manager_service_spec.rb
@@ -1,7 +1,5 @@
 # frozen_string_literal: true
 
-require "spec_helper"
-
 RSpec.describe AssetManagerService do
   describe "#upload_bytes" do
     it "uploads a byte stream to Asset Manager and returns the asset URL" do

--- a/spec/services/document_publishing_service_spec.rb
+++ b/spec/services/document_publishing_service_spec.rb
@@ -1,7 +1,5 @@
 # frozen_string_literal: true
 
-require "spec_helper"
-
 RSpec.describe DocumentPublishingService do
   describe "#publish_draft" do
     it "keeps track of the publication state" do

--- a/spec/services/document_unpublishing_service_spec.rb
+++ b/spec/services/document_unpublishing_service_spec.rb
@@ -1,0 +1,15 @@
+# frozen_string_literal: true
+
+RSpec.describe DocumentUnpublishingService do
+  describe "#retire" do
+    it "withdraws a document in publishing-api with an explanatory note" do
+      document = create(:document)
+      explanatory_note = "The document is out of date"
+
+      stub_publishing_api_unpublish(document.content_id, body: { type: "withdrawal", explanation: explanatory_note })
+      DocumentUnpublishingService.new.retire(document, explanatory_note)
+
+      assert_publishing_api_unpublish(document.content_id, type: "withdrawal", explanation: explanatory_note)
+    end
+  end
+end

--- a/spec/services/document_unpublishing_service_spec.rb
+++ b/spec/services/document_unpublishing_service_spec.rb
@@ -75,10 +75,9 @@ RSpec.describe DocumentUnpublishingService do
 
   describe "#remove_and_redirect" do
     let(:document) { create(:document) }
+    let(:redirect_path) { "/redirect-path" }
 
     it "removes documents with a redirect" do
-      redirect_path = "/redirect-path"
-
       stub_publishing_api_unpublish(document.content_id, body: { type: "redirect", alternative_path: redirect_path })
       DocumentUnpublishingService.new.remove_and_redirect(document, redirect_path)
 
@@ -87,7 +86,6 @@ RSpec.describe DocumentUnpublishingService do
 
     it "deletes assets associated with redirected documents" do
       asset = create(:image, :in_asset_manager, document: document)
-      redirect_path = "/redirect-path"
 
       stub_publishing_api_unpublish(document.content_id, body: { type: "redirect", alternative_path: redirect_path })
       asset_manager_request = asset_manager_delete_asset(asset.asset_manager_id)

--- a/spec/services/document_unpublishing_service_spec.rb
+++ b/spec/services/document_unpublishing_service_spec.rb
@@ -48,6 +48,14 @@ RSpec.describe DocumentUnpublishingService do
 
       assert_requested(asset_manager_request)
     end
+
+    it "accepts an optional explanatory note" do
+      explanatory_note = "The reason document has been removed"
+      stub_publishing_api_unpublish(document.content_id, body: { type: "gone", explanation: explanatory_note })
+      DocumentUnpublishingService.new.remove(document, explanatory_note: explanatory_note)
+
+      assert_publishing_api_unpublish(document.content_id, type: "gone", explanation: explanatory_note)
+    end
   end
 
   describe "#remove_and_redirect" do

--- a/spec/services/document_unpublishing_service_spec.rb
+++ b/spec/services/document_unpublishing_service_spec.rb
@@ -6,19 +6,26 @@ RSpec.describe DocumentUnpublishingService do
     let(:explanatory_note) { "The document is out of date" }
 
     it "withdraws a document in publishing-api with an explanatory note" do
-      stub_publishing_api_unpublish(document.content_id, body: { type: "withdrawal", explanation: explanatory_note })
+      stub_publishing_api_unpublish(document.content_id, body: { type: "withdrawal", explanation: explanatory_note, locale: "en" })
       DocumentUnpublishingService.new.retire(document, explanatory_note)
 
-      assert_publishing_api_unpublish(document.content_id, type: "withdrawal", explanation: explanatory_note)
+      assert_publishing_api_unpublish(document.content_id, type: "withdrawal", explanation: explanatory_note, locale: "en")
     end
 
     it "does not delete assets for retired documents" do
       asset = create(:image, :in_asset_manager, document: document)
 
-      stub_publishing_api_unpublish(document.content_id, body: { type: "withdrawal", explanation: explanatory_note })
+      stub_publishing_api_unpublish(document.content_id, body: { type: "withdrawal", explanation: explanatory_note, locale: "en" })
       DocumentUnpublishingService.new.retire(document, explanatory_note)
 
       assert_not_requested asset_manager_delete_asset(asset.asset_manager_id)
+    end
+
+    it "sets the locale of the document if specified" do
+      stub_publishing_api_unpublish(document.content_id, body: { type: "withdrawal", explanation: explanatory_note, locale: "fr" })
+      DocumentUnpublishingService.new.retire(document, explanatory_note, locale: "fr")
+
+      assert_publishing_api_unpublish(document.content_id, type: "withdrawal", explanation: explanatory_note, locale: "fr")
     end
   end
 

--- a/spec/services/document_unpublishing_service_spec.rb
+++ b/spec/services/document_unpublishing_service_spec.rb
@@ -14,13 +14,22 @@ RSpec.describe DocumentUnpublishingService do
   end
 
   describe "#remove" do
-    it "removes a document" do
-      document = create(:document)
+    let(:document) { create(:document) }
 
+    it "removes a document" do
       stub_publishing_api_unpublish(document.content_id, body: { type: "gone" })
       DocumentUnpublishingService.new.remove(document)
 
       assert_publishing_api_unpublish(document.content_id, type: "gone")
+    end
+
+    it "allows removed documents to be redirected" do
+      redirect_path = "/redirect-path"
+
+      stub_publishing_api_unpublish(document.content_id, body: { type: "redirect", alternative_path: redirect_path })
+      DocumentUnpublishingService.new.remove(document, redirect_path: redirect_path)
+
+      assert_publishing_api_unpublish(document.content_id, type: "redirect", alternative_path: redirect_path)
     end
   end
 end

--- a/spec/services/document_unpublishing_service_spec.rb
+++ b/spec/services/document_unpublishing_service_spec.rb
@@ -33,15 +33,15 @@ RSpec.describe DocumentUnpublishingService do
     let(:document) { create(:document) }
 
     it "removes a document" do
-      stub_publishing_api_unpublish(document.content_id, body: { type: "gone" })
+      stub_publishing_api_unpublish(document.content_id, body: { type: "gone", locale: "en" })
       DocumentUnpublishingService.new.remove(document)
 
-      assert_publishing_api_unpublish(document.content_id, type: "gone")
+      assert_publishing_api_unpublish(document.content_id, type: "gone", locale: "en")
     end
 
     it "deletes assets associated with removed documents" do
       asset = create(:image, :in_asset_manager, document: document)
-      stub_publishing_api_unpublish(document.content_id, body: { type: "gone" })
+      stub_publishing_api_unpublish(document.content_id, body: { type: "gone", locale: "en" })
       asset_manager_request = asset_manager_delete_asset(asset.asset_manager_id)
 
       DocumentUnpublishingService.new.remove(document)
@@ -51,18 +51,25 @@ RSpec.describe DocumentUnpublishingService do
 
     it "accepts an optional explanatory note" do
       explanatory_note = "The reason document has been removed"
-      stub_publishing_api_unpublish(document.content_id, body: { type: "gone", explanation: explanatory_note })
+      stub_publishing_api_unpublish(document.content_id, body: { type: "gone", explanation: explanatory_note, locale: "en" })
       DocumentUnpublishingService.new.remove(document, explanatory_note: explanatory_note)
 
-      assert_publishing_api_unpublish(document.content_id, type: "gone", explanation: explanatory_note)
+      assert_publishing_api_unpublish(document.content_id, type: "gone", explanation: explanatory_note, locale: "en")
     end
 
     it "accepts an optional alternative path" do
       alternative_path = "/look-here-instead"
-      stub_publishing_api_unpublish(document.content_id, body: { type: "gone", alternative_path: alternative_path })
+      stub_publishing_api_unpublish(document.content_id, body: { type: "gone", alternative_path: alternative_path, locale: "en" })
       DocumentUnpublishingService.new.remove(document, alternative_path: alternative_path)
 
-      assert_publishing_api_unpublish(document.content_id, type: "gone", alternative_path: alternative_path)
+      assert_publishing_api_unpublish(document.content_id, type: "gone", alternative_path: alternative_path, locale: "en")
+    end
+
+    it "sets the locale of the document if specified" do
+      stub_publishing_api_unpublish(document.content_id, body: { type: "gone", locale: "fr" })
+      DocumentUnpublishingService.new.remove(document, locale: "fr")
+
+      assert_publishing_api_unpublish(document.content_id, type: "gone", locale: "fr")
     end
   end
 

--- a/spec/services/document_unpublishing_service_spec.rb
+++ b/spec/services/document_unpublishing_service_spec.rb
@@ -12,4 +12,15 @@ RSpec.describe DocumentUnpublishingService do
       assert_publishing_api_unpublish(document.content_id, type: "withdrawal", explanation: explanatory_note)
     end
   end
+
+  describe "#remove" do
+    it "removes a document" do
+      document = create(:document)
+
+      stub_publishing_api_unpublish(document.content_id, body: { type: "gone" })
+      DocumentUnpublishingService.new.remove(document)
+
+      assert_publishing_api_unpublish(document.content_id, type: "gone")
+    end
+  end
 end

--- a/spec/services/document_unpublishing_service_spec.rb
+++ b/spec/services/document_unpublishing_service_spec.rb
@@ -56,6 +56,14 @@ RSpec.describe DocumentUnpublishingService do
 
       assert_publishing_api_unpublish(document.content_id, type: "gone", explanation: explanatory_note)
     end
+
+    it "accepts an optional alternative path" do
+      alternative_path = "/look-here-instead"
+      stub_publishing_api_unpublish(document.content_id, body: { type: "gone", alternative_path: alternative_path })
+      DocumentUnpublishingService.new.remove(document, alternative_path: alternative_path)
+
+      assert_publishing_api_unpublish(document.content_id, type: "gone", alternative_path: alternative_path)
+    end
   end
 
   describe "#remove_and_redirect" do

--- a/spec/services/document_unpublishing_service_spec.rb
+++ b/spec/services/document_unpublishing_service_spec.rb
@@ -94,5 +94,13 @@ RSpec.describe DocumentUnpublishingService do
 
       assert_requested(asset_manager_request)
     end
+
+    it "accepts an optional explanatory note" do
+      explanatory_note = "The reason document has been removed"
+      stub_publishing_api_unpublish(document.content_id, body: { type: "redirect", alternative_path: redirect_path, explanation: explanatory_note })
+      DocumentUnpublishingService.new.remove_and_redirect(document, redirect_path, explanatory_note: explanatory_note)
+
+      assert_publishing_api_unpublish(document.content_id, type: "redirect", alternative_path: redirect_path, explanation: explanatory_note)
+    end
   end
 end

--- a/spec/services/document_unpublishing_service_spec.rb
+++ b/spec/services/document_unpublishing_service_spec.rb
@@ -78,16 +78,16 @@ RSpec.describe DocumentUnpublishingService do
     let(:redirect_path) { "/redirect-path" }
 
     it "removes documents with a redirect" do
-      stub_publishing_api_unpublish(document.content_id, body: { type: "redirect", alternative_path: redirect_path })
+      stub_publishing_api_unpublish(document.content_id, body: { type: "redirect", alternative_path: redirect_path, locale: "en" })
       DocumentUnpublishingService.new.remove_and_redirect(document, redirect_path)
 
-      assert_publishing_api_unpublish(document.content_id, type: "redirect", alternative_path: redirect_path)
+      assert_publishing_api_unpublish(document.content_id, type: "redirect", alternative_path: redirect_path, locale: "en")
     end
 
     it "deletes assets associated with redirected documents" do
       asset = create(:image, :in_asset_manager, document: document)
 
-      stub_publishing_api_unpublish(document.content_id, body: { type: "redirect", alternative_path: redirect_path })
+      stub_publishing_api_unpublish(document.content_id, body: { type: "redirect", alternative_path: redirect_path, locale: "en" })
       asset_manager_request = asset_manager_delete_asset(asset.asset_manager_id)
 
       DocumentUnpublishingService.new.remove_and_redirect(document, redirect_path)
@@ -97,10 +97,17 @@ RSpec.describe DocumentUnpublishingService do
 
     it "accepts an optional explanatory note" do
       explanatory_note = "The reason document has been removed"
-      stub_publishing_api_unpublish(document.content_id, body: { type: "redirect", alternative_path: redirect_path, explanation: explanatory_note })
+      stub_publishing_api_unpublish(document.content_id, body: { type: "redirect", alternative_path: redirect_path, explanation: explanatory_note, locale: "en" })
       DocumentUnpublishingService.new.remove_and_redirect(document, redirect_path, explanatory_note: explanatory_note)
 
-      assert_publishing_api_unpublish(document.content_id, type: "redirect", alternative_path: redirect_path, explanation: explanatory_note)
+      assert_publishing_api_unpublish(document.content_id, type: "redirect", alternative_path: redirect_path, explanation: explanatory_note, locale: "en")
+    end
+
+    it "sets the locale of the document if specified" do
+      stub_publishing_api_unpublish(document.content_id, body: { type: "redirect", alternative_path: redirect_path, locale: "fr" })
+      DocumentUnpublishingService.new.remove_and_redirect(document, redirect_path, locale: "fr")
+
+      assert_publishing_api_unpublish(document.content_id, type: "redirect", alternative_path: redirect_path, locale: "fr")
     end
   end
 end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -19,6 +19,7 @@ GovukTest.configure
 WebMock.disable_net_connect!(allow_localhost: true)
 Capybara.automatic_label_click = true
 ActiveRecord::Migration.maintain_test_schema!
+Rails.application.load_tasks
 
 Capybara.server = :puma, { Silent: true }
 Capybara::Chromedriver::Logger.raise_js_errors = true


### PR DESCRIPTION
Trello: https://trello.com/c/H3jeLoZW

## Motivation

We don't currently support unpublishing or withdrawing a document (which in our app has the terminology of remove and retire respectively).

Our intention is to do this for users if they ask us to do so while in private beta.

This implements the minimal functionality required to allow users to request a document be retired/removed via zendesk. Only the backend call to publishing-api has been implemented, and is executed via a rake task.

The frontend and changes to the "state" of the document will be implemented later.
