### PR TITLE
Re-approach the markdown editor styling

### DIFF
--- a/app/assets/javascripts/components/markdown-editor.js
+++ b/app/assets/javascripts/components/markdown-editor.js
@@ -24,12 +24,15 @@ MarkdownEditor.prototype.init = function () {
   // Enable toggle bar
   this.$head.style.display = 'block'
 
-  // Handle events
+  // Handle button events
   this.$previewButton.addEventListener('click', $module.boundPreviewButtonClick)
   this.$editButton.addEventListener('click', $module.boundEditButtonClick)
 
-  // Bubble focus events
-  this.bubbleFocus(this.$input, this.$container)
+  // Reflect focus events
+  this.reflectFocusStateToContainer(this.$input, this.$container)
+  this.bubbleFocusEventToComponent(this.$input)
+  this.bubbleFocusEventToComponent(this.$editButton)
+  this.bubbleFocusEventToComponent(this.$previewButton)
 }
 
 MarkdownEditor.prototype.handlePreviewButton = function (event) {
@@ -126,13 +129,24 @@ MarkdownEditor.prototype.setTargetBlank = function (container) {
   }
 }
 
-// Bubble focus and blur events from specified element to container
-MarkdownEditor.prototype.bubbleFocus = function (element, container) {
+// Reflect focus and blur events to component
+MarkdownEditor.prototype.bubbleFocusEventToComponent = function (element) {
+  var $module = this.$module
   element.addEventListener('focus', function (event) {
-    container.classList.add('app-c-markdown-editor__container--focused')
+    $module.dispatchEvent(new window.Event('focus'))
   }, true)
   element.addEventListener('blur', function (event) {
-    container.classList.remove('app-c-markdown-editor__container--focused')
+    $module.dispatchEvent(new window.Event('blur'))
+  }, true)
+}
+
+// Reflect focus and blur element state to container
+MarkdownEditor.prototype.reflectFocusStateToContainer = function (element, container) {
+  element.addEventListener('focus', function (event) {
+    container && container.classList.add('app-c-markdown-editor__container--focused')
+  }, true)
+  element.addEventListener('blur', function (event) {
+    container && container.classList.remove('app-c-markdown-editor__container--focused')
   }, true)
 }
 

--- a/app/assets/javascripts/components/markdown-editor.js
+++ b/app/assets/javascripts/components/markdown-editor.js
@@ -3,6 +3,7 @@
 function MarkdownEditor ($module) {
   this.$module = $module
   this.$head = $module.querySelector('.js-markdown-editor__head')
+  this.$container = $module.querySelector('.js-markdown-editor__container')
   this.$input = $module.querySelector('textarea')
   this.$preview = $module.querySelector('.js-markdown-preview-body .govuk-textarea')
   this.$previewButton = $module.querySelector('.js-markdown-preview-button')
@@ -26,6 +27,9 @@ MarkdownEditor.prototype.init = function () {
   // Handle events
   this.$previewButton.addEventListener('click', $module.boundPreviewButtonClick)
   this.$editButton.addEventListener('click', $module.boundEditButtonClick)
+
+  // Bubble focus events
+  this.bubbleFocus(this.$input, this.$container)
 }
 
 MarkdownEditor.prototype.handlePreviewButton = function (event) {
@@ -37,7 +41,7 @@ MarkdownEditor.prototype.handlePreviewButton = function (event) {
   }
 
   // Mirror textarea's height
-  this.$preview.style.height = this.$input.offsetHeight + 'px'
+  this.$preview.style.height = this.$input.offsetHeight + this.$editorToolbar.offsetHeight + 'px'
 
   // Clear previous preview
   this.$preview.innerHTML = ''
@@ -120,6 +124,16 @@ MarkdownEditor.prototype.setTargetBlank = function (container) {
       anchor.setAttribute('target', '_blank')
     })
   }
+}
+
+// Bubble focus and blur events from specified element to container
+MarkdownEditor.prototype.bubbleFocus = function (element, container) {
+  element.addEventListener('focus', function (event) {
+    container.classList.add('app-c-markdown-editor__container--focused')
+  }, true)
+  element.addEventListener('blur', function (event) {
+    container.classList.remove('app-c-markdown-editor__container--focused')
+  }, true)
 }
 
 var $govspeak = document.querySelector('[data-module="markdown-editor"]')

--- a/app/assets/stylesheets/components/_markdown-editor.scss
+++ b/app/assets/stylesheets/components/_markdown-editor.scss
@@ -6,22 +6,23 @@ $toolbar-button-size: 50px;
 
 .app-c-markdown-editor {
   .govuk-textarea {
-    padding-top: (govuk-spacing(9) + $toolbar-button-size);
+    border-top: none;
     resize: vertical;
+
+    &:focus {
+      outline: none;
+    }
   }
 }
 
