### PR TITLE
Replace TODO for Webmock with API method

### DIFF
--- a/spec/features/editing_images/upload_lead_image_spec.rb
+++ b/spec/features/editing_images/upload_lead_image_spec.rb
@@ -32,8 +32,7 @@ RSpec.feature "Upload a lead image" do
     asset_manager_update_asset(@asset_id)
     stub_publishing_api_put_content(Document.last.content_id, {})
     click_on "Crop image"
-    # TODO: Replace with https://github.com/bblimke/webmock/blob/d8686502442d9830dcccd24a1120ac08413d857a/lib/webmock/api.rb#L69 when it's released
-    WebMock::RequestRegistry.instance.reset!
+    reset_executed_requests!
   end
 
   def and_i_fill_in_the_metadata

--- a/spec/features/workflow/preview_publishing_api_down_spec.rb
+++ b/spec/features/workflow/preview_publishing_api_down_spec.rb
@@ -40,7 +40,7 @@ RSpec.feature "Previewing a document when the Publishing API is down" do
   end
 
   def when_the_publishing_api_is_up
-    WebMock::RequestRegistry.instance.reset!
+    reset_executed_requests!
     @request = stub_publishing_api_put_content(Document.last.content_id, {})
   end
 

--- a/spec/formats/news_story_spec.rb
+++ b/spec/formats/news_story_spec.rb
@@ -33,8 +33,7 @@ RSpec.feature "Create a news story", format: true do
     publishing_api_has_lookups(base_path => document.content_id)
 
     click_on "Save"
-    # TODO: Replace with https://github.com/bblimke/webmock/blob/d8686502442d9830dcccd24a1120ac08413d857a/lib/webmock/api.rb#L69 when it's released
-    WebMock::RequestRegistry.instance.reset!
+    reset_executed_requests!
   end
 
   def and_i_add_some_tags

--- a/spec/formats/press_release_spec.rb
+++ b/spec/formats/press_release_spec.rb
@@ -33,8 +33,7 @@ RSpec.feature "Create a press release", format: true do
     publishing_api_has_lookups(base_path => document.content_id)
 
     click_on "Save"
-    # TODO: Replace with https://github.com/bblimke/webmock/blob/d8686502442d9830dcccd24a1120ac08413d857a/lib/webmock/api.rb#L69 when it's released
-    WebMock::RequestRegistry.instance.reset!
+    reset_executed_requests!
   end
 
   def and_i_add_some_tags


### PR DESCRIPTION
Made possible after https://github.com/alphagov/content-publisher/pull/658.