### PR TITLE
Disable mobile preview on mobile and use the default one instead

### DIFF
--- a/app/assets/stylesheets/components/_page-preview.scss
+++ b/app/assets/stylesheets/components/_page-preview.scss
@@ -48,8 +48,13 @@ $mobile-border-bottom-width: 68px;
 }
 
 .app-c-preview__google {
-  max-width: 600px;
-  -webkit-font-smoothing: auto;
+  display: none;
+
+  @include govuk-media-query($from: tablet) {
+    display: block;
+    max-width: 600px;
+    -webkit-font-smoothing: auto;
+  }
 }
 
 .app-c-preview__google-title {

--- a/app/assets/stylesheets/components/_page-preview.scss
+++ b/app/assets/stylesheets/components/_page-preview.scss
@@ -6,12 +6,30 @@ $mobile-frame-height: 585px;
 $mobile-border-width: 17px;
 $mobile-border-bottom-width: 68px;
 
+.app-c-preview {
+  .govuk-tabs__list {
+    display: none;
+
+    @include govuk-media-query($from: tablet) {
+      display: block;
+    }
+  }
+
+  .govuk-tabs__title {
+    display: none;
+  }
+}
+
 .app-c-preview__mobile {
-  display: block;
-  width: $mobile-frame-width + 2 * $mobile-border-width;
-  height: $mobile-frame-height + $mobile-border-width + $mobile-border-bottom-width;
-  background-image: image-url("components/preview-mobile.svg");
-  background-repeat: no-repeat;
+  display: none;
+
+  @include govuk-media-query($from: tablet) {
+    display: block;
+    width: $mobile-frame-width + 2 * $mobile-border-width;
+    height: $mobile-frame-height + $mobile-border-width + $mobile-border-bottom-width;
+    background-image: image-url("components/preview-mobile.svg");
+    background-repeat: no-repeat;
+  }
 }
 
 .app-c-preview__mobile-iframe {


### PR DESCRIPTION
This PR updates the page preview component to drop the mobile frame and only present the default preview and the Google search snippet.

## Desktop
### Before and After
<img width="959" alt="screen shot 2018-12-04 at 16 17 44" src="https://user-images.githubusercontent.com/788096/49456435-f8943e80-f7e0-11e8-9a7f-b69f95163107.png">


## Mobile
### Before
<img width="395" alt="screen shot 2018-12-04 at 16 21 55" src="https://user-images.githubusercontent.com/788096/49456449-01851000-f7e1-11e8-91c5-ca95b16645f1.png">

### After
<img width="395" alt="screen shot 2018-12-04 at 16 19 04" src="https://user-images.githubusercontent.com/788096/49456454-05189700-f7e1-11e8-826e-d52468fe8fc1.png">


[Trello card](https://trello.com/c/qMVliSBq)