### PR TITLE
Add internal notes backend

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -18,6 +18,7 @@ gem "kaminari", "~> 1"
 gem "paper_trail", "~> 10.1"
 gem "pg", "~> 1"
 gem "plek", "~> 2"
+gem "rinku", "~> 2"
 gem "uglifier", "~> 4"
 
 group :development do

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -444,6 +444,7 @@ DEPENDENCIES
   pg (~> 1)
   plek (~> 2)
   rails (~> 5.2)
+  rinku (~> 2)
   rspec-rails (~> 3)
   simplecov (~> 0.16)
   uglifier (~> 4)

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -12,4 +12,8 @@ module ApplicationHelper
   def strip_scheme_from_url(url)
     url.sub(/^https?\:\/\//, "")
   end
+
+  def escape_and_link(unsafe_text)
+    Rinku.auto_link(html_escape(unsafe_text))
+  end
 end

--- a/app/models/document.rb
+++ b/app/models/document.rb
@@ -5,6 +5,8 @@ class Document < ApplicationRecord
 
   has_many :images, dependent: :destroy
   has_many :timeline_entries, dependent: :destroy
+  has_many :internal_notes, dependent: :destroy
+
   belongs_to :lead_image, class_name: "Image", optional: true, foreign_key: :lead_image_id, inverse_of: :document
   belongs_to :creator, class_name: "User", optional: true, foreign_key: :creator_id, inverse_of: :documents
   belongs_to :last_editor, class_name: "User", optional: true, foreign_key: :last_editor_id, inverse_of: :documents

--- a/app/models/internal_note.rb
+++ b/app/models/internal_note.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+class InternalNote < ApplicationRecord
+  belongs_to :document
+  belongs_to :user, optional: true
+  belongs_to :timeline_entry, class_name: "TimelineEntry", foreign_key: :timeline_entries_id, inverse_of: :internal_note
+end

--- a/app/models/timeline_entry.rb
+++ b/app/models/timeline_entry.rb
@@ -24,6 +24,7 @@ class TimelineEntry < ApplicationRecord
     create_preview
     retired
     removed
+    internal_note
   ].freeze
 
   validates_inclusion_of :entry_type, in: ENTRY_TYPES

--- a/app/models/timeline_entry.rb
+++ b/app/models/timeline_entry.rb
@@ -3,8 +3,10 @@
 class TimelineEntry < ApplicationRecord
   belongs_to :document
   belongs_to :user, optional: true
+
   has_one :retirement, foreign_key: :timeline_entries_id, dependent: :destroy, inverse_of: :timeline_entry
   has_one :removal, foreign_key: :timeline_entries_id, dependent: :destroy, inverse_of: :timeline_entry
