### PR TITLE
Add data-gtm attributes for document type and status

### DIFF
--- a/app/views/components/_metadata.html.erb
+++ b/app/views/components/_metadata.html.erb
@@ -1,16 +1,17 @@
 <%
-  items||= []
-  inline||= false
+  items ||= []
+  inline ||= false
+  list_classes = %w(app-c-metadata__list)
+  list_classes << 'app-c-metadata__list--inline' if inline
+  data_attributes ||= nil
 %>
-<div class="app-c-metadata">
-
+<%= tag.div class: 'app-c-metadata', data: data_attributes do %>
   <% if items.any? %>
-  <dl class="app-c-metadata__list <%= 'app-c-metadata__list--inline' if inline %>">
-    <% items.each do |item| %>
-      <dt class="app-c-metadata__title"><%= item[:field] %>:</dt>
-      <dd class="app-c-metadata__description"><%= item[:value] %></dd>
+    <%= tag.dl class: list_classes do %>
+      <% items.each do |item| %>
+        <%= tag.dt item[:field] + ':', class: 'app-c-metadata__title' %>
+        <%= tag.dd item[:value], class: 'app-c-metadata__description' %>
+      <% end %>
     <% end %>
-  </dl>
   <% end %>
-
-</div>
+<% end %>

--- a/app/views/components/docs/metadata.yml
+++ b/app/views/components/docs/metadata.yml
@@ -7,6 +7,9 @@ accessibility_criteria: |
 examples:
   default:
     data:
+      data_attributes:
+        gtm-document-type: "News story"
+        gtm-document-status: "Draft"
       items:
       - field: "Status"
         value: "Saved as draft"

--- a/app/views/documents/show.html.erb
+++ b/app/views/documents/show.html.erb
@@ -1,12 +1,6 @@
 <% content_for :back_link, render_back_link(href: documents_path) %>
 <% content_for :title, @document.title_or_fallback %>
 <% content_for :context, @document.document_type.label %>
-<% content_for :data_layer_js do %>
-  dataLayer.push({
-    "document-type": "<%= @document.document_type.label %>",
-    "document-status": "<%= t("user_facing_states.#{@document.user_facing_state}.name") %>"
-  })
-<% end %>
 
 <%= render "govuk_publishing_components/components/tabs", {
   panel_border: false,

--- a/app/views/documents/show/_document_metadata.html.erb
+++ b/app/views/documents/show/_document_metadata.html.erb
@@ -21,6 +21,10 @@
         field: t("documents.show.metadata.last_edited_by"),
         value: @document.last_editor&.name || I18n.t!("documents.show.metadata.unknown_user")
       },
-    ]
+    ],
+    data_attributes: {
+      "gtm-document-type": @document.document_type.label,
+      "gtm-document-status": t("user_facing_states.#{@document.user_facing_state}.name")
+    }
   } %>
 </div>

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -6,8 +6,7 @@
 
   <script>
     var dataLayer = [{ 'dimension1': '<%= current_user.organisation_slug %>' }];
-    dataLayer.push({ 'gtm.blacklist' : ['html', 'customScripts', 'nonGoogleScripts', 'customPixels']});
-<%= yield(:data_layer_js) %>
+    dataLayer.push({ 'gtm.blacklist': ['html', 'customScripts', 'nonGoogleScripts', 'customPixels'] });
   </script>
   <% if ENV["GOOGLE_TAG_MANAGER_ID"] %>
     <%= render "govuk_publishing_components/components/google_tag_manager_script", {


### PR DESCRIPTION
This PR replaces document type and status pushed to dataLayer with `data-gtm` attributes

[Trello card](https://trello.com/c/QHmf1x47)