### PR TITLE
Disables grammarly plugin for markdown editor

### DIFF
--- a/app/views/documents/fields/_govspeak_input.html.erb
+++ b/app/views/documents/fields/_govspeak_input.html.erb
@@ -7,7 +7,8 @@
       },
       textarea: {
         data: {
-          "contextual-guidance": "document-contents-guidance"
+          "contextual-guidance": "document-contents-guidance",
+          "gramm": "false", # Disables grammerly plugin for markdown editor
         },
         id: schema.id,
         name: "document[contents][#{schema.id}]",


### PR DESCRIPTION
Grammarly interferes with markdown editor making it impossible to insert and preview

How to replicate:

- Install grammarly
- Go to edit markdown field
- Experience grim position absolute issues

https://trello.com/c/1pgYWuWB/447-enable-markdown-editor-to-work-with-grammarly