+  has_one :internal_note, foreign_key: :timeline_entries_id, dependent: :destroy, inverse_of: :timeline_entry
 
   ENTRY_TYPES = %w[
     created

--- a/app/views/documents/show/_history_tab.html.erb
+++ b/app/views/documents/show/_history_tab.html.erb
@@ -1,31 +1,39 @@
 <% displayed_edition_number = nil %>
 
-<% @document.timeline_entries.includes(:user).order(created_at: :desc).includes(:retirement).includes(:removal).each do |entry| %>
-  <div class="app-timeline-entry govuk-!-margin-bottom-6">
-    <% if displayed_edition_number != entry.edition_number %>
-      <h3 class="govuk-heading-m"><%= t "documents.history.edition_header", number: entry.edition_number.ordinalize %></h3>
-      <% displayed_edition_number = entry.edition_number %>
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-two-thirds">
+    <% @document.timeline_entries.includes(:user).order(created_at: :desc).includes(:retirement, :removal, :internal_note).each do |entry| %>
+      <div class="app-timeline-entry govuk-!-margin-bottom-6">
+        <% if displayed_edition_number != entry.edition_number %>
+          <h3 class="govuk-heading-m"><%= t "documents.history.edition_header", number: entry.edition_number.ordinalize %></h3>
+          <% displayed_edition_number = entry.edition_number %>
+        <% end %>
+
+        <h4 class="govuk-heading-s govuk-!-margin-bottom-1">
+          <%= t "documents.history.entry_types.#{entry.entry_type}" %>
+        </h4>
+
+        <div class="app-timeline-entry__dateline">
+          <%= entry.created_at.strftime("%d %B %Y at %l:%M%P") %> by <%= entry.username_or_unknown %>
+        </div>
+
+        <% if entry.internal_note.present? %>
+          <%= simple_format(escape_and_link(entry.internal_note.body)) %>
+        <% end %>
+
+        <% if entry.retirement.present? %>
+          <%= entry.retirement.explanatory_note %>
+        <% elsif entry.removal.present? %>
+          <% if entry.removal.explanatory_note.present? %>
+            <p><%= entry.removal.explanatory_note %></p>
+          <% end %>
+          <% if entry.removal.redirect %>
+            <p>Redirected to <%= link_to(Plek.new.website_root + entry.removal.alternative_path) %></p>
+          <% elsif entry.removal.alternative_path.present? %>
+            <p><%= link_to(Plek.new.website_root + entry.removal.alternative_path) %></p>
+          <% end %>
+        <% end %>
+      </div>
     <% end %>
-
-    <h4 class="govuk-heading-s govuk-!-margin-bottom-1">
-      <%= t "documents.history.entry_types.#{entry.entry_type}" %>
-    </h4>
-
-    <% if entry.retirement.present? %>
-      <%= entry.retirement.explanatory_note %>
-    <% elsif entry.removal.present? %>
-      <% if entry.removal.explanatory_note.present? %>
-        <p><%= entry.removal.explanatory_note %></p>
-      <% end %>
-      <% if entry.removal.redirect %>
-        <p>Redirected to <%= link_to(Plek.new.website_root + entry.removal.alternative_path) %></p>
-      <% elsif entry.removal.alternative_path.present? %>
-        <p><%= link_to(Plek.new.website_root + entry.removal.alternative_path) %></p>
-      <% end %>
-    <% end %>
-
-    <div class="app-timeline-entry__dateline">
-      <%= entry.created_at.strftime("%d %B %Y at %l:%M%P") %> by <%= entry.username_or_unknown %>
-    </div>
   </div>
-<% end %>
+</div>

--- a/config/locales/en/documents/history.yml
+++ b/config/locales/en/documents/history.yml
@@ -18,3 +18,4 @@ en:
         create_preview: "Create preview"
         retired: "Retired"
         removed: "Removed"
+        internal_note: "Internal note"

--- a/db/migrate/20181212165840_create_internal_notes.rb
+++ b/db/migrate/20181212165840_create_internal_notes.rb
@@ -1,0 +1,14 @@
+# frozen_string_literal: true
+
+class CreateInternalNotes < ActiveRecord::Migration[5.2]
+  def change
+    create_table :internal_notes do |t|
+      t.text :body, null: false
+      t.references :document, foreign_key: { on_delete: :cascade }, null: false
+      t.references :user, foreign_key: { on_delete: :nullify }
+      t.references :timeline_entries, foreign_key: true, null: false
+
+      t.timestamps
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -85,6 +85,18 @@ ActiveRecord::Schema.define(version: 2018_12_14_112140) do
     t.index ["document_id"], name: "index_images_on_document_id"
   end
 
+  create_table "internal_notes", force: :cascade do |t|
+    t.text "body", null: false
+    t.bigint "document_id", null: false
+    t.bigint "user_id"
+    t.bigint "timeline_entries_id", null: false
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["document_id"], name: "index_internal_notes_on_document_id"
+    t.index ["timeline_entries_id"], name: "index_internal_notes_on_timeline_entries_id"
+    t.index ["user_id"], name: "index_internal_notes_on_user_id"
+  end
+
   create_table "removals", force: :cascade do |t|
     t.string "explanatory_note"
     t.string "alternative_path"
@@ -144,6 +156,9 @@ ActiveRecord::Schema.define(version: 2018_12_14_112140) do
   add_foreign_key "documents", "users", column: "last_editor_id"
   add_foreign_key "images", "active_storage_blobs", column: "blob_id", on_delete: :cascade
   add_foreign_key "images", "documents", on_delete: :cascade
+  add_foreign_key "internal_notes", "documents", on_delete: :cascade
+  add_foreign_key "internal_notes", "timeline_entries", column: "timeline_entries_id"
+  add_foreign_key "internal_notes", "users", on_delete: :nullify
   add_foreign_key "removals", "timeline_entries", column: "timeline_entries_id", on_delete: :cascade
   add_foreign_key "retirements", "timeline_entries", column: "timeline_entries_id", on_delete: :cascade
   add_foreign_key "timeline_entries", "documents", on_delete: :cascade

--- a/spec/factories/internal_note_factory.rb
+++ b/spec/factories/internal_note_factory.rb
@@ -1,0 +1,10 @@
+# frozen_string_literal: true
+
+FactoryBot.define do
+  factory :internal_note do
+    body { "Amazing internal note" }
+    document
+    user
+    timeline_entry
+  end
+end

--- a/spec/factories/timeline_entry_factory.rb
+++ b/spec/factories/timeline_entry_factory.rb
@@ -1,0 +1,10 @@
+# frozen_string_literal: true
+
+FactoryBot.define do
+  factory :timeline_entry do
+    entry_type { "internal_note" }
+    document
+    user
+    edition_number { 1 }
+  end
+end

--- a/spec/features/workflow/internal_note_spec.rb
+++ b/spec/features/workflow/internal_note_spec.rb
@@ -1,0 +1,31 @@
+# frozen_string_literal: true
+
+RSpec.feature "Displaying an internal note" do
+  scenario do
+    given_there_is_a_document_with_a_internal_note
+    when_i_visit_the_document_page
+    then_i_should_see_the_internal_note
+  end
+
+  def given_there_is_a_document_with_a_internal_note
+    @document = create(:document)
+    @timeline_entry = create(:timeline_entry, entry_type: "internal_note", document: @document)
+    @internal_note = create(
+      :internal_note,
+      body: "Belvita's are pure joy",
+      timeline_entry: @timeline_entry,
+      document: @document,
+    )
+  end
+
+  def when_i_visit_the_document_page
+    visit document_path(@document)
+  end
+
+  def then_i_should_see_the_internal_note
+    within("#document-history") do
+      expect(page).to have_content(I18n.t!("documents.history.entry_types.internal_note"))
+      expect(page).to have_content(@internal_note.body)
+    end
+  end
+end

--- a/spec/helpers/application_helper_spec.rb
+++ b/spec/helpers/application_helper_spec.rb
@@ -1,0 +1,20 @@
+# frozen_string_literal: true
+
+RSpec.describe ApplicationHelper, type: :helper do
+  describe "formats a body of text" do
+    it "returns a hyper link when given a URI" do
+      text = "govuk lives here - https://www.gov.uk/"
+      expect(helper.escape_and_link(text)).to match("govuk lives here - <a href=\"https://www.gov.uk/\">https://www.gov.uk/</a>")
+    end
+
+    it "returns a mailto link when given a email address" do
+      text = "You can email me here - email123@gmail.com"
+      expect(helper.escape_and_link(text)).to match("You can email me here - <a href=\"mailto:email123@gmail.com\">email123@gmail.com</a>")
+    end
+
+    it "returns a body of text that converts html tags to html entities " do
+      text = "Some html tags <p><b>bold paragraph</b></p>"
+      expect(helper.escape_and_link(text)).to match("Some html tags &lt;p&gt;&lt;b&gt;bold paragraph&lt;/b&gt;&lt;/p&gt;")
+    end
+  end
+end


### PR DESCRIPTION
Initial creation of the internal notes feature. Currently you can only create a internal note from the console which then displays in the document history section of the document page.

Trello:
https://trello.com/c/jilfIus0/547-mvp-of-reading-internal-notes

## Example:
<img width="814" alt="screen shot 2018-12-17 at 16 16 48" src="https://user-images.githubusercontent.com/24479188/50100690-fbe3ed00-0218-11e9-9c14-60dd28ff3b0a.png">

