### PR TITLE
Block changing revision on a live edition

### DIFF
--- a/app/models/edition.rb
+++ b/app/models/edition.rb
@@ -147,6 +147,8 @@ class Edition < ApplicationRecord
   end
 
   def assign_revision(revision, user)
+    raise "cannot update revision on a live edition" if live?
+
     assign_attributes(revision: revision,
                       last_edited_by: user,
                       last_edited_at: Time.zone.now)

--- a/spec/models/revision_spec.rb
+++ b/spec/models/revision_spec.rb
@@ -1,6 +1,8 @@
 # frozen_string_literal: true
 
 RSpec.describe Revision do
+  include ActiveSupport::Testing::TimeHelpers
+
   describe ".create_initial" do
     let(:document) { build(:document) }
 
@@ -278,6 +280,53 @@ RSpec.describe Revision do
       )
 
       expect(new_revision).to be(revision)
+    end
+  end
+
+  describe "#assign_revision" do
+    context "when an edition is live" do
+      it "raises an error" do
+        edition = build(:edition, :published)
+
+        expect { edition.assign_revision(build(:revision), build(:user)) }
+          .to raise_error(RuntimeError, "cannot update revision on a live edition")
+      end
+    end
+
+    context "when an edition is not live" do
+      it "sets the revision" do
+        edition = build(:edition)
+        revision = build(:revision)
+
+        edition.assign_revision(revision, build(:user))
+        expect(edition.revision).to be(revision)
+      end
+
+      it "sets who last edited it" do
+        edition = build(:edition)
+        user = build(:user)
+
+        edition.assign_revision(build(:revision), user)
+        expect(edition.last_edited_by).to be(user)
+      end
+
+      it "sets the last edited time" do
+        edition = build(:edition)
+
+        travel_to(Time.current) do
+          edition.assign_revision(build(:revision), build(:user))
+
+          expect(edition.last_edited_at).to eq(Time.current)
+        end
+      end
+
+      it "does not save the record" do
+        edition = build(:edition)
+
+        edition.assign_revision(build(:revision), build(:user))
+
+        expect(edition).to be_new_record
+      end
     end
   end
 end


### PR DESCRIPTION
Trello: https://trello.com/c/5JMGsuBj/581-follow-up-work-from-versioning-review

This is a somewhat crude exception that prevents the situation where a
user is able to edit a live edition by preventing this with an exception
at the point of assigning a revision.

I'm writing the fateful words that haunt a developer in later years that
this is intended to be temporary. Ideally we'd have a view or an alert
presented to the user to describe the edition is now live and you should
create a new edition to make changes.

Before versioning was introduced this behaviour was managed by the
PreviewService which would automatically create a new edition if a user
managed to edit a live edition. This behaviour doesn't feel correct as
creating a new edition is quite a big step for a document so a user
shouldn't be unaware that they have just done that (unless we were to
focus the UI on making this more obvious).

With this an attempt to do this will cause our application to raise an
error and give the user an error screen, which is not ideal but is
simple and doesn't risk inconsistent data.

The expectation is for this to stand until we can define a
service/process that can deal with conflicts like this and cases where a
user is editing a stale item.