### PR TITLE
Add requirement for image credit

### DIFF
--- a/app/services/requirements/image_checker.rb
+++ b/app/services/requirements/image_checker.rb
@@ -23,7 +23,7 @@ module Requirements
         issues << Issue.new(:alt_text, :too_long, max_length: ALT_TEXT_MAX_LENGTH, filename: image.filename)
       end
 
-      if @image.caption.to_s.length > CAPTION_MAX_LENGTH
+      if image.caption.to_s.length > CAPTION_MAX_LENGTH
         issues << Issue.new(:caption, :too_long, max_length: CAPTION_MAX_LENGTH, filename: image.filename)
       end
 

--- a/app/services/requirements/image_checker.rb
+++ b/app/services/requirements/image_checker.rb
@@ -4,6 +4,7 @@ module Requirements
   class ImageChecker
     ALT_TEXT_MAX_LENGTH = 125
     CAPTION_MAX_LENGTH = 160
+    CREDIT_MAX_LENGTH = 160
 
     attr_reader :image
 
@@ -24,6 +25,10 @@ module Requirements
 
       if @image.caption.to_s.length > CAPTION_MAX_LENGTH
         issues << Issue.new(:caption, :too_long, max_length: CAPTION_MAX_LENGTH, filename: image.filename)
+      end
+
+      if image.credit.to_s.length > CREDIT_MAX_LENGTH
+        issues << Issue.new(:credit, :too_long, max_length: CREDIT_MAX_LENGTH, filename: image.filename)
       end
 
       CheckerIssues.new(issues)

--- a/config/locales/en/requirements.yml
+++ b/config/locales/en/requirements.yml
@@ -46,6 +46,10 @@ en:
       too_long:
         form_message: "Enter an image caption that is fewer than %{max_length} characters long"
         summary_message: "Enter a shorter caption for ‘%{filename}’"
+    credit:
+      too_long:
+        form_message: "Enter an image credit that is fewer than %{max_length} characters long"
+        summary_message: "Enter a shorter credit for ‘%{filename}’"
     image_upload:
       no_file:
         form_message: Select a file to upload

--- a/spec/services/requirements/image_checker_spec.rb
+++ b/spec/services/requirements/image_checker_spec.rb
@@ -42,5 +42,17 @@ RSpec.describe Requirements::ImageChecker do
       summary_message = issues.items_for(:caption, style: "summary").first[:text]
       expect(summary_message).to eq(I18n.t!("requirements.caption.too_long.summary_message", max_length: max_length, filename: image.filename))
     end
+
+    it "returns an issue if the credit is too long" do
+      max_length = Requirements::ImageChecker::CREDIT_MAX_LENGTH
+      image = build(:image, credit: "a" * (max_length + 1))
+      issues = Requirements::ImageChecker.new(image).pre_preview_issues
+
+      form_message = issues.items_for(:credit).first[:text]
+      expect(form_message).to eq(I18n.t!("requirements.credit.too_long.form_message", max_length: max_length))
+
+      summary_message = issues.items_for(:credit, style: "summary").first[:text]
+      expect(summary_message).to eq(I18n.t!("requirements.credit.too_long.summary_message", max_length: max_length, filename: image.filename))
+    end
   end
 end


### PR DESCRIPTION
Trello: https://trello.com/c/hGmJ5BfV

## What's changed

Restrict the number of characters a user can enter in the credit field to 160 characters.

![screen shot 2018-12-18 at 13 39 00](https://user-images.githubusercontent.com/5793815/50157822-4f624380-02ca-11e9-9271-1a193c6e77f3.png)
