### PR TITLE
Rename retirement to withdrawal

### DIFF
--- a/app/controllers/unpublish_controller.rb
+++ b/app/controllers/unpublish_controller.rb
@@ -5,7 +5,7 @@ class UnpublishController < ApplicationController
     @document = Document.with_current_edition.find_by_param(params[:id])
   end
 
-  def retire
+  def withdraw
     @document = Document.with_current_edition.find_by_param(params[:id])
   end
 end

--- a/app/models/status.rb
+++ b/app/models/status.rb
@@ -27,7 +27,7 @@ class Status < ApplicationRecord
                 submitted_for_review: "submitted_for_review",
                 published: "published",
                 published_but_needs_2i: "published_but_needs_2i",
-                retired: "retired",
+                withdrawn: "withdrawn",
                 removed: "removed",
                 discarded: "discarded",
                 superseded: "superseded" }

--- a/app/models/timeline_entry.rb
+++ b/app/models/timeline_entry.rb
@@ -38,7 +38,7 @@ class TimelineEntry < ApplicationRecord
                      image_updated: "image_updated",
                      image_removed: "image_removed",
                      new_edition: "new_edition",
-                     retired: "retired",
+                     withdrawn: "withdrawn",
                      removed: "removed",
                      internal_note: "internal_note",
                      draft_discarded: "draft_discarded",

--- a/app/models/withdrawal.rb
+++ b/app/models/withdrawal.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-class Retirement < ApplicationRecord
+class Withdrawal < ApplicationRecord
   self.table_name = "versioned_retirements"
 
   has_one :status, as: :details, dependent: :restrict_with_exception

--- a/app/services/unpublish_service.rb
+++ b/app/services/unpublish_service.rb
@@ -13,15 +13,15 @@ class UnpublishService
         locale: edition.locale,
       )
 
-      retirement = Retirement.new(explanatory_note: explanatory_note)
+      withdrawal = Withdrawal.new(explanatory_note: explanatory_note)
 
-      edition.assign_status(:retired, nil, status_details: retirement)
+      edition.assign_status(:retired, nil, status_details: withdrawal)
       edition.save!
 
       TimelineEntry.create_for_status_change(
         entry_type: :retired,
         status: edition.status,
-        details: retirement,
+        details: withdrawal,
       )
     end
   end

--- a/app/services/unpublish_service.rb
+++ b/app/services/unpublish_service.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 class UnpublishService
-  def retire(edition, explanatory_note)
+  def withdraw(edition, explanatory_note)
     Document.transaction do
       edition.document.lock!
       check_unpublishable(edition)

--- a/app/services/unpublish_service.rb
+++ b/app/services/unpublish_service.rb
@@ -15,7 +15,7 @@ class UnpublishService
 
       withdrawal = Withdrawal.new(explanatory_note: explanatory_note)
 
-      edition.assign_status(:retired, nil, status_details: withdrawal)
+      edition.assign_status(:withdrawn, nil, status_details: withdrawal)
       edition.save!
 
       TimelineEntry.create_for_status_change(

--- a/app/services/unpublish_service.rb
+++ b/app/services/unpublish_service.rb
@@ -19,7 +19,7 @@ class UnpublishService
       edition.save!
 
       TimelineEntry.create_for_status_change(
-        entry_type: :retired,
+        entry_type: :withdrawn,
         status: edition.status,
         details: withdrawal,
       )

--- a/app/views/documents/index/_filters.html.erb
+++ b/app/views/documents/index/_filters.html.erb
@@ -34,7 +34,7 @@
                               submitted_for_review
                               published
                               published_but_needs_2i
-                              retired
+                              withdrawn
                               removed]
     state_select = selectable_states.map do |state|
       [t("user_facing_states.#{state}.name"), state]

--- a/app/views/documents/show/_actions.html.erb
+++ b/app/views/documents/show/_actions.html.erb
@@ -20,16 +20,16 @@
           data_attributes: { gtm: "create-new-edition" } %>
       <% end %>
 
-      <%= link_to "Retire", withdraw_path(@edition.document), class: "govuk-link govuk-link--no-visited-state" %>
+      <%= link_to "Withdraw", withdraw_path(@edition.document), class: "govuk-link govuk-link--no-visited-state" %>
       <%= link_to "Remove", remove_path(@edition.document), class: "govuk-link app-link--destructive app-link--right" %>
     <% elsif @edition.status.published? %>
       <%= form_tag create_edition_path(@edition.document) do %>
         <%= render "govuk_publishing_components/components/button", text: "Create new edition", data_attributes: { gtm: "create-new-edition" } %>
       <% end %>
 
