### PR TITLE
Loosen rails linter

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -20,6 +20,9 @@ Rails:
 Rails/InverseOf:
   Enabled: false
 
+Rails/HasManyOrHasOneDependent:
+  Enabled: false
+
 Style/FrozenStringLiteralComment:
   Enabled: true
   Exclude:

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -17,6 +17,9 @@ Metrics/BlockLength:
 Rails:
   Enabled: true
 
+Rails/InverseOf:
+  Enabled: false
+
 Style/FrozenStringLiteralComment:
   Enabled: true
   Exclude:

--- a/app/models/content_revision.rb
+++ b/app/models/content_revision.rb
@@ -9,8 +9,6 @@ class ContentRevision < ApplicationRecord
 
   belongs_to :created_by, class_name: "User", optional: true
 
-  has_many :revisions, inverse_of: :content_revision, dependent: :restrict_with_exception
-
   def readonly?
     !new_record?
   end

--- a/app/models/document.rb
+++ b/app/models/document.rb
@@ -12,11 +12,11 @@ class Document < ApplicationRecord
 
   has_one :live_edition, -> { where(live: true) }, class_name: "Edition"
 
-  has_many :editions, dependent: :restrict_with_exception
+  has_many :editions
 
-  has_many :revisions, dependent: :restrict_with_exception
+  has_many :revisions
 
-  has_many :timeline_entries, dependent: :delete_all
+  has_many :timeline_entries
 
   delegate :topics, to: :document_topics
 

--- a/app/models/document.rb
+++ b/app/models/document.rb
@@ -8,9 +8,15 @@ class Document < ApplicationRecord
 
   belongs_to :created_by, class_name: "User", optional: true
 
-  has_one :current_edition, -> { where(current: true) }, class_name: "Edition"
+  has_one :current_edition,
+          -> { where(current: true) },
+          class_name: "Edition",
+          inverse_of: :document
 
-  has_one :live_edition, -> { where(live: true) }, class_name: "Edition"
+  has_one :live_edition,
+          -> { where(live: true) },
+          class_name: "Edition",
+          inverse_of: :document
 
   has_many :editions
 

--- a/app/models/document.rb
+++ b/app/models/document.rb
@@ -8,11 +8,9 @@ class Document < ApplicationRecord
 
   belongs_to :created_by, class_name: "User", optional: true
 
-  # rubocop:disable Rails/InverseOf
   has_one :current_edition, -> { where(current: true) }, class_name: "Edition"
 
   has_one :live_edition, -> { where(live: true) }, class_name: "Edition"
-  # rubocop:enable Rails/InverseOf
 
   has_many :editions, dependent: :restrict_with_exception
 

--- a/app/models/edition.rb
+++ b/app/models/edition.rb
@@ -31,13 +31,13 @@ class Edition < ApplicationRecord
 
   belongs_to :last_edited_by, class_name: "User", optional: true
 
-  belongs_to :document, inverse_of: :editions
+  belongs_to :document
 
-  belongs_to :revision, inverse_of: :current_for_editions
+  belongs_to :revision
 
-  belongs_to :status, inverse_of: :status_of
+  belongs_to :status
 
-  has_many :statuses, dependent: :delete_all, inverse_of: :edition
+  has_many :statuses, dependent: :delete_all
 
   has_many :timeline_entries, dependent: :delete_all
 

--- a/app/models/edition.rb
+++ b/app/models/edition.rb
@@ -37,11 +37,11 @@ class Edition < ApplicationRecord
 
   belongs_to :status
 
-  has_many :statuses, dependent: :delete_all
+  has_many :statuses
 
-  has_many :timeline_entries, dependent: :delete_all
+  has_many :timeline_entries
 
-  has_many :internal_notes, dependent: :delete_all
+  has_many :internal_notes
 
   has_and_belongs_to_many :revisions,
                           -> { order("versioned_revisions.number DESC") },

--- a/app/models/image.rb
+++ b/app/models/image.rb
@@ -15,7 +15,6 @@ class Image < ApplicationRecord
 
   has_many :image_revisions,
            class_name: "Image::Revision",
