### PR TITLE
[DO NOT MERGE] Add document withdrawal workflow

### DIFF
--- a/app/controllers/unwithdraw_controller.rb
+++ b/app/controllers/unwithdraw_controller.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+class UnwithdrawController < ApplicationController
+  def index
+    @document = Document.find_by_param(params[:id])
+  end
+end

--- a/app/controllers/withdraw_controller.rb
+++ b/app/controllers/withdraw_controller.rb
@@ -4,6 +4,11 @@ class WithdrawController < ApplicationController
   def create
     @document = Document.find_by_param(params[:id])
     @public_explanation = @document.retirement&.explanatory_note || params[:public_explanation]
+    if current_user.has_permission?(User::MANAGING_EDITOR_PERMISSION)
+      render :create
+    else
+      render :non_managing_editor
+    end
   end
 
   def new

--- a/app/controllers/withdraw_controller.rb
+++ b/app/controllers/withdraw_controller.rb
@@ -26,6 +26,12 @@ class WithdrawController < ApplicationController
     end
 
     UnpublishService.new.retire(@document, public_explanation)
+  rescue GdsApi::BaseError => e
+    GovukError.notify(e)
+    redirect_to withdraw_path(@document),
+      alert_with_description: t("withdraw_document.withdraw.flashes.publishing_api_error"),
+      public_explanation: public_explanation
+  else
     redirect_to @document
   end
 end

--- a/app/controllers/withdraw_controller.rb
+++ b/app/controllers/withdraw_controller.rb
@@ -3,12 +3,24 @@
 class WithdrawController < ApplicationController
   def create
     @document = Document.find_by_param(params[:id])
+    @public_explanation = @document.retirement&.explanatory_note || params[:public_explanation]
   end
 
   def new
-    document = Document.find_by_param(params[:id])
+    @document = Document.find_by_param(params[:id])
     public_explanation = params[:public_explanation]
-    UnpublishService.new.retire(document, public_explanation)
-    redirect_to document
+    issues = Requirements::PublicExplanationChecker.new(public_explanation).pre_withdrawal_issues
+    if issues.any?
+      flash.now["alert_with_items"] = {
+        "title" => I18n.t!("withdraw_document.withdraw.flashes.requirements"),
+        "items" => issues.items,
+      }
+
+      render :create, public_explanation: public_explanation
+      return
+    end
+
+    UnpublishService.new.retire(@document, public_explanation)
+    redirect_to @document
   end
 end

--- a/app/controllers/withdraw_controller.rb
+++ b/app/controllers/withdraw_controller.rb
@@ -4,4 +4,11 @@ class WithdrawController < ApplicationController
   def create
     @document = Document.find_by_param(params[:id])
   end
+
+  def new
+    document = Document.find_by_param(params[:id])
+    public_explanation = params[:public_explanation]
+    UnpublishService.new.retire(document, public_explanation)
+    redirect_to document
+  end
 end

--- a/app/controllers/withdraw_controller.rb
+++ b/app/controllers/withdraw_controller.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+class WithdrawController < ApplicationController
+  def create
+    @document = Document.find_by_param(params[:id])
+  end
+end

--- a/app/controllers/withdraw_controller.rb
+++ b/app/controllers/withdraw_controller.rb
@@ -25,7 +25,7 @@ class WithdrawController < ApplicationController
       return
     end
 
-    UnpublishService.new.retire(@document, public_explanation)
+    UnpublishService.new.retire(@document, public_explanation, current_user)
   rescue GdsApi::BaseError => e
     GovukError.notify(e)
     redirect_to withdraw_path(@document),

--- a/app/models/document.rb
+++ b/app/models/document.rb
@@ -81,4 +81,8 @@ class Document < ApplicationRecord
   def withdrawn_by
     @withdrawn_by ||= self.timeline_entries.where(entry_type: "retired").order(:created_at).last.user
   end
+
+  def withdrawn?
+    user_facing_state == "retired"
+  end
 end

--- a/app/models/document.rb
+++ b/app/models/document.rb
@@ -73,4 +73,8 @@ class Document < ApplicationRecord
     @document_topics_index ||= TopicIndexService.new
     DocumentTopics.find_by_document(self, @document_topics_index)
   end
+
+  def retirement
+    self.timeline_entries.where(entry_type: "retired").order(:created_at).last&.retirement
+  end
 end

--- a/app/models/document.rb
+++ b/app/models/document.rb
@@ -77,4 +77,8 @@ class Document < ApplicationRecord
   def retirement
     self.timeline_entries.where(entry_type: "retired").order(:created_at).last&.retirement
   end
+
+  def withdrawn_by
+    @withdrawn_by ||= self.timeline_entries.where(entry_type: "retired").order(:created_at).last.user
+  end
 end

--- a/app/models/document.rb
+++ b/app/models/document.rb
@@ -6,6 +6,7 @@ class Document < ApplicationRecord
   has_many :images, dependent: :destroy
   has_many :timeline_entries, dependent: :destroy
   has_many :internal_notes, dependent: :destroy
+  has_many :retirements, dependent: :destroy
 
   belongs_to :lead_image, class_name: "Image", optional: true, foreign_key: :lead_image_id, inverse_of: :document
   belongs_to :creator, class_name: "User", optional: true, foreign_key: :creator_id, inverse_of: :documents
@@ -75,7 +76,7 @@ class Document < ApplicationRecord
   end
 
   def retirement
-    self.timeline_entries.where(entry_type: "retired").order(:created_at).last&.retirement
+    @retirement ||= self.retirements.order(:created_at).last
   end
 
   def withdrawn_by

--- a/app/models/retirement.rb
+++ b/app/models/retirement.rb
@@ -2,6 +2,7 @@
 
 class Retirement < ApplicationRecord
   belongs_to :timeline_entry, class_name: "TimelineEntry", foreign_key: :timeline_entries_id, inverse_of: :retirement
+  belongs_to :document
   validates_inclusion_of :entry_type, in: %w[retired]
 
   def entry_type

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -9,4 +9,5 @@ class User < ApplicationRecord
 
   PRE_RELEASE_FEATURES_PERMISSION = "pre_release_features"
   DEBUG_PERMISSION = "debug"
+  MANAGING_EDITOR_PERMISSION = "managing_editor"
 end

--- a/app/services/requirements/public_explanation_checker.rb
+++ b/app/services/requirements/public_explanation_checker.rb
@@ -1,0 +1,27 @@
+# frozen_string_literal: true
+
+module Requirements
+  class PublicExplanationChecker
+    PUBLIC_EXPLANATION_MAX_LENGTH = 600
+
+    attr_reader :public_explanation
+
+    def initialize(public_explanation)
+      @public_explanation = public_explanation
+    end
+
+    def pre_withdrawal_issues
+      issues = []
+
+      if public_explanation.blank?
+        issues << Issue.new(:public_explanation, :blank)
+      end
+
+      if public_explanation.to_s.size > PUBLIC_EXPLANATION_MAX_LENGTH
+        issues << Issue.new(:public_explanation, :too_long, max_length: PUBLIC_EXPLANATION_MAX_LENGTH)
+      end
+
+      CheckerIssues.new(issues)
+    end
+  end
+end

