### PR TITLE
Add more Google Tag Manager data attributes

### DIFF
--- a/app/views/components/_markdown_editor.html.erb
+++ b/app/views/components/_markdown_editor.html.erb
@@ -15,28 +15,58 @@
       </div>
       <div class="app-c-markdown-editor__toolbar">
         <markdown-toolbar class="app-c-markdown-editor__toolbar-group" for="<%= textarea[:id] %>">
-          <md-header-2 class="app-c-markdown-editor__toolbar-button" data-gtm="markdown-toolbar-selection">
-            <i class="app-c-markdown-editor__toolbar-icon app-c-markdown-editor__toolbar-icon--heading-2" title="Heading level 2" aria-hidden="true"></i>
+          <md-header-2 class="app-c-markdown-editor__toolbar-button">
+            <i
+              class="app-c-markdown-editor__toolbar-icon app-c-markdown-editor__toolbar-icon--heading-2"
+              title="Heading level 2"
+              aria-hidden="true"
+              data-gtm="markdown-toolbar-selection"
+            ></i>
             <span class="govuk-visually-hidden">Heading level 2</span>
           </md-header-2>
-          <md-header-3 class="app-c-markdown-editor__toolbar-button" data-gtm="markdown-toolbar-selection">
-            <i class="app-c-markdown-editor__toolbar-icon app-c-markdown-editor__toolbar-icon--heading-3" title="Heading level 3" aria-hidden="true"></i>
+          <md-header-3 class="app-c-markdown-editor__toolbar-button">
+            <i
+              class="app-c-markdown-editor__toolbar-icon app-c-markdown-editor__toolbar-icon--heading-3"
+              title="Heading level 3"
+              aria-hidden="true"
+              data-gtm="markdown-toolbar-selection"
+            ></i>
             <span class="govuk-visually-hidden">Heading level 3</span>
           </md-header-3>
-          <md-link class="app-c-markdown-editor__toolbar-button" data-gtm="markdown-toolbar-selection">
-            <i class="app-c-markdown-editor__toolbar-icon app-c-markdown-editor__toolbar-icon--link" title="Link" aria-hidden="true"></i>
+          <md-link class="app-c-markdown-editor__toolbar-button">
+            <i
+              class="app-c-markdown-editor__toolbar-icon app-c-markdown-editor__toolbar-icon--link"
+              title="Link"
+              aria-hidden="true"
+              data-gtm="markdown-toolbar-selection"
+            ></i>
             <span class="govuk-visually-hidden">Link</span>
           </md-link>
-          <md-quote class="app-c-markdown-editor__toolbar-button" data-gtm="markdown-toolbar-selection">
-            <i class="app-c-markdown-editor__toolbar-icon app-c-markdown-editor__toolbar-icon--blockquote" title="Blockquote" aria-hidden="true"></i>
+          <md-quote class="app-c-markdown-editor__toolbar-button">
+            <i
+              class="app-c-markdown-editor__toolbar-icon app-c-markdown-editor__toolbar-icon--blockquote"
+              title="Blockquote"
+              aria-hidden="true"
+              data-gtm="markdown-toolbar-selection"
+            ></i>
             <span class="govuk-visually-hidden">Blockquote</span>
           </md-quote>
-          <md-ordered-list class="app-c-markdown-editor__toolbar-button" data-gtm="markdown-toolbar-selection">
-            <i class="app-c-markdown-editor__toolbar-icon app-c-markdown-editor__toolbar-icon--numbered-list" title="Numbered list" aria-hidden="true"></i>
+          <md-ordered-list class="app-c-markdown-editor__toolbar-button">
+            <i
+              class="app-c-markdown-editor__toolbar-icon app-c-markdown-editor__toolbar-icon--numbered-list"
+              title="Numbered list"
+              aria-hidden="true"
+              data-gtm="markdown-toolbar-selection"
+            ></i>
             <span class="govuk-visually-hidden">Numbered list</span>
           </md-ordered-list>
-          <md-unordered-list class="app-c-markdown-editor__toolbar-button" data-gtm="markdown-toolbar-selection">
-            <i class="app-c-markdown-editor__toolbar-icon app-c-markdown-editor__toolbar-icon--bullets" title="Bullets" aria-hidden="true"></i>
+          <md-unordered-list class="app-c-markdown-editor__toolbar-button">
+            <i
+              class="app-c-markdown-editor__toolbar-icon app-c-markdown-editor__toolbar-icon--bullets"
+              title="Bullets"
+              aria-hidden="true"
+              data-gtm="markdown-toolbar-selection"
+            ></i>
             <span class="govuk-visually-hidden">Bullets</span>
           </md-unordered-list>
           <button name="submit" type="submit" value="add_contact" class="app-c-markdown-editor__toolbar-button app-c-markdown-editor__toolbar-button--text app-c-markdown-editor__toolbar-button--end">Add contact</button>

