### PR TITLE
Change all foreign keys to restrict on deletion

### DIFF
--- a/db/migrate/20190123105011_restrict_delete_for_all_foreign_keys.rb
+++ b/db/migrate/20190123105011_restrict_delete_for_all_foreign_keys.rb
@@ -1,0 +1,123 @@
+# frozen_string_literal: true
+
+class RestrictDeleteForAllForeignKeys < ActiveRecord::Migration[5.2]
+  def up
+    remove_foreign_key "versioned_content_revisions", column: "created_by_id"
+    remove_foreign_key "versioned_documents", column: "created_by_id"
+    remove_foreign_key "versioned_edition_revisions", column: "edition_id"
+    remove_foreign_key "versioned_edition_revisions", column: "revision_id"
+    remove_foreign_key "versioned_editions", column: "created_by_id"
+    remove_foreign_key "versioned_editions", column: "last_edited_by_id"
+    remove_foreign_key "versioned_image_assets", column: "superseded_by_id"
+    remove_foreign_key "versioned_image_assets", column: "file_revision_id"
+    remove_foreign_key "versioned_image_file_revisions", column: "created_by_id"
+    remove_foreign_key "versioned_image_metadata_revisions", column: "created_by_id"
+    remove_foreign_key "versioned_image_revisions", column: "created_by_id"
+    remove_foreign_key "versioned_images", column: "created_by_id"
+    remove_foreign_key "versioned_internal_notes", column: "created_by_id"
+    remove_foreign_key "versioned_internal_notes", column: "edition_id"
+    remove_foreign_key "versioned_revision_image_revisions", column: "revision_id"
+    remove_foreign_key "versioned_revision_statuses", column: "revision_id"
+    remove_foreign_key "versioned_revision_statuses", column: "status_id"
+    remove_foreign_key "versioned_revisions", column: "created_by_id"
+    remove_foreign_key "versioned_revisions", column: "preceded_by_id"
+    remove_foreign_key "versioned_statuses", column: "created_by_id"
+    remove_foreign_key "versioned_statuses", column: "edition_id"
+    remove_foreign_key "versioned_tags_revisions", column: "created_by_id"
+    remove_foreign_key "versioned_timeline_entries", column: "created_by_id"
+    remove_foreign_key "versioned_timeline_entries", column: "document_id"
+    remove_foreign_key "versioned_timeline_entries", column: "edition_id"
+    remove_foreign_key "versioned_timeline_entries", column: "revision_id"
+    remove_foreign_key "versioned_timeline_entries", column: "status_id"
+    remove_foreign_key "versioned_update_revisions", column: "created_by_id"
+
+    add_foreign_key "versioned_content_revisions", "users", column: "created_by_id", on_delete: :restrict
+    add_foreign_key "versioned_documents", "users", column: "created_by_id", on_delete: :restrict
+    add_foreign_key "versioned_edition_revisions", "versioned_editions", column: "edition_id", on_delete: :restrict
+    add_foreign_key "versioned_edition_revisions", "versioned_revisions", column: "revision_id", on_delete: :restrict
+    add_foreign_key "versioned_editions", "users", column: "created_by_id", on_delete: :restrict
+    add_foreign_key "versioned_editions", "users", column: "last_edited_by_id", on_delete: :restrict
+    add_foreign_key "versioned_image_assets", "versioned_image_assets", column: "superseded_by_id", on_delete: :restrict
+    add_foreign_key "versioned_image_assets", "versioned_image_file_revisions", column: "file_revision_id", on_delete: :restrict
+    add_foreign_key "versioned_image_file_revisions", "users", column: "created_by_id", on_delete: :restrict
+    add_foreign_key "versioned_image_metadata_revisions", "users", column: "created_by_id", on_delete: :restrict
+    add_foreign_key "versioned_image_revisions", "users", column: "created_by_id", on_delete: :restrict
+    add_foreign_key "versioned_images", "users", column: "created_by_id", on_delete: :restrict
+    add_foreign_key "versioned_internal_notes", "users", column: "created_by_id", on_delete: :restrict
+    add_foreign_key "versioned_internal_notes", "versioned_editions", column: "edition_id", on_delete: :restrict
+    add_foreign_key "versioned_revision_image_revisions", "versioned_revisions", column: "revision_id", on_delete: :restrict
+    add_foreign_key "versioned_revision_statuses", "versioned_revisions", column: "revision_id", on_delete: :restrict
+    add_foreign_key "versioned_revision_statuses", "versioned_statuses", column: "status_id", on_delete: :restrict
+    add_foreign_key "versioned_revisions", "users", column: "created_by_id", on_delete: :restrict
+    add_foreign_key "versioned_revisions", "versioned_revisions", column: "preceded_by_id", on_delete: :restrict
+    add_foreign_key "versioned_statuses", "users", column: "created_by_id", on_delete: :restrict
+    add_foreign_key "versioned_statuses", "versioned_editions", column: "edition_id", on_delete: :restrict
+    add_foreign_key "versioned_tags_revisions", "users", column: "created_by_id", on_delete: :restrict
+    add_foreign_key "versioned_timeline_entries", "users", column: "created_by_id", on_delete: :restrict
+    add_foreign_key "versioned_timeline_entries", "versioned_documents", column: "document_id", on_delete: :restrict
+    add_foreign_key "versioned_timeline_entries", "versioned_editions", column: "edition_id", on_delete: :restrict
+    add_foreign_key "versioned_timeline_entries", "versioned_revisions", column: "revision_id", on_delete: :restrict
+    add_foreign_key "versioned_timeline_entries", "versioned_statuses", column: "status_id", on_delete: :restrict
+    add_foreign_key "versioned_update_revisions", "users", column: "created_by_id", on_delete: :restrict
+  end
+
+  def down
+    remove_foreign_key "versioned_content_revisions", column: "created_by_id"
+    remove_foreign_key "versioned_documents", column: "created_by_id"
+    remove_foreign_key "versioned_edition_revisions", column: "edition_id"
+    remove_foreign_key "versioned_edition_revisions", column: "revision_id"
+    remove_foreign_key "versioned_editions", column: "created_by_id"
+    remove_foreign_key "versioned_editions", column: "last_edited_by_id"
+    remove_foreign_key "versioned_image_assets", column: "superseded_by_id"
+    remove_foreign_key "versioned_image_assets", column: "file_revision_id"
+    remove_foreign_key "versioned_image_file_revisions", column: "created_by_id"
+    remove_foreign_key "versioned_image_metadata_revisions", column: "created_by_id"
+    remove_foreign_key "versioned_image_revisions", column: "created_by_id"
+    remove_foreign_key "versioned_images", column: "created_by_id"
+    remove_foreign_key "versioned_internal_notes", column: "created_by_id"
+    remove_foreign_key "versioned_internal_notes", column: "edition_id"
+    remove_foreign_key "versioned_revision_image_revisions", column: "revision_id"
+    remove_foreign_key "versioned_revision_statuses", column: "revision_id"
+    remove_foreign_key "versioned_revision_statuses", column: "status_id"
+    remove_foreign_key "versioned_revisions", column: "created_by_id"
+    remove_foreign_key "versioned_revisions", column: "preceded_by_id"
+    remove_foreign_key "versioned_statuses", column: "created_by_id"
+    remove_foreign_key "versioned_statuses", column: "edition_id"
+    remove_foreign_key "versioned_tags_revisions", column: "created_by_id"
+    remove_foreign_key "versioned_timeline_entries", column: "created_by_id"
+    remove_foreign_key "versioned_timeline_entries", column: "document_id"
+    remove_foreign_key "versioned_timeline_entries", column: "edition_id"
+    remove_foreign_key "versioned_timeline_entries", column: "revision_id"
+    remove_foreign_key "versioned_timeline_entries", column: "status_id"
+    remove_foreign_key "versioned_update_revisions", column: "created_by_id"
+
+    add_foreign_key "versioned_content_revisions", "users", column: "created_by_id", on_delete: :nullify
+    add_foreign_key "versioned_documents", "users", column: "created_by_id", on_delete: :nullify
+    add_foreign_key "versioned_edition_revisions", "versioned_editions", column: "edition_id", on_delete: :cascade
+    add_foreign_key "versioned_edition_revisions", "versioned_revisions", column: "revision_id", on_delete: :cascade
+    add_foreign_key "versioned_editions", "users", column: "created_by_id", on_delete: :nullify
+    add_foreign_key "versioned_editions", "users", column: "last_edited_by_id", on_delete: :nullify
+    add_foreign_key "versioned_image_assets", "versioned_image_assets", column: "superseded_by_id", on_delete: :nullify
+    add_foreign_key "versioned_image_assets", "versioned_image_file_revisions", column: "file_revision_id", on_delete: :cascade
+    add_foreign_key "versioned_image_file_revisions", "users", column: "created_by_id", on_delete: :nullify
+    add_foreign_key "versioned_image_metadata_revisions", "users", column: "created_by_id", on_delete: :nullify
+    add_foreign_key "versioned_image_revisions", "users", column: "created_by_id", on_delete: :nullify
+    add_foreign_key "versioned_images", "users", column: "created_by_id", on_delete: :nullify
+    add_foreign_key "versioned_internal_notes", "users", column: "created_by_id", on_delete: :nullify
+    add_foreign_key "versioned_internal_notes", "versioned_editions", column: "edition_id", on_delete: :cascade
+    add_foreign_key "versioned_revision_image_revisions", "versioned_revisions", column: "revision_id", on_delete: :cascade
+    add_foreign_key "versioned_revision_statuses", "versioned_revisions", column: "revision_id", on_delete: :cascade
+    add_foreign_key "versioned_revision_statuses", "versioned_statuses", column: "status_id", on_delete: :cascade
+    add_foreign_key "versioned_revisions", "users", column: "created_by_id", on_delete: :nullify
+    add_foreign_key "versioned_revisions", "versioned_revisions", column: "preceded_by_id", on_delete: :nullify
+    add_foreign_key "versioned_statuses", "users", column: "created_by_id", on_delete: :nullify
+    add_foreign_key "versioned_statuses", "versioned_editions", column: "edition_id", on_delete: :cascade
+    add_foreign_key "versioned_tags_revisions", "users", column: "created_by_id", on_delete: :nullify
+    add_foreign_key "versioned_timeline_entries", "users", column: "created_by_id", on_delete: :nullify
+    add_foreign_key "versioned_timeline_entries", "versioned_documents", column: "document_id", on_delete: :cascade
+    add_foreign_key "versioned_timeline_entries", "versioned_editions", column: "edition_id", on_delete: :cascade
+    add_foreign_key "versioned_timeline_entries", "versioned_revisions", column: "revision_id", on_delete: :nullify
+    add_foreign_key "versioned_timeline_entries", "versioned_statuses", column: "status_id", on_delete: :nullify
+    add_foreign_key "versioned_update_revisions", "users", column: "created_by_id", on_delete: :nullify
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2019_01_22_104549) do
+ActiveRecord::Schema.define(version: 2019_01_23_105011) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -259,46 +259,46 @@ ActiveRecord::Schema.define(version: 2019_01_22_104549) do
     t.bigint "created_by_id"
   end
 
