### PR TITLE
Add image credit to the payload for publishing-api

### DIFF
--- a/app/services/publishing_api_payload.rb
+++ b/app/services/publishing_api_payload.rb
@@ -53,6 +53,7 @@ private
       "url" => document.lead_image.asset_manager_file_url,
       "alt_text" => document.lead_image.alt_text,
       "caption" => document.lead_image.caption,
+      "credit" => document.lead_image.credit,
     }
   end
 

--- a/spec/services/publishing_api_payload_spec.rb
+++ b/spec/services/publishing_api_payload_spec.rb
@@ -95,7 +95,13 @@ RSpec.describe PublishingApiPayload do
     end
 
     it "includes a lead image if present" do
-      image = build(:image, alt_text: "image alt text", caption: "image caption", asset_manager_file_url: "http:://assets-manager.gov.uk/image.jpg")
+      image = build(
+        :image,
+        alt_text: "image alt text",
+        caption: "image caption",
+        asset_manager_file_url: "http:://assets-manager.gov.uk/image.jpg",
+        credit: "image credit",
+      )
       document_type = build(:document_type, lead_image: true)
       document = build(:document, document_type_id: document_type.id, lead_image: image)
 
@@ -105,6 +111,7 @@ RSpec.describe PublishingApiPayload do
         "url" => "http:://assets-manager.gov.uk/image.jpg",
         "alt_text" => "image alt text",
         "caption" => "image caption",
+        "credit" => "image credit",
       }
 
       expect(payload["details"]["image"]).to match a_hash_including(payload_hash)


### PR DESCRIPTION
Trello: https://trello.com/c/hGmJ5BfV
Follows on from https://github.com/alphagov/govuk-content-schemas/pull/850

## Motivation
Content Publisher allows publishers to add an image credit, but at the moment we don't have a way to access this data in the frontend.

This step passes the image credit to the payload for publishing-api so it is available for use by the frontend applications.