### PR TITLE
Allow documents to be "removed" or "retired"

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -33,6 +33,7 @@ end
 group :development, :test do
   gem "byebug", "~> 10"
   gem "capybara-chromedriver-logger"
+  gem "climate_control"
   gem "factory_bot_rails", "~> 4"
   gem "govuk-lint", "~> 3"
   gem "govuk_schemas", "~> 3.2"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -86,6 +86,7 @@ GEM
     chromedriver-helper (2.1.0)
       archive-zip (~> 0.10)
       nokogiri (~> 1.8)
+    climate_control (0.2.0)
     colorize (0.8.1)
     commander (4.4.7)
       highline (~> 2.0.0)
@@ -420,6 +421,7 @@ DEPENDENCIES
   brakeman (~> 4)
   byebug (~> 10)
   capybara-chromedriver-logger
+  climate_control
   factory_bot_rails (~> 4)
   foreman (~> 0.85)
   gds-api-adapters (~> 54)

--- a/README.md
+++ b/README.md
@@ -86,6 +86,10 @@ content publisher directory and run:
 bundle exec rake import:whitehall_news INPUT=/tmp/whitehall-export.json
 ```
 
+### User support
+
+- [Retiring and removing documents](docs/retiring-and-removing-documents.md)
+
 ## Licence
 
 [MIT License](LICENCE)

--- a/app/services/document_unpublishing_service.rb
+++ b/app/services/document_unpublishing_service.rb
@@ -22,6 +22,10 @@ class DocumentUnpublishingService
     delete_assets(document.images)
   end
 
+  def remove_and_redirect(document, redirect_path)
+    GdsApi.publishing_api_v2.unpublish(document.content_id, type: "redirect", alternative_path: redirect_path)
+  end
+
 private
 
   def delete_assets(assets)

--- a/app/services/document_unpublishing_service.rb
+++ b/app/services/document_unpublishing_service.rb
@@ -22,8 +22,13 @@ class DocumentUnpublishingService
     delete_assets(document.images)
   end
 
-  def remove_and_redirect(document, redirect_path)
-    GdsApi.publishing_api_v2.unpublish(document.content_id, type: "redirect", alternative_path: redirect_path)
+  def remove_and_redirect(document, redirect_path, explanatory_note: nil)
+    GdsApi.publishing_api_v2.unpublish(
+      document.content_id,
+      type: "redirect",
+      explanation: explanatory_note,
+      alternative_path: redirect_path,
+    )
 
     delete_assets(document.images)
   end

--- a/app/services/document_unpublishing_service.rb
+++ b/app/services/document_unpublishing_service.rb
@@ -10,11 +10,12 @@ class DocumentUnpublishingService
     )
   end
 
-  def remove(document, explanatory_note: nil)
+  def remove(document, explanatory_note: nil, alternative_path: nil)
     GdsApi.publishing_api_v2.unpublish(
       document.content_id,
       type: "gone",
       explanation: explanatory_note,
+      alternative_path: alternative_path,
     )
 
     delete_assets(document.images)

--- a/app/services/document_unpublishing_service.rb
+++ b/app/services/document_unpublishing_service.rb
@@ -28,6 +28,7 @@ class DocumentUnpublishingService
       type: "redirect",
       explanation: explanatory_note,
       alternative_path: redirect_path,
+      locale: document.locale,
     )
 
     delete_assets(document.images)

--- a/app/services/document_unpublishing_service.rb
+++ b/app/services/document_unpublishing_service.rb
@@ -2,6 +2,11 @@
 
 class DocumentUnpublishingService
   def retire(document, explanatory_note)
-    GdsApi.publishing_api_v2.unpublish(document.content_id, type: "withdrawal", explanation: explanatory_note)
+    GdsApi.publishing_api_v2.unpublish(
+      document.content_id,
+      type: "withdrawal",
+      explanation: explanatory_note,
+      locale: document.locale,
+    )
   end
 end

--- a/app/services/document_unpublishing_service.rb
+++ b/app/services/document_unpublishing_service.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+class DocumentUnpublishingService
+  def retire(document, explanatory_note)
+    GdsApi.publishing_api_v2.unpublish(document.content_id, type: "withdrawal", explanation: explanatory_note)
+  end
+end

--- a/app/services/document_unpublishing_service.rb
+++ b/app/services/document_unpublishing_service.rb
@@ -10,8 +10,13 @@ class DocumentUnpublishingService
     )
   end
 
-  def remove(document)
-    GdsApi.publishing_api_v2.unpublish(document.content_id, type: "gone")
+  def remove(document, explanatory_note: nil)
+    GdsApi.publishing_api_v2.unpublish(
+      document.content_id,
+      type: "gone",
+      explanation: explanatory_note,
+    )
+
     delete_assets(document.images)
   end
 

--- a/app/services/document_unpublishing_service.rb
+++ b/app/services/document_unpublishing_service.rb
@@ -9,4 +9,8 @@ class DocumentUnpublishingService
       locale: document.locale,
     )
   end
+
+  def remove(document)
+    GdsApi.publishing_api_v2.unpublish(document.content_id, type: "gone")
+  end
 end

--- a/app/services/document_unpublishing_service.rb
+++ b/app/services/document_unpublishing_service.rb
@@ -24,6 +24,8 @@ class DocumentUnpublishingService
 
   def remove_and_redirect(document, redirect_path)
     GdsApi.publishing_api_v2.unpublish(document.content_id, type: "redirect", alternative_path: redirect_path)
+
+    delete_assets(document.images)
   end
 
 private

--- a/app/services/document_unpublishing_service.rb
+++ b/app/services/document_unpublishing_service.rb
@@ -16,6 +16,7 @@ class DocumentUnpublishingService
       type: "gone",
       explanation: explanatory_note,
       alternative_path: alternative_path,
+      locale: document.locale,
     )
 
     delete_assets(document.images)

--- a/app/services/document_unpublishing_service.rb
+++ b/app/services/document_unpublishing_service.rb
@@ -12,5 +12,14 @@ class DocumentUnpublishingService
 
   def remove(document)
     GdsApi.publishing_api_v2.unpublish(document.content_id, type: "gone")
+    delete_assets(document.images)
+  end
+
+private
+
+  def delete_assets(assets)
+    assets.each do |asset|
+      AssetManagerService.new.delete(asset)
+    end
   end
 end

--- a/app/views/remove_document/remove.govspeak.md
+++ b/app/views/remove_document/remove.govspeak.md
@@ -1,4 +1,4 @@
-If you need to remove this content please [raise a support request and we’ll do it for you](https://support.publishing.service.gov.uk/).
+If you need to remove this content please [raise a support request and we’ll do it for you](https://support.publishing.service.gov.uk/unpublish_content_request/new).
 
 You must include any public explanation or new web address required.
 

--- a/app/views/retire_document/retire.govspeak.md
+++ b/app/views/retire_document/retire.govspeak.md
@@ -1,4 +1,4 @@
-If you need to retire this content please [raise a support request and we’ll do it for you](https://support.publishing.service.gov.uk/).
+If you need to retire this content please [raise a support request and we’ll do it for you](https://support.publishing.service.gov.uk/unpublish_content_request/new).
 
 You must include any public explanation or new web address required.
 

--- a/docs/retiring-and-removing-documents.md
+++ b/docs/retiring-and-removing-documents.md
@@ -1,0 +1,61 @@
+# Retiring and removing documents
+
+We need to allow users to unpublish content from GOV.UK. In Content Publisher we are replacing
+unpublish terminology with "retired" and "removed".
+
+Retired content is still displayed on GOV.UK, but there is an explanation box on the page that describes
+why the content is out of date.
+
+Removed content returns a 410 gone page to the user. If an explanatory note or a alternative path have been provided,
+they will be displayed in the body of the page.
+
+Removed and redirected content redirects users to another page on GOV.UK
+
+Environment variables are being used to pass parameters to the rake tasks.
+
+## Retiring documents
+
+Required parameters:
+
+- content_id
+- NOTE
+
+Optional parameters:
+
+- LOCALE (set to "en" by default)
+
+```
+rake unpublish:retire_document['a-content-id'] NOTE='A note'
+```
+
+## Removing documents
+
+Required parameters:
+
+- content_id
+
+Optional parameters:
+
+- LOCALE (set to "en" by default)
+- NOTE
+- NEW_PATH
+
+```
+rake unpublish:remove_document['a-content-id']
+```
+
+## Redirect removed documents to another page on GOV.UK
+
+Required parameters:
+
+- content_id
+- NEW_PATH
+
+Optional parameters:
+
+- LOCALE (set to "en" by default)
+- NOTE
+
+```
+rake unpublish:remove_and_redirect_document['a-content-id'] NEW_PATH='/redirect-to-here'
+```

--- a/lib/tasks/unpublish.rake
+++ b/lib/tasks/unpublish.rake
@@ -32,4 +32,23 @@ namespace :unpublish do
       alternative_path: alternative_path,
     )
   end
+
+  desc "Remove and redirect a document on GOV.UK e.g. unpublish:remove_and_redirect_document['a-content-id'] NEW_PATH='/redirect-to-here'"
+  task :remove_and_redirect_document, [:content_id] => :environment do |_, args|
+    raise "Missing content_id parameter" unless args.content_id
+    raise "Missing NEW_PATH value" if ENV["NEW_PATH"].blank?
+
+    explanatory_note = ENV["NOTE"]
+    redirect_path = ENV["NEW_PATH"]
+    locale = ENV["LOCALE"] || "en"
+
+    document = Document.find_by!(content_id: args.content_id, locale: locale)
+    raise "Document must have a published version before it can be redirected" unless document.has_live_version_on_govuk
+
+    DocumentUnpublishingService.new.remove_and_redirect(
+      document,
+      redirect_path,
+      explanatory_note: explanatory_note,
+    )
+  end
 end

--- a/lib/tasks/unpublish.rake
+++ b/lib/tasks/unpublish.rake
@@ -10,6 +10,7 @@ namespace :unpublish do
     locale = ENV["LOCALE"] || "en"
 
     document = Document.find_by!(content_id: args.content_id, locale: locale)
+    raise "Document must have a published version before it can be retired" unless document.has_live_version_on_govuk
 
     DocumentUnpublishingService.new.retire(document, explanatory_note)
   end

--- a/lib/tasks/unpublish.rake
+++ b/lib/tasks/unpublish.rake
@@ -14,4 +14,15 @@ namespace :unpublish do
 
     DocumentUnpublishingService.new.retire(document, explanatory_note)
   end
+
+  desc "Remove a document from GOV.UK e.g. unpublish:remove_document['a-content-id']"
+  task :remove_document, [:content_id] => :environment do |_, args|
+    raise "Missing content_id parameter" unless args.content_id
+
+    locale = ENV["LOCALE"] || "en"
+
+    document = Document.find_by!(content_id: args.content_id, locale: locale)
+
+    DocumentUnpublishingService.new.remove(document)
+  end
 end

--- a/lib/tasks/unpublish.rake
+++ b/lib/tasks/unpublish.rake
@@ -1,0 +1,16 @@
+# frozen_string_literal: true
+
+namespace :unpublish do
+  desc "Retire a document on GOV.UK e.g. unpublish:retire_document['a-content-id'] NOTE='A note'"
+  task :retire_document, [:content_id] => :environment do |_, args|
+    raise "Missing content_id parameter" unless args.content_id
+    raise "Missing NOTE value" if ENV["NOTE"].blank?
+
+    explanatory_note = ENV["NOTE"]
+    locale = ENV["LOCALE"] || "en"
+
+    document = Document.find_by!(content_id: args.content_id, locale: locale)
+
+    DocumentUnpublishingService.new.retire(document, explanatory_note)
+  end
+end

--- a/lib/tasks/unpublish.rake
+++ b/lib/tasks/unpublish.rake
@@ -19,10 +19,17 @@ namespace :unpublish do
   task :remove_document, [:content_id] => :environment do |_, args|
     raise "Missing content_id parameter" unless args.content_id
 
+    explanatory_note = ENV["NOTE"]
+    alternative_path = ENV["NEW_PATH"]
     locale = ENV["LOCALE"] || "en"
 
     document = Document.find_by!(content_id: args.content_id, locale: locale)
+    raise "Document must have a published version before it can be removed" unless document.has_live_version_on_govuk
 
-    DocumentUnpublishingService.new.remove(document)
+    DocumentUnpublishingService.new.remove(
+      document,
+      explanatory_note: explanatory_note,
+      alternative_path: alternative_path,
+    )
   end
 end

--- a/spec/features/workflow/unpublishing_spec.rb
+++ b/spec/features/workflow/unpublishing_spec.rb
@@ -1,0 +1,30 @@
+# frozen_string_literal: true
+
+require "rake"
+
+RSpec.feature "Unpublish documents rake tasks" do
+  describe "unpublish:retire_document" do
+    before do
+      Rake::Task["unpublish:retire_document"].reenable
+    end
+
+    it "runs the task to retire a document" do
+      document = create(:document, :published, locale: "en")
+      explanatory_note = "The reason the document is being retired"
+
+      expect_any_instance_of(DocumentUnpublishingService).to receive(:retire).with(document, explanatory_note)
+
+      ClimateControl.modify NOTE: explanatory_note do
+        Rake::Task["unpublish:retire_document"].invoke(document.content_id)
+      end
+    end
+
+    it "raises an error if a content_id is not present" do
+      expect { Rake::Task["unpublish:retire_document"].invoke }.to raise_error("Missing content_id parameter")
+    end
+
+    it "raises an error if a NOTE is not present" do
+      expect { Rake::Task["unpublish:retire_document"].invoke("a-content-id") }.to raise_error("Missing NOTE value")
+    end
+  end
+end

--- a/spec/features/workflow/unpublishing_spec.rb
+++ b/spec/features/workflow/unpublishing_spec.rb
@@ -26,5 +26,14 @@ RSpec.feature "Unpublish documents rake tasks" do
     it "raises an error if a NOTE is not present" do
       expect { Rake::Task["unpublish:retire_document"].invoke("a-content-id") }.to raise_error("Missing NOTE value")
     end
+
+    it "raises an error if the document does not have a live version on GOV.uk" do
+      document = create(:document, locale: "en")
+      explanatory_note = "The reason the document is being retired"
+
+      ClimateControl.modify NOTE: explanatory_note do
+        expect { Rake::Task["unpublish:retire_document"].invoke(document.content_id) }.to raise_error("Document must have a published version before it can be retired")
+      end
+    end
   end
 end

--- a/spec/features/workflow/unpublishing_spec.rb
+++ b/spec/features/workflow/unpublishing_spec.rb
@@ -36,4 +36,21 @@ RSpec.feature "Unpublish documents rake tasks" do
       end
     end
   end
+
+  describe "unpublish:remove_document" do
+    before do
+      Rake::Task["unpublish:remove_document"].reenable
+    end
+
+    it "runs the rake task to remove a document" do
+      document = create(:document, locale: "en")
+      expect_any_instance_of(DocumentUnpublishingService).to receive(:remove).with(document)
+
+      Rake::Task["unpublish:remove_document"].invoke(document.content_id)
+    end
+
+    it "raises an error if a content_id is not present" do
+      expect { Rake::Task["unpublish:remove_document"].invoke }.to raise_error("Missing content_id parameter")
+    end
+  end
 end

--- a/spec/services/document_unpublishing_service_spec.rb
+++ b/spec/services/document_unpublishing_service_spec.rb
@@ -35,15 +35,15 @@ RSpec.describe DocumentUnpublishingService do
     let(:document) { create(:document) }
 
     it "removes a document" do
-      stub_publishing_api_unpublish(document.content_id, body: { type: "gone" })
+      stub_publishing_api_unpublish(document.content_id, body: { type: "gone", locale: document.locale })
       DocumentUnpublishingService.new.remove(document)
 
-      assert_publishing_api_unpublish(document.content_id, type: "gone")
+      assert_publishing_api_unpublish(document.content_id, type: "gone", locale: document.locale)
     end
 
     it "deletes assets associated with removed documents" do
       asset = create(:image, :in_asset_manager, document: document)
-      stub_publishing_api_unpublish(document.content_id, body: { type: "gone" })
+      stub_publishing_api_unpublish(document.content_id, body: { type: "gone", locale: document.locale })
       asset_manager_request = asset_manager_delete_asset(asset.asset_manager_id)
 
       DocumentUnpublishingService.new.remove(document)
@@ -53,20 +53,29 @@ RSpec.describe DocumentUnpublishingService do
 
     it "accepts an optional explanatory note" do
       explanatory_note = "The reason document has been removed"
-      stub_publishing_api_unpublish(document.content_id, body: { type: "gone", explanation: explanatory_note })
+      stub_publishing_api_unpublish(document.content_id, body: { type: "gone", explanation: explanatory_note, locale: document.locale })
 
       DocumentUnpublishingService.new.remove(document, explanatory_note: explanatory_note)
 
-      assert_publishing_api_unpublish(document.content_id, type: "gone", explanation: explanatory_note)
+      assert_publishing_api_unpublish(document.content_id, type: "gone", explanation: explanatory_note, locale: document.locale)
     end
 
     it "accepts an optional alternative path" do
       alternative_path = "/look-here-instead"
-      stub_publishing_api_unpublish(document.content_id, body: { type: "gone", alternative_path: alternative_path })
+      stub_publishing_api_unpublish(document.content_id, body: { type: "gone", alternative_path: alternative_path, locale: document.locale })
 
       DocumentUnpublishingService.new.remove(document, alternative_path: alternative_path)
 
-      assert_publishing_api_unpublish(document.content_id, type: "gone", alternative_path: alternative_path)
+      assert_publishing_api_unpublish(document.content_id, type: "gone", alternative_path: alternative_path, locale: document.locale)
+    end
+
+    it "sets the locale of the document if specified" do
+      french_document = create(:document, locale: "fr")
+
+      stub_publishing_api_unpublish(french_document.content_id, body: { type: "gone", locale: french_document.locale })
+      DocumentUnpublishingService.new.remove(french_document)
+
+      assert_publishing_api_unpublish(french_document.content_id, type: "gone", locale: french_document.locale)
     end
   end
 end

--- a/spec/services/document_unpublishing_service_spec.rb
+++ b/spec/services/document_unpublishing_service_spec.rb
@@ -1,0 +1,15 @@
+# frozen_string_literal: true
+
+RSpec.describe DocumentUnpublishingService do
+  describe "#retire" do
+    it "withdraws a document in publishing-api with an explanatory note" do
+      document = create(:document)
+      explanatory_note = "The document is out of date"
+
+      stub_publishing_api_unpublish(document.content_id, body: { type: "withdrawal", explanation: explanatory_note })
+      DocumentUnpublishingService.new.retire(document, explanatory_note)
+
+      assert_publishing_api_unpublish(document.content_id, type: "withdrawal", explanation: explanatory_note)
+    end
+  end
+end

--- a/spec/services/document_unpublishing_service_spec.rb
+++ b/spec/services/document_unpublishing_service_spec.rb
@@ -84,16 +84,16 @@ RSpec.describe DocumentUnpublishingService do
     let(:redirect_path) { "/redirect-path" }
 
     it "removes documents with a redirect" do
-      stub_publishing_api_unpublish(document.content_id, body: { type: "redirect", alternative_path: redirect_path })
+      stub_publishing_api_unpublish(document.content_id, body: { type: "redirect", alternative_path: redirect_path, locale: document.locale })
       DocumentUnpublishingService.new.remove_and_redirect(document, redirect_path)
 
-      assert_publishing_api_unpublish(document.content_id, type: "redirect", alternative_path: redirect_path)
+      assert_publishing_api_unpublish(document.content_id, type: "redirect", alternative_path: redirect_path, locale: document.locale)
     end
 
     it "deletes assets associated with redirected documents" do
       asset = create(:image, :in_asset_manager, document: document)
 
-      stub_publishing_api_unpublish(document.content_id, body: { type: "redirect", alternative_path: redirect_path })
+      stub_publishing_api_unpublish(document.content_id, body: { type: "redirect", alternative_path: redirect_path, locale: document.locale })
       asset_manager_request = asset_manager_delete_asset(asset.asset_manager_id)
 
       DocumentUnpublishingService.new.remove_and_redirect(document, redirect_path)
@@ -103,11 +103,20 @@ RSpec.describe DocumentUnpublishingService do
 
     it "accepts an optional explanatory note" do
       explanatory_note = "The reason document has been removed"
-      stub_publishing_api_unpublish(document.content_id, body: { type: "redirect", alternative_path: redirect_path, explanation: explanatory_note })
+      stub_publishing_api_unpublish(document.content_id, body: { type: "redirect", alternative_path: redirect_path, explanation: explanatory_note, locale: document.locale })
 
       DocumentUnpublishingService.new.remove_and_redirect(document, redirect_path, explanatory_note: explanatory_note)
 
-      assert_publishing_api_unpublish(document.content_id, type: "redirect", alternative_path: redirect_path, explanation: explanatory_note)
+      assert_publishing_api_unpublish(document.content_id, type: "redirect", alternative_path: redirect_path, explanation: explanatory_note, locale: document.locale)
+    end
+
+    it "sets the locale of the document if specified" do
+      french_document = create(:document, locale: "fr")
+
+      stub_publishing_api_unpublish(french_document.content_id, body: { type: "redirect", alternative_path: redirect_path, locale: french_document.locale })
+      DocumentUnpublishingService.new.remove_and_redirect(french_document, redirect_path)
+
+      assert_publishing_api_unpublish(french_document.content_id, type: "redirect", alternative_path: redirect_path, locale: french_document.locale)
     end
   end
 end

--- a/spec/services/document_unpublishing_service_spec.rb
+++ b/spec/services/document_unpublishing_service_spec.rb
@@ -2,14 +2,24 @@
 
 RSpec.describe DocumentUnpublishingService do
   describe "#retire" do
+    let(:explanatory_note) { "The document is out of date" }
+
     it "withdraws a document in publishing-api with an explanatory note" do
       document = create(:document)
-      explanatory_note = "The document is out of date"
 
-      stub_publishing_api_unpublish(document.content_id, body: { type: "withdrawal", explanation: explanatory_note })
+      stub_publishing_api_unpublish(document.content_id, body: { type: "withdrawal", explanation: explanatory_note, locale: document.locale })
       DocumentUnpublishingService.new.retire(document, explanatory_note)
 
-      assert_publishing_api_unpublish(document.content_id, type: "withdrawal", explanation: explanatory_note)
+      assert_publishing_api_unpublish(document.content_id, type: "withdrawal", explanation: explanatory_note, locale: document.locale)
+    end
+
+    it "sets the locale of the document if specified" do
+      french_document = create(:document, locale: "fr")
+
+      stub_publishing_api_unpublish(french_document.content_id, body: { type: "withdrawal", explanation: explanatory_note, locale: french_document.locale })
+      DocumentUnpublishingService.new.retire(french_document, explanatory_note)
+
+      assert_publishing_api_unpublish(french_document.content_id, type: "withdrawal", explanation: explanatory_note, locale: french_document.locale)
     end
   end
 end

--- a/spec/services/document_unpublishing_service_spec.rb
+++ b/spec/services/document_unpublishing_service_spec.rb
@@ -78,4 +78,16 @@ RSpec.describe DocumentUnpublishingService do
       assert_publishing_api_unpublish(french_document.content_id, type: "gone", locale: french_document.locale)
     end
   end
+
+  describe "#remove_and_redirect" do
+    it "removes documents with a redirect" do
+      document = create(:document)
+      redirect_path = "/redirect-path"
+
+      stub_publishing_api_unpublish(document.content_id, body: { type: "redirect", alternative_path: redirect_path })
+      DocumentUnpublishingService.new.remove_and_redirect(document, redirect_path)
+
+      assert_publishing_api_unpublish(document.content_id, type: "redirect", alternative_path: redirect_path)
+    end
+  end
 end

--- a/spec/services/document_unpublishing_service_spec.rb
+++ b/spec/services/document_unpublishing_service_spec.rb
@@ -22,4 +22,15 @@ RSpec.describe DocumentUnpublishingService do
       assert_publishing_api_unpublish(french_document.content_id, type: "withdrawal", explanation: explanatory_note, locale: french_document.locale)
     end
   end
+
+  describe "#remove" do
+    it "removes a document" do
+      document = create(:document)
+
+      stub_publishing_api_unpublish(document.content_id, body: { type: "gone" })
+      DocumentUnpublishingService.new.remove(document)
+
+      assert_publishing_api_unpublish(document.content_id, type: "gone")
+    end
+  end
 end

--- a/spec/services/document_unpublishing_service_spec.rb
+++ b/spec/services/document_unpublishing_service_spec.rb
@@ -50,5 +50,14 @@ RSpec.describe DocumentUnpublishingService do
 
       assert_requested(asset_manager_request)
     end
+
+    it "accepts an optional explanatory note" do
+      explanatory_note = "The reason document has been removed"
+      stub_publishing_api_unpublish(document.content_id, body: { type: "gone", explanation: explanatory_note })
+
+      DocumentUnpublishingService.new.remove(document, explanatory_note: explanatory_note)
+
+      assert_publishing_api_unpublish(document.content_id, type: "gone", explanation: explanatory_note)
+    end
   end
 end

--- a/spec/services/document_unpublishing_service_spec.rb
+++ b/spec/services/document_unpublishing_service_spec.rb
@@ -100,5 +100,14 @@ RSpec.describe DocumentUnpublishingService do
 
       assert_requested(asset_manager_request)
     end
+
+    it "accepts an optional explanatory note" do
+      explanatory_note = "The reason document has been removed"
+      stub_publishing_api_unpublish(document.content_id, body: { type: "redirect", alternative_path: redirect_path, explanation: explanatory_note })
+
+      DocumentUnpublishingService.new.remove_and_redirect(document, redirect_path, explanatory_note: explanatory_note)
+
+      assert_publishing_api_unpublish(document.content_id, type: "redirect", alternative_path: redirect_path, explanation: explanatory_note)
+    end
   end
 end

--- a/spec/services/document_unpublishing_service_spec.rb
+++ b/spec/services/document_unpublishing_service_spec.rb
@@ -2,11 +2,10 @@
 
 RSpec.describe DocumentUnpublishingService do
   describe "#retire" do
+    let(:document) { create(:document) }
     let(:explanatory_note) { "The document is out of date" }
 
     it "withdraws a document in publishing-api with an explanatory note" do
-      document = create(:document)
-
       stub_publishing_api_unpublish(document.content_id, body: { type: "withdrawal", explanation: explanatory_note, locale: document.locale })
       DocumentUnpublishingService.new.retire(document, explanatory_note)
 
@@ -21,16 +20,35 @@ RSpec.describe DocumentUnpublishingService do
 
       assert_publishing_api_unpublish(french_document.content_id, type: "withdrawal", explanation: explanatory_note, locale: french_document.locale)
     end
+
+    it "does not delete assets for retired documents" do
+      asset = create(:image, :in_asset_manager, document: document)
+      stub_publishing_api_unpublish(document.content_id, body: { type: "withdrawal", explanation: explanatory_note, locale: document.locale })
+
+      DocumentUnpublishingService.new.retire(document, explanatory_note)
+
+      assert_not_requested asset_manager_delete_asset(asset.asset_manager_id)
+    end
   end
 
   describe "#remove" do
-    it "removes a document" do
-      document = create(:document)
+    let(:document) { create(:document) }
 
+    it "removes a document" do
       stub_publishing_api_unpublish(document.content_id, body: { type: "gone" })
       DocumentUnpublishingService.new.remove(document)
 
       assert_publishing_api_unpublish(document.content_id, type: "gone")
+    end
+
+    it "deletes assets associated with removed documents" do
+      asset = create(:image, :in_asset_manager, document: document)
+      stub_publishing_api_unpublish(document.content_id, body: { type: "gone" })
+      asset_manager_request = asset_manager_delete_asset(asset.asset_manager_id)
+
+      DocumentUnpublishingService.new.remove(document)
+
+      assert_requested(asset_manager_request)
     end
   end
 end

--- a/spec/services/document_unpublishing_service_spec.rb
+++ b/spec/services/document_unpublishing_service_spec.rb
@@ -59,5 +59,14 @@ RSpec.describe DocumentUnpublishingService do
 
       assert_publishing_api_unpublish(document.content_id, type: "gone", explanation: explanatory_note)
     end
+
+    it "accepts an optional alternative path" do
+      alternative_path = "/look-here-instead"
+      stub_publishing_api_unpublish(document.content_id, body: { type: "gone", alternative_path: alternative_path })
+
+      DocumentUnpublishingService.new.remove(document, alternative_path: alternative_path)
+
+      assert_publishing_api_unpublish(document.content_id, type: "gone", alternative_path: alternative_path)
+    end
   end
 end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -19,6 +19,7 @@ GovukTest.configure
 WebMock.disable_net_connect!(allow_localhost: true)
 Capybara.automatic_label_click = true
 ActiveRecord::Migration.maintain_test_schema!
+Rails.application.load_tasks
 
 Capybara.server = :puma, { Silent: true }
 Capybara::Chromedriver::Logger.raise_js_errors = true


### PR DESCRIPTION
Trello: https://trello.com/c/H3jeLoZW

Supersedes PR #499 

## Motivation

We don't currently support unpublishing or withdrawing a document (which in our app has the terminology of remove and retire respectively).

Our intention is to do this for users if they ask us to do so while in private beta.

This implements the minimal functionality required to allow users to request a document be retired/removed via zendesk. Only the backend call to publishing-api has been implemented, and is executed via a rake task.

The frontend and changes to the "state" of the document will be implemented later.