### PR TITLE
Iterate markdown toolbar and textarea

### DIFF
--- a/app/assets/stylesheets/components/_markdown-editor.scss
+++ b/app/assets/stylesheets/components/_markdown-editor.scss
@@ -4,7 +4,7 @@
 
 .app-c-markdown-editor {
   .govuk-textarea {
-    padding-top: (govuk-spacing(9) + govuk-spacing(7));
+    padding-top: (govuk-spacing(9) + govuk-spacing(8));
     resize: vertical;
   }
 }

--- a/app/assets/stylesheets/components/_markdown-editor.scss
+++ b/app/assets/stylesheets/components/_markdown-editor.scss
@@ -36,7 +36,7 @@
   @include govuk-font(19);
   display: inline-block;
   margin-bottom: -$govuk-border-width-form-element;
-  padding: (govuk-spacing(1) + $govuk-border-width-form-element);
+  padding: govuk-spacing(2);
   border: $govuk-border-width-form-element solid transparent;
   border-top: 0;
   border-bottom: 0;

--- a/app/assets/stylesheets/components/_markdown-editor.scss
+++ b/app/assets/stylesheets/components/_markdown-editor.scss
@@ -4,7 +4,7 @@
 
 .app-c-markdown-editor {
   .govuk-textarea {
-    padding-top: (govuk-spacing(9) + govuk-spacing(6));
+    padding-top: (govuk-spacing(9) + govuk-spacing(7));
     resize: vertical;
   }
 }
@@ -77,7 +77,7 @@
 
   .govuk-textarea {
     overflow: scroll;
-    padding-top: govuk-spacing(8);
+    padding-top: govuk-spacing(9);
   }
 }
 
@@ -107,8 +107,8 @@
 
 .app-c-markdown-editor__toolbar-icon {
   display: block;
-  width: 40px;
-  height: 40px;
+  width: 50px;
+  height: 50px;
 }
 
 .app-c-markdown-editor__toolbar-icon--heading-2 {

--- a/app/views/documents/fields/_govspeak_input.html.erb
+++ b/app/views/documents/fields/_govspeak_input.html.erb
@@ -12,7 +12,7 @@
         id: schema.id,
         name: "document[contents][#{schema.id}]",
         value: document.contents[schema.id],
-        rows: 25,
+        rows: 20,
         spellcheck: "false"
       }
     } %>


### PR DESCRIPTION
### Before
<img width="656" alt="screen shot 2018-11-27 at 14 32 45" src="https://user-images.githubusercontent.com/788096/49088542-5fe64780-f251-11e8-8511-68d4e170de4d.png">

### After
<img width="649" alt="screen shot 2018-11-27 at 14 32 01" src="https://user-images.githubusercontent.com/788096/49088552-6674bf00-f251-11e8-8d72-10f221771a1c.png">

[Trello card](https://trello.com/c/fI3HVOpp/436-update-markdown-toolbar)