### PR TITLE
Put the default image copy back

### DIFF
--- a/config/locales/en/documents/show.yml
+++ b/config/locales/en/documents/show.yml
@@ -35,7 +35,7 @@ en:
           Something went wrong when deleting your draft. Please try again or [raise a support request](https://support.publishing.service.gov.uk/technical_fault_report/new).
       lead_image:
         title: Lead image
-        no_lead_image: No image selected.
+        no_lead_image: No image selected. The default image for your department will be used.
         upload_image: Upload an image
         fields:
           alt_text: Alt text


### PR DESCRIPTION
@emmabeynon fixed default images

https://trello.com/c/w1QxJ7gk/500-update-rummager-to-lookup-organisation-default-news-image-when-setting-the-image-for-an-indexed-document?menu=filter&filter=member:emmabeynon2