### PR TITLE
Update contextual guidance

### DIFF
--- a/app/assets/javascripts/components/contextual-guidance.js
+++ b/app/assets/javascripts/components/contextual-guidance.js
@@ -19,14 +19,14 @@ ContextualGuidance.prototype.handleFocus = function (event) {
 
 ContextualGuidance.prototype.showGuidance = function (element) {
   if (element) {
-    element.classList.remove('govuk-visually-hidden')
+    element.style.display = 'block'
   }
 }
 
 ContextualGuidance.prototype.hideAllGuidance = function () {
   var $guidances = document.querySelectorAll('.app-c-contextual-guidance-wrapper')
   $guidances.forEach(function ($guidance) {
-    $guidance.classList.add('govuk-visually-hidden')
+    $guidance.style.display = 'none'
   })
 }
 
@@ -37,8 +37,6 @@ ContextualGuidance.prototype.getGuidanceId = function (element) {
 
 ContextualGuidance.prototype.init = function () {
   var $fields = this.$fields
-
-  this.hideAllGuidance()
 
   /**
   * Loop over all items with [data-contextual-guidance]

--- a/app/assets/stylesheets/components/_contextual-guidance.scss
+++ b/app/assets/stylesheets/components/_contextual-guidance.scss
@@ -13,6 +13,10 @@
   }
 }
 
+.app-c-contextual-guidance-wrapper--relative {
+  position: relative;
+}
+
 .js-enabled {
   .app-c-contextual-guidance-wrapper {
     display: none;

--- a/app/assets/stylesheets/components/_contextual-guidance.scss
+++ b/app/assets/stylesheets/components/_contextual-guidance.scss
@@ -2,12 +2,20 @@
 @import "govuk-frontend/helpers/all";
 
 .app-c-contextual-guidance-wrapper {
+  position: absolute;
+
   @include govuk-font(19);
 
   @include govuk-responsive-margin(6, "bottom");
 
   @include govuk-media-query($from: tablet) {
     padding-top: govuk-spacing(6);
+  }
+}
+
+.js-enabled {
+  .app-c-contextual-guidance-wrapper {
+    display: none;
   }
 }
 

--- a/app/assets/stylesheets/utilities/_overwrites.scss
+++ b/app/assets/stylesheets/utilities/_overwrites.scss
@@ -79,6 +79,11 @@
   }
 }
 
+.govuk-grid-column-one-third,
+.govuk-grid-column-two-thirds {
+  position: relative;
+}
+
 .app-selected-topics {
   .govuk-breadcrumbs {
     @include govuk-font(19);

--- a/app/views/components/_contextual_guidance.html.erb
+++ b/app/views/components/_contextual_guidance.html.erb
@@ -1,8 +1,9 @@
 <%
   id ||= "input-#{SecureRandom.hex(4)}"
   title ||= nil
+  relative ||= false
 %>
-<div id="<%= id %>" class="app-c-contextual-guidance-wrapper">
+<div id="<%= id %>" class="app-c-contextual-guidance-wrapper<%= " app-c-contextual-guidance-wrapper--relative" if relative %>">
   <div class="app-c-contextual-guidance">
     <h2 class="govuk-heading-s"><%= title %></h2>
     <%= yield %>

--- a/app/views/documents/fields/_govspeak_input.html.erb
+++ b/app/views/documents/fields/_govspeak_input.html.erb
@@ -22,7 +22,8 @@
     <div class="govuk-grid-column-one-third">
       <%= render "components/contextual_guidance", {
         id: "document-contents-guidance",
-        title: document.document_type_schema.guidance_for(schema.id).title
+        title: document.document_type_schema.guidance_for(schema.id).title,
+        relative: true
       } do %>
         <%= render "govuk_publishing_components/components/govspeak" do %>
           <%= govspeak_to_html document.document_type_schema.guidance_for(schema.id).body_govspeak %>


### PR DESCRIPTION
This PR changes the contextual guidance position to be absolute so it doesn't move items on the page below with an exception for the markdown guidance which will continue to be relative (otherwise it will overlap the footer)

### Before
<img width="981" alt="screen shot 2018-11-28 at 11 07 50" src="https://user-images.githubusercontent.com/788096/49147935-ee180780-f2fd-11e8-88f0-394de80b43a9.png">


### After
<img width="991" alt="screen shot 2018-11-28 at 11 08 01" src="https://user-images.githubusercontent.com/788096/49147929-ea848080-f2fd-11e8-9ef3-4016e870a6ef.png">


[Trello card](https://trello.com/c/CK8NjnuB)