### PR TITLE
Detect external url conflicts

### DIFF
--- a/app/controllers/documents_controller.rb
+++ b/app/controllers/documents_controller.rb
@@ -39,7 +39,7 @@ class DocumentsController < ApplicationController
     @document = Document.find_by_param(params[:id])
     @document.assign_attributes(update_params(@document))
     add_contact_request = params[:submit] == "add_contact"
-    @issues = Requirements::ContentChecker.new(@document).pre_preview_issues
+    @issues = Requirements::EditPageChecker.new(@document).pre_preview_issues
 
     if @issues.any?
       flash.now["alert"] = {

--- a/app/formats/document_types.yml
+++ b/app/formats/document_types.yml
@@ -8,6 +8,7 @@
   path_prefix: /government/news
   lead_image: true
   topics: true
+  check_path_conflict: true
   publishing_metadata:
     schema_name: news_article
     rendering_app: government-frontend
@@ -68,6 +69,7 @@
   path_prefix: /government/news
   lead_image: true
   topics: true
+  check_path_conflict: true
   publishing_metadata:
     schema_name: news_article
     rendering_app: government-frontend

--- a/app/services/document_type_schema.rb
+++ b/app/services/document_type_schema.rb
@@ -2,7 +2,7 @@
 
 class DocumentTypeSchema
   attr_reader :contents, :id, :label, :managed_elsewhere, :publishing_metadata,
-    :path_prefix, :tags, :guidance_govspeak, :description, :hint, :lead_image, :topics
+    :path_prefix, :tags, :guidance_govspeak, :description, :hint, :lead_image, :topics, :check_path_conflict
 
   def initialize(params = {})
     @id = params["id"]
@@ -17,6 +17,7 @@ class DocumentTypeSchema
     @hint = params["hint"]
     @lead_image = params["lead_image"]
     @topics = params["topics"]
+    @check_path_conflict = params["check_path_conflict"]
   end
 
   def self.find(document_type_id)

--- a/app/services/publish_service.rb
+++ b/app/services/publish_service.rb
@@ -1,0 +1,33 @@
+# frozen_string_literal: true
+
+class PublishService
+  attr_reader :document
+
+  def initialize(document)
+    @document = document
+  end
+
+  def publish(review_state)
+    publish_assets(document.images)
+
+    # Sending update_type in .publish is deprecated (should be in payload instead)
+    GdsApi.publishing_api_v2.publish(document.content_id, nil, locale: document.locale)
+
+    document.update!(
+      publication_state: "sent_to_live",
+      has_live_version_on_govuk: true,
+      review_state: review_state,
+    )
+  rescue GdsApi::BaseError => e
+    GovukError.notify(e)
+    document.update!(publication_state: "error_sending_to_live")
+    raise
+  end
+
+private
+
+  def publish_assets(assets)
+    asset_manager = AssetManagerService.new
+    assets.each { |asset| asset_manager.publish(asset) }
+  end
+end

--- a/app/services/requirements/document_checker.rb
+++ b/app/services/requirements/document_checker.rb
@@ -8,14 +8,13 @@ module Requirements
       @document = document
     end
 
-    def pre_preview_issues(params = {})
+    def pre_preview_issues
       issues = []
 
       document.images.each do |image|
         issues += ImageChecker.new(image).pre_preview_issues.to_a
       end
 
-      issues += PathChecker.new(document).pre_preview_issues(params).to_a
       issues += ContentChecker.new(document).pre_preview_issues.to_a
       CheckerIssues.new(issues)
     end

--- a/app/services/requirements/document_checker.rb
+++ b/app/services/requirements/document_checker.rb
@@ -8,18 +8,19 @@ module Requirements
       @document = document
     end
 
-    def pre_preview_issues
+    def pre_preview_issues(params = {})
       issues = []
 
       document.images.each do |image|
         issues += ImageChecker.new(image).pre_preview_issues.to_a
       end
 
+      issues += PathChecker.new(document).pre_preview_issues(params).to_a
       issues += ContentChecker.new(document).pre_preview_issues.to_a
       CheckerIssues.new(issues)
     end
 
-    def pre_publish_issues(params)
+    def pre_publish_issues(params = {})
       issues = []
       issues += ContentChecker.new(document).pre_publish_issues.to_a
       issues += TopicChecker.new(document).pre_publish_issues(params).to_a

--- a/app/services/requirements/edit_page_checker.rb
+++ b/app/services/requirements/edit_page_checker.rb
@@ -1,0 +1,24 @@
+# frozen_string_literal: true
+
+module Requirements
+  class EditPageChecker
+    attr_reader :document
+
+    def initialize(document)
+      @document = document
+    end
+
+    def pre_preview_issues
+      issues = []
+      issues += PathChecker.new(document).pre_preview_issues.to_a
+      issues += ContentChecker.new(document).pre_preview_issues.to_a
+      CheckerIssues.new(issues)
+    end
+
+  private
+
+    def lookup_content_id
+      GdsApi.publishing_api_v2.lookup_content_id(base_path: document.base_path)
+    end
+  end
+end

--- a/app/services/requirements/path_checker.rb
+++ b/app/services/requirements/path_checker.rb
@@ -1,0 +1,35 @@
+# frozen_string_literal: true
+
+module Requirements
+  class PathChecker
+    attr_reader :document
+
+    def initialize(document)
+      @document = document
+    end
+
+    def pre_preview_issues(rescue_api_errors: true)
+      issues = []
+
+      begin
+        if document.document_type_schema.check_path_conflict && base_path_conflict?
+          issues << Issue.new(:base_path, :conflict)
+        end
+      rescue GdsApi::BaseError => e
+        Rails.logger.error(e) if rescue_api_errors
+        raise unless rescue_api_errors
+      end
+
+      CheckerIssues.new(issues)
+    end
+
+  private
+
+    def base_path_conflict?
+      base_path_owner = GdsApi.publishing_api_v2
+        .lookup_content_id(base_path: document.base_path, with_drafts: true)
+
+      base_path_owner && base_path_owner != document.content_id
+    end
+  end
+end

--- a/app/services/requirements/path_checker.rb
+++ b/app/services/requirements/path_checker.rb
@@ -13,7 +13,7 @@ module Requirements
 
       begin
         if document.document_type_schema.check_path_conflict && base_path_conflict?
-          issues << Issue.new(:base_path, :conflict)
+          issues << Issue.new(:title, :conflict)
         end
       rescue GdsApi::BaseError => e
         Rails.logger.error(e)

--- a/app/services/requirements/path_checker.rb
+++ b/app/services/requirements/path_checker.rb
@@ -2,15 +2,13 @@
 
 module Requirements
   class PathChecker
-    CACHE_OPTIONS = { expires_in: 5.minutes, race_condition_ttl: 10.seconds }.freeze
-
     attr_reader :document
 
     def initialize(document)
       @document = document
     end
 
-    def pre_preview_issues(rescue_api_errors: true)
+    def pre_preview_issues
       issues = []
 
       begin
@@ -18,8 +16,7 @@ module Requirements
           issues << Issue.new(:base_path, :conflict)
         end
       rescue GdsApi::BaseError => e
-        Rails.logger.error(e) if rescue_api_errors
-        raise unless rescue_api_errors
+        Rails.logger.error(e)
       end
 
       CheckerIssues.new(issues)
@@ -28,14 +25,10 @@ module Requirements
   private
 
     def base_path_conflict?
-      cache_id = "lookup_content_id.#{document.base_path}"
-
-      base_path_owner = Rails.cache.fetch(cache_id, CACHE_OPTIONS) do
-        GdsApi.publishing_api_v2.lookup_content_id(
-          base_path: document.base_path,
-          with_drafts: true,
-        )
-      end
+      base_path_owner = GdsApi.publishing_api_v2.lookup_content_id(
+        base_path: document.base_path,
+        with_drafts: true,
+      )
 
       base_path_owner && base_path_owner != document.content_id
     end

--- a/app/views/documents/show/_requirements.html.erb
+++ b/app/views/documents/show/_requirements.html.erb
@@ -12,8 +12,7 @@
 } %>
 
 <% if @document.publication_state == "changes_not_sent_to_draft" %>
