### PR TITLE
Nullify users foreign key on delete for timeline_entries

### DIFF
--- a/db/migrate/20181214112140_nullify_user_for_timeline_entry.rb
+++ b/db/migrate/20181214112140_nullify_user_for_timeline_entry.rb
@@ -1,0 +1,13 @@
+# frozen_string_literal: true
+
+class NullifyUserForTimelineEntry < ActiveRecord::Migration[5.2]
+  def up
+    remove_foreign_key "timeline_entries", "users"
+    add_foreign_key "timeline_entries", "users", on_delete: :nullify
+  end
+
+  def down
+    remove_foreign_key "timeline_entries", "users"
+    add_foreign_key "timeline_entries", "users", on_delete: :restrict
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2018_12_10_133134) do
+ActiveRecord::Schema.define(version: 2018_12_14_112140) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -147,5 +147,5 @@ ActiveRecord::Schema.define(version: 2018_12_10_133134) do
   add_foreign_key "removals", "timeline_entries", column: "timeline_entries_id", on_delete: :cascade
   add_foreign_key "retirements", "timeline_entries", column: "timeline_entries_id", on_delete: :cascade
   add_foreign_key "timeline_entries", "documents", on_delete: :cascade
-  add_foreign_key "timeline_entries", "users", on_delete: :restrict
+  add_foreign_key "timeline_entries", "users", on_delete: :nullify
 end


### PR DESCRIPTION
This change alters what happens when a user is deleted. Previously, a
user could not be deleted if they had timeline_entries. Now, users_id
gets set to null on deletion of a user.

This enables us to remove users from the system without having errors
related to database relations.