### PR TITLE
Lint JavaScript tests

### DIFF
--- a/spec/javascripts/components/contextual-guidance-spec.js
+++ b/spec/javascripts/components/contextual-guidance-spec.js
@@ -1,5 +1,5 @@
 /* global describe beforeEach afterEach it expect */
-/* global ContextualGuidance */
+/* global ContextualGuidance Event */
 
 describe('Contextual guidance component', function () {
   'use strict'

--- a/spec/javascripts/components/input-length-suggester-spec.js
+++ b/spec/javascripts/components/input-length-suggester-spec.js
@@ -1,5 +1,5 @@
 /* global describe beforeEach afterEach it expect */
-/* global InputLengthSuggester */
+/* global InputLengthSuggester Event */
 
 describe('Input length suggester component', function () {
   'use strict'

--- a/spec/javascripts/components/url-preview-spec.js
+++ b/spec/javascripts/components/url-preview-spec.js
@@ -1,5 +1,5 @@
 /* global describe beforeEach afterEach it expect */
-/* global UrlPreview */
+/* global UrlPreview Event */
 
 describe('URL preview component', function () {
   'use strict'

--- a/spec/javascripts/modules/gtm-form-listener-spec.js
+++ b/spec/javascripts/modules/gtm-form-listener-spec.js
@@ -1,27 +1,30 @@
+/* global describe beforeEach afterEach it expect */
+/* global GTMFormListener Event */
+
 describe('GTM dataLayer messages for radio button submissions', function () {
   'use strict'
 
   var dataLayer
   var submitFormEvent = new Event('submit', {'bubbles': true, 'cancelable': true})
+  var container
 
   beforeEach(function () {
-    var rawForm = `
-      <form id="testForm" data-gtm="new-document" onsubmit="return false;">
-        <input type="radio" name="supertype" id="radio-news" value="news">
-        <input type="radio" name="supertype" id="radio-guidance" value="guidance">
-
-        <input type="checkbox" name="caprinae" id="checkbox-goat" value="goat">
-        <input type="checkbox" name="caprinae" id="checkbox-sheep" value="sheep">
-        <input type="checkbox" name="caprinae" id="checkbox-ibex" value="ibex">
-      </form>
-      `
-    document.body.insertAdjacentHTML('beforeend', rawForm)
+    container = document.createElement('div')
+    container.innerHTML =
+      '<form id="testForm" data-gtm="new-document" onsubmit="return false;">' +
+        '<input type="radio" name="supertype" id="radio-news" value="news">' +
+        '<input type="radio" name="supertype" id="radio-guidance" value="guidance">' +
+        '<input type="checkbox" name="caprinae" id="checkbox-goat" value="goat">' +
+        '<input type="checkbox" name="caprinae" id="checkbox-sheep" value="sheep">' +
+        '<input type="checkbox" name="caprinae" id="checkbox-ibex" value="ibex">' +
+      '</form>'
+    document.body.appendChild(container)
     dataLayer = []
     GTMFormListener.init(dataLayer)
   })
 
   afterEach(function () {
-    document.getElementById('testForm').remove()
+    document.body.removeChild(container)
   })
 
   it('should append the corrent message on submit for radios', function () {

--- a/spec/javascripts/modules/warn-before-unload-spec.js
+++ b/spec/javascripts/modules/warn-before-unload-spec.js
@@ -1,5 +1,5 @@
 /* global describe beforeEach afterEach it spyOn expect */
-/* global WarnBeforeUnload */
+/* global WarnBeforeUnload Event */
 
 describe('Warn before unload module', function () {
   'use strict'
@@ -24,7 +24,7 @@ describe('Warn before unload module', function () {
   })
 
   it('should set a before unload event when the form changes', function () {
-    spyOn(window, 'addEventListener');
+    spyOn(window, 'addEventListener')
     var input = container.querySelector('input')
     input.dispatchEvent(new Event('change', { bubbles: true }))
     expect(window.addEventListener)
@@ -32,7 +32,7 @@ describe('Warn before unload module', function () {
   })
 
   it('should remove the before unload event when the form is submitted', function () {
-    spyOn(window, 'removeEventListener');
+    spyOn(window, 'removeEventListener')
     var form = container.querySelector('form')
     form.dispatchEvent(new Event('submit'))
     expect(window.removeEventListener)


### PR DESCRIPTION
Quick clean in the JavaScript specs as a few StandardJS linting errors made their way in.
Also replaced the template literals for consistency, and, if I remember well they're not supported but our testing framework - also helps running the tests cross browser.