-      <%= link_to "Retire", withdraw_path(@edition.document), class: "govuk-link govuk-link--no-visited-state" %>
+      <%= link_to "Withdraw", withdraw_path(@edition.document), class: "govuk-link govuk-link--no-visited-state" %>
       <%= link_to "Remove", remove_path(@edition.document), class: "govuk-link app-link--destructive app-link--right" %>
-    <% elsif @edition.status.retired? %>
+    <% elsif @edition.status.withdrawn? %>
       <%= link_to "Update reason for retiring", withdraw_path(@edition.document), class: "govuk-link govuk-link--no-visited-state" %>
     <% elsif @edition.status.removed? %>
       <%= form_tag create_edition_path(@edition.document) do %>

--- a/app/views/documents/show/_actions.html.erb
+++ b/app/views/documents/show/_actions.html.erb
@@ -20,17 +20,17 @@
           data_attributes: { gtm: "create-new-edition" } %>
       <% end %>
 
-      <%= link_to "Retire", retire_path(@edition.document), class: "govuk-link govuk-link--no-visited-state" %>
+      <%= link_to "Retire", withdraw_path(@edition.document), class: "govuk-link govuk-link--no-visited-state" %>
       <%= link_to "Remove", remove_path(@edition.document), class: "govuk-link app-link--destructive app-link--right" %>
     <% elsif @edition.status.published? %>
       <%= form_tag create_edition_path(@edition.document) do %>
         <%= render "govuk_publishing_components/components/button", text: "Create new edition", data_attributes: { gtm: "create-new-edition" } %>
       <% end %>
 
-      <%= link_to "Retire", retire_path(@edition.document), class: "govuk-link govuk-link--no-visited-state" %>
+      <%= link_to "Retire", withdraw_path(@edition.document), class: "govuk-link govuk-link--no-visited-state" %>
       <%= link_to "Remove", remove_path(@edition.document), class: "govuk-link app-link--destructive app-link--right" %>
     <% elsif @edition.status.retired? %>
-      <%= link_to "Update reason for retiring", retire_path(@edition.document), class: "govuk-link govuk-link--no-visited-state" %>
+      <%= link_to "Update reason for retiring", withdraw_path(@edition.document), class: "govuk-link govuk-link--no-visited-state" %>
     <% elsif @edition.status.removed? %>
       <%= form_tag create_edition_path(@edition.document) do %>
         <%= render "govuk_publishing_components/components/button", text: "Create new edition", data_attributes: { gtm: "create-new-edition" } %>

--- a/app/views/documents/show/_history_tab.html.erb
+++ b/app/views/documents/show/_history_tab.html.erb
@@ -24,7 +24,7 @@
           <%= simple_format(escape_and_link(entry.details.body)) %>
         <% end %>
 
-        <% if entry.retired? && entry.details %>
+        <% if entry.withdrawn? && entry.details %>
           <%= entry.details.explanatory_note %>
         <% end %>
 

--- a/app/views/unpublish/withdraw.html.erb
+++ b/app/views/unpublish/withdraw.html.erb
@@ -1,5 +1,5 @@
 <% content_for :back_link, render_back_link(href: document_path(@document)) %>
-<% content_for :title, t("unpublish.retire.title") %>
+<% content_for :title, t("unpublish.withdraw.title") %>
 
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">

--- a/config/locales/en/documents/history.yml
+++ b/config/locales/en/documents/history.yml
@@ -16,7 +16,7 @@ en:
         image_removed: "Removed image"
         new_edition: "New edition"
         create_preview: "Create preview"
-        retired: "Retired"
+        withdrawn: "Withdrawn"
         removed: "Removed"
         internal_note: "Internal note"
         draft_discarded: "Draft discarded"

--- a/config/locales/en/states.yml
+++ b/config/locales/en/states.yml
@@ -8,8 +8,8 @@ en:
       name: Published but needs 2i review
     published:
       name: Published
-    retired:
-      name: Retired
+    withdrawn:
+      name: Withdrawn
     removed:
       name: Removed
     discarded:

--- a/config/locales/en/unpublish/withdraw.yml
+++ b/config/locales/en/unpublish/withdraw.yml
@@ -1,4 +1,4 @@
 en:
   unpublish:
-    retire:
+    withdraw:
       title: Sorry, this hasn't been built yet

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -34,7 +34,7 @@ Rails.application.routes.draw do
   get "/documents/:id/preview" => "preview#show", as: :preview_document
   post "/documents/:id/create-preview" => "preview#create", as: :create_preview
 
-  get "/documents/:id/retire" => "unpublish#retire", as: :retire
+  get "/documents/:id/withdraw" => "unpublish#withdraw", as: :withdraw
   get "/documents/:id/remove" => "unpublish#remove", as: :remove
 
   get "/documents/:document_id/images" => "images#index", as: :images

