### PR TITLE
Append _govspeak to translation if it's available

### DIFF
--- a/app/formats/document_types.yml
+++ b/app/formats/document_types.yml
@@ -2,7 +2,7 @@
 - id: news_story
   label: News story
   description: "News written for GOV.UK which users need, can act on, and can’t get from other sources."
-  hint: |
+  hint_govspeak: |
     Do not include advice in news stories. Do not use to promote other content.
     Read the full [guidance on news stories](https://www.gov.uk/guidance/content-design/content-types#news-story).
   path_prefix: /government/news
@@ -14,13 +14,13 @@
   guidance:
     - id: title
       title: Create a news title
-      body: The title must make clear what the content offers users. Use the words your users do to help them find this. Avoid wordplay or teases.
+      body_govspeak: The title must make clear what the content offers users. Use the words your users do to help them find this. Avoid wordplay or teases.
     - id: summary
       title: Writing a news summary
-      body: The summary explains the main point of the content and it should end with a full stop. Avoid repeating the first line of the body.
+      body_govspeak: The summary explains the main point of the content and it should end with a full stop. Avoid repeating the first line of the body.
     - id: body
       title: Writing news
-      body: |
+      body_govspeak: |
         Tell the story in the first lines with the most important information at the top. Use short words, short sentences, and short paragraphs. Use subheadings in longer content.
 
         [Guidance on news stories](https://www.gov.uk/guidance/content-design/content-types#news-story){:target="_blank"}
@@ -62,7 +62,7 @@
 - id: press_release
   label: Press release
   description: "Unedited press releases as sent to the media, and official statements from the organisation."
-  hint: |
+  hint_govspeak: |
     Do not use to promote other content. Statements to Parliament should use the Speech document type.
     Read the full [guidance on press releases](https://www.gov.uk/guidance/content-design/content-types#press-release).
   path_prefix: /government/news
@@ -74,13 +74,13 @@
   guidance:
     - id: title
       title: Title
-      body: The title should be unique and specific. It must make clear what the content offers users. Use the words your users do to help them find this. Avoid wordplay or teases.
+      body_govspeak: The title should be unique and specific. It must make clear what the content offers users. Use the words your users do to help them find this. Avoid wordplay or teases.
     - id: summary
       title: Summary
-      body: The summary should explain the main point of the story. It is the first line of the story so don’t repeat it in the body and end with a full stop.
+      body_govspeak: The summary should explain the main point of the story. It is the first line of the story so don’t repeat it in the body and end with a full stop.
     - id: body
       title: Writing a press release
-      body: |
+      body_govspeak: |
         Use short words, short sentences, and short paragraphs. Use subheadings in longer content. Avoid 'notes to editors'.
 
         [Guidance on press releases](https://www.gov.uk/guidance/content-design/content-types#press-release){:target="_blank"}

--- a/app/services/document_type_schema.rb
+++ b/app/services/document_type_schema.rb
@@ -2,7 +2,7 @@
 
 class DocumentTypeSchema
   attr_reader :contents, :id, :label, :managed_elsewhere, :publishing_metadata,
-    :path_prefix, :tags, :guidance, :description, :hint, :lead_image, :topics
+    :path_prefix, :tags, :guidance_govspeak, :description, :hint, :lead_image, :topics
 
   def initialize(params = {})
     @id = params["id"]
@@ -52,7 +52,7 @@ class DocumentTypeSchema
 
   class Guidance
     include ActiveModel::Model
-    attr_accessor :id, :title, :body
+    attr_accessor :id, :title, :body_govspeak
   end
 
   class PublishingMetadata

--- a/app/views/document_images/edit.html.erb
+++ b/app/views/document_images/edit.html.erb
@@ -38,7 +38,7 @@
         title: t("document_images.edit.form_labels.alt_text"),
       } do %>
         <%= render "govuk_publishing_components/components/govspeak" do %>
-          <%= govspeak_to_html t("document_images.edit.guidance.alt_text") %>
+          <%= govspeak_to_html t("document_images.edit.guidance.alt_text_govspeak") %>
         <% end %>
       <% end %>
     </div>
@@ -66,7 +66,7 @@
         title: t("document_images.edit.form_labels.caption"),
       } do %>
         <%= render "govuk_publishing_components/components/govspeak" do %>
-          <%= govspeak_to_html t("document_images.edit.guidance.caption") %>
+          <%= govspeak_to_html t("document_images.edit.guidance.caption_govspeak") %>
         <% end %>
       <% end %>
     </div>
@@ -93,7 +93,7 @@
         title: t("document_images.edit.form_labels.credit"),
       } do %>
         <%= render "govuk_publishing_components/components/govspeak" do %>
-          <%= govspeak_to_html t("document_images.edit.guidance.credit") %>
+          <%= govspeak_to_html t("document_images.edit.guidance.credit_govspeak") %>
         <% end %>
       <% end %>
     </div>

--- a/app/views/document_images/index.html.erb
+++ b/app/views/document_images/index.html.erb
@@ -21,7 +21,7 @@
         } %>
 
         <%= render "govuk_publishing_components/components/govspeak" do %>
