### PR TITLE
Reinstate revision edition many to many

### DIFF
--- a/app/models/versioned/edition.rb
+++ b/app/models/versioned/edition.rb
@@ -18,9 +18,12 @@ module Versioned
       # Store the edition on the status to keep a history
       status.update(edition: self) unless status.edition_id
 
-      # Used to keep an audit trail which connects revision, edition and
-      # status
+      # Used to keep an audit trail of statuses a revision has held
       revision.statuses << status unless revision.statuses.include?(status)
+
+      # Used to keep an audit trail of all the revisions that have been
+      # associated with an edition
+      revisions << revision unless revisions.include?(revision)
     end
 
     attr_readonly :number, :document_id
@@ -62,10 +65,10 @@ module Versioned
              class_name: "Versioned::InternalNote",
              dependent: :delete_all
 
-    has_many :revisions,
-             -> { distinct },
-             through: :statuses,
-             source: :revisions
+    has_and_belongs_to_many :revisions,
+                            -> { order("versioned_revisions.number DESC") },
+                            class_name: "Versioned::Revision",
+                            join_table: "versioned_edition_revisions"
 
     enum draft: { available: "available",
                   failure: "failure",

--- a/app/models/versioned/revision.rb
+++ b/app/models/versioned/revision.rb
@@ -68,10 +68,10 @@ module Versioned
                             class_name: "Versioned::Status",
                             join_table: "versioned_revision_statuses"
 
-    has_many :editions,
-             -> { distinct.reorder("versioned_editions.number DESC") },
-             through: :statuses,
-             source: :edition
+    has_and_belongs_to_many :editions,
+                            -> { order("versioned_editions.number DESC") },
+                            class_name: "Versioned::Edition",
+                            join_table: "versioned_edition_revisions"
 
     has_and_belongs_to_many :image_revisions,
                             -> { order("versioned_image_revisions.image_id ASC") },

--- a/db/migrate/20190118102825_reinstate_versioned_edition_revisions.rb
+++ b/db/migrate/20190118102825_reinstate_versioned_edition_revisions.rb
@@ -1,0 +1,20 @@
+# frozen_string_literal: true
+
+class ReinstateVersionedEditionRevisions < ActiveRecord::Migration[5.2]
+  def change
+    create_table :versioned_edition_revisions do |t|
+      t.references :edition,
+                   foreign_key: { to_table: :versioned_editions,
+                                  on_delete: :cascade },
+                   index: true,
+                   null: false
+      t.references :revision,
+                   foreign_key: { to_table: :versioned_revisions,
+                                  on_delete: :cascade },
+                   index: true,
+                   null: false
+      t.datetime :created_at, null: false
+      t.index %i[edition_id revision_id], unique: true
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2019_01_13_115603) do
+ActiveRecord::Schema.define(version: 2019_01_18_102825) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -177,6 +177,15 @@ ActiveRecord::Schema.define(version: 2019_01_13_115603) do
     t.datetime "first_published_at"
     t.index ["content_id", "locale"], name: "index_versioned_documents_on_content_id_and_locale", unique: true
     t.index ["created_by_id"], name: "index_versioned_documents_on_created_by_id"
+  end
+
+  create_table "versioned_edition_revisions", force: :cascade do |t|
+    t.bigint "edition_id", null: false
+    t.bigint "revision_id", null: false
+    t.datetime "created_at", null: false
+    t.index ["edition_id", "revision_id"], name: "index_versioned_edition_revisions_on_edition_id_and_revision_id", unique: true
+    t.index ["edition_id"], name: "index_versioned_edition_revisions_on_edition_id"
+    t.index ["revision_id"], name: "index_versioned_edition_revisions_on_revision_id"
   end
 
   create_table "versioned_editions", force: :cascade do |t|
@@ -360,6 +369,8 @@ ActiveRecord::Schema.define(version: 2019_01_13_115603) do
   add_foreign_key "versioned_asset_manager_image_variants", "versioned_image_revisions", column: "image_revision_id", on_delete: :cascade
   add_foreign_key "versioned_content_revisions", "users", column: "created_by_id", on_delete: :nullify
   add_foreign_key "versioned_documents", "users", column: "created_by_id", on_delete: :nullify
+  add_foreign_key "versioned_edition_revisions", "versioned_editions", column: "edition_id", on_delete: :cascade
+  add_foreign_key "versioned_edition_revisions", "versioned_revisions", column: "revision_id", on_delete: :cascade
   add_foreign_key "versioned_editions", "users", column: "created_by_id", on_delete: :nullify
   add_foreign_key "versioned_editions", "users", column: "last_edited_by_id", on_delete: :nullify
   add_foreign_key "versioned_editions", "versioned_documents", column: "document_id", on_delete: :restrict


### PR DESCRIPTION
Trello: https://trello.com/c/UdrY0K9l/574-migrate-to-versioned-code-database

This stops indirectly associating the edition history of a revision
through statuses and instead re-instates storing this directly. This is
to keep these concepts distinct and to remove the coupling.