### PR TITLE
Stop contacts 400ing without a contact selected

### DIFF
--- a/app/controllers/document_contacts_controller.rb
+++ b/app/controllers/document_contacts_controller.rb
@@ -11,7 +11,14 @@ class DocumentContactsController < ApplicationController
 
   def insert
     document = Document.find_by_param(params[:id])
-    contact_markdown = "[Contact:#{params.require(:contact_id)}]\n"
+    redirect_location = edit_document_path(document) + "#body"
+
+    unless params[:contact_id]
+      redirect_to redirect_location
+      return
+    end
+
+    contact_markdown = "[Contact:#{params[:contact_id]}]\n"
 
     body = document.contents.fetch("body", "").chomp
     document.contents["body"] = if body.present?
@@ -25,6 +32,6 @@ class DocumentContactsController < ApplicationController
       type: "updated_content",
     )
 
-    redirect_to edit_document_path(document) + "#body"
+    redirect_to redirect_location
   end
 end


### PR DESCRIPTION
Trello: https://trello.com/c/uYAPhvxH/504-error-not-making-a-choice-in-add-contacts-causes-this-page-isnt-working-error

This seemed a simpler approach than setting up a validation error to
avoid this error scenario.

It would have been good to have a test for this but it's not really a
feature so ¯\_(ツ)_/¯