### PR TITLE
Stop using delegate_missing_to

### DIFF
--- a/app/controllers/contacts_controller.rb
+++ b/app/controllers/contacts_controller.rb
@@ -10,7 +10,7 @@ class ContactsController < ApplicationController
   end
 
   def insert
-    Document.transaction do
+    Document.transaction do # rubocop:disable Metrics/BlockLength
       document = Document.with_current_edition.lock.find_by_param(params[:id])
 
       redirect_location = edit_document_path(document) + "#body"
@@ -21,22 +21,23 @@ class ContactsController < ApplicationController
       end
 
       contact_markdown = "[Contact:#{params[:contact_id]}]\n"
-      current_edition = document.current_edition
+      current_revision = document.current_edition.revision
 
-      body = current_edition.contents.fetch("body", "").chomp
+      body = current_revision.contents.fetch("body", "").chomp
       updated_body = if body.present?
                        "#{body}\n\n#{contact_markdown}"
                      else
                        contact_markdown
                      end
 
-      revision = current_edition.build_revision_update(
-        { contents: current_edition.contents.merge("body" => updated_body) },
+      next_revision = current_revision.build_revision_update(
+        { contents: current_revision.contents.merge("body" => updated_body) },
         current_user,
       )
 
-      if revision != current_edition.revision
-        current_edition.assign_revision(revision, current_user).save!
+      if next_revision != current_revision
+        current_edition = document.current_edition
+        current_edition.assign_revision(next_revision, current_user).save!
 
         TimelineEntry.create_for_revision(entry_type: :updated_content,
                                           edition: current_edition)

--- a/app/controllers/documents_controller.rb
+++ b/app/controllers/documents_controller.rb
@@ -46,9 +46,10 @@ class DocumentsController < ApplicationController
     Document.transaction do # rubocop:disable Metrics/BlockLength
       @document = Document.with_current_edition.lock.find_by_param(params[:id])
       current_edition = @document.current_edition
+      current_revision = current_edition.revision
 
-      @revision = current_edition.build_revision_update(update_params(@document),
-                                                        current_user)
+      @revision = current_revision.build_revision_update(update_params(@document),
+                                                         current_user)
 
       add_contact_request = params[:submit] == "add_contact"
       @issues = Requirements::EditPageChecker.new(current_edition, @revision)
@@ -64,7 +65,7 @@ class DocumentsController < ApplicationController
         return
       end
 
-      if @revision != current_edition.revision
+      if @revision != current_revision
         current_edition.assign_revision(@revision, current_user).save!
 
         TimelineEntry.create_for_revision(entry_type: :updated_content,

--- a/app/controllers/images_controller.rb
+++ b/app/controllers/images_controller.rb
@@ -29,7 +29,9 @@ class ImagesController < ApplicationController
       image_revision = ImageUploadService.new(params[:image]).call(current_user)
 
       current_edition = @document.current_edition
-      next_revision = current_edition.build_revision_update_for_image_upsert(
+      current_revision = current_edition.revision
+
+      next_revision = current_revision.build_revision_update_for_image_upsert(
         image_revision,
         current_user,
       )
@@ -65,8 +67,9 @@ class ImagesController < ApplicationController
 
       if image_revision != previous_image_revision
         current_edition = document.current_edition
+        current_revision = current_edition.revision
 
-        next_revision = current_edition.build_revision_update_for_image_upsert(
+        next_revision = current_revision.build_revision_update_for_image_upsert(
           image_revision,
           current_user,
         )
@@ -82,7 +85,7 @@ class ImagesController < ApplicationController
 
         # TODO remove old images from asset manager
 
-        PreviewService.new(current_edition).try_create_preview
+        PreviewService.new(document.current_edition).try_create_preview
       end
 
 
@@ -132,8 +135,9 @@ class ImagesController < ApplicationController
 
       if @image_revision != previous_image_revision
         current_edition = @document.current_edition
+        current_revision = current_edition.revision
 
-        next_revision = current_edition.build_revision_update_for_image_upsert(
+        next_revision = current_revision.build_revision_update_for_image_upsert(
           @image_revision,
           current_user,
         )
@@ -172,9 +176,11 @@ class ImagesController < ApplicationController
       )
 
       current_edition = document.current_edition
-      lead = image_revision == current_edition.lead_image_revision
+      current_revision = current_edition.revision
 
-      next_revision = current_edition.build_revision_update_for_image_removed(
+      lead = image_revision == current_revision.lead_image_revision
+
+      next_revision = current_revision.build_revision_update_for_image_removed(
         image_revision,
         current_user,
       )

--- a/app/controllers/lead_image_controller.rb
+++ b/app/controllers/lead_image_controller.rb
@@ -6,10 +6,12 @@ class LeadImageController < ApplicationController
       document = Document.with_current_edition.lock.find_by_param(params[:document_id])
 
       current_edition = document.current_edition
-      image_revision = current_edition.image_revisions.find_by!(image_id: params[:image_id])
+      current_revision = current_edition.revision
 
-      if current_edition.lead_image_revision != image_revision
-        next_revision = current_edition.build_revision_update(
+      image_revision = current_revision.image_revisions.find_by!(image_id: params[:image_id])
+
+      if current_revision.lead_image_revision != image_revision
+        next_revision = current_revision.build_revision_update(
           { lead_image_revision: image_revision },
           current_user,
         )
@@ -32,11 +34,12 @@ class LeadImageController < ApplicationController
       document = Document.with_current_edition.lock.find_by_param(params[:document_id])
 
       current_edition = document.current_edition
+      current_revision = current_edition.revision
 
-      if current_edition.lead_image_revision
-        image_revision = current_edition.lead_image_revision
+      if current_revision.lead_image_revision
+        image_revision = current_revision.lead_image_revision
 
-        next_revision = current_edition.build_revision_update(
+        next_revision = current_revision.build_revision_update(
           { lead_image_revision: nil },
           current_user,
         )

--- a/app/controllers/tags_controller.rb
+++ b/app/controllers/tags_controller.rb
@@ -15,15 +15,16 @@ class TagsController < ApplicationController
     Document.transaction do
       document = Document.with_current_edition.lock.find_by_param(params[:id])
 
-      current_edition = document.current_edition
+      current_revision = document.current_edition.revision
 
-      revision = current_edition.build_revision_update(
+      next_revision = current_revision.build_revision_update(
         { tags: update_params(document) },
         current_user,
       )
 
-      if revision != current_edition.revision
-        current_edition.assign_revision(revision, current_user).save!
+      if next_revision != current_revision
+        current_edition = document.current_edition
+        current_edition.assign_revision(next_revision, current_user).save!
 
         TimelineEntry.create_for_revision(entry_type: :updated_tags,
                                           edition: current_edition)

--- a/app/models/edition.rb
+++ b/app/models/edition.rb
@@ -53,7 +53,20 @@ class Edition < ApplicationRecord
   state_methods = Status.states.keys.map { |s| (s + "?").to_sym }
   delegate :state, *state_methods, to: :status
 
-  delegate_missing_to :revision
+  delegate :title,
+           :title_or_fallback,
+           :base_path,
+           :summary,
+           :contents,
+           :update_type,
+           :change_note,
+           :major?,
+           :minor?,
+           :tags,
+           :lead_image_revision,
+           :image_revisions,
+           :image_revisions_without_lead,
+           to: :revision
 
   def self.create_initial(document, user = nil, tags = {})
     revision = Revision.create_initial(document, user, tags)


### PR DESCRIPTION
Trello: https://trello.com/c/5JMGsuBj/581-follow-up-work-from-versioning-review

Edition used delegate_missing_to Revision, this was a somewhat divisive decision, so it has been changed to delegate just specific methods.

As part of this I pondered that we probably didn't want to have the `build_revision_update*` methods on an edition so I didn't delegate those and had a couple of extra lines to controllers to call them on a revision.