-           inverse_of: :image,
            dependent: :restrict_with_exception
 
   def readonly?

--- a/app/models/image.rb
+++ b/app/models/image.rb
@@ -13,9 +13,7 @@ class Image < ApplicationRecord
 
   belongs_to :created_by, class_name: "User", optional: true
 
-  has_many :image_revisions,
-           class_name: "Image::Revision",
-           dependent: :restrict_with_exception
+  has_many :image_revisions, class_name: "Image::Revision"
 
   def readonly?
     !new_record?

--- a/app/models/image/asset.rb
+++ b/app/models/image/asset.rb
@@ -9,19 +9,11 @@ class Image::Asset < ApplicationRecord
   self.table_name = "versioned_image_assets"
 
   belongs_to :file_revision,
-             class_name: "Image::FileRevision",
-             inverse_of: :assets
+             class_name: "Image::FileRevision"
 
   belongs_to :superseded_by,
              class_name: "Image::Asset",
-             inverse_of: :supersedes,
              optional: true
-
-  has_many :supersedes,
-           class_name: "Image::Asset",
-           foreign_key: :superseded_by_id,
-           inverse_of: :superseded_by,
-           dependent: :nullify
 
   enum state: { absent: "absent",
                 draft: "draft",

--- a/app/models/image/file_revision.rb
+++ b/app/models/image/file_revision.rb
@@ -24,12 +24,6 @@ class Image::FileRevision < ApplicationRecord
 
   has_many :assets,
            class_name: "Image::Asset",
-           inverse_of: :file_revision,
-           dependent: :restrict_with_exception
-
-  has_many :revisions,
-           class_name: "Image::Revision",
-           inverse_of: :file_revision,
            dependent: :restrict_with_exception
 
   delegate :content_type, to: :blob

--- a/app/models/image/file_revision.rb
+++ b/app/models/image/file_revision.rb
@@ -22,9 +22,7 @@ class Image::FileRevision < ApplicationRecord
 
   belongs_to :created_by, class_name: "User", optional: true
 
-  has_many :assets,
-           class_name: "Image::Asset",
-           dependent: :restrict_with_exception
+  has_many :assets, class_name: "Image::Asset"
 
   delegate :content_type, to: :blob
 

--- a/app/models/image/metadata_revision.rb
+++ b/app/models/image/metadata_revision.rb
@@ -12,11 +12,6 @@ class Image::MetadataRevision < ApplicationRecord
 
   belongs_to :created_by, class_name: "User", optional: true
 
-  has_many :revisions,
-           class_name: "Image::Revision",
-           inverse_of: :metadata_revision,
-           dependent: :restrict_with_exception
-
   def readonly?
     !new_record?
   end

--- a/app/models/image/revision.rb
+++ b/app/models/image/revision.rb
@@ -17,11 +17,11 @@ class Image::Revision < ApplicationRecord
                           class_name: "Revision",
                           join_table: "versioned_revision_image_revisions"
 
-  belongs_to :image, class_name: "Image", inverse_of: :image_revisions
+  belongs_to :image, class_name: "Image"
 
-  belongs_to :file_revision, class_name: "Image::FileRevision", inverse_of: :revisions
+  belongs_to :file_revision, class_name: "Image::FileRevision"
 
-  belongs_to :metadata_revision, class_name: "Image::MetadataRevision", inverse_of: :revisions
+  belongs_to :metadata_revision, class_name: "Image::MetadataRevision"
 
   delegate :alt_text,
            :caption,

--- a/app/models/internal_note.rb
+++ b/app/models/internal_note.rb
@@ -5,7 +5,7 @@ class InternalNote < ApplicationRecord
 
   belongs_to :created_by, class_name: "User", optional: true
 
-  belongs_to :edition, inverse_of: :internal_notes
+  belongs_to :edition
 
   def readonly?
     !new_record?

--- a/app/models/metadata_revision.rb
+++ b/app/models/metadata_revision.rb
@@ -12,8 +12,6 @@ class MetadataRevision < ApplicationRecord
 
   belongs_to :created_by, class_name: "User", optional: true
 
-  has_many :revisions, inverse_of: :metadata_revision, dependent: :restrict_with_exception
-
   enum update_type: { major: "major", minor: "minor" }
 
   def readonly?

--- a/app/models/removal.rb
+++ b/app/models/removal.rb
@@ -3,7 +3,7 @@
 class Removal < ApplicationRecord
   self.table_name = "versioned_removals"
 
-  has_one :status, as: :details, dependent: :restrict_with_exception
+  has_one :status, as: :details
 
   def readonly?
     !new_record?

--- a/app/models/revision.rb
+++ b/app/models/revision.rb
@@ -16,32 +16,17 @@ class Revision < ApplicationRecord
 
   belongs_to :lead_image_revision, class_name: "Image::Revision", optional: true
 
-  belongs_to :document, inverse_of: :revisions
+  belongs_to :document
 
-  belongs_to :content_revision, inverse_of: :revisions
+  belongs_to :content_revision
 
-  belongs_to :metadata_revision,
-             foreign_key: :update_revision_id,
-             inverse_of: :revisions
+  belongs_to :metadata_revision, foreign_key: :update_revision_id
 
-  belongs_to :tags_revision, inverse_of: :revisions
+  belongs_to :tags_revision
 
   belongs_to :preceded_by,
              class_name: "Revision",
-             optional: true,
-             inverse_of: :followed_by
-
-  has_one :followed_by,
-          class_name: "Revision",
-          foreign_key: :preceded_by_id,
-          inverse_of: :preceded_by,
-          dependent: :nullify
-
-  has_many :current_for_editions,
-           class_name: "Edition",
-           foreign_key: :revision_id,
-           inverse_of: :revision,
-           dependent: :restrict_with_exception
+             optional: true
 
   has_and_belongs_to_many :statuses,
                           -> { order("versioned_statuses.created_at DESC") },

--- a/app/models/status.rb
+++ b/app/models/status.rb
@@ -11,15 +11,9 @@ class Status < ApplicationRecord
 
   belongs_to :revision_at_creation, class_name: "Revision"
 
-  belongs_to :edition, optional: true, inverse_of: :statuses
+  belongs_to :edition, optional: true
 
   belongs_to :details, polymorphic: true, optional: true
-
-  has_one :status_of,
-          class_name: "Edition",
-          foreign_key: :status_id,
-          inverse_of: :status,
-          dependent: :restrict_with_exception
 
   has_and_belongs_to_many :revisions, join_table: "versioned_revision_statuses"
 

--- a/app/models/tags_revision.rb
+++ b/app/models/tags_revision.rb
@@ -9,8 +9,6 @@ class TagsRevision < ApplicationRecord
 
   belongs_to :created_by, class_name: "User", optional: true
 
-  has_many :revisions, inverse_of: :tags_revision, dependent: :restrict_with_exception
-
   def readonly?
     !new_record?
   end

--- a/app/models/timeline_entry.rb
+++ b/app/models/timeline_entry.rb
@@ -10,10 +10,10 @@ class TimelineEntry < ApplicationRecord
   # The user that performed the action for this entry
   belongs_to :created_by, class_name: "User", optional: true
 
-  belongs_to :document, inverse_of: :timeline_entries
+  belongs_to :document
 
   # If the entry is associated with a particular edition this associates
-  belongs_to :edition, optional: true, inverse_of: :timeline_entries
+  belongs_to :edition, optional: true
 
   # For a content change this associates with the revision at the time,
   # not needed for a status change as the status associates to a revision

--- a/app/models/withdrawal.rb
+++ b/app/models/withdrawal.rb
@@ -3,7 +3,7 @@
 class Withdrawal < ApplicationRecord
   self.table_name = "versioned_retirements"
 
-  has_one :status, as: :details, dependent: :restrict_with_exception
+  has_one :status, as: :details
 
   def readonly?
     !new_record?


### PR DESCRIPTION
Trello: https://trello.com/c/5JMGsuBj/581-follow-up-work-from-versioning-review

This removes the rules requiring InverseOf and HasManyOrHasOneDependent. See commits for further details.