### PR TITLE
Add download link to images

### DIFF
--- a/app/controllers/document_images_controller.rb
+++ b/app/controllers/document_images_controller.rb
@@ -132,6 +132,17 @@ class DocumentImagesController < ApplicationController
     end
   end
 
+  def download
+    image = Image.find(params[:image_id])
+    variant = image.crop_variant("960x640!").processed
+
+    send_data(
+      image.blob.service.download(variant.key),
+      filename: image.filename,
+      type: image.content_type,
+    )
+  end
+
 private
 
   def update_params

--- a/app/views/document_images/_image_list.html.erb
+++ b/app/views/document_images/_image_list.html.erb
@@ -9,19 +9,20 @@
     <% actions = [
       link_to("Edit crop", crop_document_image_path(@document, image), class: "govuk-link"),
       link_to("Edit details", edit_document_image_path(@document, image), class: "govuk-link"),
+      link_to('Download 960x640 image', download_image_path(@document, image), class: "govuk-link")
     ] %>
+
+    <% actions << capture do %>
+      <%= form_tag choose_document_lead_image_path(@document, image), class: "app-inline-block" do %>
+        <button class="govuk-link">Select as lead image</button>
+      <% end %>
+    <% end %>
 
     <% unless @document.has_live_version_on_govuk %>
       <% actions << capture do %>
         <%= form_tag destroy_document_image_path(@document, image), method: :delete, class: "app-inline-block" do %>
           <button class="govuk-link app-link--destructive">Delete image</button>
         <% end %>
-      <% end %>
-    <% end %>
-
-    <% actions << capture do %>
-      <%= form_tag choose_document_lead_image_path(@document, image), class: "app-inline-block" do %>
-        <button class="govuk-link">Select as lead image</button>
       <% end %>
     <% end %>
 

--- a/app/views/document_images/_lead_image.html.erb
+++ b/app/views/document_images/_lead_image.html.erb
@@ -11,7 +11,14 @@
   <% actions = [
     link_to("Edit crop", crop_document_image_path(@document, image), class: "govuk-link"),
     link_to("Edit details", edit_document_image_path(@document, image), class: "govuk-link"),
+    link_to('Download 960x640 image', download_image_path(@document, image), class: "govuk-link")
   ] %>
+
+  <% actions << capture do %>
+    <%= form_tag remove_document_lead_image_path(@document), method: :delete, class: "app-inline-block" do %>
+      <button class="govuk-link">Remove lead image</button>
+    <% end %>
+  <% end %>
 
   <% unless @document.has_live_version_on_govuk %>
     <% actions << capture do %>
@@ -19,12 +26,6 @@
         <%= hidden_field_tag :wizard, "lead_image" %>
         <button class="govuk-link app-link--destructive">Delete lead image</button>
       <% end %>
-    <% end %>
-  <% end %>
-
-  <% actions << capture do %>
-    <%= form_tag remove_document_lead_image_path(@document), method: :delete, class: "app-inline-block" do %>
-      <button class="govuk-link">Remove lead image</button>
     <% end %>
   <% end %>
 

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -38,6 +38,7 @@ Rails.application.routes.draw do
 
   get "/documents/:document_id/images" => "document_images#index", as: :document_images
   post "/documents/:document_id/images" => "document_images#create", as: :create_document_image
+  get "/documents/:document_id/images/:image_id/download" => "document_images#download", as: :download_image
   get "/documents/:document_id/images/:image_id/crop" => "document_images#crop", as: :crop_document_image
   patch "/documents/:document_id/images/:image_id/crop" => "document_images#update_crop"
   get "/documents/:document_id/images/:image_id/edit" => "document_images#edit", as: :edit_document_image

--- a/spec/features/editing_images/download_image_spec.rb
+++ b/spec/features/editing_images/download_image_spec.rb
@@ -1,0 +1,30 @@
+# frozen_string_literal: true
+
+RSpec.feature "Download a image" do
+  scenario do
+    given_there_is_a_document_with_images
+    when_i_visit_the_documents_image_index_page
+    and_i_click_the_link_to_download_the_image
+    then_the_image_should_have_been_downloaded
+  end
+
+  def given_there_is_a_document_with_images
+    document_type = build(:document_type, lead_image: true)
+    @document = create(:document, document_type_id: document_type.id)
+    @image = create(:image, :in_preview, document: @document)
+  end
+
+  def when_i_visit_the_documents_image_index_page
+    visit document_images_path(@document)
+  end
+
+  def and_i_click_the_link_to_download_the_image
+    within("#image-#{@image.id}") do
+      click_on("Download 960x640 image")
+    end
+  end
+
+  def then_the_image_should_have_been_downloaded
+    expect(page.response_headers["Content-Disposition"]).to eq("attachment; filename=\"#{@image.filename}\"")
+  end
+end


### PR DESCRIPTION
Clicking the download link will crop the image to 960x640 and download
it to the users computer. This is useful for whitehall users as images
uploaded here can easily be cropped and used in whitehall publisher.

Due to a discussion with Sonia, the link order has also been amended
which moves the `delete image` link to the end of the list.

Trello:
https://trello.com/c/w4aI961C/529-provide-a-960x640-download-link-for-images

## Before
<img width="964" alt="screen shot 2018-12-11 at 12 02 14" src="https://user-images.githubusercontent.com/24479188/49799350-a3a27c00-fd3c-11e8-9080-06fd7edc4ad5.png">

## After
<img width="798" alt="screen shot 2018-12-11 at 11 47 35" src="https://user-images.githubusercontent.com/24479188/49799098-f891c280-fd3b-11e8-91ec-2999de8e440f.png">