--- a/app/services/unpublish_service.rb
+++ b/app/services/unpublish_service.rb
@@ -5,7 +5,7 @@ class UnpublishService
     Document.transaction do
       document.update!(live_state: "retired")
       timeline_entry = TimelineEntry.create!(document: document, entry_type: "retired", user: user)
-      Retirement.create!(timeline_entry: timeline_entry, explanatory_note: explanatory_note)
+      Retirement.create!(timeline_entry: timeline_entry, explanatory_note: explanatory_note, document: document)
 
       GdsApi.publishing_api_v2.unpublish(
         document.content_id,

--- a/app/services/unpublish_service.rb
+++ b/app/services/unpublish_service.rb
@@ -1,10 +1,10 @@
 # frozen_string_literal: true
 
 class UnpublishService
-  def retire(document, explanatory_note)
+  def retire(document, explanatory_note, user)
     Document.transaction do
       document.update!(live_state: "retired")
-      timeline_entry = TimelineEntry.create!(document: document, entry_type: "retired")
+      timeline_entry = TimelineEntry.create!(document: document, entry_type: "retired", user: user)
       Retirement.create!(timeline_entry: timeline_entry, explanatory_note: explanatory_note)
 
       GdsApi.publishing_api_v2.unpublish(

--- a/app/views/documents/show/_actions.html.erb
+++ b/app/views/documents/show/_actions.html.erb
@@ -83,7 +83,7 @@
       <%= delete_draft_link("app-link--right") unless @document.has_live_version_on_govuk %>
     <% end %>
 
-    <% if @document.has_live_version_on_govuk? %>
+    <% if @document.has_live_version_on_govuk? && @document.user_facing_state != "retired" %>
       <hr class="govuk-section-break govuk-section-break--m govuk-section-break--visible" />
       <%= link_to "View published edition on GOV.UK", DocumentUrl.new(@document).public_url, class: "govuk-link govuk-link--no-visited-state" %>
     <% end %>

--- a/app/views/documents/show/_actions.html.erb
+++ b/app/views/documents/show/_actions.html.erb
@@ -80,11 +80,11 @@
       <%= link_to "Publish", publish_confirmation_path(@document), class: "govuk-link govuk-link--no-visited-state" %>
 
       <%= delete_draft_link("app-link--right") unless @document.has_live_version_on_govuk %>
-    <% elsif @document.user_facing_state == "retired" %>
+    <% elsif @document.withdrawn? %>
       <%= render "govuk_publishing_components/components/button", text: "Undo withdraw", data_attributes: { gtm: "undo-withdraw" }, href: unwithdraw_path(@document) %>
     <% end %>
 
-    <% if @document.has_live_version_on_govuk? && @document.user_facing_state != "retired" %>
+    <% if @document.has_live_version_on_govuk? && !@document.withdrawn? %>
       <hr class="govuk-section-break govuk-section-break--m govuk-section-break--visible" />
       <%= link_to "View published edition on GOV.UK", DocumentUrl.new(@document).public_url, class: "govuk-link govuk-link--no-visited-state" %>
     <% end %>

--- a/app/views/documents/show/_actions.html.erb
+++ b/app/views/documents/show/_actions.html.erb
@@ -62,8 +62,6 @@
       <%= link_to "Remove", remove_path(@document), class: "govuk-link app-link--destructive app-link--right" %>
     <% elsif @document.user_facing_state == "retired" && !current_user.has_permission?(User::PRE_RELEASE_FEATURES_PERMISSION)%>
       <%= link_to "Update reason for retiring", retire_path(@document), class: "govuk-link govuk-link--no-visited-state" %>
-    <% elsif @document.user_facing_state == "retired" && current_user.has_permission?(User::PRE_RELEASE_FEATURES_PERMISSION) %>
-      <%= link_to "Change public explanation", withdraw_path(@document), class: "govuk-link govuk-link--no-visited-state" %>
     <% elsif @document.user_facing_state == "removed" %>
       <%= form_tag create_edition_path(@document) do %>
         <%= render "govuk_publishing_components/components/button", text: "Create new edition", data_attributes: { gtm: "create-new-edition" } %>

--- a/app/views/documents/show/_actions.html.erb
+++ b/app/views/documents/show/_actions.html.erb
@@ -77,10 +77,11 @@
       <% end %>
 
       <%= render "govuk_publishing_components/components/button", text: "Preview", href: preview_document_path(@document), secondary: true %>
-
       <%= link_to "Publish", publish_confirmation_path(@document), class: "govuk-link govuk-link--no-visited-state" %>
 
       <%= delete_draft_link("app-link--right") unless @document.has_live_version_on_govuk %>
+    <% elsif @document.user_facing_state == "retired" %>
+      <%= render "govuk_publishing_components/components/button", text: "Undo withdraw", data_attributes: { gtm: "undo-withdraw" }, href: unwithdraw_path(@document) %>
     <% end %>
 
     <% if @document.has_live_version_on_govuk? && @document.user_facing_state != "retired" %>

--- a/app/views/documents/show/_actions.html.erb
+++ b/app/views/documents/show/_actions.html.erb
@@ -62,6 +62,8 @@
       <%= link_to "Remove", remove_path(@document), class: "govuk-link app-link--destructive app-link--right" %>
     <% elsif @document.user_facing_state == "retired" && !current_user.has_permission?(User::PRE_RELEASE_FEATURES_PERMISSION)%>
       <%= link_to "Update reason for retiring", retire_path(@document), class: "govuk-link govuk-link--no-visited-state" %>
+    <% elsif @document.user_facing_state == "retired" && current_user.has_permission?(User::PRE_RELEASE_FEATURES_PERMISSION) %>
+      <%= link_to "Change public explanation", withdraw_path(@document), class: "govuk-link govuk-link--no-visited-state" %>
     <% elsif @document.user_facing_state == "removed" %>
       <%= form_tag create_edition_path(@document) do %>
         <%= render "govuk_publishing_components/components/button", text: "Create new edition", data_attributes: { gtm: "create-new-edition" } %>

--- a/app/views/documents/show/_actions.html.erb
+++ b/app/views/documents/show/_actions.html.erb
@@ -44,16 +44,23 @@
           data_attributes: { gtm: "create-new-edition" } %>
       <% end %>
 
-      <%= link_to "Retire", retire_path(@document), class: "govuk-link govuk-link--no-visited-state" %>
+      <% if current_user.has_permission?(User::PRE_RELEASE_FEATURES_PERMISSION) %>
+        <%= link_to "Withdraw", withdraw_path(@document), class: "govuk-link govuk-link--no-visited-state" %>
+      <% else %>
+        <%= link_to "Retire", legacy_retire_path(@document), class: "govuk-link app-link--no-visited-state" %>
+      <% end %>
       <%= link_to "Remove", remove_path(@document), class: "govuk-link app-link--destructive app-link--right" %>
     <% elsif @document.user_facing_state == "published" %>
       <%= form_tag create_edition_path(@document) do %>
         <%= render "govuk_publishing_components/components/button", text: "Create new edition", data_attributes: { gtm: "create-new-edition" } %>
       <% end %>
-
-      <%= link_to "Retire", retire_path(@document), class: "govuk-link govuk-link--no-visited-state" %>
+      <% if current_user.has_permission?(User::PRE_RELEASE_FEATURES_PERMISSION) %>
+        <%= link_to "Withdraw", withdraw_path(@document), class: "govuk-link govuk-link--no-visited-state" %>
+      <% else %>
+        <%= link_to "Retire", legacy_retire_path(@document), class: "govuk-link app-link--no-visited-state" %>
+      <% end %>
       <%= link_to "Remove", remove_path(@document), class: "govuk-link app-link--destructive app-link--right" %>
-    <% elsif @document.user_facing_state == "retired" %>
+    <% elsif @document.user_facing_state == "retired" && !current_user.has_permission?(User::PRE_RELEASE_FEATURES_PERMISSION)%>
       <%= link_to "Update reason for retiring", retire_path(@document), class: "govuk-link govuk-link--no-visited-state" %>
     <% elsif @document.user_facing_state == "removed" %>
       <%= form_tag create_edition_path(@document) do %>

--- a/app/views/documents/show/_document_metadata.html.erb
+++ b/app/views/documents/show/_document_metadata.html.erb
@@ -1,4 +1,4 @@
-<% if @document.user_facing_state == "retired" %>
+<% if @document.withdrawn? %>
   <% metadata = [
       field: t("documents.show.metadata.withdrawn_by"),
       value: @document.withdrawn_by&.name || I18n.t!("documents.show.metadata.unknown_user")

--- a/app/views/documents/show/_document_metadata.html.erb
+++ b/app/views/documents/show/_document_metadata.html.erb
@@ -1,3 +1,25 @@
+<% if @document.user_facing_state == "retired" %>
+  <% metadata = [
+      field: t("documents.show.metadata.withdrawn_by"),
+      value: @document.withdrawn_by&.name || I18n.t!("documents.show.metadata.unknown_user")
+  ] %>
+<% else %>
+  <% metadata = [
+    {
+      field: t("documents.show.metadata.created_at"),
+      value: @document.created_at.strftime("%l:%M%P on %d %B %Y")
+    },
+    {
+      field: t("documents.show.metadata.created_by"),
+      value: @document.creator&.name || I18n.t!("documents.show.metadata.unknown_user")
+    },
+    {
+      field: t("documents.show.metadata.last_edited_by"),
+      value: @document.last_editor&.name || I18n.t!("documents.show.metadata.unknown_user")
+    }
+  ] %>
+<% end %>
+
 <div class="app-side">
   <%= render "components/metadata", {
     items: [
@@ -9,18 +31,6 @@
         field: t("documents.show.metadata.updated_at"),
         value: @document.updated_at.strftime("%l:%M%P on %d %B %Y")
       },
-      {
-        field: t("documents.show.metadata.created_at"),
-        value: @document.created_at.strftime("%l:%M%P on %d %B %Y")
-      },
-      {
-        field: t("documents.show.metadata.created_by"),
-        value: @document.creator&.name || I18n.t!("documents.show.metadata.unknown_user")
-      },
-      {
-        field: t("documents.show.metadata.last_edited_by"),
-        value: @document.last_editor&.name || I18n.t!("documents.show.metadata.unknown_user")
-      },
-    ]
+    ] + metadata
   } %>
 </div>

--- a/app/views/documents/show/_summary_tab.html.erb
+++ b/app/views/documents/show/_summary_tab.html.erb
@@ -3,7 +3,9 @@
     <% if flash[:submitted_for_review] %>
       <%= render "documents/show/submitted_for_review" %>
     <% end %>
-
+    <% if @document.user_facing_state == "retired" && current_user.has_permission?(User::PRE_RELEASE_FEATURES_PERMISSION) %>
+      <%= render "documents/show/withdrawn_notice" %>
+    <% end %>
     <%= render "documents/show/requirements" %>
     <%= render "documents/show/contents" %>
 

--- a/app/views/documents/show/_summary_tab.html.erb
+++ b/app/views/documents/show/_summary_tab.html.erb
@@ -3,7 +3,7 @@
     <% if flash[:submitted_for_review] %>
       <%= render "documents/show/submitted_for_review" %>
     <% end %>
-    <% if @document.user_facing_state == "retired" && current_user.has_permission?(User::PRE_RELEASE_FEATURES_PERMISSION) %>
+    <% if @document.withdrawn? && current_user.has_permission?(User::PRE_RELEASE_FEATURES_PERMISSION) %>
       <%= render "documents/show/withdrawn_notice" %>
     <% end %>
     <%= render "documents/show/requirements" %>

--- a/app/views/documents/show/_withdrawn_notice.html.erb
+++ b/app/views/documents/show/_withdrawn_notice.html.erb
@@ -1,0 +1,10 @@
+<%= render "govuk_publishing_components/components/notice", {
+  title: I18n.t("documents.show.withdrawn.title",
+                document_type: @document.document_type.label.downcase,
+                withdrawn_date: @document.retirement.created_at.strftime("%d %B %Y"))
+} do %>
+  <%= @document.retirement.explanatory_note %>
+  <p>
+  <p>
+  <%= link_to "Change public explanation", withdraw_path(@document), class: "govuk-link govuk-link--no-visited-state" %>
+<% end %>

--- a/app/views/unwithdraw/index.html.erb
+++ b/app/views/unwithdraw/index.html.erb
@@ -1,0 +1,8 @@
+<% content_for :back_link, render_back_link(href: document_path(@document)) %>
+<% content_for :title, t("unwithdraw_document.unwithdraw.title") %>
+
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-two-thirds">
+    <%= render_govspeak(File.read("app/views/unwithdraw/unwithdraw.govspeak.md")) %>
+  </div>
+</div>

--- a/app/views/unwithdraw/unwithdraw.govspeak.md
+++ b/app/views/unwithdraw/unwithdraw.govspeak.md
@@ -1,0 +1,1 @@
+If you need to undo the withdrawal of this content please [raise a support request and we’ll do it for you](https://support.publishing.service.gov.uk/unpublish_content_request/new).

--- a/app/views/withdraw/create.html.erb
+++ b/app/views/withdraw/create.html.erb
@@ -1,0 +1,7 @@
+<% content_for :back_link, render_back_link(href: document_path(@document)) %>
+<% content_for :title, t("withdraw_document.withdraw.title", title: @document.title) %>
+
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-two-thirds">
+  </div>
+</div>

--- a/app/views/withdraw/create.html.erb
+++ b/app/views/withdraw/create.html.erb
@@ -16,6 +16,7 @@
           bold: true
         },
         id: "withdrawal_public_explanation",
+        value: @document.retirement&.explanatory_note,
         name: "public_explanation",
         rows: 6,
         data: {

--- a/app/views/withdraw/create.html.erb
+++ b/app/views/withdraw/create.html.erb
@@ -3,5 +3,26 @@
 
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
+    <%= render_govspeak(t("withdraw_document.withdraw.intro_paragraph")) %>
+  </div>
+</div>
+
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-two-thirds">
+    <%= form_tag(new_withdrawal_path(@document)) do %>
+      <%= render "govuk_publishing_components/components/textarea", {
+        label: {
+          text: t("withdraw_document.withdraw.public_explanation.title"),
+          bold: true
+        },
+        id: "withdrawal_public_explanation",
+        name: "public_explanation",
+        rows: 6,
+      }%>
+      <%= render "govuk_publishing_components/components/button", {
+        text: "Withdraw document", margin_bottom: true
+      } %>
+    <% end %>
+    <%= link_to "Cancel", document_path(@document), class: "govuk-link govuk-link--no-visited-state" %>
   </div>
 </div>

--- a/app/views/withdraw/create.html.erb
+++ b/app/views/withdraw/create.html.erb
@@ -16,7 +16,7 @@
           bold: true
         },
         id: "withdrawal_public_explanation",
-        value: @document.retirement&.explanatory_note,
+        value: @public_explanation,
         name: "public_explanation",
         rows: 6,
         data: {

--- a/app/views/withdraw/create.html.erb
+++ b/app/views/withdraw/create.html.erb
@@ -18,11 +18,22 @@
         id: "withdrawal_public_explanation",
         name: "public_explanation",
         rows: 6,
+        data: {
+          "contextual-guidance": "withdrawal-public-explanation-guidance",
+        }
       }%>
       <%= render "govuk_publishing_components/components/button", {
         text: "Withdraw document", margin_bottom: true
       } %>
     <% end %>
     <%= link_to "Cancel", document_path(@document), class: "govuk-link govuk-link--no-visited-state" %>
+  </div>
+  <div class="govuk-grid-column-one-third">
+    <%= render "components/contextual_guidance", {
+      id: "withdrawal-public-explanation-guidance",
+      title: t("withdraw_document.withdraw.public_explanation.guidance_title"),
+    } do %>
+      <%= render_govspeak(t("withdraw_document.withdraw.public_explanation.guidance")) %>
+    <% end %>
   </div>
 </div>

--- a/app/views/withdraw/non_managing_editor.html.erb
+++ b/app/views/withdraw/non_managing_editor.html.erb
@@ -1,0 +1,8 @@
+<% content_for :back_link, render_back_link(href: document_path(@document)) %>
+<% content_for :title, t("withdraw_document.no_managing_editor_permission.title") %>
+
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-two-thirds">
+    <%= render_govspeak(t("withdraw_document.no_managing_editor_permission.content")) %>
+  </div>
+</div>

--- a/config/locales/en/documents/show.yml
+++ b/config/locales/en/documents/show.yml
@@ -8,6 +8,8 @@ en:
       tabs:
         summary: Document summary
         history: Document history
+      withdrawn:
+        title: "This %{document_type} was withdrawn on %{withdrawn_date}"
       topics:
         title: Topics
         no_topics: No topics.

--- a/config/locales/en/documents/show.yml
+++ b/config/locales/en/documents/show.yml
@@ -51,6 +51,7 @@ en:
         created_by: Document created by
         unknown_user: Unknown
         last_edited_by: Last edited by
+        withdrawn_by: Withdrawn by
       flashes:
         pre_preview_issues:
           warning: To preview this document you need to

--- a/config/locales/en/requirements.yml
+++ b/config/locales/en/requirements.yml
@@ -59,3 +59,8 @@ en:
         form_message: "Select an image file under %{max_size} in size"
       too_small:
         form_message: "Select an image at least %{width} pixels wide by %{height} pixels high"
+    public_explanation:
+      too_long:
+        form_message: "Enter a public explanation that is fewer than %{max_length} characters long"
+      blank:
+        form_message: Enter a public explanation

--- a/config/locales/en/states.yml
+++ b/config/locales/en/states.yml
@@ -9,7 +9,7 @@ en:
     published:
       name: Published
     retired:
-      name: Retired
+      name: Withdrawn
     removed:
       name: Removed
 

--- a/config/locales/en/unwithdraw/unwithdraw.yml
+++ b/config/locales/en/unwithdraw/unwithdraw.yml
@@ -1,0 +1,4 @@
+en:
+  unwithdraw_document:
+    unwithdraw:
+      title: Sorry, this hasn't been built yet

--- a/config/locales/en/withdraw/withdraw.yml
+++ b/config/locales/en/withdraw/withdraw.yml
@@ -12,3 +12,9 @@ en:
         [Full guidance on withdrawing content](https://www.gov.uk/guidance/how-to-publish-on-gov-uk/unpublishing-and-archiving)
       flashes:
         requirements: You need to
+    no_managing_editor_permission:
+      title: Only a managing editor can remove or withdraw a live page
+      content: |
+        If you think this content is not relevant anymore or that it shouldn’t be on GOV.UK, speak to the managing editor for your organisation.
+
+        Read the [full guidance on removing (unpublishing) and withdrawing content](https://www.gov.uk/guidance/how-to-publish-on-gov-uk/unpublishing-and-archiving)).

--- a/config/locales/en/withdraw/withdraw.yml
+++ b/config/locales/en/withdraw/withdraw.yml
@@ -1,0 +1,4 @@
+en:
+  withdraw_document:
+    withdraw:
+      title: "Withdraw '%{title}'"

--- a/config/locales/en/withdraw/withdraw.yml
+++ b/config/locales/en/withdraw/withdraw.yml
@@ -2,3 +2,9 @@ en:
   withdraw_document:
     withdraw:
       title: "Withdraw '%{title}'"
+      public_explanation:
+        title: "Public explanation"
+      intro_paragraph: |
+        Withdrawn content stays online but a banner tells users it is no longer current government information.
+
+        [Full guidance on withdrawing content](https://www.gov.uk/guidance/how-to-publish-on-gov-uk/unpublishing-and-archiving)

--- a/config/locales/en/withdraw/withdraw.yml
+++ b/config/locales/en/withdraw/withdraw.yml
@@ -10,3 +10,5 @@ en:
         Withdrawn content stays online but a banner tells users it is no longer current government information.
 
         [Full guidance on withdrawing content](https://www.gov.uk/guidance/how-to-publish-on-gov-uk/unpublishing-and-archiving)
+      flashes:
+        requirements: You need to

--- a/config/locales/en/withdraw/withdraw.yml
+++ b/config/locales/en/withdraw/withdraw.yml
@@ -12,6 +12,9 @@ en:
         [Full guidance on withdrawing content](https://www.gov.uk/guidance/how-to-publish-on-gov-uk/unpublishing-and-archiving)
       flashes:
         requirements: You need to
+        publishing_api_error:
+          title: Something has gone wrong
+          description_govspeak: Something went wrong when withdrawing this document. Please try again or [raise a support request](https://support.publishing.service.gov.uk/technical_fault_report/new).
     no_managing_editor_permission:
       title: Only a managing editor can remove or withdraw a live page
       content: |

--- a/config/locales/en/withdraw/withdraw.yml
+++ b/config/locales/en/withdraw/withdraw.yml
@@ -4,6 +4,8 @@ en:
       title: "Withdraw '%{title}'"
       public_explanation:
         title: "Public explanation"
+        guidance_title: Writing public explanation
+        guidance: Explain to users why the page has been withdrawn. You can link to alternative content with markdown.
       intro_paragraph: |
         Withdrawn content stays online but a banner tells users it is no longer current government information.
 

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -33,7 +33,8 @@ Rails.application.routes.draw do
   get "/documents/:id/preview" => "preview#show", as: :preview_document
   post "/documents/:id/create-preview" => "preview#create", as: :create_preview
 
-  get "/documents/:id/retire" => "unpublish#retire", as: :retire
+  get "/documents/:id/withdraw" => "withdraw#create", as: :withdraw
+  get "/documents/:id/retire" => "unpublish#retire", as: :legacy_retire
   get "/documents/:id/remove" => "unpublish#remove", as: :remove
 
   get "/documents/:document_id/images" => "images#index", as: :images

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -35,6 +35,7 @@ Rails.application.routes.draw do
 
   get "/documents/:id/withdraw" => "withdraw#create", as: :withdraw
   post "/documents/:id/withdraw" => "withdraw#new", as: :new_withdrawal
+  get "/documents/:id/unwithdraw" => "unwithdraw#index", as: :unwithdraw
   get "/documents/:id/retire" => "unpublish#retire", as: :legacy_retire
   get "/documents/:id/remove" => "unpublish#remove", as: :remove
 

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -34,6 +34,7 @@ Rails.application.routes.draw do
   post "/documents/:id/create-preview" => "preview#create", as: :create_preview
 
   get "/documents/:id/withdraw" => "withdraw#create", as: :withdraw
+  post "/documents/:id/withdraw" => "withdraw#new", as: :new_withdrawal
   get "/documents/:id/retire" => "unpublish#retire", as: :legacy_retire
   get "/documents/:id/remove" => "unpublish#remove", as: :remove
 

--- a/db/migrate/20181221114444_add_document_foreign_key_to_retirement.rb
+++ b/db/migrate/20181221114444_add_document_foreign_key_to_retirement.rb
@@ -1,0 +1,8 @@
+# frozen_string_literal: true
+
+class AddDocumentForeignKeyToRetirement < ActiveRecord::Migration[5.2]
+  def change
+    add_column :retirements, :document_id, :bigint
+    add_foreign_key :retirements, :documents
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2018_12_14_112140) do
+ActiveRecord::Schema.define(version: 2018_12_21_114444) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -44,16 +44,16 @@ ActiveRecord::Schema.define(version: 2018_12_14_112140) do
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.json "contents", default: {}
-    t.string "base_path"
     t.text "summary"
+    t.string "base_path"
     t.json "tags", default: {}
     t.string "publication_state", null: false
     t.bigint "creator_id"
     t.string "review_state", null: false
-    t.bigint "lead_image_id"
     t.boolean "has_live_version_on_govuk", default: false, null: false
     t.text "change_note"
     t.string "update_type"
+    t.bigint "lead_image_id"
     t.integer "current_edition_number", null: false
     t.bigint "last_editor_id"
     t.string "live_state"
@@ -112,6 +112,7 @@ ActiveRecord::Schema.define(version: 2018_12_14_112140) do
     t.bigint "timeline_entries_id", null: false
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
+    t.bigint "document_id"
     t.index ["timeline_entries_id"], name: "index_retirements_on_timeline_entries_id"
   end
 
@@ -160,6 +161,7 @@ ActiveRecord::Schema.define(version: 2018_12_14_112140) do
   add_foreign_key "internal_notes", "timeline_entries", column: "timeline_entries_id"
   add_foreign_key "internal_notes", "users", on_delete: :nullify
   add_foreign_key "removals", "timeline_entries", column: "timeline_entries_id", on_delete: :cascade
+  add_foreign_key "retirements", "documents"
   add_foreign_key "retirements", "timeline_entries", column: "timeline_entries_id", on_delete: :cascade
   add_foreign_key "timeline_entries", "documents", on_delete: :cascade
   add_foreign_key "timeline_entries", "users", on_delete: :nullify

--- a/lib/tasks/unpublish.rake
+++ b/lib/tasks/unpublish.rake
@@ -12,7 +12,7 @@ namespace :unpublish do
     document = Document.find_by!(content_id: args.content_id, locale: locale)
     raise "Document must have a published version before it can be retired" unless document.has_live_version_on_govuk
 
-    UnpublishService.new.retire(document, explanatory_note)
+    UnpublishService.new.retire(document, explanatory_note, nil)
   end
 
   desc "Remove a document from GOV.UK e.g. unpublish:remove_document['a-content-id']"

--- a/spec/factories/document_factory.rb
+++ b/spec/factories/document_factory.rb
@@ -27,5 +27,11 @@ FactoryBot.define do
       summary { SecureRandom.alphanumeric(10) }
       publication_state { "sent_to_live" }
     end
+
+    trait :retired do
+      has_live_version_on_govuk { true }
+      publication_state { "sent_to_live" }
+      live_state { "retired" }
+    end
   end
 end

--- a/spec/features/managing_editor_spec.rb
+++ b/spec/features/managing_editor_spec.rb
@@ -1,0 +1,73 @@
+# frozen_string_literal: true
+
+RSpec.feature "Managing editor permissions" do
+  scenario do
+    given_there_is_a_published_document
+    when_i_dont_have_the_managing_editor_permission
+    and_i_visit_the_document_page
+    and_i_click_on_withdraw
+    then_i_see_a_message_to_ask_my_managing_editor_to_withdraw_content
+    when_i_do_have_the_managing_editor_permission
+    and_i_visit_the_document_page
+    and_i_click_on_withdraw
+    then_i_can_see_a_public_explanation_form
+
+    given_there_is_a_withdrawn_document
+    when_i_dont_have_the_managing_editor_permission
+    and_i_visit_the_withdrawn_document_page
+    and_i_click_on_change_public_explanation
+    then_i_see_a_message_to_ask_my_managing_editor_to_withdraw_content
+    when_i_do_have_the_managing_editor_permission
+    and_i_visit_the_withdrawn_document_page
+    and_i_click_on_change_public_explanation
+    then_i_can_see_a_public_explanation_form
+  end
+
+  def given_there_is_a_published_document
+    @document = create(:document, :published)
+  end
+
+  def when_i_dont_have_the_managing_editor_permission
+    user = User.first
+    user.update_attribute(:permissions,
+                          user.permissions - [User::MANAGING_EDITOR_PERMISSION])
+  end
+
+  def and_i_visit_the_document_page
+    visit document_path(@document)
+  end
+
+  def and_i_click_on_withdraw
+    click_on "Withdraw"
+  end
+
+  def then_i_see_a_message_to_ask_my_managing_editor_to_withdraw_content
+    expect(page).to have_content(
+      "Only a managing editor can remove or withdraw a live page",
+    )
+  end
+
+  def when_i_do_have_the_managing_editor_permission
+    user = User.first
+    user.update_attribute(:permissions,
+                          user.permissions + [User::MANAGING_EDITOR_PERMISSION])
+  end
+
+  def then_i_can_see_a_public_explanation_form
+    expect(page).to have_field("public_explanation")
+  end
+
+  def given_there_is_a_withdrawn_document
+    document = create(:document, :retired)
+    timeline_entry = create(:timeline_entry, entry_type: "retired", document_id: document.id)
+    create(:retirement, timeline_entry: timeline_entry)
+  end
+
+  def and_i_visit_the_withdrawn_document_page
+    visit document_path(Document.last)
+  end
+
+  def and_i_click_on_change_public_explanation
+    click_on "Change public explanation"
+  end
+end

--- a/spec/features/managing_editor_spec.rb
+++ b/spec/features/managing_editor_spec.rb
@@ -60,7 +60,7 @@ RSpec.feature "Managing editor permissions" do
   def given_there_is_a_withdrawn_document
     document = create(:document, :retired)
     timeline_entry = create(:timeline_entry, entry_type: "retired", document_id: document.id)
-    create(:retirement, timeline_entry: timeline_entry)
+    create(:retirement, timeline_entry: timeline_entry, document: document)
   end
 
   def and_i_visit_the_withdrawn_document_page

--- a/spec/features/workflow/unpublish_spec.rb
+++ b/spec/features/workflow/unpublish_spec.rb
@@ -12,7 +12,7 @@ RSpec.feature "Unpublish documents rake tasks" do
       document = create(:document, :published, locale: "en")
       explanatory_note = "The reason the document is being retired"
 
-      expect_any_instance_of(UnpublishService).to receive(:retire).with(document, explanatory_note)
+      expect_any_instance_of(UnpublishService).to receive(:retire).with(document, explanatory_note, nil)
 
       ClimateControl.modify NOTE: explanatory_note do
         Rake::Task["unpublish:retire_document"].invoke(document.content_id)

--- a/spec/features/workflow/unwithdraw_document_spec.rb
+++ b/spec/features/workflow/unwithdraw_document_spec.rb
@@ -11,7 +11,7 @@ RSpec.feature "Unwithdraw a document" do
   def given_there_is_a_withdrawn_document
     @document = create(:document, :retired)
     timeline_entry = create(:timeline_entry, entry_type: "retired", document_id: @document.id)
-    create(:retirement, timeline_entry: timeline_entry)
+    create(:retirement, timeline_entry: timeline_entry, document: @document)
   end
 
   def when_i_visit_the_document_page

--- a/spec/features/workflow/unwithdraw_document_spec.rb
+++ b/spec/features/workflow/unwithdraw_document_spec.rb
@@ -1,0 +1,28 @@
+# frozen_string_literal: true
+
+RSpec.feature "Unwithdraw a document" do
+  scenario do
+    given_there_is_a_withdrawn_document
+    when_i_visit_the_document_page
+    and_i_click_on_undo_withdraw
+    then_i_see_the_feature_is_currently_unavailable
+  end
+
+  def given_there_is_a_withdrawn_document
+    @document = create(:document, :retired)
+    timeline_entry = create(:timeline_entry, entry_type: "retired", document_id: @document.id)
+    create(:retirement, timeline_entry: timeline_entry)
+  end
+
+  def when_i_visit_the_document_page
+    visit document_path(@document)
+  end
+
+  def and_i_click_on_undo_withdraw
+    click_on "Undo withdraw"
+  end
+
+  def then_i_see_the_feature_is_currently_unavailable
+    expect(page).to have_content("Sorry, this hasn't been built yet")
+  end
+end

--- a/spec/features/workflow/withdraw_document_publishing_api_down_spec.rb
+++ b/spec/features/workflow/withdraw_document_publishing_api_down_spec.rb
@@ -1,0 +1,50 @@
+# frozen_string_literal: true
+
+RSpec.feature "Withdraw a document when Publishing API is down" do
+  scenario do
+    given_there_is_a_published_document
+    given_i_have_the_managing_editor_permission
+    when_i_visit_the_withdraw_document_page
+    and_the_publishing_api_is_down
+    when_i_fill_in_the_public_explanation
+    and_click_on_withdraw_document
+    then_i_see_a_withdrawal_error_message
+    and_the_document_has_not_been_withdrawn
+  end
+
+  def given_there_is_a_published_document
+    @document = create(:document, :published)
+  end
+
+  def given_i_have_the_managing_editor_permission
+    user = User.first
+    user.update_attribute(:permissions,
+                          user.permissions + [User::MANAGING_EDITOR_PERMISSION])
+  end
+
+  def when_i_visit_the_withdraw_document_page
+    visit withdraw_path(@document)
+  end
+
+  def and_the_publishing_api_is_down
+    publishing_api_isnt_available
+  end
+
+  def when_i_fill_in_the_public_explanation
+    fill_in "public_explanation", with: "An explanation"
+  end
+
+  def and_click_on_withdraw_document
+    click_on "Withdraw document"
+  end
+
+  def then_i_see_a_withdrawal_error_message
+    expect(page).to have_content(I18n.t!("withdraw_document.withdraw.flashes.publishing_api_error.title"))
+  end
+
+  def and_the_document_has_not_been_withdrawn
+    expect(Retirement.count).to eq(0)
+    expect(TimelineEntry.count).to eq(0)
+    expect(Document.last.live_state).not_to eq("retired")
+  end
+end

--- a/spec/features/workflow/withdraw_document_requirements_spec.rb
+++ b/spec/features/workflow/withdraw_document_requirements_spec.rb
@@ -1,0 +1,54 @@
+# frozen_string_literal: true
+
+RSpec.feature "Document withdrawl requirements" do
+  scenario do
+    given_there_is_a_published_document
+    given_i_have_the_managing_editor_permission
+    when_i_visit_the_document_withdrawal_page
+    and_i_click_withdraw_document
+    then_i_see_an_error_to_enter_an_public_explanation
+
+    when_i_enter_an_public_explanation_that_is_too_long
+    and_i_click_withdraw_document
+    then_i_see_an_error_to_enter_a_shorter_public_explanation
+  end
+
+  def given_there_is_a_published_document
+    @document = create(:document, :published)
+  end
+
+  def given_i_have_the_managing_editor_permission
+    user = User.first
+    user.update_attribute(:permissions,
+                          user.permissions + [User::MANAGING_EDITOR_PERMISSION])
+  end
+
+  def when_i_visit_the_document_withdrawal_page
+    visit withdraw_path(@document)
+  end
+
+  def and_i_click_withdraw_document
+    click_on "Withdraw document"
+  end
+
+  def then_i_see_an_error_to_enter_an_public_explanation
+    within(".gem-c-error-summary") do
+      expect(page).to have_content(I18n.t!("requirements.public_explanation.blank.form_message"))
+    end
+  end
+
+  def when_i_enter_an_public_explanation_that_is_too_long
+    fill_in "public_explanation", with: "a" * (Requirements::PublicExplanationChecker::PUBLIC_EXPLANATION_MAX_LENGTH + 1)
+  end
+
+  def then_i_see_an_error_to_enter_a_shorter_public_explanation
+    within(".gem-c-error-summary") do
+      expect(page).to have_content(
+        I18n.t!(
+          "requirements.public_explanation.too_long.form_message",
+          max_length: Requirements::PublicExplanationChecker::PUBLIC_EXPLANATION_MAX_LENGTH,
+        ),
+      )
+    end
+  end
+end

--- a/spec/features/workflow/withdraw_document_spec.rb
+++ b/spec/features/workflow/withdraw_document_spec.rb
@@ -9,6 +9,10 @@ RSpec.feature "Withdraw a document" do
     when_i_fill_in_the_public_explanation
     and_click_on_withdraw_document
     then_i_see_the_document_has_been_withdrawn
+
+    when_i_click_to_change_the_public_explanation
+    then_i_can_see_the_existing_public_explanation
+    and_i_can_edit_the_public_explanation
   end
 
   def given_there_is_a_published_document
@@ -46,5 +50,22 @@ RSpec.feature "Withdraw a document" do
     expect(timeline_entry.retirement.explanatory_note).to eq("An explanation")
     expect(@document.reload.live_state).to eq("retired")
     expect(page).to have_content(I18n.t!("user_facing_states.retired.name"))
+  end
+
+  def when_i_click_to_change_the_public_explanation
+    click_on "Change public explanation"
+  end
+
+  def then_i_can_see_the_existing_public_explanation
+    expect(page).to have_field("public_explanation", with: Retirement.last.explanatory_note)
+  end
+
+  def and_i_can_edit_the_public_explanation
+    explanation = "A different explanation"
+    body = { type: "withdrawal", explanation: explanation, locale: @document.locale }
+    stub_publishing_api_unpublish(@document.content_id, body: body)
+    fill_in "public_explanation", with: explanation
+    click_on "Withdraw document"
+    expect(Retirement.last.explanatory_note).to eq(explanation)
   end
 end

--- a/spec/features/workflow/withdraw_document_spec.rb
+++ b/spec/features/workflow/withdraw_document_spec.rb
@@ -3,6 +3,7 @@
 RSpec.feature "Withdraw a document" do
   scenario do
     given_there_is_a_published_document
+    given_i_have_the_managing_editor_permission
     when_i_visit_the_document_page
     and_i_click_on_withdraw
     then_i_see_that_i_can_withdraw_the_document
@@ -21,6 +22,12 @@ RSpec.feature "Withdraw a document" do
 
   def when_i_visit_the_document_page
     visit document_path(@document)
+  end
+
+  def given_i_have_the_managing_editor_permission
+    user = User.first
+    user.update_attribute(:permissions,
+                          user.permissions + [User::MANAGING_EDITOR_PERMISSION])
   end
 
   def and_i_click_on_withdraw

--- a/spec/features/workflow/withdraw_document_spec.rb
+++ b/spec/features/workflow/withdraw_document_spec.rb
@@ -1,0 +1,26 @@
+# frozen_string_literal: true
+
+RSpec.feature "Withdraw a document" do
+  scenario do
+    given_there_is_a_published_document
+    when_i_visit_the_document_page
+    and_i_click_on_withdraw
+    then_i_see_that_i_can_withdraw_the_document
+  end
+
+  def given_there_is_a_published_document
+    @document = create(:document, :published)
+  end
+
+  def when_i_visit_the_document_page
+    visit document_path(@document)
+  end
+
+  def and_i_click_on_withdraw
+    click_on "Withdraw"
+  end
+
+  def then_i_see_that_i_can_withdraw_the_document
+    expect(page).to have_content "Withdraw '#{@document.title}'"
+  end
+end

--- a/spec/features/workflow/withdraw_document_spec.rb
+++ b/spec/features/workflow/withdraw_document_spec.rb
@@ -29,6 +29,8 @@ RSpec.feature "Withdraw a document" do
 
   def when_i_fill_in_the_public_explanation
     fill_in "public_explanation", with: "An explanation"
+    expect(page).to have_content(I18n.t!("withdraw_document.withdraw.public_explanation.guidance_title"))
+    expect(page).to have_content(I18n.t!("withdraw_document.withdraw.public_explanation.guidance"))
   end
 
   def and_click_on_withdraw_document

--- a/spec/features/workflow/withdraw_document_spec.rb
+++ b/spec/features/workflow/withdraw_document_spec.rb
@@ -63,6 +63,7 @@ RSpec.feature "Withdraw a document" do
                                          document_type: document_type,
                                          withdrawn_date: retirement.created_at.strftime("%d %B %Y")))
     expect(page).to have_content(timeline_entry.retirement.explanatory_note)
+    expect(page).to have_content(I18n.t!("documents.show.metadata.withdrawn_by") + ": #{timeline_entry.user.name}")
   end
 
   def when_i_click_to_change_the_public_explanation

--- a/spec/features/workflow/withdraw_document_spec.rb
+++ b/spec/features/workflow/withdraw_document_spec.rb
@@ -45,11 +45,17 @@ RSpec.feature "Withdraw a document" do
 
   def then_i_see_the_document_has_been_withdrawn
     timeline_entry = TimelineEntry.last
+    document_type = Document.last.document_type.label.downcase
+    retirement = Retirement.last
     expect(timeline_entry.entry_type).to eq("retired")
     expect(timeline_entry.document_id).to eq(@document.id)
     expect(timeline_entry.retirement.explanatory_note).to eq("An explanation")
     expect(@document.reload.live_state).to eq("retired")
     expect(page).to have_content(I18n.t!("user_facing_states.retired.name"))
+    expect(page).to have_content(I18n.t!("documents.show.withdrawn.title",
+                                         document_type: document_type,
+                                         withdrawn_date: retirement.created_at.strftime("%d %B %Y")))
+    expect(page).to have_content(timeline_entry.retirement.explanatory_note)
   end
 
   def when_i_click_to_change_the_public_explanation

--- a/spec/features/workflow/withdraw_document_spec.rb
+++ b/spec/features/workflow/withdraw_document_spec.rb
@@ -6,6 +6,9 @@ RSpec.feature "Withdraw a document" do
     when_i_visit_the_document_page
     and_i_click_on_withdraw
     then_i_see_that_i_can_withdraw_the_document
+    when_i_fill_in_the_public_explanation
+    and_click_on_withdraw_document
+    then_i_see_the_document_has_been_withdrawn
   end
 
   def given_there_is_a_published_document
@@ -22,5 +25,24 @@ RSpec.feature "Withdraw a document" do
 
   def then_i_see_that_i_can_withdraw_the_document
     expect(page).to have_content "Withdraw '#{@document.title}'"
+  end
+
+  def when_i_fill_in_the_public_explanation
+    fill_in "public_explanation", with: "An explanation"
+  end
+
+  def and_click_on_withdraw_document
+    body = { type: "withdrawal", explanation: "An explanation", locale: @document.locale }
+    stub_publishing_api_unpublish(@document.content_id, body: body)
+    click_on "Withdraw document"
+  end
+
+  def then_i_see_the_document_has_been_withdrawn
+    timeline_entry = TimelineEntry.last
+    expect(timeline_entry.entry_type).to eq("retired")
+    expect(timeline_entry.document_id).to eq(@document.id)
+    expect(timeline_entry.retirement.explanatory_note).to eq("An explanation")
+    expect(@document.reload.live_state).to eq("retired")
+    expect(page).to have_content(I18n.t!("user_facing_states.retired.name"))
   end
 end

--- a/spec/services/requirements/public_explanation_checker_spec.rb
+++ b/spec/services/requirements/public_explanation_checker_spec.rb
@@ -1,0 +1,28 @@
+# frozen_string_literal: true
+
+RSpec.describe Requirements::PublicExplanationChecker do
+  describe "#pre_withdrawal_issues" do
+    let(:max_length) { Requirements::PublicExplanationChecker::PUBLIC_EXPLANATION_MAX_LENGTH }
+
+    it "returns no issues if there are none" do
+      public_explanation = "a" * max_length
+      issues = Requirements::PublicExplanationChecker.new(public_explanation).pre_withdrawal_issues
+      expect(issues.items).to be_empty
+    end
+
+    it "returns an issue if there is no public explanation" do
+      issues = Requirements::PublicExplanationChecker.new(nil).pre_withdrawal_issues
+
+      message = issues.items_for(:public_explanation).first[:text]
+      expect(message).to eq(I18n.t!("requirements.public_explanation.blank.form_message"))
+    end
+
+    it "returns an issue if the public explanation is too long" do
+      public_explanation = "a" * (max_length + 1)
+      issues = Requirements::PublicExplanationChecker.new(public_explanation).pre_withdrawal_issues
+
+      message = issues.items_for(:public_explanation).first[:text]
+      expect(message).to eq(I18n.t!("requirements.public_explanation.too_long.form_message", max_length: max_length))
+    end
+  end
+end


### PR DESCRIPTION
I've marked this as DNM as it's being changed for versioning work - Kevin

For https://trello.com/c/GGxgDv3W/533-add-form-to-let-users-retire-a-document

This adds a frontend interface so that users with managing editor permissions can withdraw a document.

When I started on this story this functionality was called "retire"; we've now decided to use "withdraw" instead.  While the public-facing elements of the application with only refer to "withdrawing", a lot of the internals still refer to "retiring".  A separate PR will deal with updating internal references to make it clear and consistent.

1) All users see a button to withdraw a document:
<img width="343" alt="screen shot 2018-12-21 at 11 21 41" src="https://user-images.githubusercontent.com/13434452/50340363-a22e3c00-0512-11e9-9658-e85b1ebe7fb4.png">

2) Users without managing editor permissions will see guidance about asking their managing editor to withdraw a document if they click the 'Withdraw' button:
<img width="747" alt="screen shot 2018-12-21 at 11 28 42" src="https://user-images.githubusercontent.com/13434452/50340610-9a22cc00-0513-11e9-9be0-ddfd28d0facd.png">

3) Only users with managing editor permissions will see a form to withdraw a document, and will see guidance for the public explanation:
<img width="1041" alt="public_explanation" src="https://user-images.githubusercontent.com/13434452/50340314-6c895300-0512-11e9-8606-da4a10f93ccb.png">

4) Users will see an error if they do not provide a public explanation:
<img width="985" alt="screen shot 2018-12-21 at 11 23 24" src="https://user-images.githubusercontent.com/13434452/50340437-e02b6000-0512-11e9-8b02-6102fe63ed9d.png">

