### PR TITLE
Disable contextual guidance overflow for image credit field

### DIFF
--- a/app/views/document_images/edit.html.erb
+++ b/app/views/document_images/edit.html.erb
@@ -91,6 +91,7 @@
       <%= render "components/contextual_guidance", {
         id: "credit-guidance",
         title: t("document_images.edit.form_labels.credit"),
+        relative: true
       } do %>
         <%= render "govuk_publishing_components/components/govspeak" do %>
           <%= govspeak_to_html t("document_images.edit.guidance.credit_govspeak") %>


### PR DESCRIPTION
This PR disables the contextual guidance overflow for the image credit field.