### PR TITLE
 Replace draft column on versioned_editions

### DIFF
--- a/app/models/versioned/edition.rb
+++ b/app/models/versioned/edition.rb
@@ -70,12 +70,6 @@ module Versioned
                             class_name: "Versioned::Revision",
                             join_table: "versioned_edition_revisions"
 
-    enum draft: { available: "available",
-                  failure: "failure",
-                  not_applicable: "not_applicable",
-                  requirements_not_met: "requirements_not_met" },
-         _prefix: true
-
     delegate :content_id, :locale, :document_type, :topics, to: :document
 
     # delegate each state enum method
@@ -93,7 +87,6 @@ module Versioned
       create!(created_by: user,
               current: true,
               document: document,
-              draft: :requirements_not_met,
               last_edited_by: user,
               number: document.next_edition_number,
               revision: revision,
@@ -113,7 +106,6 @@ module Versioned
       create!(created_by: user,
               current: true,
               document: preceding_edition.document,
-              draft: :requirements_not_met,
               last_edited_by: user,
               number: preceding_edition.document.next_edition_number,
               revision: revision,
@@ -131,7 +123,6 @@ module Versioned
                               state: :draft)
 
       update!(current: true,
-              draft: :requirements_not_met,
               last_edited_by: user,
               last_edited_at: Time.zone.now,
               revision: revision,

--- a/app/services/versioned/delete_draft_service.rb
+++ b/app/services/versioned/delete_draft_service.rb
@@ -18,12 +18,12 @@ module Versioned
       discard_draft
 
       current_edition.assign_status(:discarded, user)
-                     .update!(current: false, draft: :not_applicable)
+                     .update!(current: false)
 
       live_edition = document.live_edition
       live_edition&.update!(current: true)
     rescue GdsApi::BaseError
-      document.current_edition.draft_failure!
+      document.current_edition.update!(revision_synced: false)
       raise
     end
 

--- a/app/services/versioned/publish_service.rb
+++ b/app/services/versioned/publish_service.rb
@@ -43,7 +43,6 @@ module Versioned
       status = with_review ? :published : :published_but_needs_2i
       current_edition.assign_status(status, user)
       current_edition.live = true
-      current_edition.draft = :not_applicable
       current_edition.save!
     end
 

--- a/app/views/versioned/documents/show/_actions.html.erb
+++ b/app/views/versioned/documents/show/_actions.html.erb
@@ -8,21 +8,7 @@
                 data: { gtm: "delete-draft" })
       end
     %>
-    <% if @edition.draft_requirements_not_met? %>
-      <%= form_tag versioned_create_preview_path(@edition.document) do %>
-        <%= render "govuk_publishing_components/components/button", text: "Preview" %>
-      <% end %>
-
-      <%= delete_draft_link %>
-    <% elsif @edition.draft_failure? %>
-      <%= render_govspeak(t("documents.show.sidebar.error_creating_preview_govspeak")) %>
-
-      <%= form_tag versioned_create_preview_path(@edition.document) do %>
-        <%= render "govuk_publishing_components/components/button", text: "Try again" %>
-      <% end %>
-
-      <%= delete_draft_link %>
-    <% elsif @edition.status.published_but_needs_2i? %>
+    <% if @edition.status.published_but_needs_2i? %>
       <%= form_tag versioned_approve_document_path(@edition.document) do %>
         <%= render "govuk_publishing_components/components/button", text: "Approve" %>
       <% end %>
@@ -59,6 +45,12 @@
                  secondary: true %>
 
       <%= delete_draft_link("app-link--right") %>
+    <% elsif !@edition.revision_synced %>
+      <%= form_tag versioned_create_preview_path(@edition.document) do %>
+        <%= render "govuk_publishing_components/components/button", text: "Preview" %>
+      <% end %>
+
+      <%= delete_draft_link %>
     <% else %>
       <%= form_tag versioned_submit_document_for_2i_path(@edition.document) do %>
         <%= render "govuk_publishing_components/components/button", text: "Submit for 2i review" %>

--- a/app/views/versioned/documents/show/_requirements.html.erb
+++ b/app/views/versioned/documents/show/_requirements.html.erb
@@ -11,7 +11,7 @@
   }
 } %>
 
-<% if @edition.draft_requirements_not_met? %>
+<% if !@edition.revision_synced %>
   <% draft_issues = Versioned::Requirements::EditionChecker.new(@edition).pre_preview_issues %>
 
   <% if draft_issues.any? %>

--- a/db/migrate/20190118121447_add_revision_synced_to_versioned_editions.rb
+++ b/db/migrate/20190118121447_add_revision_synced_to_versioned_editions.rb
@@ -1,0 +1,11 @@
+# frozen_string_literal: true
+
+class AddRevisionSyncedToVersionedEditions < ActiveRecord::Migration[5.2]
+  def change
+    add_column :versioned_editions,
+               :revision_synced,
+               :boolean,
+               null: false,
+               default: false
+  end
+end

