### PR TITLE
DRY-up test requirements

### DIFF
--- a/spec/services/asset_manager_service_spec.rb
+++ b/spec/services/asset_manager_service_spec.rb
@@ -1,7 +1,5 @@
 # frozen_string_literal: true
 
-require "spec_helper"
-
 RSpec.describe AssetManagerService do
   describe "#upload_bytes" do
     it "uploads a byte stream to Asset Manager and returns the asset URL" do

--- a/spec/services/document_publishing_service_spec.rb
+++ b/spec/services/document_publishing_service_spec.rb
@@ -1,7 +1,5 @@
 # frozen_string_literal: true
 
-require "spec_helper"
-
 RSpec.describe DocumentPublishingService do
   describe "#publish_draft" do
     it "keeps track of the publication state" do


### PR DESCRIPTION
Content Publisher has been configured to automatically include spec_helper when the tests are run,
so these entries are not required.