-  add_foreign_key "versioned_content_revisions", "users", column: "created_by_id", on_delete: :nullify
-  add_foreign_key "versioned_documents", "users", column: "created_by_id", on_delete: :nullify
-  add_foreign_key "versioned_edition_revisions", "versioned_editions", column: "edition_id", on_delete: :cascade
-  add_foreign_key "versioned_edition_revisions", "versioned_revisions", column: "revision_id", on_delete: :cascade
-  add_foreign_key "versioned_editions", "users", column: "created_by_id", on_delete: :nullify
-  add_foreign_key "versioned_editions", "users", column: "last_edited_by_id", on_delete: :nullify
+  add_foreign_key "versioned_content_revisions", "users", column: "created_by_id", on_delete: :restrict
+  add_foreign_key "versioned_documents", "users", column: "created_by_id", on_delete: :restrict
+  add_foreign_key "versioned_edition_revisions", "versioned_editions", column: "edition_id", on_delete: :restrict
+  add_foreign_key "versioned_edition_revisions", "versioned_revisions", column: "revision_id", on_delete: :restrict
+  add_foreign_key "versioned_editions", "users", column: "created_by_id", on_delete: :restrict
+  add_foreign_key "versioned_editions", "users", column: "last_edited_by_id", on_delete: :restrict
   add_foreign_key "versioned_editions", "versioned_documents", column: "document_id", on_delete: :restrict
   add_foreign_key "versioned_editions", "versioned_revisions", column: "revision_id", on_delete: :restrict
   add_foreign_key "versioned_editions", "versioned_statuses", column: "status_id", on_delete: :restrict
