### PR TITLE
[WIP] Replace attr_accessors by inerhiting ReadonlyModel

### DIFF
--- a/app/models/concerns/readonly_model.rb
+++ b/app/models/concerns/readonly_model.rb
@@ -1,0 +1,17 @@
+# frozen_string_literal: true
+
+class ReadonlyModel
+  include ActiveModel::Model
+
+private
+
+  def assign_attributes(new_attributes)
+    new_attributes.each do |key, value|
+      instance_variable_set(:"@#{key}", value)
+    end
+  end
+
+  def attributes=(args)
+    assign_attributes(args)
+  end
+end

--- a/app/models/document_topics.rb
+++ b/app/models/document_topics.rb
@@ -1,9 +1,7 @@
 # frozen_string_literal: true
 
-class DocumentTopics
-  include ActiveModel::Model
-
-  attr_accessor :document, :version, :topics, :index
+class DocumentTopics < ReadonlyModel
+  attr_reader :document, :version, :topics, :index
 
   def self.find_by_document(document, index)
     publishing_api = GdsApi.publishing_api_v2
@@ -27,7 +25,6 @@ class DocumentTopics
 
   def patch(topic_content_ids, version)
     topics = topic_content_ids.map { |topic_content_id| Topic.find(topic_content_id, index) }
-    self.version = version
 
     GdsApi.publishing_api_v2.patch_links(
       document.content_id,

--- a/app/models/topic.rb
+++ b/app/models/topic.rb
@@ -1,8 +1,6 @@
 # frozen_string_literal: true
 
-class Topic
-  include ActiveModel::Model
-
+class Topic < ReadonlyModel
   def self.govuk_homepage(index)
     find(TopicIndexService::GOVUK_HOMEPAGE_CONTENT_ID, index)
   end
@@ -12,7 +10,7 @@ class Topic
     raw_topic ? new(raw_topic.merge(index: index)) : nil
   end
 
-  attr_accessor :title, :child_content_ids, :legacy_topic_content_ids, :parent_content_id, :content_id, :index
+  attr_reader :title, :child_content_ids, :legacy_topic_content_ids, :parent_content_id, :content_id, :index
 
   delegate :hash, to: :content_id
 

--- a/app/services/document_type.rb
+++ b/app/services/document_type.rb
@@ -1,24 +1,8 @@
 # frozen_string_literal: true
 
-class DocumentType
+class DocumentType < ReadonlyModel
   attr_reader :contents, :id, :label, :managed_elsewhere, :publishing_metadata,
     :path_prefix, :tags, :guidance_govspeak, :description, :hint, :lead_image, :topics, :check_path_conflict
-
-  def initialize(params = {})
-    @id = params["id"]
-    @label = params["label"]
-    @managed_elsewhere = params["managed_elsewhere"]
-    @contents = params["contents"].to_a.map(&Field.method(:new))
-    @publishing_metadata = PublishingMetadata.new(params["publishing_metadata"])
-    @path_prefix = params["path_prefix"]
-    @tags = params["tags"].to_a.map(&TagField.method(:new))
-    @guidance = params["guidance"].to_a.map(&Guidance.method(:new))
-    @description = params["description"]
-    @hint = params["hint"]
-    @lead_image = params["lead_image"]
-    @topics = params["topics"]
-    @check_path_conflict = params["check_path_conflict"]
-  end
 
   def self.find(id)
     item = all.find { |document_type| document_type.id == id }
@@ -28,14 +12,23 @@ class DocumentType
   def self.all
     @all ||= begin
       types = YAML.load_file("app/formats/document_types.yml")
-      types.map { |data| DocumentType.new(data) }
+      types.map { |data| new.from_hash(data) }
     end
   end
 
   def self.add(params)
-    document_type = new(params)
+    document_type = new.from_hash(params)
     all << document_type
     document_type
+  end
+
+  def from_hash(hash)
+    hash["contents"] = hash["contents"].to_a.map(&Field.method(:new))
+    hash["publishing_metadata"] = PublishingMetadata.new(hash["publishing_metadata"])
+    hash["tags"] = hash["tags"].to_a.map(&TagField.method(:new))
+    hash["guidance"] = hash["guidance"].to_a.map(&Guidance.method(:new))
+    assign_attributes(hash)
+    self
   end
 
   def managed_elsewhere_url
@@ -46,23 +39,19 @@ class DocumentType
     @guidance.find { |guidance| guidance.id == id }
   end
 
-  class TagField
-    include ActiveModel::Model
-    attr_accessor :id, :label, :type, :document_type, :hint
+  class TagField < ReadonlyModel
+    attr_reader :id, :label, :type, :document_type, :hint
   end
 
-  class Guidance
-    include ActiveModel::Model
-    attr_accessor :id, :title, :body_govspeak
+  class Guidance < ReadonlyModel
+    attr_reader :id, :title, :body_govspeak
   end
 
-  class PublishingMetadata
-    include ActiveModel::Model
-    attr_accessor :schema_name, :rendering_app
+  class PublishingMetadata < ReadonlyModel
+    attr_reader :schema_name, :rendering_app
   end
 
-  class Field
-    include ActiveModel::Model
-    attr_accessor :id, :label, :type
+  class Field < ReadonlyModel
+    attr_reader :id, :label, :type
   end
 end

--- a/app/services/supertype.rb
+++ b/app/services/supertype.rb
@@ -1,27 +1,24 @@
 # frozen_string_literal: true
 
-class Supertype
+class Supertype < ReadonlyModel
   attr_reader :id, :label, :description, :managed_elsewhere, :hint, :document_types
-
-  def initialize(params = {})
-    @id = params["id"]
-    @label = params["label"]
-    @description = params["description"]
-    @managed_elsewhere = params["managed_elsewhere"]
-    @hint = params["hint"]
-    @document_types = params["display_document_types"].to_a.map { |type| DocumentType.find(type) }
-  end
 
   def self.all
     @all ||= begin
       raw = YAML.load_file("app/formats/supertypes.yml")
-      raw.map { |r| Supertype.new(r) }
+      raw.map { |r| new.from_hash(r) }
     end
   end
 
   def self.find(id)
     item = all.find { |supertype| supertype.id == id }
     item || (raise RuntimeError, "Supertype #{id} not found")
+  end
+
+  def from_hash(hash)
+    hash["document_types"] = hash["display_document_types"].to_a.map(&DocumentType.method(:find))
+    assign_attributes(hash)
+    self
   end
 
   def managed_elsewhere_url


### PR DESCRIPTION
We have a number of classes, such as DocumentType and Topic, that
act as interfaces to static (readonly) data. Previously, some of these
classes used attr_accessors so they could include ActiveModel::Model,
which helps to DRY-up the way their instances are constructed.

This replaces the use of attr_accessor with attr_reader by changing each
model to extend a slightly modified version of ActiveModel::Model that
also makes the update_attributes and attributes= methods private.