### PR TITLE
Display change notes for major updates only

### DIFF
--- a/app/services/publishing_api_payload.rb
+++ b/app/services/publishing_api_payload.rb
@@ -12,7 +12,7 @@ class PublishingApiPayload
   end
 
   def payload
-    {
+    payload = {
       "base_path" => document.base_path,
       "title" => document.title,
       "locale" => document.locale,
@@ -22,7 +22,6 @@ class PublishingApiPayload
       "publishing_app" => PUBLISHING_APP,
       "rendering_app" => publishing_metadata.rendering_app,
       "update_type" => document.update_type,
-      "change_note" => document.change_note,
       "details" => details,
       "routes" => [
         { "path" => document.base_path, "type" => "exact" },
@@ -32,6 +31,8 @@ class PublishingApiPayload
         "auth_bypass_ids" => [DocumentUrl.new(document).auth_bypass_id],
       },
     }
+    payload["change_note"] = document.change_note if major_update?
+    payload
   end
 
 private
@@ -92,5 +93,9 @@ private
     else
       document.contents[field.id]
     end
+  end
+
+  def major_update?
+    document.update_type == "major"
   end
 end

--- a/app/views/documents/edit/_change_notes.html.erb
+++ b/app/views/documents/edit/_change_notes.html.erb
@@ -1,35 +1,5 @@
-<div class="govuk-grid-row">
-  <div class="govuk-grid-column-two-thirds">
-    <% legend_text = tag.p(
-      tag.strong(t("documents.edit.update_type.title")),
-      class: "govuk-!-margin-bottom-3")
-    %>
-
-    <%= render "govuk_publishing_components/components/fieldset", legend_text: legend_text do %>
-      <%= render "govuk_publishing_components/components/radio", {
-        name: "document[update_type]",
-        id: "update-type",
-        items: [
-          {
-            value: "minor",
-            text: t("documents.edit.update_type.minor_name"),
-            conditional: tag.p(t("documents.edit.update_type.minor_hint"), class: "govuk-body"),
-            checked: @document.update_type == "minor",
-          },
-          {
-            value: "major",
-            text: t("documents.edit.update_type.major_name"),
-            conditional: tag.p(t("documents.edit.update_type.major_hint"), class: "govuk-body"),
-            checked: @document.update_type == "major",
-          }
-        ]
-      } %>
-    <% end %>
-  </div>
-</div>
-
-<div class="govuk-grid-row">
-  <div class="govuk-grid-column-two-thirds">
+<% textarea = capture do %>
+    <%= tag.p(t("documents.edit.update_type.major_hint"), class: "govuk-body") %>
     <%= render "govuk_publishing_components/components/textarea", {
       label: {
         text: t("documents.edit.change_note.title"),
@@ -42,8 +12,34 @@
         "contextual-guidance": "change-note-guidance"
       }
     } %>
+<% end %>
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-two-thirds">
+    <% legend_text = tag.p(
+      tag.strong(t("documents.edit.update_type.title")),
+      class: "govuk-!-margin-bottom-3")
+    %>
+    <%= render "govuk_publishing_components/components/fieldset", legend_text: legend_text, data: { "contextual-guidance": "change-note-guidance" } do %>
+      <%= render "govuk_publishing_components/components/radio", {
+        name: "document[update_type]",
+        id: "update-type",
+        items: [
+          {
+            value: "major",
+            text: t("documents.edit.update_type.major_name"),
+            conditional: textarea,
+            checked: @document.update_type == "major",
+          },
+          {
+            value: "minor",
+            text: t("documents.edit.update_type.minor_name"),
+            conditional: tag.p(t("documents.edit.update_type.minor_hint"), class: "govuk-body"),
+            checked: @document.update_type == "minor",
+          }
+        ]
+      } %>
+    <% end %>
   </div>
-
   <div class="govuk-grid-column-one-third">
     <%= render "components/contextual_guidance", {
       id: "change-note-guidance",

--- a/app/views/documents/edit/_change_notes.html.erb
+++ b/app/views/documents/edit/_change_notes.html.erb
@@ -1,9 +1,7 @@
 <% textarea = capture do %>
-    <%= tag.p(t("documents.edit.update_type.major_hint"), class: "govuk-body") %>
     <%= render "govuk_publishing_components/components/textarea", {
       label: {
         text: t("documents.edit.change_note.title"),
-        bold: true
       },
       name: "document[change_note]",
       value: @document.change_note,
@@ -33,7 +31,6 @@
           {
             value: "minor",
             text: t("documents.edit.update_type.minor_name"),
-            conditional: tag.p(t("documents.edit.update_type.minor_hint"), class: "govuk-body"),
             checked: @document.update_type == "minor",
           }
         ]

--- a/config/locales/en/documents/edit.yml
+++ b/config/locales/en/documents/edit.yml
@@ -15,17 +15,15 @@ en:
         no_title: You haven't entered a title yet.
         error: Unable to preview address, please edit title and try again.
       change_note:
-        title: Change note
+        title: Public change note
         guidance_title: Writing change notes
         guidance: |
-          Describe the change. Include any new or updated information where possible, or summarise and refer to specific sections if it cannot be included.
+          Describe the change for users. Include or refer to any new or updated information. This change note will be published on the page and emailed to subscribers. The 'last updated' date will change.
 
           [Full guidance on change notes](https://www.gov.uk/guidance/content-design/writing-for-gov-uk#change-notes)
       update_type:
-        title: Is the change significant to users?
-        minor_name: There’s no change to the published information. For example, spelling corrections.
-        minor_hint: The ‘last updated’ date will not change, the change note will not be public, and subscribers will not be emailed.
-        major_name: There’s a change to the published information.
-        major_hint: The ‘last updated’ date will change, the change note will be published on the page and emailed to subscribers.
+        title: Is the content change significant to users?
+        minor_name: No - a minor style update
+        major_name: Yes - information has been added or updated
       flashes:
         requirements: You need to

--- a/spec/services/publishing_api_payload_spec.rb
+++ b/spec/services/publishing_api_payload_spec.rb
@@ -109,5 +109,19 @@ RSpec.describe PublishingApiPayload do
 
       expect(payload["details"]["image"]).to match a_hash_including(payload_hash)
     end
+
+    it "includes a change note if the update type is 'major'" do
+      document = create(:document, update_type: "major", change_note: "A change note")
+      payload = PublishingApiPayload.new(document).payload
+
+      expect(payload).to match a_hash_including("change_note" => "A change note")
+    end
+
+    it "does not include a change note if the update type is 'minor'" do
+      document = create(:document, update_type: "minor", change_note: "A change note")
+      payload = PublishingApiPayload.new(document).payload
+
+      expect(payload).not_to match a_hash_including("change_note" => "A change note")
+    end
   end
 end


### PR DESCRIPTION
For https://trello.com/c/Ms2oWVgS/445-implement-changes-to-change-notes

We are currently showing the change note text area to users regardless of whether the changes they have made are major or minor updates.  Since user shouldn't need to provide a change note when making a minor update, we change this so that the text area only appears when the user has indicated that their changes are major.

This PR also update the copy in this section as per https://docs.google.com/presentation/d/1FW5YCuksU_HQnlK6wyQnQNalRDRvrzRQwy1cTHNWmZA/edit#slide=id.g45aa9227d9_0_594

Note that this implementation means that the contextual guidance for change notes is now aligned with the bottom of the title question, rather than the top of the change note text area.

## Before
<img width="1023" alt="screen shot 2018-11-28 at 17 17 31" src="https://user-images.githubusercontent.com/13434452/49169472-baef6b80-f331-11e8-87e5-941e1b01136c.png">

## After
<img width="1016" alt="screen shot 2018-11-28 at 17 10 19" src="https://user-images.githubusercontent.com/13434452/49169498-c6db2d80-f331-11e8-8aff-290e516e1778.png">

<img width="535" alt="screen shot 2018-11-28 at 17 02 02" src="https://user-images.githubusercontent.com/13434452/49169510-ccd10e80-f331-11e8-8db6-bf9e447a40b2.png">