5) Users will see an error if they provide a public explanation that is too long:
<img width="993" alt="screen shot 2018-12-21 at 11 24 30" src="https://user-images.githubusercontent.com/13434452/50340486-081ac380-0513-11e9-8746-94dfec0d358d.png">

6) Users will see an error if the Publishing API is down when they attempt to withdraw a document:
<img width="989" alt="screen shot 2018-12-21 at 11 26 30" src="https://user-images.githubusercontent.com/13434452/50340548-4c0dc880-0513-11e9-8b3d-ee5de984bf9d.png">

7) All users will see a withdrawal notice with the date the document was withdrawn, the public explanation and a link to the change the public explanation.  They will also see a withdrawn status and the name of the person that withdrew the document.  
<img width="993" alt="withdrawn_summary_screen" src="https://user-images.githubusercontent.com/13434452/50340326-74e18e00-0512-11e9-9e8e-dff4c16fbd15.png">

8) When users click "Undo withdraw" they will see a page explaining that the feature hasn't been built yet.
<img width="658" alt="screen shot 2018-12-21 at 11 27 14" src="https://user-images.githubusercontent.com/13434452/50340572-634cb600-0513-11e9-9ec5-63a85e33808d.png">

Outstanding items:
- [ ] @paola-roccuzzo to provide a character limit for the explanatory note