### PR TITLE
Report errors to Sentry

### DIFF
--- a/app/controllers/document_contacts_controller.rb
+++ b/app/controllers/document_contacts_controller.rb
@@ -5,7 +5,7 @@ class DocumentContactsController < ApplicationController
     @document = Document.find_by_param(params[:id])
     @contacts_by_organisation = ContactsService.new.all_by_organisation
   rescue GdsApi::BaseError => e
-    Rails.logger.error(e)
+    GovukError.notify(e)
     render "search_api_down", status: :service_unavailable
   end
 

--- a/app/controllers/document_images_controller.rb
+++ b/app/controllers/document_images_controller.rb
@@ -2,7 +2,7 @@
 
 class DocumentImagesController < ApplicationController
   rescue_from GdsApi::BaseError do |e|
-    Rails.logger.error(e)
+    GovukError.notify(e)
     redirect_to document_images_path, alert_with_description: t("document_images.index.flashes.api_error")
   end
 

--- a/app/controllers/document_tags_controller.rb
+++ b/app/controllers/document_tags_controller.rb
@@ -2,7 +2,7 @@
 
 class DocumentTagsController < ApplicationController
   rescue_from GdsApi::BaseError do |e|
-    Rails.logger.error(e)
+    GovukError.notify(e)
     render "#{action_name}_api_down", status: :service_unavailable
   end
 

--- a/app/controllers/document_topics_controller.rb
+++ b/app/controllers/document_topics_controller.rb
@@ -18,8 +18,8 @@ class DocumentTopicsController < ApplicationController
     document = Document.find_by_param(params[:document_id])
     document.document_topics.patch(params.fetch(:topics, []), params[:version].to_i)
     redirect_to document_path(document), notice: t("documents.show.flashes.topics_updated")
-  rescue GdsApi::HTTPConflict => e
-    Rails.logger.error(e)
+  rescue GdsApi::HTTPConflict
+    Rails.logger.warn("Conflict updating topics for #{document.content_id} at version #{params[:version].to_i}")
     redirect_to document_topics_path, alert_with_description: t("document_topics.edit.flashes.topic_update_conflict")
   rescue GdsApi::BaseError => e
     GovukError.notify(e)

--- a/app/controllers/document_topics_controller.rb
+++ b/app/controllers/document_topics_controller.rb
@@ -4,7 +4,7 @@ class DocumentTopicsController < ApplicationController
   include GDS::SSO::ControllerMethods
 
   rescue_from GdsApi::BaseError do |e|
-    Rails.logger.error(e)
+    GovukError.notify(e)
     render "#{action_name}_api_down", status: :service_unavailable
   end
 
@@ -22,7 +22,7 @@ class DocumentTopicsController < ApplicationController
     Rails.logger.error(e)
     redirect_to document_topics_path, alert_with_description: t("document_topics.edit.flashes.topic_update_conflict")
   rescue GdsApi::BaseError => e
-    Rails.logger.error(e)
+    GovukError.notify(e)
     redirect_to document, alert_with_description: t("documents.show.flashes.topic_update_error")
   end
 end

--- a/app/controllers/documents_controller.rb
+++ b/app/controllers/documents_controller.rb
@@ -28,7 +28,7 @@ class DocumentsController < ApplicationController
     DeleteDraftService.new(document).delete
     redirect_to documents_path
   rescue GdsApi::BaseError => e
-    Rails.logger.error(e)
+    GovukError.notify(e)
     redirect_to document, alert_with_description: t("documents.show.flashes.delete_draft_error")
   end
 

--- a/app/controllers/documents_controller.rb
+++ b/app/controllers/documents_controller.rb
@@ -58,9 +58,6 @@ class DocumentsController < ApplicationController
     else
       redirect_to @document
     end
-  rescue GdsApi::BaseError => e
-    Rails.logger.error(e)
-    redirect_to @document, alert_with_description: t("documents.show.flashes.preview_error")
   end
 
   def generate_path

--- a/app/controllers/preview_controller.rb
+++ b/app/controllers/preview_controller.rb
@@ -16,7 +16,7 @@ class PreviewController < ApplicationController
 
     redirect_to preview_document_path(document)
   rescue GdsApi::BaseError => e
-    Rails.logger.error(e)
+    GovukError.notify(e)
     redirect_to document_path(document), alert_with_description: t("documents.show.flashes.preview_error")
   end
 

--- a/app/controllers/publish_document_controller.rb
+++ b/app/controllers/publish_document_controller.rb
@@ -9,7 +9,7 @@ class PublishDocumentController < ApplicationController
       return
     end
   rescue GdsApi::BaseError => e
-    Rails.logger.error(e)
+    GovukError.notify(e)
     redirect_to @document, alert_with_description: t("documents.show.flashes.publish_error")
   end
 

--- a/app/controllers/publish_document_controller.rb
+++ b/app/controllers/publish_document_controller.rb
@@ -25,8 +25,7 @@ class PublishDocumentController < ApplicationController
     end
 
     redirect_to document_published_path(document)
-  rescue GdsApi::BaseError => e
-    Rails.logger.error(e)
+  rescue GdsApi::BaseError
     redirect_to document, alert_with_description: t("documents.show.flashes.publish_error")
   end
 

