### PR TITLE
Fix alternate path bug

### DIFF
--- a/app/views/documents/show/_history_tab.html.erb
+++ b/app/views/documents/show/_history_tab.html.erb
@@ -17,7 +17,7 @@
       <p><%= entry.removal.explanatory_note %></p>
       <% if entry.removal.redirect %>
         <p>Redirected to <%= link_to(Plek.new.website_root + entry.removal.alternative_path) %></p>
-      <% else %>
+      <% elsif entry.removal.alternative_path.present? %>
         <p><%= link_to(Plek.new.website_root + entry.removal.alternative_path) %></p>
       <% end %>
     <% end %>

--- a/app/views/documents/show/_history_tab.html.erb
+++ b/app/views/documents/show/_history_tab.html.erb
@@ -14,7 +14,9 @@
     <% if entry.retirement.present? %>
       <%= entry.retirement.explanatory_note %>
     <% elsif entry.removal.present? %>
-      <p><%= entry.removal.explanatory_note %></p>
+      <% if entry.removal.explanatory_note.present? %>
+        <p><%= entry.removal.explanatory_note %></p>
+      <% end %>
       <% if entry.removal.redirect %>
         <p>Redirected to <%= link_to(Plek.new.website_root + entry.removal.alternative_path) %></p>
       <% elsif entry.removal.alternative_path.present? %>


### PR DESCRIPTION
Fixes bug introduced in PR #575
Trello: https://trello.com/c/exMkuccz

The alternate_path is an optional field for removed documents. It is only required if the document is also being automatically redirected.

Add a guard so we don't try and display a link to this path if it doesn't exist.

Error in sentry: https://sentry.io/govuk/app-content-publisher/issues/792806891