-          <%= govspeak_to_html t("document_images.index.description") %>
+          <%= govspeak_to_html t("document_images.index.description_govspeak") %>
         <% end %>
 
         <%= render "govuk_publishing_components/components/button", {

--- a/app/views/documents/edit.html.erb
+++ b/app/views/documents/edit.html.erb
@@ -44,7 +44,7 @@
           id: "document-title-guidance",
           title: @document.document_type_schema.guidance_for("title").title
         } do %>
-          <p class="govuk-body"><%= @document.document_type_schema.guidance_for("title").body %></p>
+          <p class="govuk-body"><%= @document.document_type_schema.guidance_for("title").body_govspeak %></p>
         <% end %>
       </div>
     <% end %>
@@ -72,7 +72,7 @@
           id: "document-summary-guidance",
           title: @document.document_type_schema.guidance_for("summary").title
         } do %>
-          <p class="govuk-body"><%= @document.document_type_schema.guidance_for("summary").body %></p>
+          <p class="govuk-body"><%= @document.document_type_schema.guidance_for("summary").body_govspeak %></p>
         <% end %>
       </div>
     </div>

--- a/app/views/documents/fields/_govspeak_input.html.erb
+++ b/app/views/documents/fields/_govspeak_input.html.erb
@@ -25,7 +25,7 @@
         title: document.document_type_schema.guidance_for(schema.id).title
       } do %>
         <%= render "govuk_publishing_components/components/govspeak" do %>
-          <%= govspeak_to_html document.document_type_schema.guidance_for(schema.id).body %>
+          <%= govspeak_to_html document.document_type_schema.guidance_for(schema.id).body_govspeak %>
         <% end %>
 
         <h3 class="govuk-heading-s"><%= t("documents.edit.fields.govspeak.title") %></h3>

--- a/app/views/documents/index.html.erb
+++ b/app/views/documents/index.html.erb
@@ -21,7 +21,7 @@
 
     <% if @documents.none? %>
       <div class="govuk-body">
-        <%= govspeak_to_html t("documents.index.search_results.guidance") %>
+        <%= govspeak_to_html t("documents.index.search_results.guidance_govspeak") %>
       </div>
     <% else %>
       <%= render "documents/index/results" %>

--- a/app/views/documents/show/_actions.html.erb
+++ b/app/views/documents/show/_actions.html.erb
@@ -10,7 +10,7 @@
       <% end %>
     <% elsif @document.publication_state == "error_sending_to_draft" %>
       <%= render "govuk_publishing_components/components/govspeak" do %>
-        <%= govspeak_to_html t("documents.show.sidebar.error_creating_preview") %>
+        <%= govspeak_to_html t("documents.show.sidebar.error_creating_preview_govspeak") %>
       <% end %>
 
       <%= form_tag create_preview_path(@document) do %>
