### PR TITLE
Suggest ideal length in character counts

### DIFF
--- a/app/assets/javascripts/application.js
+++ b/app/assets/javascripts/application.js
@@ -8,6 +8,7 @@
 //= require components/autocomplete.js
 //= require components/error-alert.js
 //= require components/image-cropper.js
+//= require components/input-length-suggester.js
 //= require components/markdown-editor.js
 //= require components/url-preview.js
 //= require vendor/@alphagov/miller-columns-element/dist/index.umd.js

--- a/app/assets/javascripts/components/input-length-suggester.js
+++ b/app/assets/javascripts/components/input-length-suggester.js
@@ -1,0 +1,55 @@
+function InputLengthSuggester ($module) {
+  this.$module = $module
+  this.$target = document.getElementById($module.getAttribute('data-for'))
+  this.messageTemplate = $module.getAttribute('data-message')
+  var showFrom = parseInt($module.getAttribute('data-show-from'), 10)
+  this.showFrom = showFrom > 0 ? showFrom : 0
+  this.pollInterval = null
+}
+
+InputLengthSuggester.prototype.init = function () {
+  if (!this.$target || !this.messageTemplate) {
+    return
+  }
+  this.update()
+
+  // these 3 cover most bases for a consistent experience
+  this.$target.addEventListener('keydown', this.update.bind(this))
+  this.$target.addEventListener('keyup', this.update.bind(this))
+  this.$target.addEventListener('change', this.update.bind(this))
+
+  // set-up polling
+  this.$target.addEventListener('focus', this.handleFocus.bind(this))
+  this.$target.addEventListener('blur', this.handleBlur.bind(this))
+}
+
+InputLengthSuggester.prototype.update = function () {
+  var count = this.$target.value.length
+  this.$module.textContent = this.messageTemplate.replace(/{count}/g, count)
+  if (count >= this.showFrom) {
+    this.$module.classList.remove('app-c-input-length-suggester__hidden')
+  } else {
+    this.$module.classList.add('app-c-input-length-suggester__hidden')
+  }
+}
+
+InputLengthSuggester.prototype.handleFocus = function () {
+  if (!this.pollInterval) {
+    // according to https://github.com/alphagov/govuk-frontend/blob/29c50367474396a090b31b66bc9a2de3046ed816/src/components/character-count/character-count.js#L119-L121
+    // screen readers may modify the input value directly via JS so we have to
+    // poll to catch those updates
+    this.pollInterval = setInterval(this.update.bind(this), 1000)
+  }
+}
+
+InputLengthSuggester.prototype.handleBlur = function () {
+  if (this.pollInterval) {
+    clearInterval(this.pollInterval)
+    this.pollInterval = null
+  }
+}
+
+var inputLengthSuggesters = document.querySelectorAll('[data-module="input-length-suggester"]')
+for (var i = 0; i < inputLengthSuggesters.length; i++) {
+  new InputLengthSuggester(inputLengthSuggesters[i]).init()
+}

--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -22,6 +22,7 @@
 @import "components/image-cropper";
 @import "components/side-nav";
 @import "components/miller-columns";
+@import "components/input_length_suggester";
 
 @import "utilities/display";
 @import "utilities/overwrites";

--- a/app/assets/stylesheets/components/_input_length_suggester.scss
+++ b/app/assets/stylesheets/components/_input_length_suggester.scss
@@ -1,0 +1,3 @@
+.app-c-input-length-suggester__hidden {
+  visibility: hidden;
+}

--- a/app/views/components/_input_length_suggester.erb
+++ b/app/views/components/_input_length_suggester.erb
@@ -1,0 +1,13 @@
+<% show_from ||= nil %>
+<%= tag.span(
+  class: "govuk-hint app-c-input-length-suggester app-c-input-length-suggester__hidden",
+  data: {
+    module: "input-length-suggester",
+    for: for_id,
+    "show-from": show_from,
+    message: message
+  },
+  aria: {
+    live: "polite",
+  },
+) do %>&nbsp;<% end %>

--- a/app/views/components/docs/input_length_suggester.yml
+++ b/app/views/components/docs/input_length_suggester.yml
@@ -1,0 +1,14 @@
+name: Input Length Suggester
+description: To suggest an input has a certain amount of characters
+accessibility_criteria: |
+  The component must:
+
+  * be hidden by default
+  * be visible when a specified character number is reached
+  * poll for changes to support screen readers
+examples:
+  default:
+    data:
+      for_id: "an-input"
+      show_from: 10
+      message: "This field should be less than 15 characters. Current characters: {count}"

