### PR TITLE
Update the state of retired and removed documents

### DIFF
--- a/app/models/document.rb
+++ b/app/models/document.rb
@@ -27,8 +27,15 @@ class Document < ApplicationRecord
     reviewed
   ].freeze
 
+  LIVE_STATES = %w[
+    published
+    retired
+    removed
+  ].freeze
+
   validates_inclusion_of :publication_state, in: PUBLICATION_STATES
   validates_inclusion_of :review_state, in: REVIEW_STATES
+  validates_inclusion_of :live_state, in: LIVE_STATES, allow_nil: true, unless: :has_live_version_on_govuk
   validates_inclusion_of :update_type, in: %w[major minor], allow_nil: true
 
   def document_type_schema

--- a/app/models/remove.rb
+++ b/app/models/remove.rb
@@ -1,0 +1,5 @@
+# frozen_string_literal: true
+
+class Remove < ApplicationRecord
+  belongs_to :timeline_entry, class_name: "TimelineEntry", foreign_key: :timeline_entries_id, inverse_of: :remove
+end

--- a/app/models/remove.rb
+++ b/app/models/remove.rb
@@ -2,4 +2,9 @@
 
 class Remove < ApplicationRecord
   belongs_to :timeline_entry, class_name: "TimelineEntry", foreign_key: :timeline_entries_id, inverse_of: :remove
+  validates_inclusion_of :entry_type, in: %w[removed]
+
+  def entry_type
+    self.timeline_entry.entry_type
+  end
 end

--- a/app/models/retire.rb
+++ b/app/models/retire.rb
@@ -1,0 +1,5 @@
+# frozen_string_literal: true
+
+class Retire < ApplicationRecord
+  belongs_to :timeline_entry, class_name: "TimelineEntry", foreign_key: :timeline_entries_id, inverse_of: :retire
+end

--- a/app/models/retire.rb
+++ b/app/models/retire.rb
@@ -2,4 +2,9 @@
 
 class Retire < ApplicationRecord
   belongs_to :timeline_entry, class_name: "TimelineEntry", foreign_key: :timeline_entries_id, inverse_of: :retire
+  validates_inclusion_of :entry_type, in: %w[retired]
+
+  def entry_type
+    self.timeline_entry.entry_type
+  end
 end

--- a/app/models/timeline_entry.rb
+++ b/app/models/timeline_entry.rb
@@ -4,6 +4,7 @@ class TimelineEntry < ApplicationRecord
   belongs_to :document
   belongs_to :user, optional: true
   has_one :retire, foreign_key: :timeline_entries_id, dependent: :destroy, inverse_of: :timeline_entry
+  has_one :remove, foreign_key: :timeline_entries_id, dependent: :destroy, inverse_of: :timeline_entry
 
   ENTRY_TYPES = %w[
     created

--- a/app/models/timeline_entry.rb
+++ b/app/models/timeline_entry.rb
@@ -18,6 +18,8 @@ class TimelineEntry < ApplicationRecord
     image_removed
     new_edition
     create_preview
+    retired
+    removed
   ].freeze
 
   validates_inclusion_of :entry_type, in: ENTRY_TYPES

--- a/app/models/timeline_entry.rb
+++ b/app/models/timeline_entry.rb
@@ -3,6 +3,7 @@
 class TimelineEntry < ApplicationRecord
   belongs_to :document
   belongs_to :user, optional: true
+  has_one :retire, foreign_key: :timeline_entries_id, dependent: :destroy, inverse_of: :timeline_entry
 
   ENTRY_TYPES = %w[
     created

--- a/app/models/timeline_entry.rb
+++ b/app/models/timeline_entry.rb
@@ -25,6 +25,11 @@ class TimelineEntry < ApplicationRecord
   ].freeze
 
   validates_inclusion_of :entry_type, in: ENTRY_TYPES
