### PR TITLE
Use Time.current everywhere

### DIFF
--- a/app/models/edition.rb
+++ b/app/models/edition.rb
@@ -10,7 +10,7 @@ class Edition < ApplicationRecord
 
   before_create do
     # set a default value for last_edited_at works better than using DB default
-    self.last_edited_at = Time.zone.now unless last_edited_at
+    self.last_edited_at = Time.current unless last_edited_at
   end
 
   after_save do
@@ -118,7 +118,7 @@ class Edition < ApplicationRecord
 
     update!(current: true,
             last_edited_by: user,
-            last_edited_at: Time.zone.now,
+            last_edited_at: Time.current,
             revision: revision,
             status: status)
   end
@@ -137,7 +137,7 @@ class Edition < ApplicationRecord
     attributes = { status: status }
 
     if update_last_edited
-      attributes[:last_edited_at] = Time.zone.now
+      attributes[:last_edited_at] = Time.current
       attributes[:last_edited_by] = user
     end
 
@@ -151,7 +151,7 @@ class Edition < ApplicationRecord
 
     assign_attributes(revision: revision,
                       last_edited_by: user,
-                      last_edited_at: Time.zone.now)
+                      last_edited_at: Time.current)
 
     self
   end

--- a/app/services/publish_service.rb
+++ b/app/services/publish_service.rb
@@ -48,7 +48,7 @@ private
   def set_first_published_at
     return if document.first_published_at
 
-    document.update!(first_published_at: Time.zone.now)
+    document.update!(first_published_at: Time.current)
   end
 
   def publish_new_images

--- a/app/services/topic_index_service.rb
+++ b/app/services/topic_index_service.rb
@@ -32,13 +32,13 @@ private
 
   def raw_level_one_topics
     @raw_level_one_topics ||= begin
-      start_time = Time.zone.now
+      start_time = Time.current
 
       topics = publishing_api.get_expanded_links(GOVUK_HOMEPAGE_CONTENT_ID)
         .dig("expanded_links", "level_one_taxons")
 
       topics.each do |raw_topic|
-        raise GdsApi::TimedOutException.new if Time.zone.now - start_time > TOPIC_INDEX_TIMEOUT
+        raise GdsApi::TimedOutException.new if Time.current - start_time > TOPIC_INDEX_TIMEOUT
 
         topic_content_id = raw_topic["content_id"]
         raw_topic["links"] = publishing_api.get_expanded_links(topic_content_id)["expanded_links"]

--- a/spec/factories/edition_factory.rb
+++ b/spec/factories/edition_factory.rb
@@ -2,7 +2,7 @@
 
 FactoryBot.define do
   factory :edition do
-    last_edited_at { Time.zone.now }
+    last_edited_at { Time.current }
     current { true }
     live { false }
     revision_synced { true }

--- a/spec/tasks/whitehall_news_importer_spec.rb
+++ b/spec/tasks/whitehall_news_importer_spec.rb
@@ -8,7 +8,7 @@ RSpec.describe Tasks::WhitehallNewsImporter do
       content_id: SecureRandom.uuid,
       editions: [
         {
-          created_at: Time.zone.now,
+          created_at: Time.current,
           news_article_type: { key: "news_story" },
           translations: [
             {
@@ -132,7 +132,7 @@ RSpec.describe Tasks::WhitehallNewsImporter do
         content_id: SecureRandom.uuid,
         editions: [
           {
-            created_at: Time.zone.now,
+            created_at: Time.current,
             news_article_type: { key: "news_story" },
             translations: [
               {
@@ -152,7 +152,7 @@ RSpec.describe Tasks::WhitehallNewsImporter do
             force_published: false,
           },
           {
-            created_at: Time.zone.now - 1.day,
+            created_at: Time.current - 1.day,
             news_article_type: { key: "news_story" },
             translations: [
               {


### PR DESCRIPTION
Trello: https://trello.com/c/5JMGsuBj/581-follow-up-work-from-versioning-review

This makes this consistent rather than using Time.current in some places
and Time.zone.now in others.