### PR TITLE
Remove delegated current_edition methods from document

### DIFF
--- a/app/models/document.rb
+++ b/app/models/document.rb
@@ -22,9 +22,6 @@ class Document < ApplicationRecord
 
   delegate :topics, to: :document_topics
 
-  delegate :title, :base_path, :title_or_fallback, to: :current_edition, allow_nil: true, prefix: true
-  delegate :title, :base_path, to: :live_edition, allow_nil: true, prefix: true
-
   scope :with_current_edition, -> do
     join_tables = { current_edition: %i[revision status] }
     joins(join_tables).includes(join_tables)

--- a/app/views/debug/index.html.erb
+++ b/app/views/debug/index.html.erb
@@ -1,5 +1,5 @@
 <% content_for :back_link, render_back_link(href: document_path(@document)) %>
-<% title = @document.current_edition&.title ? "‘#{@document.current_edition_title}’" : @document.to_param %>
+<% title = @document.current_edition&.title ? "‘#{@document.current_edition.title}’" : @document.to_param %>
 <% content_for :title, "Revision history for #{title}" %>
 
 <% @revisions.each.with_index do |revision, index| %>

--- a/app/views/images/edit.html.erb
+++ b/app/views/images/edit.html.erb
@@ -1,4 +1,4 @@
-<% content_for :title, t("images.edit.title", title: @document.current_edition_title_or_fallback) %>
+<% content_for :title, t("images.edit.title", title: @document.current_edition.title_or_fallback) %>
 
 <% if params[:wizard] == "lead_image" %>
   <% content_for :back_link, render_back_link(href: crop_image_path(@document, @image_revision.image_id, wizard: params[:wizard])) %>

--- a/app/views/topics/edit_api_down.html.erb
+++ b/app/views/topics/edit_api_down.html.erb
@@ -1,5 +1,5 @@
 <% content_for :back_link, render_back_link(href: document_path(@document)) %>
-<% content_for :title, t("topics.edit.title", title: @document.current_edition_title_or_fallback) %>
+<% content_for :title, t("topics.edit.title", title: @document.current_edition.title_or_fallback) %>
 
 <p class="govuk-body">
   <%= t("topics.edit.api_down") %>

--- a/spec/features/editing_content/url_preview_spec.rb
+++ b/spec/features/editing_content/url_preview_spec.rb
@@ -20,7 +20,7 @@ RSpec.feature "Shows a preview of the URL", js: true do
   def given_there_is_a_document
     @document = create(:document, :with_current_edition)
     @document_path_prefix = @document.document_type.path_prefix
-    @document_base_path = @document.current_edition_base_path
+    @document_base_path = @document.current_edition.base_path
   end
 
   def when_i_go_to_edit_the_document

--- a/spec/features/workflow/show_with_creator_spec.rb
+++ b/spec/features/workflow/show_with_creator_spec.rb
@@ -18,7 +18,7 @@ RSpec.feature "Viewing a document with a creator" do
   end
 
   def when_i_visit_the_document_page
-    click_on @document.current_edition_title
+    click_on @document.current_edition.title
   end
 
   def then_i_see_who_created_the_document

--- a/spec/services/path_generator_service_spec.rb
+++ b/spec/services/path_generator_service_spec.rb
@@ -6,9 +6,9 @@ RSpec.describe PathGeneratorService do
       service = PathGeneratorService.new
       original_document = create(:document, :with_current_edition)
       new_document = build(:document, document_type_id: original_document.document_type_id)
-      publishing_api_has_lookups("#{original_document.current_edition_base_path}": nil)
-      expect(service.path(new_document, original_document.current_edition_title))
-        .to eq("#{original_document.current_edition_base_path}-1")
+      publishing_api_has_lookups("#{original_document.current_edition.base_path}": nil)
+      expect(service.path(new_document, original_document.current_edition.title))
+        .to eq("#{original_document.current_edition.base_path}-1")
     end
 
     it "raises a 'Path unable to be generated' when many variations of that path are in use" do


### PR DESCRIPTION
Trello: https://trello.com/c/5JMGsuBj/581-follow-up-work-from-versioning-review

Using these didn't seem to add much value and seems to introduce some
confusion. Using a current_edition_title vs current_edition.title
doesn't save any characters.

So the main reason for these to exist is to conform to the Law of
Demeter, which we can always go back to if needed.