### PR TITLE
Adds no results message

### DIFF
--- a/app/assets/javascripts/components/autocomplete.js
+++ b/app/assets/javascripts/components/autocomplete.js
@@ -14,7 +14,7 @@ if ($autocompletes) {
     new window.accessibleAutocomplete.enhanceSelectElement({ // eslint-disable-line no-new, new-cap
       selectElement: $el,
       minLength: 3,
-      showNoOptionsFound: false,
+      showNoOptionsFound: true,
       customAttributes: customAttributes
     })
   })


### PR DESCRIPTION
Ticket: 
- ~https://trello.com/c/pYDNDc14/565-issue-search-contacts-does-not-start-showing-choices-until-the-third-character-typed~
- https://trello.com/c/qXFrMELH/624-autocomplete-does-not-show-users-any-message-in-an-event-of-no-result

Screenshots:
<img width="1103" alt="screen shot 2018-12-19 at 10 41 00" src="https://user-images.githubusercontent.com/4599889/50215343-9d368480-037a-11e9-834a-69e1acc89887.png">

