### PR TITLE
Fix markdown preview not working on Microsoft Edge

### DIFF
--- a/app/assets/javascripts/components/markdown-editor.js
+++ b/app/assets/javascripts/components/markdown-editor.js
@@ -55,11 +55,10 @@ MarkdownEditor.prototype.handlePreviewButton = function (event) {
     .then(function (text) {
       $preview.innerHTML = text
       MarkdownEditor.prototype.setTargetBlank($preview)
+      $preview.classList.add('app-c-markdown-editor__govspeak--rendered')
     })
     .catch(function () {
       $preview.innerHTML = 'Error previewing content'
-    })
-    .finally(function () {
       $preview.classList.add('app-c-markdown-editor__govspeak--rendered')
     })
 


### PR DESCRIPTION
https://trello.com/c/NZ6oOwYo/461-preview-tab-on-the-edit-content-page-doesnt-work-in-ie-11-and-edge

Previously we used Promise.prototype.finally to ensure we added a
particular CSS class irrespective of the outcome of the promise.
Unfortuantely this is only supported in the newest versions of MS Edge.

This moves and duplicates this one line into the .then and .catch blocks
as an alternative to using .finally. This is the only place we use this
method in the app, so it doesn't seem worth fixing with a polyfill.