### PR TITLE
Various versioning related boolean updates

### DIFF
--- a/app/controllers/editions_controller.rb
+++ b/app/controllers/editions_controller.rb
@@ -7,7 +7,7 @@ class EditionsController < ApplicationController
 
       current_edition = document.current_edition
 
-      if !current_edition.live
+      unless current_edition.live?
         # This should probably be a bad request
         redirect_to document
         return

--- a/app/controllers/publish_controller.rb
+++ b/app/controllers/publish_controller.rb
@@ -20,7 +20,7 @@ class PublishController < ApplicationController
     Document.transaction do
       @document = Document.with_current_edition.lock.find_by_param(params[:id])
 
-      if @document.current_edition.live
+      if @document.current_edition.live?
         redirect_to published_path(@document)
         return
       end

--- a/app/models/document.rb
+++ b/app/models/document.rb
@@ -82,8 +82,4 @@ class Document < ApplicationRecord
 
     current_edition.created_at == current_edition.updated_at
   end
-
-  def live?
-    live_edition.present?
-  end
 end

--- a/app/models/edition.rb
+++ b/app/models/edition.rb
@@ -89,6 +89,10 @@ class Edition < ApplicationRecord
             status: status)
   end
 
+  def editable?
+    !live?
+  end
+
   def resume_discarded(live_edition, user)
     revision = live_edition.revision.build_revision_update(
       { change_note: "", update_type: "major" },

--- a/app/services/delete_draft_service.rb
+++ b/app/services/delete_draft_service.rb
@@ -10,7 +10,7 @@ class DeleteDraftService
 
   def delete
     raise "Trying to delete a document without a current edition" unless document.current_edition
-    raise "Trying to delete a live document" if document.current_edition.live
+    raise "Trying to delete a live document" if document.current_edition.live?
 
     current_edition = document.current_edition
     current_edition.image_revisions.each { |ir| delete_image_revision(ir) }

--- a/app/services/requirements/content_checker.rb
+++ b/app/services/requirements/content_checker.rb
@@ -51,7 +51,7 @@ module Requirements
         end
       end
 
-      if edition.document.live? && revision.update_type == "major" && revision.change_note.blank?
+      if edition.document.live_edition && revision.update_type == "major" && revision.change_note.blank?
         issues << Issue.new(:change_note, :blank)
       end
 

--- a/app/views/debug/index.html.erb
+++ b/app/views/debug/index.html.erb
@@ -9,9 +9,9 @@
 
   <div>
     <%
-      edition_text = if revision.editions.any? { |e| e.live && e.revision_id == revision.id }
+      edition_text = if revision.editions.any? { |e| e.live? && e.revision_id == revision.id }
                        " - Live"
-                     elsif revision.editions.any? { |e| e.current && e.revision_id == revision.id }
+                     elsif revision.editions.any? { |e| e.current? && e.revision_id == revision.id }
                        " - Draft"
                      end
     %>

--- a/app/views/documents/edit.html.erb
+++ b/app/views/documents/edit.html.erb
@@ -106,7 +106,7 @@
     <%= render "documents/fields/#{field.type}_input", field: field, document: @document, revision: @revision %>
   <% end %>
 
-  <% if @document.live? %>
+  <% if @document.live_edition %>
     <%= render "documents/edit/change_notes" %>
   <% end %>
 

--- a/app/views/documents/show/_actions.html.erb
+++ b/app/views/documents/show/_actions.html.erb
@@ -63,7 +63,7 @@
       <%= delete_draft_link("app-link--right") %>
     <% end %>
 
-    <% if @edition.document.live? %>
+    <% if @edition.document.live_edition %>
       <hr class="govuk-section-break govuk-section-break--m govuk-section-break--visible" />
       <%= link_to "View published edition on GOV.UK", EditionUrl.new(@edition.document.live_edition).public_url, class: "govuk-link govuk-link--no-visited-state" %>
     <% end %>

--- a/app/views/documents/show/_actions.html.erb
+++ b/app/views/documents/show/_actions.html.erb
@@ -45,7 +45,7 @@
                  secondary: true %>
 
       <%= delete_draft_link("app-link--right") %>
-    <% elsif !@edition.revision_synced %>
+    <% elsif !@edition.revision_synced? %>
       <%= form_tag create_preview_path(@edition.document) do %>
         <%= render "govuk_publishing_components/components/button", text: "Preview" %>
       <% end %>

--- a/app/views/documents/show/_contents.html.erb
+++ b/app/views/documents/show/_contents.html.erb
@@ -25,7 +25,7 @@
   id: "content",
   title: {
     text: t("documents.show.contents.title"),
-    change_url: !@edition.live && edit_document_path(@edition.document)
+    change_url: @edition.editable? && edit_document_path(@edition.document)
   },
   items: [
     {

--- a/app/views/documents/show/_history_tab.html.erb
+++ b/app/views/documents/show/_history_tab.html.erb
@@ -35,7 +35,7 @@
           <% end %>
 
           <% if removal.alternative_path.present? %>
-            <% if removal.redirect %>
+            <% if removal.redirect? %>
               <p>
                 Redirected to
                 <%= link_to(Plek.new.website_root + removal.alternative_path,

--- a/app/views/documents/show/_lead_image.html.erb
+++ b/app/views/documents/show/_lead_image.html.erb
@@ -22,7 +22,7 @@
   id: "lead-image",
   title: {
     text: t("documents.show.lead_image.title"),
-    change_url: !@edition.live && images_path(@edition.document),
+    change_url: @edition.editable? && images_path(@edition.document),
   },
   block: lead_image_block
 } %>

--- a/app/views/documents/show/_requirements.html.erb
+++ b/app/views/documents/show/_requirements.html.erb
@@ -11,7 +11,7 @@
   }
 } %>
 
-<% if !@edition.revision_synced %>
+<% unless @edition.revision_synced? %>
   <% draft_issues = Requirements::EditionChecker.new(@edition).pre_preview_issues %>
 
   <% if draft_issues.any? %>

--- a/app/views/documents/show/_tags.html.erb
+++ b/app/views/documents/show/_tags.html.erb
@@ -15,7 +15,7 @@
     id: "tags",
     title: {
       text: t("documents.show.tags.title"),
-      change_url: !@edition.live && tags_path(@edition.document)
+      change_url: @edition.editable? && tags_path(@edition.document)
     },
     items: tags
   } %>

