### PR TITLE
Update image in Asset Manager (vs delete/recreate)

### DIFF
--- a/app/services/asset_manager_service.rb
+++ b/app/services/asset_manager_service.rb
@@ -16,6 +16,11 @@ class AssetManagerService
                                       auth_bypass_ids: [])
   end
 
+  def update_bytes(asset, content)
+    file = AssetManagerFile.from_bytes(asset, content)
+    GdsApi.asset_manager.update_asset(asset.asset_manager_id, file: file)
+  end
+
   def delete(asset)
     GdsApi.asset_manager.delete_asset(asset.asset_manager_id)
   end

--- a/app/services/image_update_service.rb
+++ b/app/services/image_update_service.rb
@@ -15,20 +15,13 @@ class ImageUpdateService
     end
 
     if need_to_update_asset_manager?
-      asset_manager_file_url = upload_to_asset_manager(image)
-      AssetManagerService.new.delete(image)
-      image.asset_manager_file_url = asset_manager_file_url
-      image.publication_state = "draft"
+      AssetManagerService.new.update_bytes(image, image.cropped_bytes)
     end
 
     image.save!
   end
 
 private
-
-  def upload_to_asset_manager(image)
-    AssetManagerService.new.upload_bytes(image, image.cropped_bytes)
-  end
 
   def need_to_update_asset_manager?
     (image.changed_attributes.keys & CROP_ATTRIBUTES).any?

--- a/spec/features/editing_images/edit_image_crop_asset_manager_down_spec.rb
+++ b/spec/features/editing_images/edit_image_crop_asset_manager_down_spec.rb
@@ -13,7 +13,7 @@ RSpec.feature "Edit image crop when Asset Manager is down", js: true do
   def given_there_is_a_document_with_images
     document_type = build(:document_type, lead_image: true)
     document = create(:document, document_type_id: document_type.id)
-    create(:image, :in_preview, document: document, crop_y: 167, fixture: "1000x1000.jpg")
+    @image = create(:image, :in_preview, document: document, crop_y: 167, fixture: "1000x1000.jpg")
   end
 
   def when_i_visit_the_images_page
@@ -21,7 +21,7 @@ RSpec.feature "Edit image crop when Asset Manager is down", js: true do
   end
 
   def and_asset_manager_is_down
-    asset_manager_upload_failure
+    asset_manager_update_failure(@image.asset_manager_id)
   end
 
   def and_i_crop_the_image

--- a/spec/features/editing_images/edit_image_crop_spec.rb
+++ b/spec/features/editing_images/edit_image_crop_spec.rb
@@ -11,16 +11,16 @@ RSpec.feature "Edit image crop", js: true do
 
   def given_there_is_a_document_with_images
     document_type = build(:document_type, lead_image: true)
-    document = create(:document, document_type_id: document_type.id)
+    @document = create(:document, document_type_id: document_type.id)
 
-    create(:image,
-           :in_preview,
-           document: document,
-           crop_x: 0,
-           crop_y: 167,
-           crop_width: 1000,
-           crop_height: 666,
-           fixture: "1000x1000.jpg")
+    @image = create(:image,
+                    :in_preview,
+                    document: @document,
+                    crop_x: 0,
+                    crop_y: 167,
+                    crop_width: 1000,
+                    crop_height: 666,
+                    fixture: "1000x1000.jpg")
   end
 
   def when_i_visit_the_images_page
@@ -37,21 +37,21 @@ RSpec.feature "Edit image crop", js: true do
     bottom_right_handle = find(".cropper-point.point-se")
     bottom_right_handle.drag_to(find(".govuk-heading-l"))
 
-    @upload_request = asset_manager_receives_an_asset("asset_manager_file_url")
-    @delete_request = asset_manager_delete_asset(Image.last.asset_manager_id)
+    @asset_update_request = asset_manager_update_asset(@image.asset_manager_id)
     @publishing_api_request = stub_any_publishing_api_put_content
 
     click_on "Crop image"
   end
 
   def then_the_image_crop_is_updated
-    expect(@upload_request).to have_been_requested
-    expect(@delete_request).to have_been_requested
-    expect(Image.last.crop_y).to eq(0)
-    expect(Image.last.crop_x).to eq(0)
-    expect(Image.last.crop_width).to eq(960)
-    expect(Image.last.crop_height).to eq(640)
-    expect(page).to have_content(I18n.t!("images.index.flashes.cropped", file: Image.last.filename))
+    expect(@asset_update_request).to have_been_requested
+    @image.reload
+
+    expect(@image.crop_y).to eq(0)
+    expect(@image.crop_x).to eq(0)
+    expect(@image.crop_width).to eq(960)
+    expect(@image.crop_height).to eq(640)
+    expect(page).to have_content(I18n.t!("images.index.flashes.cropped", file: @image.filename))
   end
 
   def and_the_preview_creation_succeeded
@@ -61,7 +61,7 @@ RSpec.feature "Edit image crop", js: true do
       expect(JSON.parse(req.body)["details"].keys).to_not include("image")
     }).to have_been_requested
 
-    click_on "Back"
+    visit document_path(@document)
     expect(page).to have_content(I18n.t!("user_facing_states.draft.name"))
     expect(page).to have_content(I18n.t!("documents.show.lead_image.no_lead_image"))
 

--- a/spec/features/editing_images/edit_image_metadata_spec.rb
+++ b/spec/features/editing_images/edit_image_metadata_spec.rb
@@ -20,7 +20,7 @@ RSpec.feature "Edit image metadata" do
   end
 
   def and_i_edit_the_image_metadata
-    @request = stub_publishing_api_put_content(Document.last.content_id, {})
+    @publishing_api_request = stub_publishing_api_put_content(Document.last.content_id, {})
     click_on "Edit details"
     fill_in "alt_text", with: "Some alt text"
     fill_in "caption", with: "A caption"
@@ -29,7 +29,6 @@ RSpec.feature "Edit image metadata" do
   end
 
   def then_i_see_the_image_is_updated
-    expect(@request).to have_been_requested
     expect(page).to have_content(I18n.t!("images.index.flashes.details_edited", file: @image.filename))
     expect(page).to have_content("Some alt text")
     expect(page).to have_content("A caption")
@@ -37,7 +36,7 @@ RSpec.feature "Edit image metadata" do
   end
 
   def and_the_preview_creation_succeeded
-    expect(@request).to have_been_requested
+    expect(@publishing_api_request).to have_been_requested
 
     expect(a_request(:put, /content/).with { |req|
       expect(JSON.parse(req.body)["details"].keys).to_not include("image")

--- a/spec/features/editing_images/upload_lead_image_spec.rb
+++ b/spec/features/editing_images/upload_lead_image_spec.rb
@@ -29,7 +29,7 @@ RSpec.feature "Upload a lead image" do
   end
 
   def and_i_crop_the_image
-    asset_manager_delete_asset(@asset_id)
+    asset_manager_update_asset(@asset_id)
     stub_publishing_api_put_content(Document.last.content_id, {})
     click_on "Crop image"
     # TODO: Replace with https://github.com/bblimke/webmock/blob/d8686502442d9830dcccd24a1120ac08413d857a/lib/webmock/api.rb#L69 when it's released


### PR DESCRIPTION
https://trello.com/c/czJdLQCW/552-updating-assets-in-assetmanager-requires-mutating-an-image-to-upload-a-new-asset-deleting-the-old-asset-then-updating-the-databa

Previously we used to delete and recreate images in Asset Manager
whenever the crop was changed. This changes the update code to do this
using a single request.