### PR TITLE
Iterate title summary requirements

### DIFF
--- a/app/controllers/documents_controller.rb
+++ b/app/controllers/documents_controller.rb
@@ -90,7 +90,9 @@ private
     contents_params = document.document_type_schema.contents.map(&:id)
     base_path = PathGeneratorService.new.path(document, params.require(:document)[:title])
     title = params.require(:document)[:title]&.strip
-    params.require(:document).permit(:summary, :update_type, :change_note, contents: contents_params)
-      .merge(base_path: base_path, title: title)
+    summary = params.require(:document)[:summary].strip
+
+    params.require(:document).permit(:update_type, :change_note, contents: contents_params)
+      .merge(base_path: base_path, title: title, summary: summary)
   end
 end

--- a/app/controllers/documents_controller.rb
+++ b/app/controllers/documents_controller.rb
@@ -88,9 +88,9 @@ private
 
   def update_params(document)
     contents_params = document.document_type_schema.contents.map(&:id)
-    base_path = PathGeneratorService.new.path(document, params[:document][:title])
-
-    params.require(:document).permit(:title, :summary, :update_type, :change_note, contents: contents_params)
-      .merge(base_path: base_path)
+    base_path = PathGeneratorService.new.path(document, params.require(:document)[:title])
+    title = params.require(:document)[:title]&.strip
+    params.require(:document).permit(:summary, :update_type, :change_note, contents: contents_params)
+      .merge(base_path: base_path, title: title)
   end
 end

--- a/app/services/requirements/content_checker.rb
+++ b/app/services/requirements/content_checker.rb
@@ -2,7 +2,7 @@
 
 module Requirements
   class ContentChecker
-    TITLE_MAX_LENGTH = 150
+    TITLE_MAX_LENGTH = 300
 
     attr_reader :document
 

--- a/app/services/requirements/content_checker.rb
+++ b/app/services/requirements/content_checker.rb
@@ -30,6 +30,10 @@ module Requirements
         issues << Issue.new(:summary, :too_long, max_length: SUMMARY_MAX_LENGTH)
       end
 
+      if document.summary.to_s.lines.count > 1
+        issues << Issue.new(:summary, :multiline)
+      end
+
       CheckerIssues.new(issues)
     end
 

--- a/app/services/requirements/content_checker.rb
+++ b/app/services/requirements/content_checker.rb
@@ -3,6 +3,7 @@
 module Requirements
   class ContentChecker
     TITLE_MAX_LENGTH = 300
+    SUMMARY_MAX_LENGTH = 600
 
     attr_reader :document
 
@@ -23,6 +24,10 @@ module Requirements
 
       if document.title.to_s.lines.count > 1
         issues << Issue.new(:title, :multiline)
+      end
+
+      if document.summary.to_s.size > SUMMARY_MAX_LENGTH
+        issues << Issue.new(:summary, :too_long, max_length: SUMMARY_MAX_LENGTH)
       end
 
       CheckerIssues.new(issues)

--- a/app/views/documents/edit.html.erb
+++ b/app/views/documents/edit.html.erb
@@ -52,17 +52,21 @@
 
   <div class="govuk-grid-row">
     <div class="govuk-grid-column-two-thirds">