--- a/app/views/documents/edit.html.erb
+++ b/app/views/documents/edit.html.erb
@@ -9,23 +9,27 @@
 <%= form_for(@document, html: {'autocomplete': 'off'}, data: {'module': 'edit-document-form', 'url-preview-path': generate_path_path}) do |f| %>
   <div class="govuk-grid-row">
     <div class="govuk-grid-column-two-thirds">
-      <%= render "govuk_publishing_components/components/character_count", {
-        textarea: {
-          label: {
-            text: t("documents.edit.form_labels.title"),
-            bold: true
-          },
-          name: "document[title]",
-          value: @document.title,
-          error_items: @issues&.items_for(:title),
-          rows: 2,
-          data: {
-            "url-preview": "input",
-            "contextual-guidance": "document-title-guidance"
-          }
+      <%= render "govuk_publishing_components/components/textarea", {
+        label: {
+          text: t("documents.edit.form_labels.title"),
+          bold: true
         },
-        maxlength: Requirements::ContentChecker::TITLE_MAX_LENGTH
-      } %>
+        id: "document_title",
+        name: "document[title]",
+        value: @document.title,
+        error_items: @issues&.items_for(:title),
+        rows: 2,
+        data: {
+          "url-preview": "input",
+          "contextual-guidance": "document-title-guidance"
+        }
+      } do %>
+        <%= render "components/input_length_suggester", {
+          for_id: "document_title",
+          show_from: 55,
+          message: "Title should be under 65 characters. Current length: {count}",
+        } %>
+      <% end %>
 
       <%= render "components/url_preview", {
         title: t("documents.edit.url_preview.available"),
@@ -52,22 +56,26 @@
 
   <div class="govuk-grid-row">
     <div class="govuk-grid-column-two-thirds">
-      <%= render "govuk_publishing_components/components/character_count", {
-        textarea: {
-          label: {
-            text: t("documents.edit.form_labels.summary"),
-            bold: true
-          },
-          name: "document[summary]",
-          value: @document.summary,
-          error_items: @issues&.items_for(:summary),
-          rows: 4,
-          data: {
-            "contextual-guidance": "document-summary-guidance"
-          }
+      <%= render "govuk_publishing_components/components/textarea", {
+        label: {
+          text: t("documents.edit.form_labels.summary"),
+          bold: true
         },
-        maxlength: Requirements::ContentChecker::SUMMARY_MAX_LENGTH
-      } %>
+        id: "document_summary",
+        name: "document[summary]",
+        value: @document.summary,
+        error_items: @issues&.items_for(:summary),
+        rows: 4,
+        data: {
+          "contextual-guidance": "document-summary-guidance"
+        }
+      } do %>
+        <%= render "components/input_length_suggester", {
+          for_id: "document_summary",
+          show_from: 120,
+          message: "Summary should be under 140 characters. Current length: {count}",
+        } %>
+      <% end %>
     </div>
 
     <% if @document.document_type_schema.guidance_for("summary") %>

--- a/app/views/documents/edit.html.erb
+++ b/app/views/documents/edit.html.erb
@@ -19,6 +19,7 @@
         value: @document.title,
         error_items: @issues&.items_for(:title),
         rows: 2,
+        maxlength: Requirements::ContentChecker::TITLE_MAX_LENGTH,
         data: {
           "url-preview": "input",
           "contextual-guidance": "document-title-guidance"
@@ -66,6 +67,7 @@
         value: @document.summary,
         error_items: @issues&.items_for(:summary),
         rows: 4,
+        maxlength: Requirements::ContentChecker::SUMMARY_MAX_LENGTH,
         data: {
           "contextual-guidance": "document-summary-guidance"
         }

--- a/config/initializers/govuk_publishing_components.rb
+++ b/config/initializers/govuk_publishing_components.rb
@@ -4,5 +4,5 @@ GovukPublishingComponents.configure do |c|
   c.application_print_stylesheet = nil
 
   c.application_stylesheet = "application"
-  c.application_javascript = nil
+  c.application_javascript = "application"
 end


### PR DESCRIPTION
Trello: https://trello.com/c/M3d7G6YG/501-iterate-character-count-text-and-rules

This is to resolve the somewhat misleading approach we had to character counts where we told users how many characters were remaining on a hard limit rather than suggesting they enter a value less than the ideal amount.

Demo:
![nov-28-2018 18-59-02](https://user-images.githubusercontent.com/282717/49175111-b7fb7780-f33f-11e8-9dd7-400d7acb25e8.gif)