+  validate :can_only_have_one_associated_type
+
+  def can_only_have_one_associated_type
+    self.retire.nil? || self.remove.nil?
+  end
 
   def username_or_unknown
     user ? user.name : "Unknown user"

--- a/app/models/timeline_entry.rb
+++ b/app/models/timeline_entry.rb
@@ -2,7 +2,7 @@
 
 class TimelineEntry < ApplicationRecord
   belongs_to :document
-  belongs_to :user
+  belongs_to :user, optional: true
 
   ENTRY_TYPES = %w[
     created

--- a/app/services/document_unpublishing_service.rb
+++ b/app/services/document_unpublishing_service.rb
@@ -35,6 +35,7 @@ class DocumentUnpublishingService
     )
 
     delete_assets(document.images)
+    TimelineEntry.create!(document: document, entry_type: "removed")
   end
 
 private

--- a/app/services/document_unpublishing_service.rb
+++ b/app/services/document_unpublishing_service.rb
@@ -9,6 +9,7 @@ class DocumentUnpublishingService
       locale: document.locale,
     )
 
+    document.update!(live_state: "retired")
     TimelineEntry.create!(document: document, entry_type: "retired")
   end
 

--- a/app/services/document_unpublishing_service.rb
+++ b/app/services/document_unpublishing_service.rb
@@ -23,6 +23,7 @@ class DocumentUnpublishingService
     )
 
     delete_assets(document.images)
+    document.update!(live_state: "removed")
     TimelineEntry.create!(document: document, entry_type: "removed")
   end
 

--- a/app/services/document_unpublishing_service.rb
+++ b/app/services/document_unpublishing_service.rb
@@ -19,7 +19,12 @@ class DocumentUnpublishingService
   def remove(document, explanatory_note: nil, alternative_path: nil)
     Document.transaction do
       document.update!(live_state: "removed")
-      TimelineEntry.create!(document: document, entry_type: "removed")
+      timeline_entry = TimelineEntry.create!(document: document, entry_type: "removed")
+      Remove.create!(
+        timeline_entry: timeline_entry,
+        explanatory_note: explanatory_note,
+        alternative_path: alternative_path,
+      )
 
       GdsApi.publishing_api_v2.unpublish(
         document.content_id,

--- a/app/services/document_unpublishing_service.rb
+++ b/app/services/document_unpublishing_service.rb
@@ -33,17 +33,20 @@ class DocumentUnpublishingService
   end
 
   def remove_and_redirect(document, redirect_path, explanatory_note: nil)
-    GdsApi.publishing_api_v2.unpublish(
-      document.content_id,
-      type: "redirect",
-      explanation: explanatory_note,
-      alternative_path: redirect_path,
-      locale: document.locale,
-    )
+    Document.transaction do
+      document.update!(live_state: "removed")
+      TimelineEntry.create!(document: document, entry_type: "removed")
+
+      GdsApi.publishing_api_v2.unpublish(
+        document.content_id,
+        type: "redirect",
+        explanation: explanatory_note,
+        alternative_path: redirect_path,
+        locale: document.locale,
+      )
+    end
 
     delete_assets(document.images)
-    document.update!(live_state: "removed")
-    TimelineEntry.create!(document: document, entry_type: "removed")
   end
 
 private

--- a/app/services/document_unpublishing_service.rb
+++ b/app/services/document_unpublishing_service.rb
@@ -8,6 +8,8 @@ class DocumentUnpublishingService
       explanation: explanatory_note,
       locale: document.locale,
     )
+
+    TimelineEntry.create!(document: document, entry_type: "retired")
   end
 
   def remove(document, explanatory_note: nil, alternative_path: nil)

--- a/app/services/document_unpublishing_service.rb
+++ b/app/services/document_unpublishing_service.rb
@@ -22,6 +22,7 @@ class DocumentUnpublishingService
     )
 
     delete_assets(document.images)
+    TimelineEntry.create!(document: document, entry_type: "removed")
   end
 
   def remove_and_redirect(document, redirect_path, explanatory_note: nil)

