### PR TITLE
Rename UpdateRevision to MetadataRevision

### DIFF
--- a/app/controllers/debug_controller.rb
+++ b/app/controllers/debug_controller.rb
@@ -17,13 +17,13 @@ class DebugController < ApplicationController
       :created_by,
       :editions,
       :tags_revision,
-      :update_revision,
+      :metadata_revision,
       {
         preceded_by: %i[content_revision
                         image_revisions
                         lead_image_revision
                         tags_revision
-                        update_revision] << image_preload,
+                        metadata_revision] << image_preload,
         statuses: :created_by,
       }.merge(image_preload),
     ]
@@ -45,11 +45,11 @@ class DebugController < ApplicationController
     common_except = %i[id created_at created_by_id]
     content = revision.content_revision.as_json(except: common_except)
     tags = revision.tags_revision.as_json(except: common_except)
-    update = revision.update_revision.as_json(except: common_except)
+    metadata = revision.metadata_revision.as_json(except: common_except)
     lead_image = image_revision_hash(revision.lead_image_revision)
     images = revision.image_revisions.map { |r| image_revision_hash(r) }
 
-    content.merge(tags).merge(update).merge(lead_image: lead_image, images: images)
+    content.merge(tags).merge(metadata).merge(lead_image: lead_image, images: images)
   end
 
   def image_revision_hash(image_revision)

--- a/app/models/metadata_revision.rb
+++ b/app/models/metadata_revision.rb
@@ -1,15 +1,18 @@
 # frozen_string_literal: true
 
-# A revision of update information (change note, update type) for a document.
-# This is accessed through a Revision object
-class UpdateRevision < ApplicationRecord
+# This stores the metadata component of a revision, by metadata we mean
+# supporting data that explains the revision which is represented by
+# update_type and change_note fields.
+#
+# This model is immutable.
+class MetadataRevision < ApplicationRecord
   self.table_name = "versioned_update_revisions"
 
   COMPARISON_IGNORE_FIELDS = %w[id created_at created_by_id].freeze
 
   belongs_to :created_by, class_name: "User", optional: true
 
-  has_many :revisions, inverse_of: :update_revision, dependent: :restrict_with_exception
+  has_many :revisions, inverse_of: :metadata_revision, dependent: :restrict_with_exception
 
   enum update_type: { major: "major", minor: "minor" }
 

--- a/app/models/revision.rb
+++ b/app/models/revision.rb
@@ -20,7 +20,9 @@ class Revision < ApplicationRecord
 
   belongs_to :content_revision, inverse_of: :revisions
 
-  belongs_to :update_revision, inverse_of: :revisions
+  belongs_to :metadata_revision,
+             foreign_key: :update_revision_id,
+             inverse_of: :revisions
 
   belongs_to :tags_revision, inverse_of: :revisions
 
@@ -66,7 +68,7 @@ class Revision < ApplicationRecord
            :change_note,
            :major?,
            :minor?,
-           to: :update_revision
+           to: :metadata_revision
 
   delegate :tags, to: :tags_revision
 
@@ -76,7 +78,7 @@ class Revision < ApplicationRecord
       document: document,
       number: document.next_revision_number,
       content_revision: ContentRevision.new(created_by: user),
-      update_revision: UpdateRevision.new(
+      metadata_revision: MetadataRevision.new(
         change_note: "First published.",
         update_type: "major",
         created_by: user,
@@ -154,7 +156,7 @@ private
 
       next_revision = preceding_revision.dup
       content_revision(next_revision)
-      update_revision(next_revision)
+      metadata_revision(next_revision)
       tags_revision(next_revision)
       lead_image_revision(next_revision)
       image_revisions(next_revision)
@@ -181,12 +183,12 @@ private
       end
     end
 
-    def update_revision(next_revision)
-      update = attributes.slice(:update_type, :change_note)
-      unless update.empty?
-        revision = next_revision.update_revision
-                                .build_revision_update(update, user)
-        next_revision.update_revision = revision
+    def metadata_revision(next_revision)
+      metadata = attributes.slice(:update_type, :change_note)
+      unless metadata.empty?
+        revision = next_revision.metadata_revision
+                                .build_revision_update(metadata, user)
+        next_revision.metadata_revision = revision
       end
     end
 

--- a/lib/tasks/whitehall_news_importer.rb
+++ b/lib/tasks/whitehall_news_importer.rb
@@ -38,7 +38,7 @@ module Tasks
             body: embed_contacts(translation["body"], whitehall_document.fetch("contacts", {})),
           },
         ),
-        update_revision: UpdateRevision.new(
+        metadata_revision: MetadataRevision.new(
           update_type: whitehall_edition["minor_change"] ? "minor" : "major",
         ),
         tags_revision: TagsRevision.new(tags: tags(whitehall_edition)),

--- a/spec/factories/metadata_revision_factory.rb
+++ b/spec/factories/metadata_revision_factory.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 FactoryBot.define do
-  factory :update_revision do
+  factory :metadata_revision do
     update_type { "major" }
     association :created_by, factory: :user
   end

--- a/spec/factories/revision_factory.rb
+++ b/spec/factories/revision_factory.rb
@@ -31,9 +31,9 @@ FactoryBot.define do
         )
       end
 