--- a/docs/withdrawing-and-removing-documents.md
+++ b/docs/withdrawing-and-removing-documents.md
@@ -1,9 +1,9 @@
-# Retiring and removing documents
+# Withdrawing and removing documents
 
 We need to allow users to unpublish content from GOV.UK. In Content Publisher we are replacing
-unpublish terminology with "retired" and "removed".
+unpublish terminology with "withdrawn" and "removed".
 
-Retired content is still displayed on GOV.UK, but there is an explanation box on the page that describes
+Withdrawn content is still displayed on GOV.UK, but there is an explanation box on the page that describes
 why the content is out of date.
 
 Removed content returns a 410 gone page to the user. If an explanatory note or a alternative path have been provided,
@@ -13,7 +13,7 @@ Removed and redirected content redirects users to another page on GOV.UK
 
 Environment variables are being used to pass parameters to the rake tasks.
 
-## Retiring documents
+## Withdrawing documents
 
 Required parameters:
 
@@ -25,7 +25,7 @@ Optional parameters:
 - LOCALE (set to "en" by default)
 
 ```
-rake unpublish:retire['a-content-id'] NOTE='A note'
+rake unpublish:withdraw['a-content-id'] NOTE='A note'
 ```
 
 ## Removing documents

--- a/lib/tasks/unpublish.rake
+++ b/lib/tasks/unpublish.rake
@@ -1,8 +1,8 @@
 # frozen_string_literal: true
 
 namespace :unpublish do
-  desc "Retire a document on GOV.UK e.g. unpublish:retire['a-content-id'] NOTE='A note'"
-  task :retire, [:content_id] => :environment do |_, args|
+  desc "Withdraw a document on GOV.UK e.g. unpublish:withdraw['a-content-id'] NOTE='A note'"
+  task :withdraw, [:content_id] => :environment do |_, args|
     raise "Missing content_id parameter" unless args.content_id
     raise "Missing NOTE value" if ENV["NOTE"].blank?
 
@@ -10,7 +10,7 @@ namespace :unpublish do
     locale = ENV["LOCALE"] || "en"
 
     document = Document.find_by!(content_id: args.content_id, locale: locale)
-    raise "Document must have a published version before it can be retired" unless document.live_edition
+    raise "Document must have a published version before it can be withdrawn" unless document.live_edition
 
     UnpublishService.new.withdraw(document.live_edition, explanatory_note)
   end

--- a/lib/tasks/unpublish.rake
+++ b/lib/tasks/unpublish.rake
@@ -12,7 +12,7 @@ namespace :unpublish do
     document = Document.find_by!(content_id: args.content_id, locale: locale)
     raise "Document must have a published version before it can be retired" unless document.live_edition
 
-    UnpublishService.new.retire(document.live_edition, explanatory_note)
+    UnpublishService.new.withdraw(document.live_edition, explanatory_note)
   end
 
   desc "Remove a document from GOV.UK e.g. unpublish:remove['a-content-id']"

--- a/spec/factories/withdrawal_factory.rb
+++ b/spec/factories/withdrawal_factory.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 FactoryBot.define do
-  factory :retirement do
+  factory :withdrawal do
     explanatory_note { SecureRandom.alphanumeric }
   end
 end

--- a/spec/features/workflow/unpublish_spec.rb
+++ b/spec/features/workflow/unpublish_spec.rb
@@ -5,39 +5,39 @@ require "rake"
 RSpec.feature "Unpublish rake tasks" do
   let(:edition) { create(:edition, :published, locale: "en") }
 
-  describe "unpublish:retire" do
+  describe "unpublish:withdraw" do
     before do
-      Rake::Task["unpublish:retire"].reenable
+      Rake::Task["unpublish:withdraw"].reenable
     end
 
-    it "runs the task to retire an edition" do
-      explanatory_note = "The reason the document is being retired"
+    it "runs the task to withdraw an edition" do
+      explanatory_note = "The reason the document is being withdrawn"
 
       expect_any_instance_of(UnpublishService)
-        .to receive(:retire).with(edition, explanatory_note)
+        .to receive(:withdraw).with(edition, explanatory_note)
 
       ClimateControl.modify NOTE: explanatory_note do
-        Rake::Task["unpublish:retire"].invoke(edition.content_id)
+        Rake::Task["unpublish:withdraw"].invoke(edition.content_id)
       end
     end
 
     it "raises an error if a content_id is not present" do
-      expect { Rake::Task["unpublish:retire"].invoke }
+      expect { Rake::Task["unpublish:withdraw"].invoke }
         .to raise_error("Missing content_id parameter")
     end
 
     it "raises an error if a NOTE is not present" do