@@ -18,7 +18,7 @@
       <% end %>
     <% elsif @document.publication_state == "error_deleting_draft" %>
       <%= render "govuk_publishing_components/components/govspeak" do %>
-        <%= govspeak_to_html t("documents.show.sidebar.error_deleting_draft") %>
+        <%= govspeak_to_html t("documents.show.sidebar.error_deleting_draft_govspeak") %>
       <% end %>
 
       <%= form_tag document_path(@document), method: :delete do %>
@@ -26,7 +26,7 @@
       <% end %>
     <% elsif @document.publication_state == "error_sending_to_live" %>
       <%= render "govuk_publishing_components/components/govspeak" do %>
-        <%= govspeak_to_html t("documents.show.sidebar.error_publishing_live") %>
+        <%= govspeak_to_html t("documents.show.sidebar.error_publishing_live_govspeak") %>
       <% end %>
 
       <%= render "govuk_publishing_components/components/button", text: "Retry publishing", href: publish_document_path(@document) %>

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -59,7 +59,7 @@
         message: flash["alert_with_description"].fetch("title"),
         description: capture do
           render "govuk_publishing_components/components/govspeak" do
-            govspeak_to_html(flash["alert_with_description"].fetch("description"))
+            govspeak_to_html(flash["alert_with_description"].fetch("description_govspeak"))
           end
         end
       } %>

--- a/app/views/new_document/choose_document_type.html.erb
+++ b/app/views/new_document/choose_document_type.html.erb
@@ -11,7 +11,7 @@
             value: document_type.id,
             text: document_type.label,
             hint_text: document_type.description,
-            conditional: document_type.hint ? tag.div(govspeak_to_html(document_type.hint), class: "govuk-body") : nil,
+            conditional: document_type.hint ? tag.div(govspeak_to_html(document_type.hint_govspeak), class: "govuk-body") : nil,
             bold: true,
           }
         }

--- a/app/views/publish_document/published.html.erb
+++ b/app/views/publish_document/published.html.erb
@@ -10,7 +10,7 @@
       } %>
 
       <%= render "govuk_publishing_components/components/govspeak" do %>
-        <%= govspeak_to_html t("publish_document.published.reviewed.body", title: @document.title) %>
+        <%= govspeak_to_html t("publish_document.published.reviewed.body_govspeak", title: @document.title) %>
 
         <%= link_to(nil, DocumentUrl.new(@document).public_url, class: "govuk-link") %>
       <% end %>
@@ -20,7 +20,7 @@
       } %>
 
       <%= render "govuk_publishing_components/components/govspeak" do %>
-        <%= govspeak_to_html t("publish_document.published.published_without_review.body", title: @document.title) %>
+        <%= govspeak_to_html t("publish_document.published.published_without_review.body_govspeak", title: @document.title) %>
 
         <p> <%= t("publish_document.published.published_without_review.send_label") %> </p>
 

--- a/app/views/publisher_information/publisher_updates.html.erb
+++ b/app/views/publisher_information/publisher_updates.html.erb
@@ -5,7 +5,7 @@
     <h1 class='govuk-heading-l page-title'><%= t("publisher_information.publisher_updates.title") %></h1>
 
     <%= render "govuk_publishing_components/components/govspeak" do %>
-        <%= govspeak_to_html t("publisher_information.publisher_updates.summary") %>
+        <%= govspeak_to_html t("publisher_information.publisher_updates.summary_govspeak") %>
     <% end %>
     <%= render "govuk_publishing_components/components/govspeak" do %>
         <%= govspeak_to_html File.read("app/views/publisher_information/publisher_updates.govspeak.md") %>

--- a/config/locales/en/document_images/edit.yml
+++ b/config/locales/en/document_images/edit.yml
@@ -9,6 +9,6 @@ en:
       flashes:
         requirements: You need to
       guidance:
-        alt_text: A simple and specific description of what the image shows. This helps screen-readers and search engines.
-        caption: This text appears on the page under the image.
-        credit: You must have the rights to use this image. Images should be credited to their source. For example, Getty Images. Open Government Licence (OGL) images do not need to be credited.
+        alt_text_govspeak: A simple and specific description of what the image shows. This helps screen-readers and search engines.
+        caption_govspeak: This text appears on the page under the image.
+        credit_govspeak: You must have the rights to use this image. Images should be credited to their source. For example, Getty Images. Open Government Licence (OGL) images do not need to be credited.

--- a/config/locales/en/document_images/index.yml
+++ b/config/locales/en/document_images/index.yml
@@ -2,7 +2,7 @@ en:
   document_images:
     index:
       title: "Images for ‘%{title}’"
-      description: Images can be jpg, png or gif files. [Full guidance on images](https://www.gov.uk/guidance/how-to-publish-on-gov-uk/images-and-videos)
+      description_govspeak: Images can be jpg, png or gif files. [Full guidance on images](https://www.gov.uk/guidance/how-to-publish-on-gov-uk/images-and-videos)
       upload_image: Upload an image
       alt_text: Alt text
       caption: Image caption
@@ -21,4 +21,4 @@ en:
         deleted: "Image “%{file}” has been deleted"
         api_error:
           title: Something has gone wrong
-          description: Something went wrong when uploading your file. Please try again or [raise a support request](https://support.publishing.service.gov.uk/technical_fault_report/new).
+          description_govspeak: Something went wrong when uploading your file. Please try again or [raise a support request](https://support.publishing.service.gov.uk/technical_fault_report/new).

--- a/config/locales/en/document_topics/edit.yml
+++ b/config/locales/en/document_topics/edit.yml
@@ -6,4 +6,4 @@ en:
       flashes:
         topic_update_conflict:
           title: Somebody else changed the topics before you could
-          description:  Your changes have not been saved. Please try again.
+          description_govspeak:  Your changes have not been saved. Please try again.

--- a/config/locales/en/documents/index.yml
+++ b/config/locales/en/documents/index.yml
@@ -19,7 +19,7 @@ en:
           other: "<strong>%{count}</strong> documents"
         untitled: No title
         page_info: "%{page} of %{pages}"
-        guidance: |
+        guidance_govspeak: |
           Improve your search results:
 
             * removing filters

--- a/config/locales/en/documents/show.yml
+++ b/config/locales/en/documents/show.yml
@@ -27,11 +27,11 @@ en:
           minor: There’s no change to the published information. For example, spelling corrections.
           major: There’s a change to the published information.
       sidebar:
-        error_creating_preview: |
+        error_creating_preview_govspeak: |
           Something went wrong when creating the preview page. Please try again or [raise a support request](https://support.publishing.service.gov.uk/technical_fault_report/new).
-        error_publishing_live: |
+        error_publishing_live_govspeak: |
           Something went wrong when publishing. Please try again or [raise a support request](https://support.publishing.service.gov.uk/technical_fault_report/new).
-        error_deleting_draft: |
+        error_deleting_draft_govspeak: |
           Something went wrong when deleting your draft. Please try again or [raise a support request](https://support.publishing.service.gov.uk/technical_fault_report/new).
       lead_image:
         title: Lead image
@@ -58,13 +58,13 @@ en:
           error: Before you can publish this document you need to
         preview_error:
           title: Something has gone wrong
-          description: Something went wrong when creating the preview page. Please try again or [raise a support request](https://support.publishing.service.gov.uk/technical_fault_report/new).
+          description_govspeak: Something went wrong when creating the preview page. Please try again or [raise a support request](https://support.publishing.service.gov.uk/technical_fault_report/new).
         publish_error:
           title: Something has gone wrong
-          description: Something went wrong when publishing. Please try again or [raise a support request](https://support.publishing.service.gov.uk/technical_fault_report/new).
+          description_govspeak: Something went wrong when publishing. Please try again or [raise a support request](https://support.publishing.service.gov.uk/technical_fault_report/new).
         2i_error:
           title: Something has gone wrong
-          description: Something went wrong when submitting your content for 2i review. Please try again or [raise a support request](https://support.publishing.service.gov.uk/technical_fault_report/new).
+          description_govspeak: Something went wrong when submitting your content for 2i review. Please try again or [raise a support request](https://support.publishing.service.gov.uk/technical_fault_report/new).
         approved: Content has been reviewed and approved
         submitted_for_review:
           title: Content has been marked as ready for 2i review
@@ -72,7 +72,7 @@ en:
         delete_draft: Are you sure you want to delete this draft
         delete_draft_error:
           title: Something has gone wrong
-          description: Something went wrong when deleting your draft. Please try again or [raise a support request](https://support.publishing.service.gov.uk/technical_fault_report/new).
+          description_govspeak: Something went wrong when deleting your draft. Please try again or [raise a support request](https://support.publishing.service.gov.uk/technical_fault_report/new).
         lead_image:
           added: "Image “%{file}” has been uploaded and selected as the lead image"
           chosen: "Image “%{file}” has been selected as the lead image"
@@ -81,4 +81,4 @@ en:
         topics_updated: Topics updated on all editions
         topic_update_error:
           title: Something has gone wrong
-          description: Something went wrong when saving your changes. Please try again or [raise a support request](https://support.publishing.service.gov.uk/technical_fault_report/new).
+          description_govspeak: Something went wrong when saving your changes. Please try again or [raise a support request](https://support.publishing.service.gov.uk/technical_fault_report/new).

--- a/config/locales/en/publish_document/published.yml
+++ b/config/locales/en/publish_document/published.yml
@@ -4,14 +4,14 @@ en:
       title: Content has been published
       reviewed:
         title: Content has been published
-        body: |
+        body_govspeak: |
           ‘%{title}’ has been published on GOV.UK.
 
           It may take 5 minutes to appear live.
 
       published_without_review:
         title: Content has been published but still needs 2i review
-        body: |
+        body_govspeak: |
           ‘%{title}’ has been published on GOV.UK.
 
           It may take 5 minutes to appear live.

--- a/config/locales/en/publisher_information/publisher_updates.yml
+++ b/config/locales/en/publisher_information/publisher_updates.yml
@@ -2,4 +2,4 @@ en:
   publisher_information:
     publisher_updates:
       title: What's new in Content Publisher
-      summary: Summary of updates to Content Publisher, content design guidance, or the design of GOV.UK.
+      summary_govspeak: Summary of updates to Content Publisher, content design guidance, or the design of GOV.UK.

--- a/docs/adr/0004-editing-microcopy.md
+++ b/docs/adr/0004-editing-microcopy.md
@@ -46,6 +46,7 @@ Although we could use translations to extract all of the strings in the applicat
    * **Domain data** that's static is extracted into custom YAML files. This application has two static models (DocumentTypeSchema and SupertypeSchema) that encapsulate domain concepts where the data is part of the application. We think domain data - whether it's a backend setting or a label - should be defined in one place so it can change together. In this application, we've chosen to store the backing files for the two static models in `app/formats`.
    * **Global strings** (states and validation messages) are extracted using translations. As these strings aren't page-specific, we put them at the top-level of the translation hierarchy (in `states.yml` and `validations.yml`).
    * **All other strings** are extracted using translations, in a hierarchy that follows the structure of the `app/views` directory. For example, the above example relates to `app/views/publish_document/published.html.erb`.
+   * **Small amounts of govspeak and HTML** are extracted using translations as for other strings, with '\_html' or '\_govspeak' appended to the final component of the key to indicate they support rich text.
 
 Every instance of a string in the tests has been replaced according to the above rules, such that the tests continue to pass when an extracted string is changed. **Link and button labels** are not replaced, as they are not extracted in the code.
 


### PR DESCRIPTION
https://trello.com/c/AiMKvMd2/424-update-naming-of-html-and-govspeak-fields-in-locale-and-config-files

This updates every locale key (or domain model attribute) that refers to
text rendered with govspeak, to better indicate where govspeak is
supported and where it's not. I've also updated the ADR with this
additional rule so that this new convention is documented.