-  <% draft_issues = Requirements::DocumentChecker.new(@document)
-    .pre_preview_issues %>
+  <% draft_issues = Requirements::DocumentChecker.new(@document).pre_preview_issues %>
 
   <% if draft_issues.any? %>
     <% if flash[:tried_to_preview] %>
@@ -31,8 +30,7 @@
 <% end %>
 
 <% if @document.publication_state == "sent_to_draft" %>
-  <% publish_issues = Requirements::DocumentChecker.new(@document)
-    .pre_publish_issues(rescue_api_errors: !flash[:tried_to_publish])  %>
+  <% publish_issues = Requirements::DocumentChecker.new(@document).pre_publish_issues %>
 
   <% if publish_issues.any? %>
     <% if flash[:tried_to_publish] %>

--- a/config/locales/en/requirements.yml
+++ b/config/locales/en/requirements.yml
@@ -37,3 +37,7 @@ en:
       too_long:
         form_message: "Enter an image caption that is fewer than %{max_length} characters long"
         summary_message: "Enter a shorter caption for “%{filename}”"
+    base_path:
+      conflict:
+        form_message: "Enter a title that does not conflict with an existing document"
+        summary_message: "Enter a title that does not conflict with an existing document"

--- a/config/locales/en/requirements.yml
+++ b/config/locales/en/requirements.yml
@@ -10,6 +10,9 @@ en:
       multiline:
         form_message: Remove line breaks from the title
         summary_message: Remove line breaks from the title
