### PR TITLE
Remove contenteditable

### DIFF
--- a/app/assets/javascripts/components/markdown-toolbar.js
+++ b/app/assets/javascripts/components/markdown-toolbar.js
@@ -583,13 +583,11 @@
     var after = textarea.value.slice(textarea.selectionEnd);
 
     if (canInsertText === null || canInsertText === true) {
-      textarea.contentEditable = 'true';
       try {
         canInsertText = document.execCommand('insertText', false, text);
       } catch (error) {
         canInsertText = false;
       }
-      textarea.contentEditable = 'false';
     }
 
     if (canInsertText && !textarea.value.slice(0, textarea.selectionStart).endsWith(text)) {


### PR DESCRIPTION
as it currently blocks users from inserting text after using the injectors

### Note
This change was done in the main repository: https://github.com/alphagov/markdown-toolbar-element/pull/2. This PR updates the compiled JavaScript file.

https://trello.com/c/fLfbI7Vi