--- a/app/views/components/_markdown_guidance.html.erb
+++ b/app/views/components/_markdown_guidance.html.erb
@@ -1,6 +1,7 @@
 <div class="app-c-markdown-guidance">
   <%= render "govuk_publishing_components/components/details", {
-        title: "Acronyms"
+        title: "Acronyms",
+        data_attributes: { gtm: "markdown-guidance-details" }
   } do %>
     <p>Definitions for acronyms that will appear if the user hovers the mouse over it.</p>
     <p>Add each definition in its own paragraph at the end of the body copy.</p>
@@ -10,7 +11,8 @@
   <% end %>
 
   <%= render "govuk_publishing_components/components/details", {
-        title: "Addresses"
+        title: "Addresses",
+        data_attributes: { gtm: "markdown-guidance-details" }
   } do %>
     <p>Add $A before and after an address to inset it.</p>
     <pre class="app-c-markdown-guidance__code-snippet">
@@ -22,7 +24,8 @@
   <% end %>
 
   <%= render "govuk_publishing_components/components/details", {
-        title: "Call to action"
+        title: "Call to action",
+        data_attributes: { gtm: "markdown-guidance-details" }
   } do %>
     <p>Add $CTA before and after a paragraph to highlight an action for the user.</p>
     <pre class="app-c-markdown-guidance__code-snippet">
@@ -33,7 +36,8 @@
   <% end %>
 
   <%= render "govuk_publishing_components/components/details", {
-        title: "Email links"
+        title: "Email links",
+        data_attributes: { gtm: "markdown-guidance-details" }
   } do %>
     <p>Add < and > brackets around email addresses to make them a link.</p>
     <pre class="app-c-markdown-guidance__code-snippet">
@@ -42,7 +46,8 @@
   <% end %>
 
   <%= render "govuk_publishing_components/components/details", {
-        title: "Tables"
+        title: "Tables",
+        data_attributes: { gtm: "markdown-guidance-details" }
   } do %>
     <p>Add | to separate data into columns and put each row on a new line.</p>
     <pre class="app-c-markdown-guidance__code-snippet">
@@ -62,11 +67,12 @@
   <% end %>
 
   <%= render "govuk_publishing_components/components/details", {
-        title: "Bar charts"
+        title: "Bar charts",
+        data_attributes: { gtm: "markdown-guidance-details" }
   } do %>
     <p>Add {barchart} at the end of numeric tables to display a simple bar chart.</p>
     <pre class="app-c-markdown-guidance__code-snippet">
-    Name | Number | Number 
+    Name | Number | Number
     -|-|-
     Thing | 120 | 445
     Thing | 154 | 228

--- a/app/views/components/_page_preview.html.erb
+++ b/app/views/components/_page_preview.html.erb
@@ -8,7 +8,10 @@
       <%= render "govuk_publishing_components/components/copy_to_clipboard",
         label: "Send this link to someone so they can see a preview of how the document will appear on GOV.UK. No password is needed.",
         copyable_content: utm_uri.to_s,
-        button_text: "Copy link" %>
+        button_text: "Copy link",
+        button_data_attributes: { gtm: "copy-url-for-preview-cta" },
+        input_data_attributes: { gtm: "copy-url-for-preview-manual" }
+      %>
     <% end %>
   </div>
 </div>

--- a/app/views/components/_page_preview.html.erb
+++ b/app/views/components/_page_preview.html.erb
@@ -41,16 +41,19 @@
         id: "mobile",
         label: "Mobile",
         content: mobile_preview,
+        tab_data_attributes: { gtm: "tab-list-selection" },
       },
       {
         id: "desktop",
         label: "Desktop and tablet",
         content: desktop_and_tablet,
+        tab_data_attributes: { gtm: "tab-list-selection" }
       },
       {
         id: "search-engine",
         label: "Search engine snippet",
         content: snippet_preview,
+        tab_data_attributes: { gtm: "tab-list-selection" },
       },
     ]
   } %>

--- a/app/views/document_contacts/search.html.erb
+++ b/app/views/document_contacts/search.html.erb
@@ -9,7 +9,10 @@
   end
 %>
 