+      conflict:
+        form_message: "Enter a title that hasn’t been used before - the system cannot create a unique URL otherwise"
+        summary_message: "Enter a title that hasn’t been used before - the system cannot create a unique URL otherwise"
     summary:
       blank:
         form_message: Enter a summary
@@ -37,7 +40,3 @@ en:
       too_long:
         form_message: "Enter an image caption that is fewer than %{max_length} characters long"
         summary_message: "Enter a shorter caption for “%{filename}”"
-    base_path:
-      conflict:
-        form_message: "Enter a title that does not conflict with an existing document"
-        summary_message: "Enter a title that does not conflict with an existing document"

--- a/spec/formats/news_story_spec.rb
+++ b/spec/formats/news_story_spec.rb
@@ -28,6 +28,10 @@ RSpec.feature "Create a news story", format: true do
     fill_in "document[title]", with: "A great title"
     fill_in "document[summary]", with: "A great summary"
 
+    document = Document.first
+    base_path = document.document_type_schema.path_prefix + "/a-great-title"
+    publishing_api_has_lookups(base_path => document.content_id)
+
     click_on "Save"
     # TODO: Replace with https://github.com/bblimke/webmock/blob/d8686502442d9830dcccd24a1120ac08413d857a/lib/webmock/api.rb#L69 when it's released
     WebMock::RequestRegistry.instance.reset!

--- a/spec/formats/press_release_spec.rb
+++ b/spec/formats/press_release_spec.rb
@@ -28,6 +28,10 @@ RSpec.feature "Create a press release", format: true do
     fill_in "document[title]", with: "A great title"
     fill_in "document[summary]", with: "A great summary"
 
