### PR TITLE
Update autocomplete component to support custom template

### DIFF
--- a/app/assets/javascripts/components/autocomplete.js
+++ b/app/assets/javascripts/components/autocomplete.js
@@ -15,7 +15,7 @@ if ($autocompletes) {
     new accessibleAutocomplete.enhanceSelectElement({
       selectElement: $el,
       minLength: 3,
-      showNoOptionsFound: false,
+      defaultValue: '',
       customAttributes: customAttributes
     })
   })
@@ -38,6 +38,39 @@ if ($multiselects) {
       multiple: true,
       customAttributes: customAttributes
     })
+  })
+}
+
+var $customTemplateAutocomplete = document.querySelector('[data-module="autocomplete-custom-template"]')
+if ($customTemplateAutocomplete) {
+
+  new accessibleAutocomplete.enhanceSelectElement({
+    selectElement: $customTemplateAutocomplete,
+    minLength: 3,
+    showNoOptionsFound: false,
+    autoselect: false,
+    defaultValue: '',
+    templates: {
+      inputValue: function (result) {
+        if (result) {
+          return result.split(' - ')[0]
+        }
+      },
+      suggestion: function (result) {
+        if (result) {
+          var resultItems = result.split(' - ')
+          var elem = document.createElement('span')
+          elem.textContent = resultItems[0]
+          if (resultItems[1]) {
+            var hintContainer = document.createElement('span')
+            hintContainer.className = 'autocomplete__option-hint'
+            hintContainer.textContent = resultItems[1]
+            elem.appendChild(hintContainer)
+          }
+          return elem.innerHTML
+        }
+      }
+    }
   })
 }
 /* eslint-enable */

--- a/app/assets/stylesheets/components/_autocomplete.scss
+++ b/app/assets/stylesheets/components/_autocomplete.scss
@@ -5,6 +5,19 @@
   @include govuk-font(19);
 }
 
+.autocomplete__option-hint {
+  display: block;
+  @include govuk-font(16);
+  color: $govuk-secondary-text-colour;
+}
+
+.autocomplete__option--focused,
+.autocomplete__option:hover {
+  .autocomplete__option-hint {
+    color: #fff;
+  }
+}
+
 .js-enabled {
   .app-c-autocomplete__multiselect-instructions {
     display: none;

--- a/app/assets/stylesheets/components/_autocomplete.scss
+++ b/app/assets/stylesheets/components/_autocomplete.scss
@@ -14,7 +14,7 @@
 .autocomplete__option--focused,
 .autocomplete__option:hover {
   .autocomplete__option-hint {
-    color: #fff;
+    color: govuk-colour('white');
   }
 }
 

--- a/app/views/components/docs/autocomplete.yml
+++ b/app/views/components/docs/autocomplete.yml
@@ -12,6 +12,8 @@ examples:
       name: autocomplete
       label:
         text: Select your country
+      data:
+        module: autocomplete
       options:
         -
           - France
@@ -29,6 +31,8 @@ examples:
       name: autocomplete-selected
       label:
         text: Select your country
+      data:
+        module: autocomplete
       options:
         -
           - France
@@ -48,6 +52,8 @@ examples:
       name: autocomplete-multiselect
       label:
         text: Select your country
+      data:
+        module: autocomplete-multiselect
       multiple: true
       options:
         -
@@ -66,6 +72,8 @@ examples:
       name: autocomplete-multiselect-selected
       label:
         text: Select your country
+      data:
+        module: autocomplete-multiselect
       multiple: true
       options:
         -

--- a/app/views/components/docs/autocomplete.yml
+++ b/app/views/components/docs/autocomplete.yml
@@ -16,6 +16,9 @@ examples:
         module: autocomplete
       options:
         -
+          - Select a country
+          -
+        -
           - France
           - fr
         -
@@ -57,6 +60,9 @@ examples:
       multiple: true
       options:
         -
+          - Select a country
+          -
+        -
           - France
           - fr
         -
@@ -88,3 +94,24 @@ examples:
       selected_options:
           - fr
           - de
+  autocomplete_with_custom_template:
+    data:
+      id: autocomplete-custom-template
+      name: autocomplete-custom-template
+      label:
+        text: Select your country
+      data:
+        module: autocomplete-custom-template
+      options:
+        -
+          - Select a country
+          -
+        -
+          - France - Paris
+          - fr
+        -
+          - United Arab Emirates - Abu Dhabi
+          - ae
+        -
+          - United Kingdom - London
+          - uk

--- a/app/views/document_contacts/search.html.erb
+++ b/app/views/document_contacts/search.html.erb
@@ -17,7 +17,7 @@
     },
     options: ["", ""] + contact_options,
     data: {
-      module: "autocomplete",
+      module: "autocomplete-custom-template",
     }
   } %>
 
@@ -25,4 +25,3 @@
     text: "Insert contact", margin_bottom: true
   } %>
 <% end %>
-


### PR DESCRIPTION
This PR:
- adds a new option for the autocomplete to support custom template
- add the custom template version of autocomplete to contacts

👉 [Preview component](https://content-publisher-revie-pr-571.herokuapp.com/component-guide/autocomplete/autocomplete_with_custom_template)

[Trello card](https://trello.com/c/05U8l7DF)