### PR TITLE
Render topics using GOV.UK's breadcrumb component

### DIFF
--- a/app/assets/stylesheets/utilities/_overwrites.scss
+++ b/app/assets/stylesheets/utilities/_overwrites.scss
@@ -78,3 +78,9 @@
     font-size: inherit;
   }
 }
+
+.app-selected-topics {
+  .govuk-breadcrumbs {
+    @include govuk-font(19);
+  }
+}

--- a/app/views/documents/show/_topics.html.erb
+++ b/app/views/documents/show/_topics.html.erb
@@ -1,7 +1,7 @@
 <% begin %>
   <% breadcrumbs = capture do %>
     <% if @document.topics.any? %>
-      <ul class="govuk-list">
+      <ul class="app-selected-topics govuk-list">
         <% @document.topics.each do |topic| %>
           <li>
             <%= render "govuk_publishing_components/components/breadcrumbs", {

--- a/app/views/documents/show/_topics.html.erb
+++ b/app/views/documents/show/_topics.html.erb
@@ -1,15 +1,15 @@
 <% begin %>
   <% breadcrumbs = capture do %>
     <% if @document.topics.any? %>
-      <div class="topic-breadcrumb">
+      <ul class="govuk-list">
         <% @document.topics.each do |topic| %>
-          <ol>
-            <% topic.breadcrumb.each do |crumb_topic| %>
-              <li><%= crumb_topic.title %></li>
-            <% end %>
-          </ol>
+          <li>
+            <%= render "govuk_publishing_components/components/breadcrumbs", {
+                breadcrumbs: topic.breadcrumb.map { |crumb_topic| { title: crumb_topic.title } }
+            } %>
+          </li>
         <% end %>
-      </div>
+      </ul>
     <% else %>
       <%= t("documents.show.topics.no_topics") %>
     <% end %>

--- a/spec/features/editing_topics/show_topics_spec.rb
+++ b/spec/features/editing_topics/show_topics_spec.rb
@@ -46,7 +46,7 @@ RSpec.feature "Show the topics for a document" do
   end
 
   def then_i_see_the_topic_breadcrumb
-    within("#topics .topic-breadcrumb") do
+    within("#topics .govuk-list") do
       expect(page).to have_content("Level One Topic")
       expect(page).to have_content("Level Two Topic")
       expect(page).to have_content("Level Three Topic")

--- a/spec/features/editing_topics/show_topics_spec.rb
+++ b/spec/features/editing_topics/show_topics_spec.rb
@@ -46,7 +46,7 @@ RSpec.feature "Show the topics for a document" do
   end
 
   def then_i_see_the_topic_breadcrumb
-    within("#topics .govuk-list") do
+    within("#topics") do
       expect(page).to have_content("Level One Topic")
       expect(page).to have_content("Level Two Topic")
       expect(page).to have_content("Level Three Topic")


### PR DESCRIPTION
Changing the way of rendering a topic from an enumerated list of more
specific categories to rendering it like "A > B > C", in the same way
breadcrumb trails are used to show web page path ways to users in other
parts of GOV.UK.