-      expect { Rake::Task["unpublish:retire"].invoke("a-content-id") }
+      expect { Rake::Task["unpublish:withdraw"].invoke("a-content-id") }
         .to raise_error("Missing NOTE value")
     end
 
     it "raises an error if the document does not have a live version on GOV.uk" do
       draft = create(:edition, locale: "en")
-      explanatory_note = "The reason the document is being retired"
+      explanatory_note = "The reason the document is being withdrawn"
 
       ClimateControl.modify NOTE: explanatory_note do
-        expect { Rake::Task["unpublish:retire"].invoke(draft.content_id) }
-          .to raise_error("Document must have a published version before it can be retired")
+        expect { Rake::Task["unpublish:withdraw"].invoke(draft.content_id) }
+          .to raise_error("Document must have a published version before it can be withdrawn")
       end
     end
   end

--- a/spec/services/unpublish_service_spec.rb
+++ b/spec/services/unpublish_service_spec.rb
@@ -43,7 +43,7 @@ RSpec.describe UnpublishService do
       UnpublishService.new.withdraw(edition, explanatory_note)
       edition.reload
 
-      expect(edition.status).to be_retired
+      expect(edition.status).to be_withdrawn
       expect(edition.status.details.explanatory_note).to eq(explanatory_note)
     end
 

--- a/spec/services/unpublish_service_spec.rb
+++ b/spec/services/unpublish_service_spec.rb
@@ -13,7 +13,7 @@ RSpec.describe UnpublishService do
 
   before { stub_any_publishing_api_unpublish }
 
-  describe "#retire" do
+  describe "#withdraw" do
     let(:explanatory_note) { "The document is out of date" }
 
     it "withdraws an edition in publishing-api with an explanatory note" do
@@ -21,26 +21,26 @@ RSpec.describe UnpublishService do
                                               body: { type: "withdrawal",
                                                       explanation: explanatory_note,
                                                       locale: edition.locale })
-      UnpublishService.new.retire(edition, explanatory_note)
+      UnpublishService.new.withdraw(edition, explanatory_note)
 
       expect(request).to have_been_requested
     end
 
-    it "does not delete assets for retired editions" do
+    it "does not delete assets for withdrawn editions" do
       delete_request = stub_asset_manager_deletes_assets
-      UnpublishService.new.retire(edition_with_image, explanatory_note)
+      UnpublishService.new.withdraw(edition_with_image, explanatory_note)
 
       expect(delete_request).not_to have_been_requested
     end
 
     it "adds an entry in the timeline of the document" do
-      UnpublishService.new.retire(edition, explanatory_note)
+      UnpublishService.new.withdraw(edition, explanatory_note)
 
       expect(edition.timeline_entries.first.entry_type).to eq("retired")
     end
 
     it "updates the edition status" do
-      UnpublishService.new.retire(edition, explanatory_note)
+      UnpublishService.new.withdraw(edition, explanatory_note)
       edition.reload
 
       expect(edition.status).to be_retired
@@ -50,7 +50,7 @@ RSpec.describe UnpublishService do
     context "when the given edition is a draft" do
       it "raises an error" do
         draft_edition = create(:edition)
-        expect { UnpublishService.new.retire(draft_edition, explanatory_note) }
+        expect { UnpublishService.new.withdraw(draft_edition, explanatory_note) }
           .to raise_error RuntimeError, "attempted to unpublish an edition other than the live edition"
       end
     end
@@ -63,7 +63,7 @@ RSpec.describe UnpublishService do
                               current: false,
                               document: draft_edition.document)
 
-        expect { UnpublishService.new.retire(live_edition, explanatory_note) }
+        expect { UnpublishService.new.withdraw(live_edition, explanatory_note) }
           .to raise_error RuntimeError, "Publishing API does not support unpublishing while there is a draft"
       end
     end

--- a/spec/services/unpublish_service_spec.rb
+++ b/spec/services/unpublish_service_spec.rb
@@ -36,7 +36,7 @@ RSpec.describe UnpublishService do
     it "adds an entry in the timeline of the document" do
       UnpublishService.new.withdraw(edition, explanatory_note)
 
-      expect(edition.timeline_entries.first.entry_type).to eq("retired")
+      expect(edition.timeline_entries.first.entry_type).to eq("withdrawn")
     end
 
     it "updates the edition status" do


### PR DESCRIPTION
For https://trello.com/c/oyI7eOlC/586-change-all-internal-references-to-retirement-withdrawal

This renames internal references to "retirement" to "withdrawal" ahead of building out the withdrawal workflow to ensure consistency and avoid future confusion.  This does not include renaming the `versioned_retirements` table, which will be renamed at a later date along with the other `versioned_` prefixed tables