### PR TITLE
Fix markdown editor CSS

### DIFF
--- a/app/assets/stylesheets/components/_markdown-editor.scss
+++ b/app/assets/stylesheets/components/_markdown-editor.scss
@@ -98,6 +98,8 @@ $toolbar-button-size: 50px;
   @include govuk-focusable-fill;
   display: inline-block;
   background: none;
+  width: $toolbar-button-size;
+  height: $toolbar-button-size;
 
   &:focus {
     outline-offset: -$govuk-focus-width;
@@ -113,13 +115,14 @@ $toolbar-button-size: 50px;
   display: inline-block;
   fill: currentColor;
   background: inherit;
+  pointer-events: none;
 }
 
 .app-c-markdown-editor__toolbar-button--text {
   @include govuk-font($size: 16, $weight: bold);
   border: none;
   border-left: 4px solid govuk-colour('white');
-  height: $toolbar-button-size;
+  width: auto;
   vertical-align: top;
   background: transparent;
   padding: govuk-spacing(3);


### PR DESCRIPTION
Not setting a default height and width on toolbar buttons results in not having these elements visible on the page unless there is a content/icon inside. Even when we set these values there is chance that the click will actually happen on the `<svg>` rather the `<md->` button so we're disabling the `pointer-events` on `<svg>`s inside these buttons.

This is currently causing issues with GTM tracking not being able to determine which element was clicked (it triggers a click on the svg inside the `<md->` element instead of the `<md->` element itself.

This change doesn't visually affect the component in any way.

[Trello card](https://trello.com/c/yRnJfrDN)