### PR TITLE
Make path checker more sensitive

### DIFF
--- a/app/services/requirements/path_checker.rb
+++ b/app/services/requirements/path_checker.rb
@@ -28,6 +28,8 @@ module Requirements
       base_path_owner = GdsApi.publishing_api_v2.lookup_content_id(
         base_path: document.base_path,
         with_drafts: true,
+        exclude_document_types: [],
+        exclude_unpublishing_types: [],
       )
 
       base_path_owner && base_path_owner != document.content_id


### PR DESCRIPTION
https://sentry.io/govuk/app-content-publisher/issues/682768231/events/39171131112/

Previously we used the Publishing API defaults to lookup any existing
owner (content_id) for a base_path, which excluded certain document
types like redirects. This overrides the default to check all types.