+    document = Document.first
+    base_path = document.document_type_schema.path_prefix + "/a-great-title"
+    publishing_api_has_lookups(base_path => document.content_id)
+
     click_on "Save"
     # TODO: Replace with https://github.com/bblimke/webmock/blob/d8686502442d9830dcccd24a1120ac08413d857a/lib/webmock/api.rb#L69 when it's released
     WebMock::RequestRegistry.instance.reset!

--- a/spec/services/requirements/path_checker_spec.rb
+++ b/spec/services/requirements/path_checker_spec.rb
@@ -34,11 +34,11 @@ RSpec.describe Requirements::PathChecker do
         publishing_api_has_lookups(document.base_path => SecureRandom.uuid)
         issues = Requirements::PathChecker.new(document).pre_preview_issues
 
-        form_message = issues.items_for(:base_path).first[:text]
-        expect(form_message).to eq(I18n.t!("requirements.base_path.conflict.form_message"))
+        form_message = issues.items_for(:title).first[:text]
+        expect(form_message).to eq(I18n.t!("requirements.title.conflict.form_message"))
 
-        summary_message = issues.items_for(:base_path, style: "summary").first[:text]
-        expect(summary_message).to eq(I18n.t!("requirements.base_path.conflict.summary_message"))
+        summary_message = issues.items_for(:title, style: "summary").first[:text]
+        expect(summary_message).to eq(I18n.t!("requirements.title.conflict.summary_message"))
       end
     end
 
@@ -54,7 +54,7 @@ RSpec.describe Requirements::PathChecker do
         schema = build :document_type_schema, check_path_conflict: true
         document = build :document, document_type: schema.id
         issues = Requirements::PathChecker.new(document).pre_preview_issues
-        expect(issues.items_for(:base_path)).to be_empty
+        expect(issues.items_for(:title)).to be_empty
       end
     end
   end

--- a/spec/services/requirements/path_checker_spec.rb
+++ b/spec/services/requirements/path_checker_spec.rb
@@ -49,20 +49,12 @@ RSpec.describe Requirements::PathChecker do
           .to_return(status: 503)
       end
 
-      it "returns no issues by default (ignore exception)" do
+      it "returns no issues (ignore exception)" do
         publishing_api_isnt_available
         schema = build :document_type_schema, check_path_conflict: true
         document = build :document, document_type: schema.id
         issues = Requirements::PathChecker.new(document).pre_preview_issues
         expect(issues.items_for(:base_path)).to be_empty
-      end
-
-      it "raises an exception if we specify it should" do
-        schema = build :document_type_schema, check_path_conflict: true
-        document = build :document, document_type: schema.id
-
-        expect { Requirements::PathChecker.new(document).pre_preview_issues(rescue_api_errors: false) }
-          .to raise_error GdsApi::BaseError
       end
     end
   end

