### PR TITLE
Remove showAllValues: false

### DIFF
--- a/app/assets/javascripts/components/autocomplete.js
+++ b/app/assets/javascripts/components/autocomplete.js
@@ -15,7 +15,6 @@ if ($autocompletes) {
       selectElement: $el,
       minLength: 3,
       showNoOptionsFound: false,
-      showAllValues: true,
       customAttributes: customAttributes
     })
   })


### PR DESCRIPTION
Sorry, I accidentally introduced this [a few minutes ago](https://github.com/alphagov/content-publisher/pull/604/files#diff-e939db0e1c9c6b800d2850384df539c2R18), which disables the `minLength` and breaks in IE11.