--- a/app/controllers/review_controller.rb
+++ b/app/controllers/review_controller.rb
@@ -14,7 +14,7 @@ class ReviewController < ApplicationController
     flash[:submitted_for_review] = true
     redirect_to document
   rescue GdsApi::BaseError => e
-    Rails.logger.error(e)
+    GovukError.notify(e)
     redirect_to document, alert_with_description: t("documents.show.flashes.2i_error")
   end
 

--- a/app/services/delete_draft_service.rb
+++ b/app/services/delete_draft_service.rb
@@ -21,14 +21,14 @@ private
 
   def discard_draft
     GdsApi.publishing_api_v2.discard_draft(document.content_id)
-  rescue GdsApi::HTTPNotFound => e
-    Rails.logger.error(e)
+  rescue GdsApi::HTTPNotFound
+    Rails.logger.warn("No draft to discard for content id #{document.content_id}")
   end
 
   def delete_asset(asset)
     return unless asset.asset_manager_id
     AssetManagerService.new.delete(asset)
-  rescue GdsApi::HTTPNotFound => e
-    Rails.logger.error(e)
+  rescue GdsApi::HTTPNotFound
+    Rails.logger.warn("No asset to delete for id #{asset.asset_manager_id}")
   end
 end

--- a/app/services/preview_service.rb
+++ b/app/services/preview_service.rb
@@ -15,8 +15,6 @@ class PreviewService
   def try_create_preview(args)
     save_changes(args)
     try_publish_draft(document) unless has_issues?
-  rescue GdsApi::BaseError => e
-    Rails.logger.error(e)
   end
 
 private

--- a/app/services/preview_service.rb
+++ b/app/services/preview_service.rb
@@ -57,7 +57,7 @@ private
   def try_publish_draft(document)
     publish_draft(document)
   rescue GdsApi::BaseError => e
-    Rails.logger.error(e)
+    GovukError.notify(e)
     document.update!(publication_state: "changes_not_sent_to_draft")
   end
 

--- a/app/services/requirements/edit_page_checker.rb
+++ b/app/services/requirements/edit_page_checker.rb
@@ -14,11 +14,5 @@ module Requirements
       issues += ContentChecker.new(document).pre_preview_issues.to_a
       CheckerIssues.new(issues)
     end
-
-  private
-
-    def lookup_content_id
-      GdsApi.publishing_api_v2.lookup_content_id(base_path: document.base_path)
-    end
   end
 end

--- a/app/services/requirements/path_checker.rb
+++ b/app/services/requirements/path_checker.rb
@@ -16,7 +16,7 @@ module Requirements
           issues << Issue.new(:title, :conflict)
         end
       rescue GdsApi::BaseError => e
-        Rails.logger.error(e)
+        GovukError.notify(e)
       end
 
       CheckerIssues.new(issues)

--- a/app/services/requirements/topic_checker.rb
+++ b/app/services/requirements/topic_checker.rb
@@ -16,7 +16,7 @@ module Requirements
           issues << Issue.new(:topics, :none)
         end
       rescue GdsApi::BaseError => e
-        Rails.logger.error(e) if rescue_api_errors
+        GovukError.notify(e) if rescue_api_errors
         raise unless rescue_api_errors
       end
 

--- a/app/views/documents/index/_filters.html.erb
+++ b/app/views/documents/index/_filters.html.erb
@@ -52,7 +52,6 @@
     <% organisation_select = begin
       LinkablesService.new("organisation").select_options
     rescue GdsApi::BaseError => e
-      # Export error as we're not telling the user about it
       GovukError.notify(e)
       []
     end %>

--- a/app/views/documents/show/_tags.html.erb
+++ b/app/views/documents/show/_tags.html.erb
@@ -20,8 +20,7 @@
     items: tags
   } %>
 <% rescue GdsApi::BaseError => e %>
-  <%# Don't export the error as we're telling the user about it %>
-  <% Rails.logger.error(e) %>
+  <% GovukError.notify(e) %>
 
   <%= render "components/summary", {
     id: "tags",

--- a/app/views/documents/show/_topics.html.erb
+++ b/app/views/documents/show/_topics.html.erb
@@ -24,7 +24,7 @@
     block: breadcrumbs
   } %>
 <% rescue GdsApi::BaseError => e %>
-  <% Rails.logger.error(e) %>
+  <% GovukError.notify(e) %>
 
   <%= render "components/summary", {
     id: "topics",


### PR DESCRIPTION
Trello: https://trello.com/c/JimAFj7p/496-clear-out-and-start-monitoring-sentry-errors

This replaces all the places we were using `Rails.logger.error(e)` for handling an exception.

In places where don't anticipate there to be an error, this now reports this error to Sentry. This was changed to massively increase our chances of noticing when an error has occurred (as our code should be protecting against them) and hopefully shouldn't cause problems with noisy timeout exceptions as these are filtered out by govuk_app_config. 

In places where we do anticipate an error I've dropped to using a simple text line emitted to the Rails warning log rather than an exception sent as an error - this is to reduce the output in Kibana.

I'm expecting this might need a bit of adjustment if we find there are some errors that are intermittent, but I figure we're at the best time to deal with that now.