### PR TITLE
Handle topics 404ing for a document

### DIFF
--- a/app/models/document_topics.rb
+++ b/app/models/document_topics.rb
@@ -16,6 +16,13 @@ class DocumentTopics
       version: links["version"],
       topics: topic_content_ids.map { |topic_content_id| Topic.find(topic_content_id, index) },
     )
+  rescue GdsApi::HTTPNotFound
+    new(
+      index: index,
+      document: document,
+      version: nil,
+      topics: [],
+    )
   end
 
   def patch(topic_content_ids, version)

--- a/spec/models/document_topics_spec.rb
+++ b/spec/models/document_topics_spec.rb
@@ -1,0 +1,40 @@
+# frozen_string_literal: true
+
+RSpec.describe DocumentTopics do
+  include TopicsHelper
+
+  before { publishing_api_has_taxonomy }
+
+  describe ".find_by_document" do
+    context "when we can access topics" do
+      it "returns an object with the topics" do
+        document = build(:document)
+        publishing_api_has_links(
+          "content_id" => document.content_id,
+          "links" => {
+            "taxons" => %w(level_one_topic),
+          },
+          "version" => 1,
+        )
+
+        document_topics = DocumentTopics.find_by_document(document, TopicIndexService.new)
+
+        expect(document_topics.version).to eq(1)
+        expect(document_topics.document).to be(document)
+        expect(document_topics.topics.first&.content_id).to eq("level_one_topic")
+      end
+    end
+
+    context "when topics for a document don't exist" do
+      it "returns an empty object" do
+        document = build(:document)
+        publishing_api_does_not_have_links(document.content_id)
+        document_topics = DocumentTopics.find_by_document(document, TopicIndexService.new)
+
+        expect(document_topics.version).to be_nil
+        expect(document_topics.document).to be(document)
+        expect(document_topics.topics).to be_empty
+      end
+    end
+  end
+end


### PR DESCRIPTION
Fix for https://sentry.io/govuk/app-content-publisher/issues/703085886/

If we haven't wrote a document to the Publishing API then any call to
get the links for it will return a 404. This was previously getting
picked up in an exception handler in the view, but since this is a
pretty normal part of a documents flow then it makes sense to be handled
in the DocumentsTopic itself.