### PR TITLE
Add create internal notes form

### DIFF
--- a/app/controllers/internal_notes_controller.rb
+++ b/app/controllers/internal_notes_controller.rb
@@ -1,6 +1,9 @@
 # frozen_string_literal: true
 
 class InternalNotesController < ApplicationController
+  include GDS::SSO::ControllerMethods
+  before_action { authorise_user!(User::PRE_RELEASE_FEATURES_PERMISSION) }
+
   def create
     Document.transaction do
       document = Document.with_current_edition.lock!.find_by_param(params[:id])

--- a/app/controllers/internal_notes_controller.rb
+++ b/app/controllers/internal_notes_controller.rb
@@ -1,0 +1,35 @@
+# frozen_string_literal: true
+
+class InternalNotesController < ApplicationController
+  def create
+    Document.transaction do
+      document = Document.with_current_edition.lock!.find_by_param(params[:id])
+      note = params.fetch(:internal_note)
+
+      if note&.chomp.blank?
+        return redirect_to_document_history(document)
+      end
+
+      internal_note = InternalNote.create!(
+        body: note,
+        edition: document.current_edition,
+        created_by: current_user,
+      )
+
+      TimelineEntry.create_for_revision(
+        entry_type: :internal_note,
+        edition: document.current_edition,
+        details: internal_note,
+        created_by: current_user,
+      )
+
+      redirect_to_document_history(document)
+    end
+  end
+
+private
+
+  def redirect_to_document_history(document)
+    redirect_to("#{document_path(document)}#document-history")
+  end
+end

--- a/app/models/timeline_entry.rb
+++ b/app/models/timeline_entry.rb
@@ -58,11 +58,14 @@ class TimelineEntry < ApplicationRecord
   def self.create_for_revision(entry_type:,
                                revision: nil,
                                edition:,
-                               details: nil)
+                               details: nil,
+                               created_by: nil)
+
     revision = revision || edition.revision
