### PR TITLE
Render topics on summary page using bread crumb

### DIFF
--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -21,6 +21,7 @@
 @import "components/image-meta";
 @import "components/image-cropper";
 @import "components/side-nav";
+@import "components/topic-breadcrumb-trail";
 
 @import "utilities/display";
 @import "utilities/overwrites";

--- a/app/assets/stylesheets/components/_topic-breadcrumb-trail.scss
+++ b/app/assets/stylesheets/components/_topic-breadcrumb-trail.scss
@@ -1,0 +1,9 @@
+@import "govuk-frontend/settings/all";
+@import "govuk-frontend/helpers/all";
+@import "govuk_publishing_components/components/breadcrumbs";
+
+.topic-breadcrumb-trail {
+  .govuk-breadcrumbs__list {
+    margin-bottom: 20px;
+  }
+}

--- a/app/views/documents/show/_topics.html.erb
+++ b/app/views/documents/show/_topics.html.erb
@@ -1,11 +1,13 @@
 <% begin %>
   <% breadcrumbs = capture do %>
     <% if @document.topics.any? %>
-      <div class="topic-breadcrumb">
+      <div class="topic-breadcrumb-trail">
         <% @document.topics.each do |topic| %>
-          <ol>
+          <ol class="govuk-breadcrumbs__list">
             <% topic.breadcrumb.each do |crumb_topic| %>
-              <li><%= crumb_topic.title %></li>
+              <li class="govuk-breadcrumbs__list-item" aria-current="false">
+                <%= crumb_topic.title %>
+              </li>
             <% end %>
           </ol>
         <% end %>

--- a/spec/features/editing_topics/show_topics_spec.rb
+++ b/spec/features/editing_topics/show_topics_spec.rb
@@ -11,7 +11,7 @@ RSpec.feature "Show the topics for a document" do
 
     when_the_document_has_a_topic
     and_i_visit_the_document_page
-    then_i_see_the_topic_breadcrumb
+    then_i_see_the_topic_breadcrumb_trail
   end
 
   def given_there_is_a_document
@@ -45,8 +45,8 @@ RSpec.feature "Show the topics for a document" do
     publishing_api_has_taxonomy
   end
 
-  def then_i_see_the_topic_breadcrumb
-    within("#topics .topic-breadcrumb") do
+  def then_i_see_the_topic_breadcrumb_trail
+    within("#topics .topic-breadcrumb-trail") do
       expect(page).to have_content("Level One Topic")
       expect(page).to have_content("Level Two Topic")
       expect(page).to have_content("Level Three Topic")


### PR DESCRIPTION
Changing appearance of each topic so that rather than being rendered as an enumerated list
of progressively more specific terms, it would render it like "A > B > C" on one line,
in much the way a breadcrumb for reaching a specific web page appears elsewhere on GOV.UK
forms.

GOV.UK's govuk-breadcrumbs__list helps render a single topic.  But this class looks like
it was not designed to render well within a list of breadcrumb lists.  In order to correct
this, I made a new component that specifies that for any new govuk-breadcrumb__list.
The component adds vertical space between successive topics so it looks more readable.

See Trello card: https://trello.com/c/QHbq9VOt/455-show-topics-as-breadcrumbs-in-the-summary-page