--- a/db/migrate/20190118151754_remove_draft_from_versioned_edition.rb
+++ b/db/migrate/20190118151754_remove_draft_from_versioned_edition.rb
@@ -1,0 +1,10 @@
+# frozen_string_literal: true
+
+class RemoveDraftFromVersionedEdition < ActiveRecord::Migration[5.2]
+  def change
+    remove_column :versioned_editions,
+                  :draft,
+                  :string,
+                  null: false
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2019_01_18_102825) do
+ActiveRecord::Schema.define(version: 2019_01_18_151754) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -182,7 +182,7 @@ ActiveRecord::Schema.define(version: 2019_01_18_102825) do
     t.bigint "last_edited_by_id"
     t.bigint "status_id", null: false
     t.bigint "revision_id", null: false
-    t.string "draft", null: false
+    t.boolean "revision_synced", default: false, null: false
     t.index ["created_by_id"], name: "index_versioned_editions_on_created_by_id"
     t.index ["current"], name: "index_versioned_editions_on_current"
     t.index ["document_id", "current"], name: "index_versioned_editions_on_document_id_and_current", unique: true, where: "(current = true)"

--- a/spec/factories/versioned_edition_factory.rb
+++ b/spec/factories/versioned_edition_factory.rb
@@ -5,7 +5,7 @@ FactoryBot.define do
     last_edited_at { Time.zone.now }
     current { true }
     live { false }
-    draft { :available }
+    revision_synced { true }
     association :created_by, factory: :user
 
     transient do
@@ -77,7 +77,6 @@ FactoryBot.define do
     trait :published do
       summary { SecureRandom.alphanumeric(10) }
       live { true }
-      draft { :not_applicable }
 
       after(:build) do |edition, evaluator|
         edition.status = evaluator.association(

--- a/spec/features/versioned/editing_content/edit_document_publishing_api_down_spec.rb
+++ b/spec/features/versioned/editing_content/edit_document_publishing_api_down_spec.rb
@@ -23,7 +23,7 @@ RSpec.feature "Edit a document when the Publishing API is down" do
   end
 
   def and_i_try_preview_the_document
-    click_on "Try again"
+    click_on "Preview"
   end
 
   def then_i_see_an_error_message

--- a/spec/features/versioned/workflow/preview_publishing_api_down_spec.rb
+++ b/spec/features/versioned/workflow/preview_publishing_api_down_spec.rb
@@ -6,17 +6,17 @@ RSpec.feature "Previewing a document when the Publishing API is down" do
     when_i_visit_the_summary_page
 
     and_the_publishing_api_is_down
-    and_i_click_the_try_again_button
+    and_i_click_the_preview_button
     then_i_see_an_error_message
 
     when_the_publishing_api_is_up
-    and_i_click_the_try_again_button
+    and_i_click_the_preview_button
     then_i_see_the_preview_page
     and_the_preview_succeeded
   end
 
   def given_there_is_a_document_that_failed_to_preview
-    @edition = create :versioned_edition, draft: :failure
+    @edition = create :versioned_edition, revision_synced: false
   end
 
   def when_i_visit_the_summary_page
@@ -27,8 +27,8 @@ RSpec.feature "Previewing a document when the Publishing API is down" do
     publishing_api_isnt_available
   end
 
-  def and_i_click_the_try_again_button
-    click_on "Try again"
+  def and_i_click_the_preview_button
+    click_on "Preview"
   end
 
   def then_i_see_an_error_message

--- a/spec/features/versioned/workflow/preview_requirements_spec.rb
+++ b/spec/features/versioned/workflow/preview_requirements_spec.rb
@@ -19,7 +19,7 @@ RSpec.feature "Preview requirements" do
                       :publishable,
                       document_type_id: document_type.id,
                       lead_image_revision: @image_revision,
-                      draft: :requirements_not_met)
+                      revision_synced: false)
   end
 
   def when_i_view_the_document_summary

--- a/spec/services/versioned/delete_draft_service_spec.rb
+++ b/spec/services/versioned/delete_draft_service_spec.rb
@@ -110,7 +110,7 @@ RSpec.describe Versioned::DeleteDraftService do
 
       expect { Versioned::DeleteDraftService.new(edition.document, user).delete }
         .to raise_error(GdsApi::BaseError)
-      expect(edition.reload.draft_failure?).to be true
+      expect(edition.reload.revision_synced).to be false
     end
   end
 end


### PR DESCRIPTION
Trello: https://trello.com/c/UdrY0K9l/574-migrate-to-versioned-code-database

This replaces the string column on versioned_editions with a
publishing_api_synced column. This column is to be of most use in a
draft context where we allow state changes and edits while a document is
not on the Publishing API. Whereas once we are in the realm of live
states the Publishing API must be synced for the state to be valid.

An area of confusion this introduces is whether this still makes
semantic sense on old editions that have been replaced on Publishing
API, in theory though since to publish the next item they have been
synced so I guess it still makes sense.