### PR TITLE
Add copy and paste tracking using GTM data layer

### DIFF
--- a/app/assets/javascripts/application.js
+++ b/app/assets/javascripts/application.js
@@ -22,8 +22,9 @@
 //= require components/url-preview.js
 //= require vendor/@alphagov/miller-columns-element/dist/index.umd.js
 
-//= require modules/warn-before-unload.js
 //= require modules/gtm-form-listener.js
+//= require modules/gtm-track-copy.js
+//= require modules/warn-before-unload.js
 
 // load after other components (esp. autocomplete)
 //= require components/contextual-guidance.js

--- a/app/assets/javascripts/modules/gtm-track-copy.js
+++ b/app/assets/javascripts/modules/gtm-track-copy.js
@@ -3,33 +3,33 @@ function GTMCopyListener ($module, dataLayer) {
   this.dataLayer = dataLayer || window.dataLayer
 }
 
-GTMCopyListener.prototype.handleCopyEvent = function (component) {
+GTMCopyListener.prototype.handleCopyEvent = function (value) {
   this.dataLayer.push({
     'event': 'text-copied',
-    'component': component
+    'element': value
   })
 }
 
-GTMCopyListener.prototype.handlePasteEvent = function (component) {
+GTMCopyListener.prototype.handlePasteEvent = function (value) {
   this.dataLayer.push({
     'event': 'text-pasted',
-    'component': component
+    'element': value
   })
 }
 
 GTMCopyListener.prototype.init = function () {
   var $module = this.$module
-  var moduleName = this.$module.dataset.module
+  var datasetValue = this.$module.dataset.gtmCopyPasteTracking
   $module.addEventListener('copy', function (e) {
-    this.handleCopyEvent(moduleName)
+    this.handleCopyEvent(datasetValue)
   }.bind(this), false)
 
   $module.addEventListener('paste', function (e) {
-    this.handlePasteEvent(moduleName)
+    this.handlePasteEvent(datasetValue)
   }.bind(this), false)
 }
 
-var $trackedComponents = document.querySelectorAll('[data-module="markdown-editor"], [data-module="copy-to-clipboard"]')
+var $trackedComponents = document.querySelectorAll('[data-gtm-copy-paste-tracking]')
 $trackedComponents.forEach(function ($component) {
   new GTMCopyListener($component).init()
 })

--- a/app/assets/javascripts/modules/gtm-track-copy.js
+++ b/app/assets/javascripts/modules/gtm-track-copy.js
@@ -1,0 +1,38 @@
+function GTMCopyListener () { }
+
+GTMCopyListener.prototype.getSelectionText = function () {
+  var text = ''
+  if (window.getSelection) {
+    text = window.getSelection().toString()
+  } else if (document.selection && document.selection.type !== 'Control') {
+    text = document.selection.createRange().text
+  }
+  return text
+}
+
+GTMCopyListener.prototype.handleCopyEvent = function () {
+  window.dataLayer.push({
+    'event': 'text-copied',
+    'copiedText': this.getSelectionText(),
+    'textLength': this.getSelectionText().length
+  })
+}
+
+GTMCopyListener.prototype.handlePasteEvent = function () {
+  window.dataLayer.push({
+    'event': 'text-pasted',
+    'copiedText': 'N/A'
+  })
+}
+
+GTMCopyListener.prototype.init = function () {
+  document.addEventListener('copy', function (e) {
+    this.handleCopyEvent(e)
+  }.bind(this), false)
+
+  document.addEventListener('paste', function (e) {
+    this.handlePasteEvent(e)
+  }.bind(this), false)
+}
+
+new GTMCopyListener().init()

--- a/app/assets/javascripts/modules/gtm-track-copy.js
+++ b/app/assets/javascripts/modules/gtm-track-copy.js
@@ -1,25 +1,35 @@
-function GTMCopyListener () { }
+function GTMCopyListener ($module, dataLayer) {
+  this.$module = $module
+  this.dataLayer = dataLayer || window.dataLayer
+}
 
-GTMCopyListener.prototype.handleCopyEvent = function () {
-  window.dataLayer.push({
-    'event': 'text-copied'
+GTMCopyListener.prototype.handleCopyEvent = function (component) {
+  this.dataLayer.push({
+    'event': 'text-copied',
+    'component': component
   })
 }
 
-GTMCopyListener.prototype.handlePasteEvent = function () {
-  window.dataLayer.push({
-    'event': 'text-pasted'
+GTMCopyListener.prototype.handlePasteEvent = function (component) {
+  this.dataLayer.push({
+    'event': 'text-pasted',
+    'component': component
   })
 }
 
 GTMCopyListener.prototype.init = function () {
-  document.addEventListener('copy', function (e) {
-    this.handleCopyEvent(e)
+  var $module = this.$module
+  var moduleName = this.$module.dataset.module
+  $module.addEventListener('copy', function (e) {
+    this.handleCopyEvent(moduleName)
   }.bind(this), false)
 
-  document.addEventListener('paste', function (e) {
-    this.handlePasteEvent(e)
+  $module.addEventListener('paste', function (e) {
+    this.handlePasteEvent(moduleName)
   }.bind(this), false)
 }
 
-new GTMCopyListener().init()
+var $trackedComponents = document.querySelectorAll('[data-module="markdown-editor"], [data-module="copy-to-clipboard"]')
+$trackedComponents.forEach(function ($component) {
+  new GTMCopyListener($component).init()
+})

--- a/app/assets/javascripts/modules/gtm-track-copy.js
+++ b/app/assets/javascripts/modules/gtm-track-copy.js
@@ -1,27 +1,14 @@
 function GTMCopyListener () { }
 
-GTMCopyListener.prototype.getSelectionText = function () {
-  var text = ''
-  if (window.getSelection) {
-    text = window.getSelection().toString()
-  } else if (document.selection && document.selection.type !== 'Control') {
-    text = document.selection.createRange().text
-  }
-  return text
-}
-
 GTMCopyListener.prototype.handleCopyEvent = function () {
   window.dataLayer.push({
-    'event': 'text-copied',
-    'copiedText': this.getSelectionText(),
-    'textLength': this.getSelectionText().length
+    'event': 'text-copied'
   })
 }
 
 GTMCopyListener.prototype.handlePasteEvent = function () {
   window.dataLayer.push({
-    'event': 'text-pasted',
-    'copiedText': 'N/A'
+    'event': 'text-pasted'
   })
 }
 

--- a/app/views/components/_page_preview.html.erb
+++ b/app/views/components/_page_preview.html.erb
@@ -9,8 +9,13 @@
         label: "Send this link to someone so they can see a preview of how the document will appear on GOV.UK. No password is needed.",
         copyable_content: utm_uri.to_s,
         button_text: "Copy link",
-        button_data_attributes: { gtm: "copy-url-for-preview-cta" },
-        input_data_attributes: { gtm: "copy-url-for-preview-manual" }
+        button_data_attributes: {
+          gtm: "copy-url-for-preview-cta"
+        },
+        input_data_attributes: {
+          gtm: "copy-url-for-preview-manual",
+          "gtm-copy-paste-tracking": "copy-url-for-preview-manual"
+        }
       %>
     <% end %>
   </div>

--- a/app/views/documents/fields/_govspeak_input.html.erb
+++ b/app/views/documents/fields/_govspeak_input.html.erb
@@ -9,7 +9,8 @@
         data: {
           "contextual-guidance": "document-contents-guidance",
           gramm: "false", # Disables grammerly plugin for markdown editor
-          gtm: "#{field.id}-input"
+          gtm: "#{field.id}-input",
+          "gtm-copy-paste-tracking": "copy-url-for-2i-approval-cta",
         },
         id: field.id,
         name: "revision[contents][#{field.id}]",

--- a/app/views/documents/show/_submitted_for_review.html.erb
+++ b/app/views/documents/show/_submitted_for_review.html.erb
@@ -3,8 +3,13 @@
     label: t("documents.show.flashes.submitted_for_review.label"),
     copyable_content: document_url(@edition.document, utm_content: "2i-link"),
     button_text: "Copy link",
-    button_data_attributes: { gtm: "copy-url-for-2i-approval-cta" },
-    input_data_attributes: { gtm: "copy-url-for-2i-approval-manual" }
+    button_data_attributes: {
+      gtm: "copy-url-for-2i-approval-cta"
+    },
+    input_data_attributes: {
+      gtm: "copy-url-for-2i-approval-manual",
+      "gtm-copy-paste-tracking": "copy-url-for-2i-approval-manual"
+    }
 ) %>
 
 <%= render "govuk_publishing_components/components/success_alert",

--- a/app/views/publish/published.html.erb
+++ b/app/views/publish/published.html.erb
@@ -26,7 +26,13 @@
         label: t("publish.published.published_without_review.send_label"),
         copyable_content: document_url(@edition.document, utm_content: "2i-link"),
         button_text: "Copy link",
-        button_data_attributes: { gtm: "published-content-copy-link-cta" } %>
+        button_data_attributes: {
+          gtm: "published-content-copy-link-cta"
+        },
+        input_data_attributes: {
+          "gtm-copy-paste-tracking": "published-content-copy-link-manual"
+        }
+    %>
     <% else %>
       <%= render "govuk_publishing_components/components/panel", {
         title: t("publish.published.reviewed.title")

--- a/spec/javascripts/modules/gtm-track-copy-spec.js
+++ b/spec/javascripts/modules/gtm-track-copy-spec.js
@@ -9,7 +9,7 @@ describe('GTM dataLayer messages for copy and paste events', function () {
   beforeEach(function () {
     container = document.createElement('div')
     container.innerHTML = '<input id="textInput" type="text" name="copy" value="the text">'
-    container.dataset.module = 'copy-to-clipboard'
+    container.dataset.gtmCopyPasteTracking = 'copy-input-value'
     document.body.appendChild(container)
     window.dataLayer = []
     new GTMCopyListener(container).init()
@@ -27,7 +27,7 @@ describe('GTM dataLayer messages for copy and paste events', function () {
     expect(window.dataLayer).toContain(
       {
         'event': 'text-copied',
-        'component': 'copy-to-clipboard'
+        'element': 'copy-input-value'
       }
     )
   })
@@ -40,7 +40,7 @@ describe('GTM dataLayer messages for copy and paste events', function () {
     expect(window.dataLayer).toContain(
       {
         'event': 'text-pasted',
-        'component': 'copy-to-clipboard'
+        'element': 'copy-input-value'
       }
     )
   })

--- a/spec/javascripts/modules/gtm-track-copy-spec.js
+++ b/spec/javascripts/modules/gtm-track-copy-spec.js
@@ -1,50 +1,55 @@
+/* global describe beforeEach afterEach it expect */
+/* global GTMCopyListener Event */
+
 describe('GTM dataLayer messages for copy and paste events', function () {
   'use strict'
 
-  var dataLayer
+  var container
 
   beforeEach(function () {
-    var rawForm = `
-      <form id="testForm">
-        <input id="textInput" type="text" name="copy" value="the text">
-      </form>
-      `
-    document.body.insertAdjacentHTML('beforeend', rawForm)
+    container = document.createElement('div')
+    container.innerHTML =
+      '<form id="testForm">' +
+        '<input id="textInput" type="text" name="copy" value="the text">' +
+      '</form>'
+    document.body.appendChild(container)
     window.dataLayer = []
     new GTMCopyListener().init()
   })
 
   afterEach(function () {
-    document.getElementById('testForm').remove()
+    document.body.removeChild(container)
   })
 
   it('should push to the dataLayer on copy', function () {
     var input = document.getElementById('textInput')
     input.select()
     if (!document.queryCommandEnabled('copy')) {
-      pending('It is only possible to trigger copy in user-initiated event handler')
+      document.dispatchEvent(new Event('copy'))
     }
+
     document.execCommand('copy')
 
-    expect(window.dataLayer).toEqual([
+    expect(window.dataLayer).toContain(
       {
-        'event': 'text-copied',
-        'copiedText': 'the-text',
-        'textLength': 8
+        'event': 'text-copied'
       }
-    ])
+    )
   })
 
   it('should push to the dataLayer on paste', function () {
     var input = document.getElementById('textInput')
     input.select()
     if (!document.queryCommandEnabled('paste')) {
-      pending('It is only possible to trigger paste in user-initiated event handler')
+      document.dispatchEvent(new Event('paste'))
     }
+
     document.execCommand('paste')
 
-    expect(window.dataLayer).toEqual([
-      { 'event': 'text-pasted' }
-    ])
+    expect(window.dataLayer).toContain(
+      {
+        'event': 'text-pasted'
+      }
+    )
   })
 })

--- a/spec/javascripts/modules/gtm-track-copy-spec.js
+++ b/spec/javascripts/modules/gtm-track-copy-spec.js
@@ -8,13 +8,11 @@ describe('GTM dataLayer messages for copy and paste events', function () {
 
   beforeEach(function () {
     container = document.createElement('div')
-    container.innerHTML =
-      '<form id="testForm">' +
-        '<input id="textInput" type="text" name="copy" value="the text">' +
-      '</form>'
+    container.innerHTML = '<input id="textInput" type="text" name="copy" value="the text">'
+    container.dataset.module = 'copy-to-clipboard'
     document.body.appendChild(container)
     window.dataLayer = []
-    new GTMCopyListener().init()
+    new GTMCopyListener(container).init()
   })
 
   afterEach(function () {
@@ -24,15 +22,12 @@ describe('GTM dataLayer messages for copy and paste events', function () {
   it('should push to the dataLayer on copy', function () {
     var input = document.getElementById('textInput')
     input.select()
-    if (!document.queryCommandEnabled('copy')) {
-      document.dispatchEvent(new Event('copy'))
-    }
-
-    document.execCommand('copy')
+    container.dispatchEvent(new Event('copy'))
 
     expect(window.dataLayer).toContain(
       {
-        'event': 'text-copied'
+        'event': 'text-copied',
+        'component': 'copy-to-clipboard'
       }
     )
   })
@@ -40,15 +35,12 @@ describe('GTM dataLayer messages for copy and paste events', function () {
   it('should push to the dataLayer on paste', function () {
     var input = document.getElementById('textInput')
     input.select()
-    if (!document.queryCommandEnabled('paste')) {
-      document.dispatchEvent(new Event('paste'))
-    }
-
-    document.execCommand('paste')
+    container.dispatchEvent(new Event('paste'))
 
     expect(window.dataLayer).toContain(
       {
-        'event': 'text-pasted'
+        'event': 'text-pasted',
+        'component': 'copy-to-clipboard'
       }
     )
   })

--- a/spec/javascripts/modules/gtm-track-copy-spec.js
+++ b/spec/javascripts/modules/gtm-track-copy-spec.js
@@ -1,0 +1,50 @@
+describe('GTM dataLayer messages for copy and paste events', function () {
+  'use strict'
+
+  var dataLayer
+
+  beforeEach(function () {
+    var rawForm = `
+      <form id="testForm">
+        <input id="textInput" type="text" name="copy" value="the text">
+      </form>
+      `
+    document.body.insertAdjacentHTML('beforeend', rawForm)
+    window.dataLayer = []
+    new GTMCopyListener().init()
+  })
+
+  afterEach(function () {
+    document.getElementById('testForm').remove()
+  })
+
+  it('should push to the dataLayer on copy', function () {
+    var input = document.getElementById('textInput')
+    input.select()
+    if (!document.queryCommandEnabled('copy')) {
+      pending('It is only possible to trigger copy in user-initiated event handler')
+    }
+    document.execCommand('copy')
+
+    expect(window.dataLayer).toEqual([
+      {
+        'event': 'text-copied',
+        'copiedText': 'the-text',
+        'textLength': 8
+      }
+    ])
+  })
+
+  it('should push to the dataLayer on paste', function () {
+    var input = document.getElementById('textInput')
+    input.select()
+    if (!document.queryCommandEnabled('paste')) {
+      pending('It is only possible to trigger paste in user-initiated event handler')
+    }
+    document.execCommand('paste')
+
+    expect(window.dataLayer).toEqual([
+      { 'event': 'text-pasted' }
+    ])
+  })
+})


### PR DESCRIPTION
This PR enables tracking of `copy` and `paste` events using GTM on specific components (initially markdown-editor and copy-link).

Author of PR: @erino; I did some clean up and updated tests.

[Trello card](https://trello.com/c/QHmf1x47)