### PR TITLE
Word-wrap SCSS helper applied to summary component

### DIFF
--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -1,6 +1,7 @@
 @import "govuk_publishing_components/all_components";
 
 @import "core/link";
+@import "helpers/app-word-wrap";
 
 @import "objects/grid";
 @import "objects/history";

--- a/app/assets/stylesheets/components/_summary.scss
+++ b/app/assets/stylesheets/components/_summary.scss
@@ -109,6 +109,7 @@
 
 .app-c-summary__answer {
   padding-bottom: govuk-em(9, 19);
+  @include app-word-wrap;
 }
 
 .app-c-summary__change {

--- a/app/assets/stylesheets/helpers/_app-word-wrap.scss
+++ b/app/assets/stylesheets/helpers/_app-word-wrap.scss
@@ -1,0 +1,13 @@
+// based on https://css-tricks.com/snippets/css/prevent-long-urls-from-breaking-out-of-container/
+@mixin app-word-wrap() {
+  // scss-lint:disable DuplicateProperty
+  overflow-wrap: break-word;
+  word-wrap: break-word;
+  -ms-word-break: break-all;
+  word-break: break-all;
+  word-break: break-word;
+  -ms-hyphens: auto;
+  -moz-hyphens: auto;
+  -webkit-hyphens: auto;
+  hyphens: auto;
+}


### PR DESCRIPTION
Trello: https://trello.com/c/Wyvjf3eH/475-entering-long-words-into-the-title-summary-body-displays-over-other-content-on-the-page

This borrows from this helpful CSS tricks article [1] a technique to
break up long lines of text that can break our applications layout.
Aside from extreme user testing (e.g. massive 100+ character words) the
most likely place we will see this is when a user has a URL in their
text.

This resolves the issue by forcing the word wrap. This does
unfortunately have a consequence that in IE11/Edge/Firefox we get breaks
in the middle of words rather than at the end (as they don't support the
non-standard property of break-word). I don't think there's a way around
that so we may have to decide to just drop this functionality if it
provides more confusion than problems it resolves.

[1]: https://css-tricks.com/snippets/css/prevent-long-urls-from-breaking-out-of-container/


This works with no problems in Chrome:

<img width="660" alt="screen shot 2018-11-26 at 17 35 46" src="https://user-images.githubusercontent.com/282717/49031412-bdbb5680-f1a1-11e8-8c4a-14d6ffc8c416.png">

breaks words in Firefox/Edge 😞:

<img width="668" alt="screen shot 2018-11-26 at 17 36 19" src="https://user-images.githubusercontent.com/282717/49031453-de83ac00-f1a1-11e8-8323-8a1cb182f861.png">

@alex-ju with regard to the word breaking aspect, do you think this is a net improvement or not? and do you have any ideas how we can defeat that?