--- a/app/services/document_unpublishing_service.rb
+++ b/app/services/document_unpublishing_service.rb
@@ -41,7 +41,13 @@ class DocumentUnpublishingService
   def remove_and_redirect(document, redirect_path, explanatory_note: nil)
     Document.transaction do
       document.update!(live_state: "removed")
-      TimelineEntry.create!(document: document, entry_type: "removed")
+      timeline_entry = TimelineEntry.create!(document: document, entry_type: "removed")
+      Remove.create!(
+        timeline_entry: timeline_entry,
+        explanatory_note: explanatory_note,
+        alternative_path: redirect_path,
+        redirect: true,
+      )
 
       GdsApi.publishing_api_v2.unpublish(
         document.content_id,

--- a/app/services/document_unpublishing_service.rb
+++ b/app/services/document_unpublishing_service.rb
@@ -4,7 +4,8 @@ class DocumentUnpublishingService
   def retire(document, explanatory_note)
     Document.transaction do
       document.update!(live_state: "retired")
-      TimelineEntry.create!(document: document, entry_type: "retired")
+      timeline_entry = TimelineEntry.create!(document: document, entry_type: "retired")
+      Retire.create!(timeline_entry: timeline_entry, explanatory_note: explanatory_note)
 
       GdsApi.publishing_api_v2.unpublish(
         document.content_id,

--- a/app/services/document_unpublishing_service.rb
+++ b/app/services/document_unpublishing_service.rb
@@ -37,6 +37,7 @@ class DocumentUnpublishingService
     )
 
     delete_assets(document.images)
+    document.update!(live_state: "removed")
     TimelineEntry.create!(document: document, entry_type: "removed")
   end
 

--- a/app/services/publish_service.rb
+++ b/app/services/publish_service.rb
@@ -17,6 +17,7 @@ class PublishService
       publication_state: "sent_to_live",
       has_live_version_on_govuk: true,
       review_state: review_state,
+      live_state: "published",
     )
   rescue GdsApi::BaseError => e
     GovukError.notify(e)

--- a/app/services/user_facing_state.rb
+++ b/app/services/user_facing_state.rb
@@ -14,6 +14,8 @@ class UserFacingState
         .where.not(review_state: "submitted_for_review")
     when :retired
       query.where(publication_state: "sent_to_live", live_state: "retired")
+    when :removed
+      query.where(publication_state: "sent_to_live", live_state: "removed")
     when :submitted_for_review
       query.where(review_state: "submitted_for_review")
     when :published_but_needs_2i
@@ -41,6 +43,8 @@ class UserFacingState
       "published_but_needs_2i"
     elsif publication_state == "sent_to_live" && live_state == "retired"
       "retired"
+    elsif publication_state == "sent_to_live" && live_state == "removed"
+      "removed"
     elsif publication_state.in?(%w[sent_to_live])
       "published"
     else

--- a/app/services/user_facing_state.rb
+++ b/app/services/user_facing_state.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 class UserFacingState
-  STATES = %w[draft submitted_for_review published_but_needs_2i published].freeze
+  STATES = %w[draft submitted_for_review published_but_needs_2i published retired removed].freeze
 
   attr_reader :document
   delegate :review_state, :publication_state, :live_state, to: :document

--- a/app/services/user_facing_state.rb
+++ b/app/services/user_facing_state.rb
@@ -4,7 +4,7 @@ class UserFacingState
   STATES = %w[draft submitted_for_review published_but_needs_2i published].freeze
 
   attr_reader :document
-  delegate :review_state, :publication_state, to: :document
+  delegate :review_state, :publication_state, :live_state, to: :document
 
   def self.scope(query, state)
     case state.to_sym
@@ -12,6 +12,8 @@ class UserFacingState
       query
         .where(publication_state: %w[changes_not_sent_to_draft sent_to_draft error_sending_to_draft error_sending_to_live error_deleting_draft])
         .where.not(review_state: "submitted_for_review")
