### PR TITLE
Fix image revisions blocking revision deletion

### DIFF
--- a/db/migrate/20190116194130_cascade_image_revision_joins_on_revision_delete.rb
+++ b/db/migrate/20190116194130_cascade_image_revision_joins_on_revision_delete.rb
@@ -1,0 +1,23 @@
+# frozen_string_literal: true
+
+class CascadeImageRevisionJoinsOnRevisionDelete < ActiveRecord::Migration[5.2]
+  def up
+    remove_foreign_key :versioned_revision_image_revisions,
+                       column: :revision_id
+
+    add_foreign_key :versioned_revision_image_revisions,
+                    :versioned_revisions,
+                    column: :revision_id,
+                    on_delete: :cascade
+  end
+
+  def down
+    remove_foreign_key :versioned_revision_image_revisions,
+                       column: :revision_id
+
+    add_foreign_key :versioned_revision_image_revisions,
+                    :versioned_revisions,
+                    column: :revision_id,
+                    on_delete: :restrict
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -396,7 +396,7 @@ ActiveRecord::Schema.define(version: 2019_01_18_151754) do
   add_foreign_key "versioned_internal_notes", "versioned_editions", column: "edition_id", on_delete: :cascade
   add_foreign_key "versioned_retirements", "users", column: "created_by_id", on_delete: :nullify
   add_foreign_key "versioned_revision_image_revisions", "versioned_image_revisions", column: "image_revision_id", on_delete: :restrict
-  add_foreign_key "versioned_revision_image_revisions", "versioned_revisions", column: "revision_id", on_delete: :restrict
+  add_foreign_key "versioned_revision_image_revisions", "versioned_revisions", column: "revision_id", on_delete: :cascade
   add_foreign_key "versioned_revision_statuses", "versioned_revisions", column: "revision_id", on_delete: :cascade
   add_foreign_key "versioned_revision_statuses", "versioned_statuses", column: "status_id", on_delete: :cascade
   add_foreign_key "versioned_revisions", "users", column: "created_by_id", on_delete: :nullify


### PR DESCRIPTION
Trello: https://trello.com/c/UdrY0K9l/574-migrate-to-versioned-code-database

Prior to this change you would be unable to delete entries out of the
revision table if there were any associations with image revisions. This
might make these prohibitively hard to delete, instead we decide since
revision is the more important concept that if you want to delete that
then lose the joins.

We don't however allow the ability to remove an image revision without
removing the join first, this is because image_revisions are part of the
state of a revision and these should only be removed (without removing
the revision) with caution and exceptional circumstance.

Like many of these on_delete behaviours these are not here for day to
day to usage of the application, and are mostly anticipated to get used
in debugging or development scenarios.