### PR TITLE
Add GOV.UK live URL to force publish confirmation page

### DIFF
--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -8,4 +8,8 @@ module ApplicationHelper
   def render_back_link(options)
     render("govuk_publishing_components/components/back_link", options)
   end
+
+  def strip_scheme_from_url(url)
+    url.sub(/^https?\:\/\//,'')
+  end
 end

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -10,6 +10,6 @@ module ApplicationHelper
   end
 
   def strip_scheme_from_url(url)
-    url.sub(/^https?\:\/\//,'')
+    url.sub(/^https?\:\/\//, "")
   end
 end

--- a/app/views/publish_document/published.html.erb
+++ b/app/views/publish_document/published.html.erb
@@ -29,8 +29,10 @@
 
         <p> <%= t("publish_document.published.published_without_review.send_label") %> </p>
 
-        <%= link_to(nil, document_url(@document, utm_content: "2i-link"), class: "govuk-link") %>
-      <% end %>
+      <%= render "govuk_publishing_components/components/copy_to_clipboard",
+        label: t("publish_document.published.published_without_review.send_label"),
+        copyable_content: document_url(@document, utm_content: "2i-link"),
+        button_text: "Copy link" %>
     <% end %>
   </div>
 </div>

--- a/app/views/publish_document/published.html.erb
+++ b/app/views/publish_document/published.html.erb
@@ -29,7 +29,7 @@
         <% stripped_url = DocumentUrl.new(@document).public_url.sub(/^https?\:\/\//,'') %>
         <%= link_to(nil, stripped_url, class: "govuk-link govuk-link--no-visited-state") %>
 
-        <h2 id="what-to-do-next">What to do next</h2>
+        <%= govspeak_to_html t("publish_document.published.published_without_review.what_to_do_govspeak") %>
       <% end %>
 
       <%= render "govuk_publishing_components/components/copy_to_clipboard",

--- a/app/views/publish_document/published.html.erb
+++ b/app/views/publish_document/published.html.erb
@@ -26,8 +26,11 @@
 
       <%= render "govuk_publishing_components/components/govspeak" do %>
         <%= govspeak_to_html t("publish_document.published.published_without_review.body_govspeak", title: @document.title) %>
+        <% stripped_url = DocumentUrl.new(@document).public_url.sub(/^https?\:\/\//,'') %>
+        <%= link_to(nil, stripped_url, class: "govuk-link govuk-link--no-visited-state") %>
 
-        <p> <%= t("publish_document.published.published_without_review.send_label") %> </p>
+        <h2 id="what-to-do-next">What to do next</h2>
+      <% end %>
 
       <%= render "govuk_publishing_components/components/copy_to_clipboard",
         label: t("publish_document.published.published_without_review.send_label"),

--- a/app/views/publish_document/published.html.erb
+++ b/app/views/publish_document/published.html.erb
@@ -17,7 +17,7 @@
       <%= render "govuk_publishing_components/components/govspeak" do %>
         <%= govspeak_to_html t("publish_document.published.reviewed.body_govspeak", title: @document.title) %>
 
-        <%= link_to(nil, DocumentUrl.new(@document).public_url, class: "govuk-link") %>
+        <%= link_to(nil, DocumentUrl.new(@document).public_url, class: "govuk-link govuk-link--no-visited-state") %>
       <% end %>
     <% else %>
       <%= render "govuk_publishing_components/components/panel", {

--- a/app/views/publish_document/published.html.erb
+++ b/app/views/publish_document/published.html.erb
@@ -17,7 +17,8 @@
       <%= render "govuk_publishing_components/components/govspeak" do %>
         <%= govspeak_to_html t("publish_document.published.reviewed.body_govspeak", title: @document.title) %>
 
-        <%= link_to(nil, DocumentUrl.new(@document).public_url, class: "govuk-link govuk-link--no-visited-state") %>
+        <% public_url = DocumentUrl.new(@document).public_url %>
+        <%= link_to(strip_scheme_from_url(public_url), public_url, class: "govuk-link govuk-link--no-visited-state") %>
       <% end %>
     <% else %>
       <%= render "govuk_publishing_components/components/panel", {
@@ -26,8 +27,8 @@
 
       <%= render "govuk_publishing_components/components/govspeak" do %>
         <%= govspeak_to_html t("publish_document.published.published_without_review.body_govspeak", title: @document.title) %>
-        <% stripped_url = DocumentUrl.new(@document).public_url.sub(/^https?\:\/\//,'') %>
-        <%= link_to(nil, stripped_url, class: "govuk-link govuk-link--no-visited-state") %>
+        <% public_url = DocumentUrl.new(@document).public_url %>
+        <%= link_to(strip_scheme_from_url(public_url), public_url, class: "govuk-link govuk-link--no-visited-state") %>
 
         <%= govspeak_to_html t("publish_document.published.published_without_review.what_to_do_govspeak") %>
       <% end %>

--- a/config/locales/en/publish_document/published.yml
+++ b/config/locales/en/publish_document/published.yml
@@ -15,6 +15,4 @@ en:
           ‘%{title}’ has been published on GOV.UK.
 
           It may take 5 minutes to appear live.
-
-          ## What to do next
         send_label: Send this document to another publisher for them to review. You or they can then approve it or create a new edition to make changes.

--- a/config/locales/en/publish_document/published.yml
+++ b/config/locales/en/publish_document/published.yml
@@ -16,3 +16,5 @@ en:
 
           It may take 5 minutes to appear live.
         send_label: Send this document to another publisher for them to review. You or they can then approve it or create a new edition to make changes.
+        what_to_do_govspeak: |
+          ## What to do next


### PR DESCRIPTION
https://trello.com/c/MrK9ulAL/474-add-govuk-live-url-to-force-publish-confirmation-page

<img width="693" alt="screen shot 2018-11-27 at 16 03 25" src="https://user-images.githubusercontent.com/15057104/49094361-06384a00-f25e-11e8-90e1-a63167d2fbc9.png">
