### PR TITLE
Upload all images to asset manager

### DIFF
--- a/spec/features/versioned/editing_images/edit_image_crop_spec.rb
+++ b/spec/features/versioned/editing_images/edit_image_crop_spec.rb
@@ -1,6 +1,8 @@
 # frozen_string_literal: true
 
 RSpec.feature "Edit image crop", js: true do
+  include AssetManagerHelper
+
   scenario do
     given_there_is_a_document_with_images
     when_i_visit_the_images_page
@@ -38,6 +40,7 @@ RSpec.feature "Edit image crop", js: true do
     bottom_right_handle.drag_to(find(".govuk-heading-l"))
 
     @publishing_api_request = stub_any_publishing_api_put_content
+    @asset_manager_requests = stub_asset_manager_receives_assets
 
     click_on "Crop image"
   end
@@ -54,6 +57,7 @@ RSpec.feature "Edit image crop", js: true do
 
   def and_the_preview_creation_succeeded
     expect(@publishing_api_request).to have_been_requested
+    expect(@asset_manager_requests).to have_been_requested.at_least_once
 
     expect(a_request(:put, /content/).with { |req|
       expect(JSON.parse(req.body)["details"].keys).to_not include("image")

--- a/spec/features/versioned/editing_images/edit_image_metadata_spec.rb
+++ b/spec/features/versioned/editing_images/edit_image_metadata_spec.rb
@@ -11,7 +11,7 @@ RSpec.feature "Edit image metadata" do
 
   def given_there_is_a_document_with_images
     document_type = build(:document_type, lead_image: true)
-    @image_revision = create(:versioned_image_revision)
+    @image_revision = create(:versioned_image_revision, :on_asset_manager)
     @edition = create(:versioned_edition,
                       document_type_id: document_type.id,
                       image_revisions: [@image_revision])

--- a/spec/features/versioned/editing_images/remove_lead_image_spec.rb
+++ b/spec/features/versioned/editing_images/remove_lead_image_spec.rb
@@ -10,7 +10,9 @@ RSpec.feature "Remove a lead image" do
 
   def given_there_is_a_document_with_a_lead_image
     document_type = build(:document_type, lead_image: true)
-    @image_revision = create(:versioned_image_revision, alt_text: "image")
+    @image_revision = create(:versioned_image_revision,
+                             :on_asset_manager,
+                             alt_text: "image")
     @edition = create(:versioned_edition,
                       document_type_id: document_type.id,
                       lead_image_revision: @image_revision)

--- a/spec/features/versioned/editing_images/upload_lead_image_spec.rb
+++ b/spec/features/versioned/editing_images/upload_lead_image_spec.rb
@@ -1,6 +1,8 @@
 # frozen_string_literal: true
 
 RSpec.feature "Upload a lead image" do
+  include AssetManagerHelper
+
   scenario do
     given_there_is_a_document
     when_i_visit_the_images_page
@@ -22,10 +24,7 @@ RSpec.feature "Upload a lead image" do
   end
 
   def and_i_upload_a_new_image
-    stub_request(:post, /assets/).to_return do
-      file_url = Plek.new.find("asset-manager") + "/media/#{SecureRandom.uuid}/1000x1000.jpg"
-      { body: { file_url: file_url }.to_json }
-    end
+    stub_asset_manager_receives_assets("1000x1000.jpg")
 
     find('form input[type="file"]').set(Rails.root.join(file_fixture("1000x1000.jpg")))
     click_on "Upload"

--- a/spec/features/versioned/workflow/delete_draft_asset_manager_down_spec.rb
+++ b/spec/features/versioned/workflow/delete_draft_asset_manager_down_spec.rb
@@ -1,6 +1,8 @@
 # frozen_string_literal: true
 
 RSpec.feature "Delete draft with Asset Manager down" do
+  include AssetManagerHelper
+
   scenario do
     given_there_is_a_document
     when_i_visit_the_document_page
@@ -21,13 +23,11 @@ RSpec.feature "Delete draft with Asset Manager down" do
   end
 
   def and_asset_manager_is_down
-    stub_request(:any, /#{Plek.new.find("asset-manager")}/)
-      .to_return(status: 503)
+    stub_asset_manager_down
   end
 
   def when_asset_manager_is_up_and_i_try_again
-    stub_request(:any, /#{Plek.new.find("asset-manager")}/)
-      .to_return(status: 200)
+    stub_asset_manager_deletes_assets
     click_on "Delete draft"
     click_on "Yes, delete draft"
   end

--- a/spec/features/versioned/workflow/delete_draft_spec.rb
+++ b/spec/features/versioned/workflow/delete_draft_spec.rb
@@ -1,6 +1,8 @@
 # frozen_string_literal: true
 
 RSpec.feature "Delete draft" do
+  include AssetManagerHelper
+
   scenario do
     given_there_is_a_document
     when_i_visit_the_document_page
@@ -20,7 +22,7 @@ RSpec.feature "Delete draft" do
 
   def and_i_delete_the_draft
     @content_request = stub_publishing_api_discard_draft(@edition.content_id)
-    @image_request = stub_request(:delete, /#{Plek.new.find("asset-manager")}/)
+    @image_request = stub_asset_manager_deletes_assets
 
     click_on "Delete draft"
     click_on "Yes, delete draft"

--- a/spec/features/versioned/workflow/publish_asset_manager_down_spec.rb
+++ b/spec/features/versioned/workflow/publish_asset_manager_down_spec.rb
@@ -1,6 +1,8 @@
 # frozen_string_literal: true
 
 RSpec.feature "Publishing a document when Asset Manager is down" do
+  include AssetManagerHelper
+
   scenario do
     given_there_is_a_document_with_a_lead_image
     and_asset_manager_is_down
@@ -19,8 +21,7 @@ RSpec.feature "Publishing a document when Asset Manager is down" do
   end
 
   def and_asset_manager_is_down
-    stub_request(:put, /#{Plek.new.find("asset-manager")}/)
-      .to_return(status: 503)
+    stub_asset_manager_updates_assets.to_return(status: 503)
     stub_any_publishing_api_publish
   end
 
@@ -35,8 +36,7 @@ RSpec.feature "Publishing a document when Asset Manager is down" do
   end
 
   def given_the_api_is_up_again_and_i_try_to_publish_the_document
-    @request = stub_request(:put, /#{Plek.new.find("asset-manager")}/)
-      .to_return(status: 200)
+    @request = stub_asset_manager_updates_assets
     visit versioned_document_path(@edition.document)
     click_on "Publish"
     click_on "Confirm publish"

--- a/spec/services/versioned/publish_service_spec.rb
+++ b/spec/services/versioned/publish_service_spec.rb
@@ -1,11 +1,10 @@
 # frozen_string_literal: true
 
 RSpec.describe Versioned::PublishService do
+  include AssetManagerHelper
+
   describe "#publish" do
-    before do
-      # stub all asset manager requests
-      stub_request(:any, /\A#{Plek.current.find('asset-manager')}/)
-    end
+    before { stub_any_asset_manager_call }
 
     context "when there is no live edition" do
       let(:edition) { create(:versioned_edition, :publishable) }

--- a/spec/services/versioned/unpublish_service_spec.rb
+++ b/spec/services/versioned/unpublish_service_spec.rb
@@ -1,6 +1,8 @@
 # frozen_string_literal: true
 
 RSpec.describe Versioned::UnpublishService do
+  include AssetManagerHelper
+
   let(:edition) { create(:versioned_edition, :published) }
   let(:edition_with_image) do
     create(:versioned_edition, :published, lead_image_revision: image_revision)
@@ -25,9 +27,10 @@ RSpec.describe Versioned::UnpublishService do
     end
 
     it "does not delete assets for retired editions" do
+      delete_request = stub_asset_manager_deletes_assets
       Versioned::UnpublishService.new.retire(edition_with_image, explanatory_note)
 
-      expect(stub_request(:delete, /asset-manager/)).not_to have_been_requested
+      expect(delete_request).not_to have_been_requested
     end
 
     it "adds an entry in the timeline of the document" do
@@ -56,7 +59,7 @@ RSpec.describe Versioned::UnpublishService do
     end
 
     it "deletes assets associated with removed editions" do
-      delete_request = stub_request(:delete, /asset-manager/)
+      delete_request = stub_asset_manager_deletes_assets
 
       Versioned::UnpublishService.new.remove(edition_with_image)
       expect(delete_request).to have_been_requested.at_least_once
@@ -149,7 +152,7 @@ RSpec.describe Versioned::UnpublishService do
     end
 
     it "deletes assets associated with redirected editions" do
-      delete_request = stub_request(:delete, /asset-manager/)
+      delete_request = stub_asset_manager_deletes_assets
 
       Versioned::UnpublishService.new.remove_and_redirect(edition_with_image,
                                                           redirect_path)

--- a/spec/support/asset_manager_helper.rb
+++ b/spec/support/asset_manager_helper.rb
@@ -3,10 +3,27 @@
 module AssetManagerHelper
   ENDPOINT = GdsApi::TestHelpers::AssetManager::ASSET_MANAGER_ENDPOINT
 
-  def stub_asset_manager_receives_assets
+  def stub_asset_manager_receives_assets(filename = nil)
     stub_request(:post, "#{ENDPOINT}/assets").to_return do
-      file_url = "#{ENDPOINT}/media/#{SecureRandom.uuid}/#{SecureRandom.alphanumeric(8)}"
+      filename ||= SecureRandom.alphanumeric(8)
+      file_url = "#{ENDPOINT}/media/#{SecureRandom.uuid}/#{filename}"
       { body: { file_url: file_url }.to_json, status: 200 }
     end
+  end
+
+  def stub_asset_manager_updates_assets
+    stub_request(:put, %r{\A#{ENDPOINT}/assets}).to_return(status: 200)
+  end
+
+  def stub_asset_manager_deletes_assets
+    stub_request(:delete, %r{\A#{ENDPOINT}/assets}).to_return(status: 200)
+  end
+
+  def stub_asset_manager_down
+    stub_request(:any, %r{\A#{ENDPOINT}}).to_return(status: 503)
+  end
+
+  def stub_any_asset_manager_call
+    stub_request(:any, %r{\A#{ENDPOINT}}).to_return(status: 200)
   end
 end

--- a/spec/support/asset_manager_helper.rb
+++ b/spec/support/asset_manager_helper.rb
@@ -1,0 +1,12 @@
+# frozen_string_literal: true
+
+module AssetManagerHelper
+  ENDPOINT = GdsApi::TestHelpers::AssetManager::ASSET_MANAGER_ENDPOINT
+
+  def stub_asset_manager_receives_assets
+    stub_request(:post, "#{ENDPOINT}/assets").to_return do
+      file_url = "#{ENDPOINT}/media/#{SecureRandom.uuid}/#{SecureRandom.alphanumeric(8)}"
+      { body: { file_url: file_url }.to_json, status: 200 }
+    end
+  end
+end


### PR DESCRIPTION
Trello: https://trello.com/c/UdrY0K9l/574-migrate-to-versioned-code-database

This undoes the change that only uploaded images to Asset Manager if the
file was the lead image. This is in preparation for inline images where
we may want to use any of these images.

As part of this the AssetManagerHelper for tests has been created to
provide access to the mocking methods that have thus far been set up
inconsistently across these tests.

We may well want to move those methods to GDS API Adapters.