--- a/spec/services/requirements/path_checker_spec.rb
+++ b/spec/services/requirements/path_checker_spec.rb
@@ -1,0 +1,69 @@
+# frozen_string_literal: true
+
+RSpec.describe Requirements::PathChecker do
+  describe "#pre_preview_issues" do
+    context "when the format does not check paths" do
+      it "returns no issues" do
+        schema = build :document_type_schema
+        document = build :document, document_type: schema.id
+        issues = Requirements::PathChecker.new(document).pre_preview_issues
+        expect(issues.items).to be_empty
+      end
+    end
+
+    context "when the Publishing API is available" do
+      it "returns no issues for unreserved paths" do
+        schema = build :document_type_schema, check_path_conflict: true
+        document = build :document, document_type: schema.id
+        publishing_api_has_lookups(document.base_path => nil)
+        issues = Requirements::PathChecker.new(document).pre_preview_issues
+        expect(issues.items).to be_empty
+      end
+
+      it "returns no issues if the document owns the path" do
+        schema = build :document_type_schema, check_path_conflict: true
+        document = build :document, document_type: schema.id
+        publishing_api_has_lookups(document.base_path => document.content_id)
+        issues = Requirements::PathChecker.new(document).pre_preview_issues
+        expect(issues.items).to be_empty
+      end
+
+      it "returns an issue if the base_path conflicts" do
+        schema = build :document_type_schema, check_path_conflict: true
+        document = build :document, document_type: schema.id
+        publishing_api_has_lookups(document.base_path => SecureRandom.uuid)
+        issues = Requirements::PathChecker.new(document).pre_preview_issues
+
+        form_message = issues.items_for(:base_path).first[:text]
+        expect(form_message).to eq(I18n.t!("requirements.base_path.conflict.form_message"))
+
+        summary_message = issues.items_for(:base_path, style: "summary").first[:text]
+        expect(summary_message).to eq(I18n.t!("requirements.base_path.conflict.summary_message"))
+      end
+    end
+
+    context "when the Publishing API is down" do
+      before do
+        # TODO: add this stub as part of the V2 helpers
+        stub_request(:post, GdsApi::TestHelpers::PublishingApi::PUBLISHING_API_ENDPOINT + "/lookup-by-base-path")
+          .to_return(status: 503)
+      end
+
+      it "returns no issues by default (ignore exception)" do
+        publishing_api_isnt_available
+        schema = build :document_type_schema, check_path_conflict: true
+        document = build :document, document_type: schema.id
+        issues = Requirements::PathChecker.new(document).pre_preview_issues
+        expect(issues.items_for(:base_path)).to be_empty
+      end
+
+      it "raises an exception if we specify it should" do
+        schema = build :document_type_schema, check_path_conflict: true
+        document = build :document, document_type: schema.id
+
+        expect { Requirements::PathChecker.new(document).pre_preview_issues(rescue_api_errors: false) }
+          .to raise_error GdsApi::BaseError
+      end
+    end
+  end
+end

--- a/spec/services/requirements/path_checker_spec.rb
+++ b/spec/services/requirements/path_checker_spec.rb
@@ -44,13 +44,10 @@ RSpec.describe Requirements::PathChecker do
 
     context "when the Publishing API is down" do
       before do
-        # TODO: add this stub as part of the V2 helpers
-        stub_request(:post, GdsApi::TestHelpers::PublishingApi::PUBLISHING_API_ENDPOINT + "/lookup-by-base-path")
-          .to_return(status: 503)
+        publishing_api_isnt_available
       end
 
       it "returns no issues (ignore exception)" do
-        publishing_api_isnt_available
         schema = build :document_type_schema, check_path_conflict: true
         document = build :document, document_type: schema.id
         issues = Requirements::PathChecker.new(document).pre_preview_issues

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -11,6 +11,7 @@ require "govuk_schemas/rspec_matchers"
 require "simplecov"
 require "webmock/rspec"
 require "gds_api/test_helpers/publishing_api_v2"
+require "gds_api/test_helpers/publishing_api"
 require "gds_api/test_helpers/asset_manager"
 
 Dir[Rails.root.join("spec", "support", "**", "*.rb")].each { |f| require f }

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -11,7 +11,6 @@ require "govuk_schemas/rspec_matchers"
 require "simplecov"
 require "webmock/rspec"
 require "gds_api/test_helpers/publishing_api_v2"
-require "gds_api/test_helpers/publishing_api"
 require "gds_api/test_helpers/asset_manager"
 
 Dir[Rails.root.join("spec", "support", "**", "*.rb")].each { |f| require f }


### PR DESCRIPTION
https://trello.com/b/mn2MqH3M/publishing-workflow-q3-18-19-doing

This is my first attempt at doing an external check for URL conflicts. One of the things I'm not keen on is that we're running this (not inexpensive) check every time we generate a preview, and perhaps we should just do it on the edit page and display an error there if the Publishing API is down.

What do people think?

On the other hand, I wanted to keep the way we do requirements consistent and avoid showing the user nasty error messages they can't do anything about - having an error on the edit page would stop people creating documents if the Publishing API is down.