-  add_foreign_key "versioned_image_assets", "versioned_image_assets", column: "superseded_by_id", on_delete: :nullify
-  add_foreign_key "versioned_image_assets", "versioned_image_file_revisions", column: "file_revision_id", on_delete: :cascade
+  add_foreign_key "versioned_image_assets", "versioned_image_assets", column: "superseded_by_id", on_delete: :restrict
+  add_foreign_key "versioned_image_assets", "versioned_image_file_revisions", column: "file_revision_id", on_delete: :restrict
   add_foreign_key "versioned_image_file_revisions", "active_storage_blobs", column: "blob_id", on_delete: :restrict
-  add_foreign_key "versioned_image_file_revisions", "users", column: "created_by_id", on_delete: :nullify
-  add_foreign_key "versioned_image_metadata_revisions", "users", column: "created_by_id", on_delete: :nullify
-  add_foreign_key "versioned_image_revisions", "users", column: "created_by_id", on_delete: :nullify
+  add_foreign_key "versioned_image_file_revisions", "users", column: "created_by_id", on_delete: :restrict
+  add_foreign_key "versioned_image_metadata_revisions", "users", column: "created_by_id", on_delete: :restrict
+  add_foreign_key "versioned_image_revisions", "users", column: "created_by_id", on_delete: :restrict
   add_foreign_key "versioned_image_revisions", "versioned_image_file_revisions", column: "file_revision_id", on_delete: :restrict
   add_foreign_key "versioned_image_revisions", "versioned_image_metadata_revisions", column: "metadata_revision_id", on_delete: :restrict
   add_foreign_key "versioned_image_revisions", "versioned_images", column: "image_id", on_delete: :restrict
