### PR TITLE
Add link to GOV.UK publishing status to the footer of content publisher

### DIFF
--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -124,6 +124,10 @@
             text: "Send us feedback"
           },
           {
+            href: "https://status.publishing.service.gov.uk",
+            text: "GOV.UK Status"
+          },
+          {
             href: "https://www.gov.uk/government/content-publishing",
             text: "How to write, publish, and improve content"
           }


### PR DESCRIPTION
https://trello.com/c/5q8xBQf7/448-add-link-to-govuk-publishing-status-to-the-footer-of-content-publisher