### PR TITLE
Use separate messages for invalid image formats

### DIFF
--- a/app/services/requirements/image_upload_checker.rb
+++ b/app/services/requirements/image_upload_checker.rb
@@ -23,8 +23,13 @@ module Requirements
         return CheckerIssues.new(issues)
       end
 
-      if unsupported_type? || animated_image?
-        issues << Issue.new(:image_upload, :format_not_allowed)
+      if unsupported_type?
+        issues << Issue.new(:image_upload, :unsupported_type)
+        return CheckerIssues.new(issues)
+      end
+
+      if animated_image?
+        issues << Issue.new(:image_upload, :animated_image)
         return CheckerIssues.new(issues)
       end
 

--- a/config/locales/en/requirements.yml
+++ b/config/locales/en/requirements.yml
@@ -49,8 +49,10 @@ en:
     image_upload:
       no_file:
         form_message: Select a file to upload
-      format_not_allowed:
-        form_message: Select a jpg, png or static gif image file
+      unsupported_type:
+        form_message: Select a jpg, png or gif image file
+      animated_image:
+        form_message: Select an image file that is not animated
       too_big:
         form_message: "Select an image file under %{max_size} in size"
       too_small:

--- a/spec/features/editing_images/upload_lead_image_requirements_spec.rb
+++ b/spec/features/editing_images/upload_lead_image_requirements_spec.rb
@@ -24,6 +24,6 @@ RSpec.feature "Upload a lead image with requirements issues" do
   end
 
   def then_i_should_see_an_error
-    expect(page).to have_content(I18n.t!("requirements.image_upload.format_not_allowed.form_message"))
+    expect(page).to have_content(I18n.t!("requirements.image_upload.unsupported_type.form_message"))
   end
 end

--- a/spec/services/requirements/image_upload_checker_spec.rb
+++ b/spec/services/requirements/image_upload_checker_spec.rb
@@ -14,11 +14,11 @@ RSpec.describe Requirements::ImageUploadChecker do
       expect(form_message).to eq(I18n.t!("requirements.image_upload.no_file.form_message"))
     end
 
-    it "returns an issue when an incorrect file type is provided" do
+    it "returns an issue when an unsupported file type is provided" do
       file = fixture_file_upload("files/text-file.txt", "text/plain")
       issues = Requirements::ImageUploadChecker.new(file).issues
       form_message = issues.items_for(:image_upload).first[:text]
-      expect(form_message).to eq(I18n.t!("requirements.image_upload.format_not_allowed.form_message"))
+      expect(form_message).to eq(I18n.t!("requirements.image_upload.unsupported_type.form_message"))
     end
 
     it "returns an issue when a file bigger than the max size is provided" do
@@ -40,7 +40,7 @@ RSpec.describe Requirements::ImageUploadChecker do
       file = fixture_file_upload("files/animated-gif.gif", "image/gif")
       issues = Requirements::ImageUploadChecker.new(file).issues
       form_message = issues.items_for(:image_upload).first[:text]
-      expect(form_message).to eq(I18n.t!("requirements.image_upload.format_not_allowed.form_message"))
+      expect(form_message).to eq(I18n.t!("requirements.image_upload.animated_image.form_message"))
     end
   end
 end


### PR DESCRIPTION
The combined message might be confusing when a user uploads an animated
image, as the message doesn't higlight this problem specifically.