+    when :retired
+      query.where(publication_state: "sent_to_live", live_state: "retired")
     when :submitted_for_review
       query.where(review_state: "submitted_for_review")
     when :published_but_needs_2i
@@ -37,6 +39,8 @@ class UserFacingState
       "draft"
     elsif review_state == "published_without_review"
       "published_but_needs_2i"
+    elsif publication_state == "sent_to_live" && live_state == "retired"
+      "retired"
     elsif publication_state.in?(%w[sent_to_live])
       "published"
     else

--- a/app/views/documents/show/_history_tab.html.erb
+++ b/app/views/documents/show/_history_tab.html.erb
@@ -15,7 +15,11 @@
       <%= entry.retire.explanatory_note %>
     <% elsif entry.remove.present? %>
       <p><%= entry.remove.explanatory_note %></p>
-      <p><%= entry.remove.alternative_path %></p>
+      <% if entry.remove.redirect %>
+        <p>Redirected to <%= entry.remove.alternative_path %></p>
+      <% else %>
+        <p><%= entry.remove.alternative_path %></p>
+      <% end %>
     <% end %>
 
     <div class="app-timeline-entry__dateline">

--- a/app/views/documents/show/_history_tab.html.erb
+++ b/app/views/documents/show/_history_tab.html.erb
@@ -11,6 +11,13 @@
       <%= t "documents.history.entry_types.#{entry.entry_type}" %>
     </h4>
 
+    <% if entry.retire.present? %>
+      <%= entry.retire.explanatory_note %>
+    <% elsif entry.remove.present? %>
+      <p><%= entry.remove.explanatory_note %></p>
+      <p><%= entry.remove.alternative_path %></p>
+    <% end %>
+
     <div class="app-timeline-entry__dateline">
       <%= entry.created_at.strftime("%d %B %Y at %l:%M%P") %> by <%= entry.username_or_unknown %>
     </div>

--- a/config/locales/en/documents/history.yml
+++ b/config/locales/en/documents/history.yml
@@ -16,3 +16,5 @@ en:
         image_removed: "Removed image"
         new_edition: "New edition"
         create_preview: "Create preview"
+        retired: "Retired"
+        removed: "Removed"

--- a/config/locales/en/states.yml
+++ b/config/locales/en/states.yml
@@ -10,6 +10,8 @@ en:
       name: Published
     retired:
       name: Retired
+    removed:
+      name: Removed
 
   publication_states:
     changes_not_sent_to_draft:

--- a/config/locales/en/states.yml
+++ b/config/locales/en/states.yml
@@ -8,6 +8,8 @@ en:
       name: Published but needs 2i review
     published:
       name: Published
+    retired:
+      name: Retired
 
   publication_states:
     changes_not_sent_to_draft:

--- a/db/migrate/20181128112113_add_live_state_to_document.rb
+++ b/db/migrate/20181128112113_add_live_state_to_document.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+class AddLiveStateToDocument < ActiveRecord::Migration[5.2]
+  def change
+    add_column :documents, :live_state, :string
+  end
+end

--- a/db/migrate/20181128142853_create_retires.rb
+++ b/db/migrate/20181128142853_create_retires.rb
@@ -1,0 +1,14 @@
+# frozen_string_literal: true
+
+class CreateRetires < ActiveRecord::Migration[5.2]
+  def change
+    create_table :retires do |t|
+      t.string :explanatory_note
+
+      # Delete all retirement entires if a timeline entry is deleted
+      t.references :timeline_entries, foreign_key: { on_delete: :cascade }, null: false
+
+      t.timestamps
+    end
+  end
+end