-      <%= render "govuk_publishing_components/components/textarea", {
-        label: {
-          text: t("documents.edit.form_labels.summary"),
-          bold: true
+      <%= render "govuk_publishing_components/components/character_count", {
+        textarea: {
+          label: {
+            text: t("documents.edit.form_labels.summary"),
+            bold: true
+          },
+          name: "document[summary]",
+          value: @document.summary,
+          error_items: @issues&.items_for(:summary),
+          rows: 4,
+          data: {
+            "contextual-guidance": "document-summary-guidance"
+          }
         },
-        name: "document[summary]",
-        value: @document.summary,
-        rows: 4,
-        data: {
-          "contextual-guidance": "document-summary-guidance"
-        }
+        maxlength: Requirements::ContentChecker::SUMMARY_MAX_LENGTH
       } %>
     </div>
 

--- a/config/locales/en/requirements.yml
+++ b/config/locales/en/requirements.yml
@@ -17,6 +17,9 @@ en:
       blank:
         form_message: Enter a summary
         summary_message: Enter a summary
+      too_long:
+        form_message: "Enter a summary that is fewer than %{max_length} characters long"
+        summary_message: Enter a shorter summary
     body:
       blank:
         form_message: Enter a body

--- a/config/locales/en/requirements.yml
+++ b/config/locales/en/requirements.yml
@@ -20,6 +20,9 @@ en:
       too_long:
         form_message: "Enter a summary that is fewer than %{max_length} characters long"
         summary_message: Enter a shorter summary
+      multiline:
+        form_message: Remove line breaks from the summary
+        summary_message: Remove line breaks from the summary
     body:
       blank:
         form_message: Enter a body

--- a/spec/features/editing_content/edit_document_with_line_breaks_and_spaces_spec.rb
+++ b/spec/features/editing_content/edit_document_with_line_breaks_and_spaces_spec.rb
@@ -5,12 +5,14 @@ RSpec.feature "Edit a document with fields containing line breaks and spaces" do
     given_there_is_a_document
     when_i_go_to_edit_the_document
     and_i_fill_in_the_title_with_leading_and_trailing_line_breaks_and_spaces
+    and_i_fill_in_the_summary_with_leading_and_trailing_line_breaks_and_spaces
     then_i_see_the_document_is_saved
     and_the_title_no_longer_has_leading_and_trailing_line_breaks_and_spaces
+    and_the_summary_no_longer_has_leading_and_trailing_line_breaks_and_spaces
   end
 
   def given_there_is_a_document
-    create(:document, title: "Existing title")
+    create(:document, title: "Existing title", summary: "Existing summary.")
   end
 
   def when_i_go_to_edit_the_document
@@ -21,12 +23,17 @@ RSpec.feature "Edit a document with fields containing line breaks and spaces" do
 
   def and_i_fill_in_the_title_with_leading_and_trailing_line_breaks_and_spaces
     fill_in "document[title]", with: " \r\nEdited title \r\n\n"
+  end
+
+  def and_i_fill_in_the_summary_with_leading_and_trailing_line_breaks_and_spaces
+    fill_in "document[summary]", with: "\n\n \rEdited summary.\n\n \r"
     stub_publishing_api_put_content(Document.last.content_id, {})
     click_on "Save"
   end
 
   def then_i_see_the_document_is_saved
     expect(page).to have_content("Edited title")
+    expect(page).to have_content("Edited summary.")
 
     within find(".app-timeline-entry:first") do
       expect(page).to have_content I18n.t!("documents.history.entry_types.updated_content")
@@ -35,5 +42,9 @@ RSpec.feature "Edit a document with fields containing line breaks and spaces" do
 
   def and_the_title_no_longer_has_leading_and_trailing_line_breaks_and_spaces
     expect(Document.last.title).to eq("Edited title")
+  end
+
+  def and_the_summary_no_longer_has_leading_and_trailing_line_breaks_and_spaces
+    expect(Document.last.summary).to eq("Edited summary.")
   end
 end

--- a/spec/features/editing_content/edit_document_with_line_breaks_and_spaces_spec.rb
+++ b/spec/features/editing_content/edit_document_with_line_breaks_and_spaces_spec.rb
@@ -1,0 +1,39 @@
+# frozen_string_literal: true
+
+RSpec.feature "Edit a document with fields containing line breaks and spaces" do
+  scenario do
+    given_there_is_a_document
+    when_i_go_to_edit_the_document
+    and_i_fill_in_the_title_with_leading_and_trailing_line_breaks_and_spaces
+    then_i_see_the_document_is_saved
+    and_the_title_no_longer_has_leading_and_trailing_line_breaks_and_spaces
+  end
+
+  def given_there_is_a_document
+    create(:document, title: "Existing title")
+  end
+
+  def when_i_go_to_edit_the_document
+    visit document_path(Document.last)
+    expect(page).to have_content("Existing title")
+    click_on "Change Content"
+  end
+
+  def and_i_fill_in_the_title_with_leading_and_trailing_line_breaks_and_spaces
+    fill_in "document[title]", with: " \r\nEdited title \r\n\n"
+    stub_publishing_api_put_content(Document.last.content_id, {})
+    click_on "Save"
+  end
+
+  def then_i_see_the_document_is_saved
+    expect(page).to have_content("Edited title")
+
+    within find(".app-timeline-entry:first") do
+      expect(page).to have_content I18n.t!("documents.history.entry_types.updated_content")
+    end
+  end
+
+  def and_the_title_no_longer_has_leading_and_trailing_line_breaks_and_spaces
+    expect(Document.last.title).to eq("Edited title")
+  end
+end

--- a/spec/services/requirements/content_checker_spec.rb
+++ b/spec/services/requirements/content_checker_spec.rb
@@ -53,6 +53,17 @@ RSpec.describe Requirements::ContentChecker do
       summary_message = issues.items_for(:summary, style: "summary").first[:text]
       expect(summary_message).to eq(I18n.t!("requirements.summary.too_long.summary_message", max_length: max_length))
     end
+
+    it "returns an issue if the summary has newlines" do
+      document = build :document, summary: "a\nb"
+      issues = Requirements::ContentChecker.new(document).pre_preview_issues
+
+      form_message = issues.items_for(:summary).first[:text]
+      expect(form_message).to eq(I18n.t!("requirements.summary.multiline.form_message"))
+
+      summary_message = issues.items_for(:summary, style: "summary").first[:text]
+      expect(summary_message).to eq(I18n.t!("requirements.summary.multiline.summary_message"))
+    end
   end
 
   describe "#pre_publish_issues" do

--- a/spec/services/requirements/content_checker_spec.rb
+++ b/spec/services/requirements/content_checker_spec.rb
@@ -41,6 +41,18 @@ RSpec.describe Requirements::ContentChecker do
       summary_message = issues.items_for(:title, style: "summary").first[:text]
       expect(summary_message).to eq(I18n.t!("requirements.title.multiline.summary_message"))
     end
+
+    it "returns an issue if the summary is too long" do
+      max_length = Requirements::ContentChecker::SUMMARY_MAX_LENGTH
+      document = build :document, summary: "a" * (max_length + 1)
+      issues = Requirements::ContentChecker.new(document).pre_preview_issues
+
+      form_message = issues.items_for(:summary).first[:text]
+      expect(form_message).to eq(I18n.t!("requirements.summary.too_long.form_message", max_length: max_length))
+
+      summary_message = issues.items_for(:summary, style: "summary").first[:text]
+      expect(summary_message).to eq(I18n.t!("requirements.summary.too_long.summary_message", max_length: max_length))
+    end
   end
 
   describe "#pre_publish_issues" do


### PR DESCRIPTION
For https://trello.com/c/fg0KKIGQ/399-iterate-title-and-summary-requirements-add-new-line-stripping

In this PR:

- Leading and trailing line breaks are stripped from title & summary input before saving
- Title maximum character count is increased to 300
<img width="682" alt="title-increase-character-count" src="https://user-images.githubusercontent.com/13434452/49152403-9a5feb00-f30a-11e8-893d-2be118d7d0c2.png">

- Maximum character count of 600 implemented for the summary
<img width="1020" alt="summary-pre-preview-character-error" src="https://user-images.githubusercontent.com/13434452/49152471-d8f5a580-f30a-11e8-9bc3-e2018c7869c4.png">

- Character count added to the summary text area
<img width="665" alt="screen shot 2018-11-28 at 12 40 22" src="https://user-images.githubusercontent.com/13434452/49152458-cf6c3d80-f30a-11e8-9960-cf23c82bd6eb.png">

- Pre-preview check implemented for line breaks in summary input
<img width="997" alt="screen shot 2018-11-28 at 12 41 15" src="https://user-images.githubusercontent.com/13434452/49152499-ed39a280-f30a-11e8-9fa0-5bbc74795252.png">

**Outstanding**
- @paola-roccuzzo to add guidance for suggested summary character limit in the sidebar guidance.
