### PR TITLE
Update support links

### DIFF
--- a/app/views/layouts/_phase_banner_elements.html.erb
+++ b/app/views/layouts/_phase_banner_elements.html.erb
@@ -1,8 +1,8 @@
 <span class="gem-c-phase-banner__banner-item">
-  <a class="govuk-link govuk-link--no-visited-state" href="<%= Plek.new.external_url_for("support") + "/technical_fault_report/new" %>"><%= t("application.phase_banner.raise_a_support_request") %></a>
+  <a class="govuk-link govuk-link--no-visited-state" href="https://support.publishing.service.gov.uk/technical_fault_report/new" %>"><%= t("application.phase_banner.raise_a_support_request") %></a>
 </span>
 <span class="gem-c-phase-banner__banner-item">
-  <a class="govuk-link govuk-link--no-visited-state" href="<%= Plek.new.external_url_for("support") + "/general_request/new" %>"><%= t("application.phase_banner.send_us_feedback") %></a>
+  <a class="govuk-link govuk-link--no-visited-state" href="https://support.publishing.service.gov.uk/general_request/new" %>"><%= t("application.phase_banner.send_us_feedback") %></a>
 </span>
 <span class="gem-c-phase-banner__banner-item">
   <a class="govuk-link govuk-link--no-visited-state" href="<%= publisher_updates_path %>"><%= t("application.phase_banner.whats_new") %></a>

--- a/app/views/layouts/_phase_banner_elements.html.erb
+++ b/app/views/layouts/_phase_banner_elements.html.erb
@@ -2,7 +2,7 @@
   <a class="govuk-link govuk-link--no-visited-state" href="https://support.publishing.service.gov.uk/technical_fault_report/new" %>"><%= t("application.phase_banner.raise_a_support_request") %></a>
 </span>
 <span class="gem-c-phase-banner__banner-item">
-  <a class="govuk-link govuk-link--no-visited-state" href="https://support.publishing.service.gov.uk/general_request/new" %>"><%= t("application.phase_banner.send_us_feedback") %></a>
+  <a class="govuk-link govuk-link--no-visited-state" href="https://support.publishing.service.gov.uk/content_publisher_feedback_request/new" %>"><%= t("application.phase_banner.send_us_feedback") %></a>
 </span>
 <span class="gem-c-phase-banner__banner-item">
   <a class="govuk-link govuk-link--no-visited-state" href="<%= publisher_updates_path %>"><%= t("application.phase_banner.whats_new") %></a>

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -116,11 +116,11 @@
         title: t("application.footer.support_and_feedback"),
         items: [
           {
-            href: Plek.new.external_url_for("support") + "/technical_fault_report/new",
+            href: "https://support.publishing.service.gov.uk/technical_fault_report/new",
             text: "Raise a support request"
           },
           {
-            href: Plek.new.external_url_for("support") + "/general_request/new",
+            href: "https://support.publishing.service.gov.uk/general_request/new",
             text: "Send us feedback"
           },
           {

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -120,7 +120,7 @@
             text: "Raise a support request"
           },
           {
-            href: "https://support.publishing.service.gov.uk/general_request/new",
+            href: "https://support.publishing.service.gov.uk/content_publisher_feedback_request/new",
             text: "Send us feedback"
           },
           {

--- a/app/views/publisher_information/request_feature.govspeak.md
+++ b/app/views/publisher_information/request_feature.govspeak.md
@@ -1,6 +1,6 @@
 ---
 
 ## Request a feature
-You can help us prioritise features by [sending us feedback](https://support.publishing.service.gov.uk/general_request/new).
+You can help us prioritise features by [sending us feedback](https://support.publishing.service.gov.uk/content_publisher_feedback_request/new).
 
 You can also talk to us and other Beta users on the [Content Publisher Basecamp forum](https://basecamp.com/2308334/projects/15740446).


### PR DESCRIPTION
Trello: https://trello.com/c/uW4kBZYc/385-build-feedback-support-form-for-beta-users

This changes our support links to be hardcoded to use production environment - so that our integration test users get production and to keep them consistent - and updates the link to be the new form we've set up.
