### PR TITLE
Fix ordered list injector

### DIFF
--- a/app/assets/javascripts/components/markdown-toolbar.js
+++ b/app/assets/javascripts/components/markdown-toolbar.js
@@ -397,7 +397,7 @@
 
       var _this14 = _possibleConstructorReturn(this, (MarkdownOrderedListButtonElement.__proto__ || Object.getPrototypeOf(MarkdownOrderedListButtonElement)).call(this));
 
-      styles.set(_this14, { prefix: '1. ', multiline: true, orderedList: true });
+      styles.set(_this14, { prefix: '1. ', multiline: true, surroundWithNewlines: true, orderedList: true });
       return _this14;
     }
 
@@ -620,7 +620,7 @@
     var text = textarea.value.slice(textarea.selectionStart, textarea.selectionEnd);
 
     var result = void 0;
-    if (styleArgs.orderedList) {
+    if (styleArgs.orderedList && text) {
       result = orderedList(textarea);
     } else if (styleArgs.multiline && isMultipleLines(text)) {
       result = multilineStyle(textarea, styleArgs);


### PR DESCRIPTION
Run the `orderedList` style args only when we have a selection, otherwise we default on a simple prefixing of the current line.

### Note
This change was done in the main repository: https://github.com/alphagov/markdown-toolbar-element/pull/3. This PR updates the compiled JavaScript file.

https://trello.com/c/37P9Kykk