+    creator = created_by || revision.created_by
 
     create!(entry_type: entry_type,
-            created_by: revision.created_by,
+            created_by: creator,
             revision: revision,
             edition: edition,
             document: edition.document,

--- a/app/views/documents/show/_history_tab.html.erb
+++ b/app/views/documents/show/_history_tab.html.erb
@@ -55,4 +55,20 @@
       </div>
     <% end %>
   </div>
+
+  <div class="govuk-grid-column-one-third">
+    <%= form_tag(create_internal_note_path(@document), method: :post) do %>
+      <%= render "govuk_publishing_components/components/textarea", {
+        label: {
+          text: t("documents.history.entry_types.internal_note"),
+          bold: true
+        },
+        name: "internal_note",
+      } %>
+
+      <%= render "govuk_publishing_components/components/button", {
+        text: t("documents.history.add_internal_note")
+      } %>
+    <% end %>
+  </div>
 </div>

--- a/app/views/documents/show/_history_tab.html.erb
+++ b/app/views/documents/show/_history_tab.html.erb
@@ -56,19 +56,21 @@
     <% end %>
   </div>
 
-  <div class="govuk-grid-column-one-third">
-    <%= form_tag(create_internal_note_path(@document), method: :post) do %>
-      <%= render "govuk_publishing_components/components/textarea", {
-        label: {
-          text: t("documents.history.entry_types.internal_note"),
-          bold: true
-        },
-        name: "internal_note",
-      } %>
+  <% if current_user.has_permission?(User::PRE_RELEASE_FEATURES_PERMISSION) %>
+    <div class="govuk-grid-column-one-third">
+      <%= form_tag(create_internal_note_path(@document), method: :post) do %>
+        <%= render "govuk_publishing_components/components/textarea", {
+          label: {
+            text: t("documents.history.entry_types.internal_note"),
+            bold: true
+          },
+          name: "internal_note",
+        } %>
 
-      <%= render "govuk_publishing_components/components/button", {
-        text: t("documents.history.add_internal_note")
-      } %>
-    <% end %>
-  </div>
+        <%= render "govuk_publishing_components/components/button", {
+          text: t("documents.history.add_internal_note")
+        } %>
+      <% end %>
+    </div>
+  <% end %>
 </div>

--- a/config/locales/en/documents/history.yml
+++ b/config/locales/en/documents/history.yml
@@ -2,6 +2,7 @@ en:
   documents:
     history:
       edition_header: "%{number} edition"
+      add_internal_note: "Add internal note"
       entry_types:
         created: "First created"
         submitted: "Submitted for review"

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -20,6 +20,8 @@ Rails.application.routes.draw do
   get "/documents/:id/delete-draft" => "documents#confirm_delete_draft", as: :delete_draft
   delete "/documents/:id" => "documents#destroy"
 
+  post "/documents/:id/internal_notes" => "internal_notes#create", as: :create_internal_note
+
   get "/documents/:id/debug" => "debug#index", as: :debug_document
 
   get "/documents/:id/search-contacts" => "contacts#search", as: :search_contacts

--- a/spec/features/workflow/access_internal_notes_without_pre_release_flag_spec.rb
+++ b/spec/features/workflow/access_internal_notes_without_pre_release_flag_spec.rb
@@ -1,0 +1,28 @@
+# frozen_string_literal: true
+
+RSpec.feature "Access internal notes without the pre-release features permission" do
+  scenario do
+    given_there_is_a_document
+    and_i_dont_have_pre_release_features_permission
+    when_i_visit_the_document_page
+    then_i_cant_see_the_input_box_for_internal_notes
+  end
+
+  def given_there_is_a_document
+    create(:document, :with_current_edition)
+  end
+
+  def and_i_dont_have_pre_release_features_permission
+    user = User.first
+    user.update_attribute(:permissions,
+                          user.permissions - [User::PRE_RELEASE_FEATURES_PERMISSION])
+  end
+
+  def when_i_visit_the_document_page
+    visit document_path(Document.last)
+  end
+
+  def then_i_cant_see_the_input_box_for_internal_notes
+    expect(page).to have_no_css("textarea[name='internal_note']")
+  end
+end

--- a/spec/features/workflow/internal_note_spec.rb
+++ b/spec/features/workflow/internal_note_spec.rb
@@ -1,31 +1,42 @@
 # frozen_string_literal: true
 
-RSpec.feature "Displaying an internal note" do
+RSpec.feature "Creating a internal note" do
   scenario do
-    given_there_is_a_document_with_a_internal_note
+    given_there_is_a_document
     when_i_visit_the_document_page
+    and_i_fill_in_and_submit_a_internal_note
     then_i_should_see_the_internal_note
+
+    and_i_submit_a_blank_internal_note
+    then_no_internal_note_is_created
   end
 
-  def given_there_is_a_document_with_a_internal_note
-    @edition = create(:edition)
-    @internal_note = create(:internal_note,
-                            body: "Belvita's are pure joy",
-                            edition: @edition)
-    create(:timeline_entry,
-           entry_type: "internal_note",
-           edition: @edition,
-           details: @internal_note)
+  def given_there_is_a_document
+    @document = create(:document, :with_current_edition)
   end
 
   def when_i_visit_the_document_page
-    visit document_path(@edition.document)
+    visit document_path(@document)
+  end
+
+  def and_i_fill_in_and_submit_a_internal_note
+    fill_in "internal_note", with: "Belvita's are incredible"
+    click_on I18n.t!("documents.history.add_internal_note")
   end
 
   def then_i_should_see_the_internal_note
     within("#document-history") do
       expect(page).to have_content(I18n.t!("documents.history.entry_types.internal_note"))
-      expect(page).to have_content(@internal_note.body)
+      expect(page).to have_content(@document.timeline_entries.last.details.body)
     end
+  end
+
+  def and_i_submit_a_blank_internal_note
+    fill_in "internal_note", with: ""
+    click_on I18n.t!("documents.history.add_internal_note")
+  end
+
+  def then_no_internal_note_is_created
+    expect(@document.timeline_entries.last.details.body).to_not eq("")
   end
 end


### PR DESCRIPTION
Currently a developer can create a internal note through the console which will in turn display a internal note on the document history page. The functionality thats been added here is to create a form so publishers can add one themselves. 

## Internal notes form
<img width="1097" alt="screen shot 2018-12-20 at 10 45 17" src="https://user-images.githubusercontent.com/24479188/50283510-fb806780-044d-11e9-8165-020de7ac03ca.png">

Sister PR to:
https://github.com/alphagov/content-publisher/pull/612

Trello:
https://trello.com/c/HCnzVUss/549-ability-to-create-internal-notes