### PR TITLE
Rename ambiguous revision method names

### DIFF
--- a/app/models/edition.rb
+++ b/app/models/edition.rb
@@ -22,7 +22,7 @@ class Edition < ApplicationRecord
 
     # Used to keep an audit trail of all the revisions that have been
     # associated with an edition
-    revisions << revision unless revisions.include?(revision)
+    all_revisions << revision unless all_revisions.include?(revision)
   end
 
   attr_readonly :number, :document_id
@@ -37,14 +37,17 @@ class Edition < ApplicationRecord
 
   belongs_to :status
 
-  has_many :statuses
+  # all the statuses this edition has held
+  has_many :all_statuses, class_name: "Status"
 
   has_many :timeline_entries
 
   has_many :internal_notes
 
-  has_and_belongs_to_many :revisions,
+  # all the revisions that have been associated with this edition
+  has_and_belongs_to_many :all_revisions,
                           -> { order("versioned_revisions.number DESC") },
+                          class_name: "Revision",
                           join_table: "versioned_edition_revisions"
 
   delegate :content_id, :locale, :document_type, :topics, to: :document


### PR DESCRIPTION
Trello: https://trello.com/c/5JMGsuBj/581-follow-up-work-from-versioning-review

We had two pairs of confusing method names on Revision: #status
and #statuses; and #revision and #revisions.

This attempts to make these more distinct by prefixing the many variants
with all. So we now have #all_statuses and #all_revisions.

The other option on this was to prefix the singular versions e.g. if we
had #current_status and #current_revision. However this feels
unnecessarily verbose since revision and status will be frequently
accessed whereas the collection equivalents are used for audit trails
and will be rarely used.

I'm not 100% sure the `all_` prefix is the best one, I thought a better
one for statuses would be #statuses_held but that didn't seem to fit
nicely with revisions.