-  add_foreign_key "versioned_images", "users", column: "created_by_id", on_delete: :nullify
-  add_foreign_key "versioned_internal_notes", "users", column: "created_by_id", on_delete: :nullify
-  add_foreign_key "versioned_internal_notes", "versioned_editions", column: "edition_id", on_delete: :cascade
+  add_foreign_key "versioned_images", "users", column: "created_by_id", on_delete: :restrict
+  add_foreign_key "versioned_internal_notes", "users", column: "created_by_id", on_delete: :restrict
+  add_foreign_key "versioned_internal_notes", "versioned_editions", column: "edition_id", on_delete: :restrict
   add_foreign_key "versioned_revision_image_revisions", "versioned_image_revisions", column: "image_revision_id", on_delete: :restrict
-  add_foreign_key "versioned_revision_image_revisions", "versioned_revisions", column: "revision_id", on_delete: :cascade
-  add_foreign_key "versioned_revision_statuses", "versioned_revisions", column: "revision_id", on_delete: :cascade
-  add_foreign_key "versioned_revision_statuses", "versioned_statuses", column: "status_id", on_delete: :cascade
-  add_foreign_key "versioned_revisions", "users", column: "created_by_id", on_delete: :nullify
+  add_foreign_key "versioned_revision_image_revisions", "versioned_revisions", column: "revision_id", on_delete: :restrict
+  add_foreign_key "versioned_revision_statuses", "versioned_revisions", column: "revision_id", on_delete: :restrict
+  add_foreign_key "versioned_revision_statuses", "versioned_statuses", column: "status_id", on_delete: :restrict
+  add_foreign_key "versioned_revisions", "users", column: "created_by_id", on_delete: :restrict
   add_foreign_key "versioned_revisions", "versioned_content_revisions", column: "content_revision_id", on_delete: :restrict
   add_foreign_key "versioned_revisions", "versioned_documents", column: "document_id", on_delete: :restrict
   add_foreign_key "versioned_revisions", "versioned_image_revisions", column: "lead_image_revision_id", on_delete: :restrict
