### PR TITLE
Remove need for pre-release features permission on topics

### DIFF
--- a/app/controllers/document_topics_controller.rb
+++ b/app/controllers/document_topics_controller.rb
@@ -2,7 +2,6 @@
 
 class DocumentTopicsController < ApplicationController
   include GDS::SSO::ControllerMethods
-  before_action { authorise_user!(User::PRE_RELEASE_FEATURES_PERMISSION) }
 
   rescue_from GdsApi::BaseError do |e|
     Rails.logger.error(e)


### PR DESCRIPTION
This seems to have got missed in https://github.com/alphagov/content-publisher/pull/467