--- a/db/migrate/20181128164501_create_removes.rb
+++ b/db/migrate/20181128164501_create_removes.rb
@@ -1,0 +1,16 @@
+# frozen_string_literal: true
+
+class CreateRemoves < ActiveRecord::Migration[5.2]
+  def change
+    create_table :removes do |t|
+      t.string :explanatory_note
+      t.string :alternative_path
+      t.boolean :redirect, default: false
+
+      # Delete all removal entires if a timeline entry is deleted
+      t.references :timeline_entries, foreign_key: { on_delete: :cascade }, null: false
+
+      t.timestamps
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2018_11_28_112113) do
+ActiveRecord::Schema.define(version: 2018_11_28_142853) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -84,6 +84,14 @@ ActiveRecord::Schema.define(version: 2018_11_28_112113) do
     t.index ["document_id"], name: "index_images_on_document_id"
   end
 
+  create_table "retires", force: :cascade do |t|
+    t.string "explanatory_note"
+    t.bigint "timeline_entries_id", null: false
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["timeline_entries_id"], name: "index_retires_on_timeline_entries_id"
+  end
+
   create_table "timeline_entries", force: :cascade do |t|
     t.string "entry_type", null: false
     t.bigint "document_id", null: false
@@ -125,6 +133,7 @@ ActiveRecord::Schema.define(version: 2018_11_28_112113) do
   add_foreign_key "documents", "users", column: "last_editor_id"
   add_foreign_key "images", "active_storage_blobs", column: "blob_id", on_delete: :cascade
   add_foreign_key "images", "documents", on_delete: :cascade
+  add_foreign_key "retires", "timeline_entries", column: "timeline_entries_id", on_delete: :cascade
   add_foreign_key "timeline_entries", "documents", on_delete: :cascade
   add_foreign_key "timeline_entries", "users", on_delete: :restrict
 end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2018_09_25_082624) do
+ActiveRecord::Schema.define(version: 2018_11_28_112113) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -56,6 +56,7 @@ ActiveRecord::Schema.define(version: 2018_09_25_082624) do
     t.string "update_type"
     t.integer "current_edition_number", null: false
     t.bigint "last_editor_id"
+    t.string "live_state"
     t.index ["base_path"], name: "index_documents_on_base_path", unique: true
     t.index ["content_id", "locale"], name: "index_documents_on_content_id_and_locale", unique: true
     t.index ["creator_id"], name: "index_documents_on_creator_id"

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2018_11_28_142853) do
+ActiveRecord::Schema.define(version: 2018_11_28_164501) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -84,6 +84,16 @@ ActiveRecord::Schema.define(version: 2018_11_28_142853) do
     t.index ["document_id"], name: "index_images_on_document_id"
   end
 
+  create_table "removes", force: :cascade do |t|
+    t.string "explanatory_note"
+    t.string "alternative_path"
+    t.boolean "redirect", default: false
+    t.bigint "timeline_entries_id", null: false
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["timeline_entries_id"], name: "index_removes_on_timeline_entries_id"
+  end
+
   create_table "retires", force: :cascade do |t|
     t.string "explanatory_note"
     t.bigint "timeline_entries_id", null: false
@@ -133,6 +143,7 @@ ActiveRecord::Schema.define(version: 2018_11_28_142853) do
   add_foreign_key "documents", "users", column: "last_editor_id"
   add_foreign_key "images", "active_storage_blobs", column: "blob_id", on_delete: :cascade
   add_foreign_key "images", "documents", on_delete: :cascade
+  add_foreign_key "removes", "timeline_entries", column: "timeline_entries_id", on_delete: :cascade
   add_foreign_key "retires", "timeline_entries", column: "timeline_entries_id", on_delete: :cascade
   add_foreign_key "timeline_entries", "documents", on_delete: :cascade
   add_foreign_key "timeline_entries", "users", on_delete: :restrict

--- a/spec/factories/remove_factory.rb
+++ b/spec/factories/remove_factory.rb
@@ -1,0 +1,8 @@
+# frozen_string_literal: true
+
+FactoryBot.define do
+  factory :remove do
+    explanatory_note { SecureRandom.alphanumeric }
+    alternative_path { explanatory_note ? "/prefix/#{explanatory_note.parameterize}" : nil }
+  end
+end

