### PR TITLE
Iterate design of 'Content has been published' confirmation screen

### DIFF
--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -79,6 +79,7 @@
     <% end %>
 
     <main class="govuk-main-wrapper<%= " govuk-main-wrapper--l" if yield(:back_link).blank?%>" id="main-content" role="main">
+      <% if yield(:title).present? %>
       <div class="govuk-grid-row">
         <div class="govuk-grid-column-two-thirds">
           <span class="govuk-caption-l"><%= yield(:context) %></span>
@@ -88,6 +89,7 @@
           <%= yield(:title_side) %>
         </div>
       </div>
+      <% end %>
       <%= yield %>
     </main>
   </div>

--- a/app/views/publish_document/published.html.erb
+++ b/app/views/publish_document/published.html.erb
@@ -12,10 +12,7 @@
       <%= render "govuk_publishing_components/components/govspeak" do %>
         <%= govspeak_to_html t("publish_document.published.reviewed.body", title: @document.title) %>
 
-        <%= render "govuk_publishing_components/components/copy_to_clipboard",
-          label: nil,
-          copyable_content: DocumentUrl.new(@document).public_url,
-          button_text: "Copy link" %>
+        <%= link_to(nil, DocumentUrl.new(@document).public_url, class: "govuk-link") %>
       <% end %>
     <% else %>
       <%= render "govuk_publishing_components/components/panel", {
@@ -25,10 +22,9 @@
       <%= render "govuk_publishing_components/components/govspeak" do %>
         <%= govspeak_to_html t("publish_document.published.published_without_review.body", title: @document.title) %>
 
-        <%= render "govuk_publishing_components/components/copy_to_clipboard",
-          label: t("publish_document.published.published_without_review.send_label"),
-          copyable_content: document_url(@document, utm_content: "2i-link"),
-          button_text: "Copy link" %>
+        <p> <%= t("publish_document.published.published_without_review.send_label") %> </p>
+
+        <%= link_to(nil, document_url(@document, utm_content: "2i-link"), class: "govuk-link") %>
       <% end %>
     <% end %>
   </div>


### PR DESCRIPTION
https://trello.com/c/JsrpqR3h/419-iterate-design-of-content-has-been-published-confirmation-screen

- Removes empty `<div class="govuk-grid-row">` above the confirmation
  panel, which was causing extra spacing.
- Removes 30px margin below title in confirmation panel (https://github.com/alphagov/govuk_publishing_components/pull/628)
- Replace copy-to-clipboard section to just show link in normal govuk-body styling