-<%= form_tag(insert_document_contact_path(@document)) do %>
+<%= form_tag(
+  insert_document_contact_path(@document),
+  data: { gtm: "insert-contact-submit" },
+) do %>
   <%= render "components/autocomplete", {
     name: "contact_id",
     label: {

--- a/app/views/document_images/index.html.erb
+++ b/app/views/document_images/index.html.erb
@@ -10,7 +10,11 @@
         </h2>
       <% end %>
 
-      <%= form_tag(create_document_image_path(@document), multipart: true) do %>
+      <%= form_tag(
+        create_document_image_path(@document),
+        multipart: true,
+        data: { gtm: "image-upload-submit" },
+      ) do %>
         <%= hidden_field_tag :wizard, "lead_image" %>
 
         <%= render "govuk_publishing_components/components/file_upload", {

--- a/app/views/documents/edit.html.erb
+++ b/app/views/documents/edit.html.erb
@@ -6,7 +6,15 @@
   <% content_for :title, t("documents.edit.title", title: @document.title_or_fallback) %>
 <% end %>
 
-<%= form_for(@document, html: {'autocomplete': 'off'}, data: {'module': 'edit-document-form', 'url-preview-path': generate_path_path, "warn-before-unload": "true"}) do |f| %>
+<%= form_for(
+  @document,
+  html: { "autocomplete": "off" },
+  data: {
+    module: "edit-document-form",
+    "url-preview-path": generate_path_path,
+    "warn-before-unload": "true",
+    gtm: "edit-document-submit",
+  }) do |f| %>
   <div class="govuk-grid-row">
     <div class="govuk-grid-column-two-thirds">
       <%= render "govuk_publishing_components/components/textarea", {

--- a/app/views/documents/show.html.erb
+++ b/app/views/documents/show.html.erb
@@ -1,6 +1,12 @@
 <% content_for :back_link, render_back_link(href: documents_path) %>
 <% content_for :title, @document.title_or_fallback %>
 <% content_for :context, @document.document_type.label %>
+<% content_for :data_layer_js do %>
+  dataLayer.push({
+    "document-type": "<%= @document.document_type.label %>",
+    "document-status": "<%= t("user_facing_states.#{@document.user_facing_state}.name") %>"
+  })
+<% end %>
 
 <%= render "govuk_publishing_components/components/tabs", {
   panel_border: false,

--- a/app/views/documents/show/_delete_draft.html.erb
+++ b/app/views/documents/show/_delete_draft.html.erb
@@ -1,5 +1,9 @@
 <% confirmation = capture do %>
-  <%= form_tag document_path(@document), method: :delete do %>
+  <%= form_tag(
+    document_path(@document),
+    method: :delete,
+    data: { gtm: "delete-draft-submit" },
+  ) do %>
     <%= render "govuk_publishing_components/components/button", {
       text: "Yes, delete draft",
       destructive: true

--- a/app/views/documents/show/_submitted_for_review.html.erb
+++ b/app/views/documents/show/_submitted_for_review.html.erb
@@ -3,9 +3,8 @@
     label: t("documents.show.flashes.submitted_for_review.label"),
     copyable_content: document_url(@document, utm_content: "2i-link"),
     button_text: "Copy link",
-    button_data_attributes: {
-      gtm: "copy-url-for-2i-approval-cta"
-    }
+    button_data_attributes: { gtm: "copy-url-for-2i-approval-cta" },
+    input_data_attributes: { gtm: "copy-url-for-2i-approval-manual" }
 ) %>
 
 <%= render "govuk_publishing_components/components/success_alert",

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -57,6 +57,7 @@
     <% if flash["alert_with_description"] %>
       <%= render "govuk_publishing_components/components/error_alert", {
         message: flash["alert_with_description"].fetch("title"),
+        data_attributes: { gtm: "global-alert" },
         description: capture do
           render "govuk_publishing_components/components/govspeak" do
             govspeak_to_html(flash["alert_with_description"].fetch("description_govspeak"))
@@ -68,13 +69,15 @@
     <% if flash["alert_with_items"] %>
       <%= render "govuk_publishing_components/components/error_summary", {
         title: flash["alert_with_items"]["title"],
-        items: flash["alert_with_items"]["items"].map(&:symbolize_keys)
+        items: flash["alert_with_items"]["items"].map(&:symbolize_keys),
+        data_attributes: { gtm: "global-alert" },
       } %>
     <% end %>
 
     <% if flash["alert"] %>
       <%= render "govuk_publishing_components/components/error_alert", {
-        message: flash["alert"]
+        message: flash["alert"],
+        data_attributes: { gtm: "global-alert" },
       } %>
     <% end %>
 

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -4,11 +4,12 @@
     <meta name="sentry-current-env" content="<%= ENV["SENTRY_CURRENT_ENV"] %>">
   <% end %>
 
+  <script>
+    var dataLayer = [{ 'dimension1': '<%= current_user.organisation_slug %>' }];
+    dataLayer.push({ 'gtm.blacklist' : ['html', 'customScripts', 'nonGoogleScripts', 'customPixels']});
+<%= yield(:data_layer_js) %>
+  </script>
   <% if ENV["GOOGLE_TAG_MANAGER_ID"] %>
-    <script>
-      var dataLayer = [{ 'dimension1': '<%= current_user.organisation_slug %>' }];
-      dataLayer.push({ 'gtm.blacklist' : ['html', 'customScripts', 'nonGoogleScripts', 'customPixels']});
-    </script>
     <%= render "govuk_publishing_components/components/google_tag_manager_script", {
       gtm_id: ENV["GOOGLE_TAG_MANAGER_ID"],
       gtm_auth: ENV["GOOGLE_TAG_MANAGER_AUTH"],


### PR DESCRIPTION
https://trello.com/c/yRnJfrDN/487-deployment-of-remaining-data-attributes-for-consistent-event-tracking-in-gtm

I paired with Andy to work out these bits of tracking so he doesn't have to rely on CSS selectors.

This does need https://github.com/alphagov/govuk_publishing_components/pull/662 to fully work as the error alert and error summary fields don't support data attributes yet, but to be honest it's probably not much of a concern if we merge this before.