--- a/spec/factories/retire_factory.rb
+++ b/spec/factories/retire_factory.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+FactoryBot.define do
+  factory :retire do
+    explanatory_note { SecureRandom.alphanumeric }
+  end
+end

--- a/spec/models/timeline_entry_spec.rb
+++ b/spec/models/timeline_entry_spec.rb
@@ -8,4 +8,13 @@ RSpec.describe TimelineEntry do
       end
     end
   end
+
+  describe "#can_only_have_one_associated_type" do
+    it "can only be associated with either a retire or a remove child" do
+      subject.id = SecureRandom.random_number(100)
+      subject.retire = build(:retire, timeline_entry: subject)
+      subject.remove = build(:remove, timeline_entry: subject)
+      expect(subject).to_not be_valid
+    end
+  end
 end

--- a/spec/services/document_unpublishing_service_spec.rb
+++ b/spec/services/document_unpublishing_service_spec.rb
@@ -163,10 +163,20 @@ RSpec.describe DocumentUnpublishingService do
     end
 
     it "adds an entry in the timeline of the document" do
-      stub_publishing_api_unpublish(document.content_id, body: { type: "redirect", alternative_path: redirect_path, locale: document.locale })
-      DocumentUnpublishingService.new.remove_and_redirect(document, redirect_path)
+      explanatory_note = "The reason document has been removed"
+      stub_publishing_api_unpublish(document.content_id, body: {
+        type: "redirect",
+        explanation: explanatory_note,
+        alternative_path: redirect_path,
+        locale: document.locale,
+      })
+
+      DocumentUnpublishingService.new.remove_and_redirect(document, redirect_path, explanatory_note: explanatory_note)
 
       expect(document.timeline_entries.first.entry_type).to eq("removed")
+      expect(document.timeline_entries.first.remove.explanatory_note).to eq(explanatory_note)
+      expect(document.timeline_entries.first.remove.alternative_path).to eq(redirect_path)
+      expect(document.timeline_entries.first.remove.redirect).to be_truthy
     end
 
     it "keeps track of the live state" do

--- a/spec/services/document_unpublishing_service_spec.rb
+++ b/spec/services/document_unpublishing_service_spec.rb
@@ -29,6 +29,13 @@ RSpec.describe DocumentUnpublishingService do
 
       assert_not_requested asset_manager_delete_asset(asset.asset_manager_id)
     end
+
+    it "adds an entry in the timeline of the document" do
+      stub_publishing_api_unpublish(document.content_id, body: { type: "withdrawal", explanation: explanatory_note, locale: document.locale })
+      DocumentUnpublishingService.new.retire(document, explanatory_note)
+
+      expect(document.timeline_entries.first.entry_type).to eq("retired")
+    end
   end
 
   describe "#remove" do

--- a/spec/services/document_unpublishing_service_spec.rb
+++ b/spec/services/document_unpublishing_service_spec.rb
@@ -132,5 +132,12 @@ RSpec.describe DocumentUnpublishingService do
 
       assert_publishing_api_unpublish(french_document.content_id, type: "redirect", alternative_path: redirect_path, locale: french_document.locale)
     end
+
+    it "adds an entry in the timeline of the document" do
+      stub_publishing_api_unpublish(document.content_id, body: { type: "redirect", alternative_path: redirect_path, locale: document.locale })
+      DocumentUnpublishingService.new.remove_and_redirect(document, redirect_path)
+
+      expect(document.timeline_entries.first.entry_type).to eq("removed")
+    end
   end
 end

--- a/spec/services/document_unpublishing_service_spec.rb
+++ b/spec/services/document_unpublishing_service_spec.rb
@@ -36,6 +36,14 @@ RSpec.describe DocumentUnpublishingService do
 
       expect(document.timeline_entries.first.entry_type).to eq("retired")
     end