-  add_foreign_key "versioned_revisions", "versioned_revisions", column: "preceded_by_id", on_delete: :nullify
+  add_foreign_key "versioned_revisions", "versioned_revisions", column: "preceded_by_id", on_delete: :restrict
   add_foreign_key "versioned_revisions", "versioned_tags_revisions", column: "tags_revision_id", on_delete: :restrict
   add_foreign_key "versioned_revisions", "versioned_update_revisions", column: "update_revision_id", on_delete: :restrict
-  add_foreign_key "versioned_statuses", "users", column: "created_by_id", on_delete: :nullify
-  add_foreign_key "versioned_statuses", "versioned_editions", column: "edition_id", on_delete: :cascade
+  add_foreign_key "versioned_statuses", "users", column: "created_by_id", on_delete: :restrict
+  add_foreign_key "versioned_statuses", "versioned_editions", column: "edition_id", on_delete: :restrict
   add_foreign_key "versioned_statuses", "versioned_revisions", column: "revision_at_creation_id", on_delete: :restrict
-  add_foreign_key "versioned_tags_revisions", "users", column: "created_by_id", on_delete: :nullify
-  add_foreign_key "versioned_timeline_entries", "users", column: "created_by_id", on_delete: :nullify
-  add_foreign_key "versioned_timeline_entries", "versioned_documents", column: "document_id", on_delete: :cascade
-  add_foreign_key "versioned_timeline_entries", "versioned_editions", column: "edition_id", on_delete: :cascade
-  add_foreign_key "versioned_timeline_entries", "versioned_revisions", column: "revision_id", on_delete: :nullify
-  add_foreign_key "versioned_timeline_entries", "versioned_statuses", column: "status_id", on_delete: :nullify
-  add_foreign_key "versioned_update_revisions", "users", column: "created_by_id", on_delete: :nullify
+  add_foreign_key "versioned_tags_revisions", "users", column: "created_by_id", on_delete: :restrict
+  add_foreign_key "versioned_timeline_entries", "users", column: "created_by_id", on_delete: :restrict
+  add_foreign_key "versioned_timeline_entries", "versioned_documents", column: "document_id", on_delete: :restrict
+  add_foreign_key "versioned_timeline_entries", "versioned_editions", column: "edition_id", on_delete: :restrict
+  add_foreign_key "versioned_timeline_entries", "versioned_revisions", column: "revision_id", on_delete: :restrict
+  add_foreign_key "versioned_timeline_entries", "versioned_statuses", column: "status_id", on_delete: :restrict
+  add_foreign_key "versioned_update_revisions", "users", column: "created_by_id", on_delete: :restrict
 end


### PR DESCRIPTION
https://trello.com/c/5JMGsuBj/581-follow-up-work-from-versioning-review

Previously we had a variety of on_delete actions for our foreign keys,
in an effort to try and facilitate deleting stuff, but without making it
too easy. As the logic for these actions was somewhat complex and we
don't actually have a use-case for deleting anything, ever, it makes
sense to just restrict deletion of anything that's referenced somewhere.