### PR TITLE
Raise errors in UnpublishService when drafts are used

### DIFF
--- a/app/services/versioned/asset_manager_service.rb
+++ b/app/services/versioned/asset_manager_service.rb
@@ -11,15 +11,6 @@ module Versioned
       upload["file_url"]
     end
 
-    def draft(asset, auth_bypass_id)
-      GdsApi.asset_manager.update_asset(
-        asset.asset_manager_id,
-        draft: true,
-        auth_bypass_ids: [auth_bypass_id],
-        redirect_url: nil,
-      )
-    end
-
     def publish(asset)
       GdsApi.asset_manager.update_asset(
         asset.asset_manager_id,

--- a/spec/services/versioned/asset_manager_service_spec.rb
+++ b/spec/services/versioned/asset_manager_service_spec.rb
@@ -45,17 +45,6 @@ RSpec.describe Versioned::AssetManagerService do
     end
   end
 
-  describe "#draft" do
-    it "updates an asset's draft status to true in Asset Manager" do
-      asset = double(:asset, asset_manager_id: "id")
-
-      body = { "draft" => true }
-      asset_manager_update_asset(asset.asset_manager_id, body)
-
-      response = Versioned::AssetManagerService.new.draft(asset, "auth_bypass_id")
-      expect(response["draft"]).to be true
-    end
-  end
   describe "#redirect" do
     it "sets a redirect_url on an asset" do
       asset = double(:asset, asset_manager_id: "id")


### PR DESCRIPTION
Trello: https://trello.com/c/UdrY0K9l/574-migrate-to-versioned-code-database

When this was originally wrote there was an expectation that you could
use it to remove/retire a live version while there is a draft present.
It transpires that this is actually not possible in the Publishing API,
the options you have there is either you can transition a draft to
unpublished (with the allow_draft option) or you can discard the draft
at the same time as unpublishing the live edition (with the
discard_draft option). Without one of these Publishing API will error
422 with:

```
"error":{"code":422,"message":"Cannot unpublish with a draft present","fields":{}}}
```

Thus this changes this code here to do checks on whether we're actually
trying to remove a live one and that a draft is not present.

As part of this work we can remove the rather complex work to check if
an asset should be removed or drafted depending on it's usage, and we
can remove the draft method on AssetManagerService as it is no longer
used.