+
+    it "keeps track of the live state" do
+      stub_publishing_api_unpublish(document.content_id, body: { type: "withdrawal", explanation: explanatory_note, locale: document.locale })
+      DocumentUnpublishingService.new.retire(document, explanatory_note)
+      document.reload
+
+      expect(document.live_state).to eq("retired")
+    end
   end
 
   describe "#remove" do

--- a/spec/services/document_unpublishing_service_spec.rb
+++ b/spec/services/document_unpublishing_service_spec.rb
@@ -84,6 +84,13 @@ RSpec.describe DocumentUnpublishingService do
 
       assert_publishing_api_unpublish(french_document.content_id, type: "gone", locale: french_document.locale)
     end
+
+    it "adds an entry in the timeline of the document" do
+      stub_publishing_api_unpublish(document.content_id, body: { type: "gone", locale: document.locale })
+      DocumentUnpublishingService.new.remove(document)
+
+      expect(document.timeline_entries.first.entry_type).to eq("removed")
+    end
   end
 
   describe "#remove_and_redirect" do

--- a/spec/services/document_unpublishing_service_spec.rb
+++ b/spec/services/document_unpublishing_service_spec.rb
@@ -155,5 +155,13 @@ RSpec.describe DocumentUnpublishingService do
 
       expect(document.timeline_entries.first.entry_type).to eq("removed")
     end
+
+    it "keeps track of the live state" do
+      stub_publishing_api_unpublish(document.content_id, body: { type: "redirect", alternative_path: redirect_path, locale: document.locale })
+      DocumentUnpublishingService.new.remove_and_redirect(document, redirect_path)
+      document.reload
+
+      expect(document.live_state).to eq("removed")
+    end
   end
 end

--- a/spec/services/document_unpublishing_service_spec.rb
+++ b/spec/services/document_unpublishing_service_spec.rb
@@ -35,6 +35,7 @@ RSpec.describe DocumentUnpublishingService do
       DocumentUnpublishingService.new.retire(document, explanatory_note)
 
       expect(document.timeline_entries.first.entry_type).to eq("retired")
+      expect(document.timeline_entries.first.retire.explanatory_note).to eq(explanatory_note)
     end
 
     it "keeps track of the live state" do

--- a/spec/services/document_unpublishing_service_spec.rb
+++ b/spec/services/document_unpublishing_service_spec.rb
@@ -95,10 +95,22 @@ RSpec.describe DocumentUnpublishingService do
     end
 
     it "adds an entry in the timeline of the document" do
-      stub_publishing_api_unpublish(document.content_id, body: { type: "gone", locale: document.locale })
-      DocumentUnpublishingService.new.remove(document)
+      explanatory_note = "The reason document has been removed"
+      alternative_path = "/look-here-instead"
+
+      stub_publishing_api_unpublish(document.content_id, body: {
+        type: "gone",
+        explanation: explanatory_note,
+        alternative_path: alternative_path,
+        locale: document.locale,
+      })
+
+      DocumentUnpublishingService.new.remove(document, explanatory_note: explanatory_note, alternative_path: alternative_path)
 
       expect(document.timeline_entries.first.entry_type).to eq("removed")
+      expect(document.timeline_entries.first.remove.explanatory_note).to eq(explanatory_note)
+      expect(document.timeline_entries.first.remove.alternative_path).to eq(alternative_path)
+      expect(document.timeline_entries.first.remove.redirect).to be_falsey
     end
 
     it "keeps track of the live state" do

--- a/spec/services/document_unpublishing_service_spec.rb
+++ b/spec/services/document_unpublishing_service_spec.rb
@@ -99,6 +99,14 @@ RSpec.describe DocumentUnpublishingService do
 
       expect(document.timeline_entries.first.entry_type).to eq("removed")
     end