-      unless revision.update_revision
-        revision.update_revision = evaluator.association(
-          :update_revision,
+      unless revision.metadata_revision
+        revision.metadata_revision = evaluator.association(
+          :metadata_revision,
           update_type: evaluator.update_type,
           change_note: evaluator.change_note,
           created_by: revision.created_by,

--- a/spec/models/metadata_revision_spec.rb
+++ b/spec/models/metadata_revision_spec.rb
@@ -1,19 +1,19 @@
 # frozen_string_literal: true
 
-RSpec.describe UpdateRevision do
+RSpec.describe MetadataRevision do
   describe "#different_to?" do
-    it "is true when update data is different" do
-      revision1 = build(:update_revision, change_note: "This")
-      revision2 = build(:update_revision, change_note: "That")
+    it "is true when data differs" do
+      revision1 = build(:metadata_revision, change_note: "This")
+      revision2 = build(:metadata_revision, change_note: "That")
 
       expect(revision1.different_to?(revision2)).to be true
     end
 
     it "is false when content is the same and only timestamps differ" do
-      revision1 = build(:update_revision,
+      revision1 = build(:metadata_revision,
                         change_note: "Same",
                         created_at: 10.days.ago)
-      revision2 = build(:update_revision,
+      revision2 = build(:metadata_revision,
                         change_note: "Same",
                         created_at: 10.weeks.ago)
 
@@ -23,7 +23,7 @@ RSpec.describe UpdateRevision do
 
   describe "#build_revision_update" do
     let(:existing_revision) do
-      create(:update_revision, update_type: :minor)
+      create(:metadata_revision, update_type: :minor)
     end
 
     it "returns the current revision if the update does not change it's content" do

--- a/spec/models/revision_spec.rb
+++ b/spec/models/revision_spec.rb
@@ -26,8 +26,8 @@ RSpec.describe Revision do
 
       expect(revision.created_by).to eq(user)
       expect(revision.content_revision.created_by).to eq(user)
+      expect(revision.metadata_revision.created_by).to eq(user)
       expect(revision.tags_revision.created_by).to eq(user)
-      expect(revision.update_revision.created_by).to eq(user)
     end
 
     it "can set tags" do
@@ -50,7 +50,7 @@ RSpec.describe Revision do
                             document: old_revision.document,
                             content_revision: old_revision.content_revision,
                             tags_revision: old_revision.tags_revision,
-                            update_revision: old_revision.update_revision,
+                            metadata_revision: old_revision.metadata_revision,
                             lead_image_revision: nil)
 
       expect(new_revision.different_to?(old_revision)).to be false
@@ -62,7 +62,7 @@ RSpec.describe Revision do
                             document: old_revision.document,
                             content_revision: build(:content_revision),
                             tags_revision: old_revision.tags_revision,
-                            update_revision: old_revision.update_revision,
+                            metadata_revision: old_revision.metadata_revision,
                             lead_image_revision: nil)
 
       expect(new_revision.different_to?(old_revision)).to be true
@@ -76,7 +76,7 @@ RSpec.describe Revision do
                             document: old_revision.document,
                             content_revision: old_revision.content_revision,
                             tags_revision: old_revision.tags_revision,
-                            update_revision: old_revision.update_revision,
+                            metadata_revision: old_revision.metadata_revision,
                             lead_image_revision: nil,
                             image_revisions: [build(:image_revision)])
 
@@ -116,8 +116,8 @@ RSpec.describe Revision do
       new_revision = revision.build_revision_update(update, user)
 
       expect(new_revision.content_revision).not_to eq(revision.content_revision)
+      expect(new_revision.metadata_revision).to eq(revision.metadata_revision)
       expect(new_revision.tags_revision).to eq(revision.tags_revision)
-      expect(new_revision.update_revision).to eq(revision.update_revision)
     end
 
     it "includes a new tags revision when tags are updated" do
@@ -126,8 +126,8 @@ RSpec.describe Revision do
       new_revision = revision.build_revision_update(update, user)
 
       expect(new_revision.content_revision).to eq(revision.content_revision)
+      expect(new_revision.metadata_revision).to eq(revision.metadata_revision)
       expect(new_revision.tags_revision).not_to eq(revision.tags_revision)
-      expect(new_revision.update_revision).to eq(revision.update_revision)
     end
 
     it "includes a new update revision when those attributes are updated" do
@@ -136,8 +136,8 @@ RSpec.describe Revision do
       new_revision = revision.build_revision_update(update, user)
 
       expect(new_revision.content_revision).to eq(revision.content_revision)
+      expect(new_revision.metadata_revision).not_to eq(revision.metadata_revision)
       expect(new_revision.tags_revision).to eq(revision.tags_revision)
-      expect(new_revision.update_revision).not_to eq(revision.update_revision)
     end
 
     it "can retain image revisions" do


### PR DESCRIPTION
Trello: https://trello.com/c/5JMGsuBj/581-follow-up-work-from-versioning-review

This hopefully provides a more useful name to follow for the model which
stores the information such as update type and change log. The previous
name UpdateRevision was not remotely self explanatory and although I'm
not sure MetadataRevision tells a whole lot more it does seem an
improvement.

It is also consistent in naming with the Image::MetadataRevision model.

To follow on from this are database migrations that change the
underlying table and column names. As we have a batch of these to do and
they may momentarily cause application errors I intend to group these.