### PR TITLE
Fix destructive link styling

### DIFF
--- a/app/assets/stylesheets/core/_link.scss
+++ b/app/assets/stylesheets/core/_link.scss
@@ -5,7 +5,13 @@
 .govuk-link.app-link--destructive {
   color: $govuk-error-colour;
 
-  &:hover {
+  &:link,
+  &:visited {
+    color: $govuk-error-colour;
+  }
+
+  &:hover,
+  &:active {
     color: govuk-colour("bright-red");
   }
 }


### PR DESCRIPTION
Trello: https://trello.com/c/98iyJWkI/536-fix-override-on-destructive-links-that-is-causing-them-to-be-blue-instead-of-red-hover-is-still-red

This style was getting overriden by govuk-frontend as the :link selector
is more specific.

Before: 
<img width="312" alt="screen shot 2018-11-23 at 15 42 30" src="https://user-images.githubusercontent.com/282717/48951458-8a28c400-ef36-11e8-8001-47addef156b3.png">

After:
<img width="315" alt="screen shot 2018-11-23 at 15 43 07" src="https://user-images.githubusercontent.com/282717/48951463-8dbc4b00-ef36-11e8-860d-69fa4d0c9a8e.png">
