### PR TITLE
Add utm-content values to copy to clipboard links

### DIFF
--- a/app/views/components/_page_preview.html.erb
+++ b/app/views/components/_page_preview.html.erb
@@ -1,9 +1,13 @@
+<%
+  utm_uri = Addressable::URI.parse(url)
+  utm_uri.query_values = (utm_uri.query_values || {}).merge(utm_content: "preview-link")
+%>
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
     <%= render "govuk_publishing_components/components/details", title: "Share document preview for fact check or approval" do %>
       <%= render "govuk_publishing_components/components/copy_to_clipboard",
         label: "Send this link to someone so they can see a preview of how the document will appear on GOV.UK. No password is needed.",
-        copyable_content: url,
+        copyable_content: utm_uri.to_s,
         button_text: "Copy link" %>
     <% end %>
   </div>

--- a/app/views/documents/show/_submitted_for_review.html.erb
+++ b/app/views/documents/show/_submitted_for_review.html.erb
@@ -1,7 +1,7 @@
 <% copy_to_clipboard = render(
   "govuk_publishing_components/components/copy_to_clipboard",
     label: t("documents.show.flashes.submitted_for_review.label"),
-    copyable_content: document_url(@document),
+    copyable_content: document_url(@document, utm_content: "2i-link"),
     button_text: "Copy link"
 ) %>
 

--- a/app/views/publish_document/published.html.erb
+++ b/app/views/publish_document/published.html.erb
@@ -27,7 +27,7 @@
 
         <%= render "govuk_publishing_components/components/copy_to_clipboard",
           label: t("publish_document.published.published_without_review.send_label"),
-          copyable_content: document_url(@document),
+          copyable_content: document_url(@document, utm_content: "2i-link"),
           button_text: "Copy link" %>
       <% end %>
     <% end %>

--- a/spec/features/workflow/submit_for_2i_spec.rb
+++ b/spec/features/workflow/submit_for_2i_spec.rb
@@ -39,7 +39,7 @@ RSpec.feature "2i" do
 
   def and_i_see_a_link_to_the_document
     review_url = find_field(I18n.t!("documents.show.flashes.submitted_for_review.label")).value
-    expect(review_url).to eq(document_url(@document))
+    expect(review_url).to match(document_url(@document))
   end
 
   def when_i_edit_the_document


### PR DESCRIPTION
Trello: https://trello.com/c/5LMeIN89/446-look-at-adding-a-suffix-to-the-preview-url-generated

This is to help Andy determine whether people are using / sharing the links

One thing I'm not sure about is using the value of utm_content=preview-link for the preview link as that link will be to draft gov.uk and not content publisher and thus may need a more specific name to distinguish it amongst other things we track on gov.uk as a whole.