### PR TITLE
Update miller-columns to v0.0.2

### DIFF
--- a/app/assets/javascripts/vendor/@alphagov/miller-columns-element/dist/index.umd.js
+++ b/app/assets/javascripts/vendor/@alphagov/miller-columns-element/dist/index.umd.js
@@ -247,11 +247,8 @@
       this.parent = parent;
       this.children = Topic.fromList(childList, this);
 
-      if (!this.children.length && this.checkbox.checked) {
-        this.selected = true;
-        if (this.parent) {
-          this.parent.childWasSelected();
-        }
+      if (this.checkbox.checked) {
+        this.select();
       } else {
         this.selected = false;
       }


### PR DESCRIPTION
This release fixes the topics constructor failing to initialise.

Review the change in the [miller-columns-element](https://github.com/alphagov/miller-columns-element/pull/6) repository.

[Trello card](https://trello.com/c/g1linbAJ)