+
+    it "keeps track of the live state" do
+      stub_publishing_api_unpublish(document.content_id, body: { type: "gone", locale: document.locale })
+      DocumentUnpublishingService.new.remove(document)
+      document.reload
+
+      expect(document.live_state).to eq("removed")
+    end
   end
 
   describe "#remove_and_redirect" do

--- a/spec/services/user_facing_state_spec.rb
+++ b/spec/services/user_facing_state_spec.rb
@@ -54,6 +54,13 @@ RSpec.describe UserFacingState do
 
       expect(UserFacingState.scope(Document, "retired")).to match([retired])
     end
+
+    it "finds items that have been published and later removed" do
+      create(:document, publication_state: "sent_to_live", live_state: "published")
+      removed = create(:document, publication_state: "sent_to_live", live_state: "removed")
+
+      expect(UserFacingState.scope(Document, "removed")).to match([removed])
+    end
   end
 
   describe "#to_s" do
@@ -127,6 +134,14 @@ RSpec.describe UserFacingState do
       state = UserFacingState.new(document).to_s
 
       expect(state).to eql("retired")
+    end
+
+    it "is removed if it has been published and later removed" do
+      document = build(:document, publication_state: "sent_to_live", live_state: "removed")
+
+      state = UserFacingState.new(document).to_s
+
+      expect(state).to eql("removed")
     end
   end
 end

--- a/spec/services/user_facing_state_spec.rb
+++ b/spec/services/user_facing_state_spec.rb
@@ -47,6 +47,13 @@ RSpec.describe UserFacingState do
     it "finds nothing for an unknown state" do
       expect(UserFacingState.scope(Document, "surprise")).to be_empty
     end
+
+    it "finds items that have been published and later retired" do
+      create(:document, publication_state: "sent_to_live", live_state: "published")
+      retired = create(:document, publication_state: "sent_to_live", live_state: "retired")
+
+      expect(UserFacingState.scope(Document, "retired")).to match([retired])
+    end
   end
 
   describe "#to_s" do
@@ -112,6 +119,14 @@ RSpec.describe UserFacingState do
       state = UserFacingState.new(document).to_s
 
       expect(state).to eql("draft")
+    end
+
+    it "is retired if it has been published and later retired" do
+      document = build(:document, publication_state: "sent_to_live", live_state: "retired")
+
+      state = UserFacingState.new(document).to_s
+
+      expect(state).to eql("retired")
     end
   end
 end


### PR DESCRIPTION
Trello: https://trello.com/c/2VIaBEOi

## Motivation

In PR #510 a task was added to allow us manually remove or retire documents in publishing-api. Now we need to reflect the state of those documents in Content Publisher.

## Terminology

An explanation of what retired and removed documents are can be found [here](https://github.com/alphagov/content-publisher/blob/master/docs/retiring-and-removing-documents.md#retiring-and-removing-documents). 

## What's changed
1. Documents can be filtered by removed or retired from the "States" drop-down
2. State of document is displayed as "retired" or "removed" on index page
3. Document history has an entry for retired documents that displays a note about why the document was retired. This is the same as the explanation that appears in the banner on the live site.
4. Document history has an entry for removed documents that displays a note about why the document was retired and an alternative path.
5. Internally sets a new `live_state` to reflect the status of a document once it has been published.

### Index page
<img width="330" alt="screen shot 2018-11-30 at 11 27 44" src="https://user-images.githubusercontent.com/5793815/49286742-02d9d400-f493-11e8-90f1-b07461bac9e6.png">

<img width="1552" alt="screen shot 2018-11-30 at 11 28 47" src="https://user-images.githubusercontent.com/5793815/49286798-24d35680-f493-11e8-95fb-b053b323c1db.png">

### Document history
![screen shot 2018-11-29 at 14 34 17 2](https://user-images.githubusercontent.com/5793815/49229576-be442f00-f3e5-11e8-8e1c-baca4547131d.png)
