### PR TITLE
Initial data attributes for Google Tag Manager

### DIFF
--- a/app/views/components/_summary.html.erb
+++ b/app/views/components/_summary.html.erb
@@ -12,7 +12,10 @@
     <%= title[:text] %>
   </h2>
   <% if title[:change_url] %>
-  <a class="app-c-summary__change-section-link" href="<%= title[:change_url] %>" title="Change <%= title[:text] %>">
+  <a class="app-c-summary__change-section-link"
+     href="<%= title[:change_url] %>"
+     title="Change <%= title[:text] %>"
+     data-tag="content-change">
     Change<span class="govuk-visually-hidden"> <%= title[:text] %></span>
   </a>
   <% end %>

--- a/app/views/publish_document/confirmation.html.erb
+++ b/app/views/publish_document/confirmation.html.erb
@@ -19,7 +19,8 @@
       } %>
 
       <%= render "govuk_publishing_components/components/button", {
-        text: "Confirm publish"
+        text: "Confirm publish",
+        data_attributes: { tag: "confirm-publish" },
       } %>
     <% end %>
   </div>


### PR DESCRIPTION
Having chatted to Andy it seems we're relying on some flaky means to track user interactions which can be solved with data attributes which may be easier to implement than initially thought.

This serves as a quick example adding a couple of basic ones just as a test for this approach.