--- a/spec/services/delete_draft_service_spec.rb
+++ b/spec/services/delete_draft_service_spec.rb
@@ -110,7 +110,7 @@ RSpec.describe DeleteDraftService do
 
       expect { DeleteDraftService.new(edition.document, user).delete }
         .to raise_error(GdsApi::BaseError)
-      expect(edition.reload.revision_synced).to be false
+      expect(edition.reload.revision_synced?).to be false
     end
   end
 end

--- a/spec/services/publish_service_spec.rb
+++ b/spec/services/publish_service_spec.rb
@@ -17,9 +17,9 @@ RSpec.describe PublishService do
                       .publish(user: create(:user), with_review: true)
         edition.reload
         expect(publish_request).to have_been_requested
-        expect(edition.live).to be(true)
         expect(edition.document.live_edition).to eq(edition)
         expect(edition).to be_published
+        expect(edition).to be_live
       end
 
       it "can specify if edition is reviewed" do

--- a/spec/services/unpublish_service_spec.rb
+++ b/spec/services/unpublish_service_spec.rb
@@ -124,7 +124,7 @@ RSpec.describe UnpublishService do
       expect(timeline_entry.entry_type).to eq("removed")
       expect(timeline_entry.details.explanatory_note).to eq(explanatory_note)
       expect(timeline_entry.details.alternative_path).to eq(alternative_path)
-      expect(timeline_entry.details.redirect).to be_falsey
+      expect(timeline_entry.details.redirect?).to be false
     end
 
     it "updates the edition status" do
@@ -132,7 +132,7 @@ RSpec.describe UnpublishService do
       edition.reload
 
       expect(edition.status).to be_removed
-      expect(edition.status.details.redirect).to be false
+      expect(edition.status.details.redirect?).to be false
     end
 
     context "when the given edition is a draft" do
@@ -206,7 +206,7 @@ RSpec.describe UnpublishService do
       expect(timeline_entry.entry_type).to eq("removed")
       expect(timeline_entry.details.explanatory_note).to eq(explanatory_note)
       expect(timeline_entry.details.alternative_path).to eq(redirect_path)
-      expect(timeline_entry.details.redirect).to be true
+      expect(timeline_entry.details.redirect?).to be true
     end
 
     it "updates the edition status" do
@@ -214,7 +214,7 @@ RSpec.describe UnpublishService do
       edition.reload
 
       expect(edition.status).to be_removed
-      expect(edition.status.details.redirect).to be true
+      expect(edition.status.details.redirect?).to be true
     end
 
     context "when the given edition is a draft" do

--- a/spec/tasks/whitehall_news_importer_spec.rb
+++ b/spec/tasks/whitehall_news_importer_spec.rb
@@ -71,7 +71,7 @@ RSpec.describe Tasks::WhitehallNewsImporter do
     Tasks::WhitehallNewsImporter.new.import(parsed_json)
 
     expect(Edition.last.status).to be_published
-    expect(Edition.last.live).to be true
+    expect(Edition.last).to be_live
   end
 
   it "can set minor update type" do
@@ -89,7 +89,7 @@ RSpec.describe Tasks::WhitehallNewsImporter do
     Tasks::WhitehallNewsImporter.new.import(parsed_json)
 
     expect(Edition.last.status).to be_published_but_needs_2i
-    expect(Edition.last.live).to be true
+    expect(Edition.last).to be_live
   end
 
   it "sets the correct states when Whitehall document state is 'rejected'" do
@@ -98,7 +98,7 @@ RSpec.describe Tasks::WhitehallNewsImporter do
     Tasks::WhitehallNewsImporter.new.import(parsed_json)
 
     expect(Edition.last.status).to be_submitted_for_review
-    expect(Edition.last.live).to be false
+    expect(Edition.last).not_to be_live
   end
 
   it "sets the correct states when Whitehall document state is 'submitted'" do
@@ -107,7 +107,7 @@ RSpec.describe Tasks::WhitehallNewsImporter do
     Tasks::WhitehallNewsImporter.new.import(parsed_json)
 
     expect(Edition.last.status).to be_submitted_for_review
-    expect(Edition.last.live).to be false
+    expect(Edition.last).not_to be_live
   end
 
   it "skips importing documents with Whitheall states that are not supported" do
@@ -181,7 +181,7 @@ RSpec.describe Tasks::WhitehallNewsImporter do
       Tasks::WhitehallNewsImporter.new.import(parsed_json)
 
       expect(Edition.last.status).to be_draft
-      expect(Edition.last.live).to be false
+      expect(Edition.last).not_to be_live
     end
   end
 end


### PR DESCRIPTION
Trello: https://trello.com/c/5JMGsuBj/581-follow-up-work-from-versioning-review

This PR comprises of a few updates in relation to ActiveRecord booleans.

It first adds in a `#editable?` method to Edition which returns the inverse of `#live?`.
It then uses a question mark suffix on the places we use ActiveRecord Booleans.
It removes a `#live?` method from Document so that's not confused with `#live?` on Edition.
And then updates tests for consistency.