-.app-c-markdown-editor__container {
-  position: relative;
+.app-c-markdown-editor__container--focused {
+  outline: $govuk-focus-width solid $govuk-focus-colour;
+  outline-offset: 0;
 }
 
 .app-c-markdown-editor__head {
   @include govuk-font(19);
   display: block;
-  position: absolute;
-  right: 0;
-  left: 0;
-  margin-bottom: -$govuk-border-width-form-element;
   border: $govuk-border-width-form-element solid $govuk-input-border-colour;
   border-bottom: 0;
   background-color: govuk-colour("white");
@@ -80,7 +81,6 @@ $toolbar-button-size: 50px;
 
   .govuk-textarea {
     overflow: scroll;
-    padding-top: govuk-spacing(9);
   }
 }
 

--- a/app/views/components/_markdown_editor.html.erb
+++ b/app/views/components/_markdown_editor.html.erb
@@ -2,8 +2,14 @@
   textarea ||= {}
   edit_button_text ||= 'Edit markdown'
   preview_button_text ||= 'Preview markdown'
+  contextual_guidance ||= nil
 %>
-<div class="app-c-markdown-editor" data-module="markdown-editor" data-govspeak-path="<%= govspeak_preview_path %>">
+<%= tag.div class: "app-c-markdown-editor",
+  data: {
+    "module": "markdown-editor",
+    "govspeak-path": govspeak_preview_path,
+    "contextual-guidance": contextual_guidance,
+  } do %>
   <%= render "govuk_publishing_components/components/label", {
       html_for: textarea[:id]
   }.merge(label.symbolize_keys) %>
@@ -48,4 +54,4 @@
       <% end %>
     </div>
   </div>
-</div>
+<% end %>

--- a/app/views/components/_markdown_editor.html.erb
+++ b/app/views/components/_markdown_editor.html.erb
@@ -7,7 +7,7 @@
   <%= render "govuk_publishing_components/components/label", {
       html_for: textarea[:id]
   }.merge(label.symbolize_keys) %>
-  <div class="app-c-markdown-editor__container">
+  <div class="app-c-markdown-editor__container js-markdown-editor__container">
     <div class="app-c-markdown-editor__head js-markdown-editor__head">
       <div class="app-c-markdown-editor__preview-toggle">
         <button type="button" class="app-c-markdown-editor__button app-c-markdown-editor__button--muted js-markdown-edit-button"><%= edit_button_text %></button>

--- a/app/views/components/docs/markdown_editor.yml
+++ b/app/views/components/docs/markdown_editor.yml
@@ -24,3 +24,4 @@ examples:
         name: markdown-editor
         id: markdown-editor
       govspeak_preview_path: "#"
+      contextual_guidance: "document-contents-guidance"

--- a/app/views/documents/fields/_govspeak_input.html.erb
+++ b/app/views/documents/fields/_govspeak_input.html.erb
@@ -7,7 +7,6 @@
       },
       textarea: {
         data: {
-          "contextual-guidance": "document-contents-guidance",
           gramm: "false", # Disables grammerly plugin for markdown editor
           gtm: "#{field.id}-input"
         },
@@ -16,7 +15,8 @@
         value: document.contents[field.id],
         rows: 20,
         spellcheck: "false"
-      }
+      },
+      contextual_guidance: "document-contents-guidance"
     } %>
   </div>
 

--- a/spec/javascripts/components/markdown-editor-spec.js
+++ b/spec/javascripts/components/markdown-editor-spec.js
@@ -167,6 +167,16 @@ describe('Markdown editor component', function () {
       var container = document.querySelector('.app-c-markdown-editor__container')
       expect(container).toHaveClass('app-c-markdown-editor__container--focused')
     })
+
+    it('should trigger a focus event on component', function () {
+      var container = document.querySelector('.app-c-markdown-editor')
+      spyOnEvent(container, 'focus')
+
+      document.querySelector('.js-markdown-editor-input textarea').focus()
+
+      expect('focus').toHaveBeenTriggeredOn(container)
+    })
+
   })
 
   describe('when blurring the textarea', function () {

--- a/spec/javascripts/components/markdown-editor-spec.js
+++ b/spec/javascripts/components/markdown-editor-spec.js
@@ -11,7 +11,7 @@ describe('Markdown editor component', function () {
     container.innerHTML =
       '<div class="app-c-markdown-editor" data-module="markdown-editor" data-govspeak-path="#">' +
         '<label for="markdown-editor" class="gem-c-label govuk-label ">Body</label>' +
-        '<div class="app-c-markdown-editor__container">' +
+        '<div class="app-c-markdown-editor__container js-markdown-editor__container">' +
           '<div class="app-c-markdown-editor__head js-markdown-editor__head">' +
             '<div class="app-c-markdown-editor__preview-toggle">' +
               '<button type="button" class="app-c-markdown-editor__button app-c-markdown-editor__button--muted js-markdown-edit-button">Edit markdown</button>' +
@@ -126,7 +126,7 @@ describe('Markdown editor component', function () {
 
   describe('when clicking "Edit markdown" button', function () {
     beforeEach(function () {
-      $('.js-markdown-edit-button').click()
+      document.querySelector('.js-markdown-edit-button').click()
     })
 
     it('should show the editor toolbar', function () {
@@ -157,6 +157,24 @@ describe('Markdown editor component', function () {
     it('should hide the default message in the preview container', function () {
       var previewBody = document.querySelector('.js-markdown-preview-body')
       expect(previewBody).not.toContainText('Nothing to preview')
+    })
+  })
+
+  describe('when focusing the textarea', function () {
+    it('should add focused class to container', function () {
+      document.querySelector('.js-markdown-editor-input textarea').focus()
+
+      var container = document.querySelector('.app-c-markdown-editor__container')
+      expect(container).toHaveClass('app-c-markdown-editor__container--focused')
+    })
+  })
+
+  describe('when blurring the textarea', function () {
+    it('should remove focused class to container', function () {
+      document.querySelector('.js-markdown-editor-input textarea').blur()
+
+      var container = document.querySelector('.app-c-markdown-editor__container')
+      expect(container).not.toHaveClass('app-c-markdown-editor__container--focused')
     })
   })
 })


### PR DESCRIPTION
Update component so is doesn't rely on absolute positioning while preserving the visual styles for focus state.

👉 [Preview markdown editor component](https://content-publisher-revie-pr-659.herokuapp.com/component-guide/markdown_editor)

Problems solved with the new approach:
 - scrolling the textarea overlaps the editor header (https://trello.com/c/uiCA2sAo)
 - grammarly interferes with the component positioning hiding the editor header (https://trello.com/c/1pgYWuWB)

[Trello card](https://trello.com/c/C7RtuUhV)
