### PR TITLE
Add withdraw workflow

### DIFF
--- a/app/controllers/unwithdraw_controller.rb
+++ b/app/controllers/unwithdraw_controller.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+class UnwithdrawController < ApplicationController
+  def index
+    @document = Document.with_current_edition.find_by_param(params[:id])
+  end
+end

--- a/app/controllers/withdraw_controller.rb
+++ b/app/controllers/withdraw_controller.rb
@@ -4,4 +4,16 @@ class WithdrawController < ApplicationController
   def new
     @document = Document.with_current_edition.find_by_param(params[:id])
   end
+
+  def create
+    Document.transaction do
+      document = Document.with_current_edition.lock!.find_by_param(params[:id])
+      public_explanation = params[:public_explanation]
+
+      #FIXME We should check that the edition is withdrawable before passing
+      # it to the UnpublishService
+      UnpublishService.new.withdraw(document.current_edition, public_explanation)
+      redirect_to document
+    end
+  end
 end

--- a/app/controllers/withdraw_controller.rb
+++ b/app/controllers/withdraw_controller.rb
@@ -6,6 +6,12 @@ class WithdrawController < ApplicationController
     edition = @document.current_edition
     @public_explanation =
       edition.withdrawn? ? edition.status.details.public_explanation : nil
+
+    if current_user.has_permission?(User::MANAGING_EDITOR_PERMISSION)
+      render :new
+    else
+      render :non_managing_editor, status: :forbidden
+    end
   end
 
   def create

--- a/app/controllers/withdraw_controller.rb
+++ b/app/controllers/withdraw_controller.rb
@@ -22,10 +22,17 @@ class WithdrawController < ApplicationController
 
         render :new
       else
-        #FIXME We should check that the edition is withdrawable before passing
-        # it to the UnpublishService
-        UnpublishService.new.withdraw(@document.current_edition, public_explanation)
-        redirect_to @document
+        begin
+          #FIXME We should check that the edition is withdrawable before passing
+          # it to the UnpublishService
+          UnpublishService.new.withdraw(@document.current_edition, public_explanation)
+          redirect_to @document
+        rescue GdsApi::BaseError => e
+          GovukError.notify(e)
+          redirect_to withdraw_path,
+            alert_with_description: t("withdraw.new.flashes.publishing_api_error"),
+            public_explanation: public_explanation
+        end
       end
     end
   end

--- a/app/controllers/withdraw_controller.rb
+++ b/app/controllers/withdraw_controller.rb
@@ -10,13 +10,23 @@ class WithdrawController < ApplicationController
 
   def create
     Document.transaction do
-      document = Document.with_current_edition.lock!.find_by_param(params[:id])
+      @document = Document.with_current_edition.lock!.find_by_param(params[:id])
       public_explanation = params[:public_explanation]
+      issues = Requirements::WithdrawalChecker.new(public_explanation).pre_withdrawal_issues
 
-      #FIXME We should check that the edition is withdrawable before passing
-      # it to the UnpublishService
-      UnpublishService.new.withdraw(document.current_edition, public_explanation)
-      redirect_to document
+      if issues.any?
+        flash["alert_with_items"] = {
+          "title" => I18n.t!("withdraw.new.flashes.requirements"),
+          "items" => issues.items,
+        }
+
+        render :new
+      else
+        #FIXME We should check that the edition is withdrawable before passing
+        # it to the UnpublishService
+        UnpublishService.new.withdraw(@document.current_edition, public_explanation)
+        redirect_to @document
+      end
     end
   end
 end

--- a/app/controllers/withdraw_controller.rb
+++ b/app/controllers/withdraw_controller.rb
@@ -3,6 +3,9 @@
 class WithdrawController < ApplicationController
   def new
     @document = Document.with_current_edition.find_by_param(params[:id])
+    edition = @document.current_edition
+    @public_explanation =
+      edition.withdrawn? ? edition.status.details.public_explanation : nil
   end
 
   def create

--- a/app/controllers/withdraw_controller.rb
+++ b/app/controllers/withdraw_controller.rb
@@ -25,7 +25,7 @@ class WithdrawController < ApplicationController
         begin
           #FIXME We should check that the edition is withdrawable before passing
           # it to the UnpublishService
-          UnpublishService.new.withdraw(@document.current_edition, public_explanation)
+          UnpublishService.new.withdraw(@document.current_edition, public_explanation, current_user)
           redirect_to @document
         rescue GdsApi::BaseError => e
           GovukError.notify(e)

--- a/app/controllers/withdraw_controller.rb
+++ b/app/controllers/withdraw_controller.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
-class UnpublishController < ApplicationController
-  def remove
+class WithdrawController < ApplicationController
+  def new
     @document = Document.with_current_edition.find_by_param(params[:id])
   end
 end

--- a/app/controllers/withdraw_controller.rb
+++ b/app/controllers/withdraw_controller.rb
@@ -7,6 +7,11 @@ class WithdrawController < ApplicationController
     @public_explanation =
       edition.withdrawn? ? edition.status.details.public_explanation : nil
 
+    if !current_user.has_permission?(User::PRE_RELEASE_FEATURES_PERMISSION)
+      render :withdraw
+      return
+    end
+
     if current_user.has_permission?(User::MANAGING_EDITOR_PERMISSION)
       render :new
     else
@@ -15,6 +20,12 @@ class WithdrawController < ApplicationController
   end
 
   def create
+    unless user_has_permissions?
+      # FIXME: this shouldn't be an exception but we've not worked out the
+      # right response - maybe bad request or a redirect with flash?
+      raise "Can't withdraw an edition without permissions"
+    end
+
     Document.transaction do
       @document = Document.with_current_edition.lock!.find_by_param(params[:id])
       public_explanation = params[:public_explanation]
@@ -41,5 +52,12 @@ class WithdrawController < ApplicationController
         end
       end
     end
+  end
+
+private
+
+  def user_has_permissions?
+    current_user.has_all_permissions?([User::MANAGING_EDITOR_PERMISSION,
+                                       User::PRE_RELEASE_FEATURES_PERMISSION])
   end
 end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -6,4 +6,5 @@ class User < ApplicationRecord
 
   PRE_RELEASE_FEATURES_PERMISSION = "pre_release_features"
   DEBUG_PERMISSION = "debug"
+  MANAGING_EDITOR_PERMISSION = "managing_editor"
 end

--- a/app/services/requirements/withdrawal_checker.rb
+++ b/app/services/requirements/withdrawal_checker.rb
@@ -1,0 +1,21 @@
+# frozen_string_literal: true
+
+module Requirements
+  class WithdrawalChecker
+    attr_reader :public_explanation
+
+    def initialize(public_explanation)
+      @public_explanation = public_explanation
+    end
+
+    def pre_withdrawal_issues
+      issues = []
+
+      if public_explanation.blank?
+        issues << Issue.new(:public_explanation, :blank)
+      end
+
+      CheckerIssues.new(issues)
+    end
+  end
+end

--- a/app/services/unpublish_service.rb
+++ b/app/services/unpublish_service.rb
@@ -9,7 +9,7 @@ class UnpublishService
       GdsApi.publishing_api_v2.unpublish(
         edition.content_id,
         type: "withdrawal",
-        explanation: public_explanation,
+        explanation: format_govspeak(public_explanation),
         locale: edition.locale,
       )
 
@@ -97,6 +97,10 @@ private
     if document.current_edition != document.live_edition
       raise "Publishing API does not support unpublishing while there is a draft"
     end
+  end
+
+  def format_govspeak(text)
+    GovspeakDocument.new(text).to_html
   end
 
   def delete_assets(edition)

--- a/app/services/unpublish_service.rb
+++ b/app/services/unpublish_service.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 class UnpublishService
-  def withdraw(edition, explanatory_note)
+  def withdraw(edition, public_explanation)
     Document.transaction do
       edition.document.lock!
       check_unpublishable(edition)
@@ -9,11 +9,11 @@ class UnpublishService
       GdsApi.publishing_api_v2.unpublish(
         edition.content_id,
         type: "withdrawal",
-        explanation: explanatory_note,
+        explanation: public_explanation,
         locale: edition.locale,
       )
 
-      withdrawal = Withdrawal.new(explanatory_note: explanatory_note)
+      withdrawal = Withdrawal.new(public_explanation: public_explanation)
 
       edition.assign_status(:withdrawn, nil, status_details: withdrawal)
       edition.save!

--- a/app/services/unpublish_service.rb
+++ b/app/services/unpublish_service.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 class UnpublishService
-  def withdraw(edition, public_explanation)
+  def withdraw(edition, public_explanation, user = nil)
     Document.transaction do
       edition.document.lock!
       check_unpublishable(edition)
@@ -15,7 +15,7 @@ class UnpublishService
 
       withdrawal = Withdrawal.new(public_explanation: public_explanation)
 
-      edition.assign_status(:withdrawn, nil, status_details: withdrawal)
+      edition.assign_status(:withdrawn, user, status_details: withdrawal)
       edition.save!
 
       TimelineEntry.create_for_status_change(

--- a/app/services/unpublish_service.rb
+++ b/app/services/unpublish_service.rb
@@ -2,16 +2,10 @@
 
 class UnpublishService
   def withdraw(edition, public_explanation, user = nil)
-    Document.transaction do
+    Document.transaction(requires_new: true) do
       edition.document.lock!
       check_unpublishable(edition)
 
-      GdsApi.publishing_api_v2.unpublish(
-        edition.content_id,
-        type: "withdrawal",
-        explanation: format_govspeak(public_explanation),
-        locale: edition.locale,
-      )
 
       withdrawal = Withdrawal.new(public_explanation: public_explanation)
 
@@ -23,11 +17,18 @@ class UnpublishService
         status: edition.status,
         details: withdrawal,
       )
+
+      GdsApi.publishing_api_v2.unpublish(
+        edition.content_id,
+        type: "withdrawal",
+        explanation: format_govspeak(public_explanation),
+        locale: edition.locale,
+      )
     end
   end
 
   def remove(edition, explanatory_note: nil, alternative_path: nil)
-    Document.transaction do
+    Document.transaction(requires_new: true) do
       edition.document.lock!
       check_unpublishable(edition)
 
@@ -56,7 +57,7 @@ class UnpublishService
   end
 
   def remove_and_redirect(edition, redirect_path, explanatory_note: nil)
-    Document.transaction do
+    Document.transaction(requires_new: true) do
       edition.document.lock!
       check_unpublishable(edition)
 

--- a/app/views/documents/show/_actions.html.erb
+++ b/app/views/documents/show/_actions.html.erb
@@ -30,7 +30,7 @@
       <%= link_to "Withdraw", withdraw_path(@edition.document), class: "govuk-link govuk-link--no-visited-state" %>
       <%= link_to "Remove", remove_path(@edition.document), class: "govuk-link app-link--destructive app-link--right" %>
     <% elsif @edition.status.withdrawn? %>
-      <%= link_to "Update reason for retiring", withdraw_path(@edition.document), class: "govuk-link govuk-link--no-visited-state" %>
+      <%= link_to "Change public explanation", withdraw_path(@edition.document), class: "govuk-link govuk-link--no-visited-state" %>
     <% elsif @edition.status.removed? %>
       <%= form_tag create_edition_path(@edition.document) do %>
         <%= render "govuk_publishing_components/components/button", text: "Create new edition", data_attributes: { gtm: "create-new-edition" } %>

--- a/app/views/documents/show/_actions.html.erb
+++ b/app/views/documents/show/_actions.html.erb
@@ -26,11 +26,8 @@
       <%= form_tag create_edition_path(@edition.document) do %>
         <%= render "govuk_publishing_components/components/button", text: "Create new edition", data_attributes: { gtm: "create-new-edition" } %>
       <% end %>
-
       <%= link_to "Withdraw", withdraw_path(@edition.document), class: "govuk-link govuk-link--no-visited-state" %>
       <%= link_to "Remove", remove_path(@edition.document), class: "govuk-link app-link--destructive app-link--right" %>
-    <% elsif @edition.status.withdrawn? %>
-      <%= link_to "Change public explanation", withdraw_path(@edition.document), class: "govuk-link govuk-link--no-visited-state" %>
     <% elsif @edition.status.removed? %>
       <%= form_tag create_edition_path(@edition.document) do %>
         <%= render "govuk_publishing_components/components/button", text: "Create new edition", data_attributes: { gtm: "create-new-edition" } %>

--- a/app/views/documents/show/_actions.html.erb
+++ b/app/views/documents/show/_actions.html.erb
@@ -48,6 +48,11 @@
       <% end %>
 
       <%= delete_draft_link %>
+    <% elsif @edition.withdrawn? %>
+      <%= render "govuk_publishing_components/components/button",
+                 text: "Undo withdrawal",
+                 data_attributes: { gtm: "undo-withdraw" },
+                 href: unwithdraw_path(@document) %>
     <% else %>
       <%= form_tag submit_document_for_2i_path(@edition.document) do %>
         <%= render "govuk_publishing_components/components/button", text: "Submit for 2i review" %>

--- a/app/views/documents/show/_document_metadata.html.erb
+++ b/app/views/documents/show/_document_metadata.html.erb
@@ -1,5 +1,31 @@
+<% if @edition.withdrawn? %>
+  <% metadata = [
+      field: t("documents.show.metadata.withdrawn_by"),
+      value: @edition.status.created_by&.name || I18n.t!("documents.show.metadata.unknown_user")
+  ] %>
+<% else %>
+  <% metadata = [
+    {
+      field: t("documents.show.metadata.created_at"),
+      value: @document.created_at.strftime("%l:%M%P on %d %B %Y")
+    },
+    {
+      field: t("documents.show.metadata.created_by"),
+      value: @document.created_by&.name || I18n.t!("documents.show.metadata.unknown_user")
+    },
+    {
+      field: t("documents.show.metadata.last_edited_by"),
+      value: @edition.last_edited_by&.name || I18n.t!("documents.show.metadata.unknown_user")
+    }
+  ] %>
+<% end %>
+
 <div class="app-side">
   <%= render "components/metadata", {
+    data_attributes: {
+      "gtm-document-type": @edition.document_type.label,
+      "gtm-document-status": t("user_facing_states.#{@edition.state}.name")
+    },
     items: [
       {
         field: t("documents.show.metadata.status"),
@@ -9,22 +35,6 @@
         field: t("documents.show.metadata.updated_at"),
         value: @edition.last_edited_at.strftime("%l:%M%P on %d %B %Y")
       },
-      {
-        field: t("documents.show.metadata.created_at"),
-        value: @edition.document.created_at.strftime("%l:%M%P on %d %B %Y")
-      },
-      {
-        field: t("documents.show.metadata.created_by"),
-        value: @edition.document.created_by&.name || I18n.t!("documents.show.metadata.unknown_user")
-      },
-      {
-        field: t("documents.show.metadata.last_edited_by"),
-        value: @edition.last_edited_by&.name || I18n.t!("documents.show.metadata.unknown_user")
-      },
-    ],
-    data_attributes: {
-      "gtm-document-type": @edition.document_type.label,
-      "gtm-document-status": t("user_facing_states.#{@edition.state}.name")
-    }
+    ] + metadata
   } %>
 </div>

--- a/app/views/documents/show/_history_tab.html.erb
+++ b/app/views/documents/show/_history_tab.html.erb
@@ -25,7 +25,7 @@
         <% end %>
 
         <% if entry.withdrawn? && entry.details %>
-          <%= entry.details.explanatory_note %>
+          <%= entry.details.public_explanation %>
         <% end %>
 
         <% if entry.removed? && entry.details %>

--- a/app/views/documents/show/_summary_tab.html.erb
+++ b/app/views/documents/show/_summary_tab.html.erb
@@ -3,7 +3,9 @@
     <% if flash[:submitted_for_review] %>
       <%= render "documents/show/submitted_for_review" %>
     <% end %>
-
+    <% if @edition.withdrawn? %>
+      <%= render "documents/show/withdrawn_notice" %>
+    <% end %>
     <%= render "documents/show/requirements" %>
     <%= render "documents/show/contents" %>
 

--- a/app/views/documents/show/_withdrawn_notice.html.erb
+++ b/app/views/documents/show/_withdrawn_notice.html.erb
@@ -1,0 +1,10 @@
+<%= render "govuk_publishing_components/components/notice", {
+  title: I18n.t("documents.show.withdrawn.title",
+                document_type: @document.document_type.label.downcase,
+                withdrawn_date: @edition.status.created_at.strftime("%d %B %Y"))
+} do %>
+  <%= @edition.status.details.public_explanation %>
+  <p>
+  <p>
+  <%= link_to "Change public explanation", withdraw_path(@document), class: "govuk-link govuk-link--no-visited-state" %>
+<% end %>

--- a/app/views/unwithdraw/index.html.erb
+++ b/app/views/unwithdraw/index.html.erb
@@ -1,0 +1,8 @@
+<% content_for :back_link, render_back_link(href: document_path(@document)) %>
+<% content_for :title, t("unwithdraw.index.title") %>
+
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-two-thirds">
+    <%= render_govspeak(File.read("app/views/unwithdraw/unwithdraw.govspeak.md")) %>
+  </div>
+</div>

--- a/app/views/unwithdraw/unwithdraw.govspeak.md
+++ b/app/views/unwithdraw/unwithdraw.govspeak.md
@@ -1,0 +1,1 @@
+If you need to undo the withdrawal of this content please [raise a support request and we’ll do it for you](https://support.publishing.service.gov.uk/unpublish_content_request/new).

--- a/app/views/withdraw/new.html.erb
+++ b/app/views/withdraw/new.html.erb
@@ -16,6 +16,7 @@
           bold: true
         },
         id: "withdrawal_public_explanation",
+        value: @public_explanation,
         name: "public_explanation",
         rows: 6,
         data: {

--- a/app/views/withdraw/new.html.erb
+++ b/app/views/withdraw/new.html.erb
@@ -1,8 +1,7 @@
 <% content_for :back_link, render_back_link(href: document_path(@document)) %>
-<% content_for :title, t("unpublish.withdraw.title") %>
+<% content_for :title, t("withdraw.new.title", title: @document.current_edition.title) %>
 
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
-    <%= render_govspeak(File.read("app/views/unpublish/unpublish.govspeak.md")) %>
   </div>
 </div>

--- a/app/views/withdraw/new.html.erb
+++ b/app/views/withdraw/new.html.erb
@@ -3,5 +3,26 @@
 
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
+    <%= render_govspeak(t("withdraw.new.intro_paragraph")) %>
+  </div>
+</div>
+
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-two-thirds">
+    <%= form_tag(withdraw_path(@document)) do %>
+      <%= render "govuk_publishing_components/components/textarea", {
+        label: {
+          text: t("withdraw.new.public_explanation.title"),
+          bold: true
+        },
+        id: "withdrawal_public_explanation",
+        name: "public_explanation",
+        rows: 6,
+      } %>
+      <%= render "govuk_publishing_components/components/button", {
+        text: "Withdraw document", margin_bottom: true
+      } %>
+    <% end %>
+    <%= link_to "Cancel", document_path(@document), class: "govuk-link govuk-link--no-visited-state" %>
   </div>
 </div>

--- a/app/views/withdraw/new.html.erb
+++ b/app/views/withdraw/new.html.erb
@@ -18,11 +18,25 @@
         id: "withdrawal_public_explanation",
         name: "public_explanation",
         rows: 6,
+        data: {
+          "contextual_guidance": "withdrawal-public-explanation-guidance",
+        }
       } %>
       <%= render "govuk_publishing_components/components/button", {
         text: "Withdraw document", margin_bottom: true
       } %>
     <% end %>
     <%= link_to "Cancel", document_path(@document), class: "govuk-link govuk-link--no-visited-state" %>
+  </div>
+  <div class="govuk-grid-column-one-third">
+    <%= render "components/contextual_guidance", {
+      id: "withdrawal-public-explanation-guidance",
+      title: t("withdraw.new.public_explanation.guidance_title"),
+    } do %>
+      <p>Explain to users why the page has been withdrawn. You can link to alternative content with markdown.</p>
+      <pre class="app-c-markdown-guidance__code-snippet">
+        [linktext](https://www.gov.uk/example)
+      </pre>
+    <% end %>
   </div>
 </div>

--- a/app/views/withdraw/non_managing_editor.html.erb
+++ b/app/views/withdraw/non_managing_editor.html.erb
@@ -1,0 +1,8 @@
+<% content_for :back_link, render_back_link(href: document_path(@document)) %>
+<% content_for :title, t("withdraw.no_managing_editor_permission.title") %>
+
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-two-thirds">
+    <%= render_govspeak(t("withdraw.no_managing_editor_permission.content")) %>
+  </div>
+</div>

--- a/app/views/withdraw/withdraw.html.erb
+++ b/app/views/withdraw/withdraw.html.erb
@@ -1,0 +1,8 @@
+<% content_for :back_link, render_back_link(href: document_path(@document)) %>
+<% content_for :title, t("unpublish.withdraw.title") %>
+
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-two-thirds">
+    <%= render_govspeak(File.read("app/views/unpublish/unpublish.govspeak.md")) %>
+  </div>
+</div>

--- a/config/locales/en/documents/show.yml
+++ b/config/locales/en/documents/show.yml
@@ -49,6 +49,7 @@ en:
         created_by: Document created by
         unknown_user: Unknown
         last_edited_by: Last edited by
+        withdrawn_by: Withdrawn by
       flashes:
         pre_preview_issues:
           warning: To preview this document you need to

--- a/config/locales/en/documents/show.yml
+++ b/config/locales/en/documents/show.yml
@@ -8,6 +8,8 @@ en:
       tabs:
         summary: Document summary
         history: Document history
+      withdrawn:
+        title: "This %{document_type} was withdrawn on %{withdrawn_date}"
       topics:
         title: Topics
         no_topics: No topics.

--- a/config/locales/en/requirements.yml
+++ b/config/locales/en/requirements.yml
@@ -61,3 +61,6 @@ en:
         form_message: "Select an image file under %{max_size} in size"
       too_small:
         form_message: "Select an image at least %{width} pixels wide by %{height} pixels high"
+    public_explanation:
+      blank:
+        form_message: Enter a public explanation

--- a/config/locales/en/unwithdraw/unwithdraw.yml
+++ b/config/locales/en/unwithdraw/unwithdraw.yml
@@ -1,0 +1,4 @@
+en:
+  unwithdraw:
+    index:
+      title: Sorry, this hasn't been built yet

--- a/config/locales/en/withdraw/withdraw.yml
+++ b/config/locales/en/withdraw/withdraw.yml
@@ -11,3 +11,6 @@ en:
         [Full guidance on withdrawing content](https://www.gov.uk/guidance/how-to-publish-on-gov-uk/unpublishing-and-archiving)
       flashes:
         requirements: You need to
+        publishing_api_error:
+          title: Something has gone wrong
+          description_govspeak: Something went wrong when withdrawing this document. Please try again or [raise a support request](https://support.publishing.service.gov.uk/technical_fault_report/new).

--- a/config/locales/en/withdraw/withdraw.yml
+++ b/config/locales/en/withdraw/withdraw.yml
@@ -14,3 +14,9 @@ en:
         publishing_api_error:
           title: Something has gone wrong
           description_govspeak: Something went wrong when withdrawing this document. Please try again or [raise a support request](https://support.publishing.service.gov.uk/technical_fault_report/new).
+    no_managing_editor_permission:
+      title: Only a managing editor can remove or withdraw a live page
+      content: |
+        If you think this content is not relevant anymore or that it shouldn’t be on GOV.UK, speak to the managing editor for your organisation.
+
+        Read the [full guidance on removing (unpublishing) and withdrawing content](https://www.gov.uk/guidance/how-to-publish-on-gov-uk/unpublishing-and-archiving)).

--- a/config/locales/en/withdraw/withdraw.yml
+++ b/config/locales/en/withdraw/withdraw.yml
@@ -9,3 +9,5 @@ en:
         Withdrawn content stays online but a banner tells users it is no longer current government information.
 
         [Full guidance on withdrawing content](https://www.gov.uk/guidance/how-to-publish-on-gov-uk/unpublishing-and-archiving)
+      flashes:
+        requirements: You need to

--- a/config/locales/en/withdraw/withdraw.yml
+++ b/config/locales/en/withdraw/withdraw.yml
@@ -4,6 +4,7 @@ en:
       title: "Withdraw '%{title}'"
       public_explanation:
         title: "Public explanation"
+        guidance_title: Writing public explanation
       intro_paragraph: |
         Withdrawn content stays online but a banner tells users it is no longer current government information.
 

--- a/config/locales/en/withdraw/withdraw.yml
+++ b/config/locales/en/withdraw/withdraw.yml
@@ -1,0 +1,4 @@
+en:
+  withdraw:
+    new:
+      title: "Withdraw '%{title}'"

--- a/config/locales/en/withdraw/withdraw.yml
+++ b/config/locales/en/withdraw/withdraw.yml
@@ -2,3 +2,9 @@ en:
   withdraw:
     new:
       title: "Withdraw '%{title}'"
+      public_explanation:
+        title: "Public explanation"
+      intro_paragraph: |
+        Withdrawn content stays online but a banner tells users it is no longer current government information.
+
+        [Full guidance on withdrawing content](https://www.gov.uk/guidance/how-to-publish-on-gov-uk/unpublishing-and-archiving)

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -38,6 +38,8 @@ Rails.application.routes.draw do
 
   get "/documents/:id/withdraw" => "withdraw#new", as: :withdraw
   post "/documents/:id/withdraw" => "withdraw#create"
+  get "/documents/:id/unwithdraw" => "unwithdraw#index", as: :unwithdraw
+
   get "/documents/:id/remove" => "unpublish#remove", as: :remove
 
   get "/documents/:document_id/images" => "images#index", as: :images

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -37,6 +37,7 @@ Rails.application.routes.draw do
   post "/documents/:id/create-preview" => "preview#create", as: :create_preview
 
   get "/documents/:id/withdraw" => "withdraw#new", as: :withdraw
+  post "/documents/:id/withdraw" => "withdraw#create"
   get "/documents/:id/remove" => "unpublish#remove", as: :remove
 
   get "/documents/:document_id/images" => "images#index", as: :images

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -36,7 +36,7 @@ Rails.application.routes.draw do
   get "/documents/:id/preview" => "preview#show", as: :preview_document
   post "/documents/:id/create-preview" => "preview#create", as: :create_preview
 
-  get "/documents/:id/withdraw" => "unpublish#withdraw", as: :withdraw
+  get "/documents/:id/withdraw" => "withdraw#new", as: :withdraw
   get "/documents/:id/remove" => "unpublish#remove", as: :remove
 
   get "/documents/:document_id/images" => "images#index", as: :images

--- a/db/migrate/20190130100821_rename_withdrawal_explanatory_note_to_public_explanation.rb
+++ b/db/migrate/20190130100821_rename_withdrawal_explanatory_note_to_public_explanation.rb
@@ -1,0 +1,8 @@
+# frozen_string_literal: true
+
+class RenameWithdrawalExplanatoryNoteToPublicExplanation < ActiveRecord::Migration[5.2]
+  def change
+    rename_column :withdrawals, :explanatory_note, :public_explanation
+    change_column_null :withdrawals, :public_explanation, false
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2019_01_25_181528) do
+ActiveRecord::Schema.define(version: 2019_01_30_100821) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -253,7 +253,7 @@ ActiveRecord::Schema.define(version: 2019_01_25_181528) do
   end
 
   create_table "withdrawals", force: :cascade do |t|
-    t.string "explanatory_note"
+    t.string "public_explanation", null: false
     t.datetime "created_at", null: false
   end
 

--- a/lib/tasks/unpublish.rake
+++ b/lib/tasks/unpublish.rake
@@ -6,13 +6,13 @@ namespace :unpublish do
     raise "Missing content_id parameter" unless args.content_id
     raise "Missing NOTE value" if ENV["NOTE"].blank?
 
-    explanatory_note = ENV["NOTE"]
+    public_explanation = ENV["NOTE"]
     locale = ENV["LOCALE"] || "en"
 
     document = Document.find_by!(content_id: args.content_id, locale: locale)
     raise "Document must have a published version before it can be withdrawn" unless document.live_edition
 
-    UnpublishService.new.withdraw(document.live_edition, explanatory_note)
+    UnpublishService.new.withdraw(document.live_edition, public_explanation)
   end
 
   desc "Remove a document from GOV.UK e.g. unpublish:remove['a-content-id']"

--- a/spec/factories/edition_factory.rb
+++ b/spec/factories/edition_factory.rb
@@ -87,5 +87,21 @@ FactoryBot.define do
         )
       end
     end
+
+    trait :withdrawn do
+      summary { SecureRandom.alphanumeric(10) }
+      live { true }
+
+      after(:build) do |edition, evaluator|
+        edition.revision = evaluator.association(:revision)
+        edition.status = evaluator.association(
+          :status,
+          :withdrawn,
+          created_by: edition.created_by,
+          state: :withdrawn,
+          revision_at_creation: edition.revision,
+        )
+      end
+    end
   end
 end

--- a/spec/factories/status_factory.rb
+++ b/spec/factories/status_factory.rb
@@ -6,4 +6,9 @@ FactoryBot.define do
     association :created_by, factory: :user
     association :revision_at_creation, factory: :revision
   end
+
+  trait :withdrawn do
+    state { :withdrawn }
+    association :details, factory: :withdrawal
+  end
 end

--- a/spec/factories/status_factory.rb
+++ b/spec/factories/status_factory.rb
@@ -5,6 +5,11 @@ FactoryBot.define do
     state { :draft }
     association :created_by, factory: :user
     association :revision_at_creation, factory: :revision
+
+    trait :withdrawn do
+      state { :withdrawn }
+      association :details, factory: :withdrawal
+    end
   end
 
   trait :withdrawn do

--- a/spec/factories/withdrawal_factory.rb
+++ b/spec/factories/withdrawal_factory.rb
@@ -2,6 +2,6 @@
 
 FactoryBot.define do
   factory :withdrawal do
-    explanatory_note { SecureRandom.alphanumeric }
+    public_explanation { SecureRandom.alphanumeric }
   end
 end

--- a/spec/features/workflow/edit_withdrawal_spec.rb
+++ b/spec/features/workflow/edit_withdrawal_spec.rb
@@ -3,6 +3,7 @@
 RSpec.feature "Edit a withdrawal" do
   scenario do
     given_there_is_a_withdrawn_edition
+    and_i_have_the_managing_editor_permission
     when_i_visit_the_summary_page
     and_i_click_to_change_the_public_explanation
     then_i_can_see_the_existing_public_explanation
@@ -11,6 +12,12 @@ RSpec.feature "Edit a withdrawal" do
 
   def given_there_is_a_withdrawn_edition
     @edition = create(:edition, :withdrawn)
+  end
+
+  def and_i_have_the_managing_editor_permission
+    user = User.first
+    user.update_attribute(:permissions,
+                          user.permissions + [User::MANAGING_EDITOR_PERMISSION])
   end
 
   def when_i_visit_the_summary_page

--- a/spec/features/workflow/edit_withdrawal_spec.rb
+++ b/spec/features/workflow/edit_withdrawal_spec.rb
@@ -1,0 +1,39 @@
+# frozen_string_literal: true
+
+RSpec.feature "Edit a withdrawal" do
+  scenario do
+    given_there_is_a_withdrawn_edition
+    when_i_visit_the_summary_page
+    and_i_click_to_change_the_public_explanation
+    then_i_can_see_the_existing_public_explanation
+    and_i_can_edit_the_public_explanation
+  end
+
+  def given_there_is_a_withdrawn_edition
+    @edition = create(:edition, :withdrawn)
+  end
+
+  def when_i_visit_the_summary_page
+    visit document_path(@edition.document)
+  end
+
+  def and_i_click_to_change_the_public_explanation
+    click_on "Change public explanation"
+  end
+
+  def then_i_can_see_the_existing_public_explanation
+    expect(page).to have_field("public_explanation", with: @edition.status.details.public_explanation)
+  end
+
+  def and_i_can_edit_the_public_explanation
+    new_explanation = "Another explanation"
+    converted_explanation = GovspeakDocument.new(new_explanation).to_html
+    body = { type: "withdrawal", explanation: converted_explanation, locale: @edition.locale }
+    stub_publishing_api_unpublish(@edition.content_id, body: body)
+
+    fill_in "public_explanation", with: new_explanation
+    click_on "Withdraw document"
+
+    expect(@edition.reload.status.details.public_explanation).to eq(new_explanation)
+  end
+end

--- a/spec/features/workflow/unwithdraw_spec.rb
+++ b/spec/features/workflow/unwithdraw_spec.rb
@@ -1,0 +1,26 @@
+# frozen_string_literal: true
+
+RSpec.feature "Unwithdraw a document" do
+  scenario do
+    given_there_is_a_withdrawn_document
+    when_i_visit_the_summary_page
+    and_i_click_on_undo_withdraw
+    then_i_see_the_feature_is_currently_unavailable
+  end
+
+  def given_there_is_a_withdrawn_document
+    @edition = create(:edition, :withdrawn)
+  end
+
+  def when_i_visit_the_summary_page
+    visit document_path(@edition.document)
+  end
+
+  def and_i_click_on_undo_withdraw
+    click_on "Undo withdrawal"
+  end
+
+  def then_i_see_the_feature_is_currently_unavailable
+    expect(page).to have_content("Sorry, this hasn't been built yet")
+  end
+end

--- a/spec/features/workflow/withdraw_publishing_api_down_spec.rb
+++ b/spec/features/workflow/withdraw_publishing_api_down_spec.rb
@@ -3,6 +3,7 @@
 RSpec.feature "Withdraw a document when Publishing API is down" do
   scenario do
     given_there_is_a_published_edition
+    and_i_have_the_managing_editor_permission
     when_i_visit_the_withdraw_document_page
     and_the_publishing_api_is_down
     when_i_fill_in_the_public_explanation
@@ -13,6 +14,12 @@ RSpec.feature "Withdraw a document when Publishing API is down" do
 
   def given_there_is_a_published_edition
     @edition = create(:edition, :published)
+  end
+
+  def and_i_have_the_managing_editor_permission
+    user = User.first
+    user.update_attribute(:permissions,
+                          user.permissions + [User::MANAGING_EDITOR_PERMISSION])
   end
 
   def when_i_visit_the_withdraw_document_page

--- a/spec/features/workflow/withdraw_publishing_api_down_spec.rb
+++ b/spec/features/workflow/withdraw_publishing_api_down_spec.rb
@@ -1,0 +1,43 @@
+# frozen_string_literal: true
+
+RSpec.feature "Withdraw a document when Publishing API is down" do
+  scenario do
+    given_there_is_a_published_edition
+    when_i_visit_the_withdraw_document_page
+    and_the_publishing_api_is_down
+    when_i_fill_in_the_public_explanation
+    and_click_on_withdraw_document
+    then_i_see_a_withdrawal_error_message
+    and_the_document_has_not_been_withdrawn
+  end
+
+  def given_there_is_a_published_edition
+    @edition = create(:edition, :published)
+  end
+
+  def when_i_visit_the_withdraw_document_page
+    visit withdraw_path(@edition.document)
+  end
+
+  def and_the_publishing_api_is_down
+    publishing_api_isnt_available
+  end
+
+  def when_i_fill_in_the_public_explanation
+    fill_in "public_explanation", with: "An explanation"
+  end
+
+  def and_click_on_withdraw_document
+    click_on "Withdraw document"
+  end
+
+  def then_i_see_a_withdrawal_error_message
+    expect(page).to have_content(I18n.t!("withdraw.new.flashes.publishing_api_error.title"))
+  end
+
+  def and_the_document_has_not_been_withdrawn
+    expect(Withdrawal.count).to eq(0)
+    expect(TimelineEntry.count).to eq(0)
+    expect(@edition.state).not_to eq("withdrawn")
+  end
+end

--- a/spec/features/workflow/withdraw_publishing_api_down_spec.rb
+++ b/spec/features/workflow/withdraw_publishing_api_down_spec.rb
@@ -43,8 +43,7 @@ RSpec.feature "Withdraw a document when Publishing API is down" do
   end
 
   def and_the_document_has_not_been_withdrawn
-    expect(Withdrawal.count).to eq(0)
-    expect(TimelineEntry.count).to eq(0)
+    @edition.reload
     expect(@edition.state).not_to eq("withdrawn")
   end
 end

--- a/spec/features/workflow/withdraw_requirements_spec.rb
+++ b/spec/features/workflow/withdraw_requirements_spec.rb
@@ -1,0 +1,28 @@
+# frozen_string_literal: true
+
+RSpec.feature "Withdrawal document requirements" do
+  scenario do
+    given_there_is_a_published_edition
+    when_i_visit_the_document_withdrawal_page
+    and_i_click_withdraw_document
+    then_i_see_an_error_to_enter_an_public_explanation
+  end
+
+  def given_there_is_a_published_edition
+    @edition = create(:edition, :published)
+  end
+
+  def when_i_visit_the_document_withdrawal_page
+    visit withdraw_path(@edition.document)
+  end
+
+  def and_i_click_withdraw_document
+    click_on "Withdraw document"
+  end
+
+  def then_i_see_an_error_to_enter_an_public_explanation
+    within(".gem-c-error-summary") do
+      expect(page).to have_content(I18n.t!("requirements.public_explanation.blank.form_message"))
+    end
+  end
+end

--- a/spec/features/workflow/withdraw_requirements_spec.rb
+++ b/spec/features/workflow/withdraw_requirements_spec.rb
@@ -3,6 +3,7 @@
 RSpec.feature "Withdrawal document requirements" do
   scenario do
     given_there_is_a_published_edition
+    and_i_have_the_managing_editor_permission
     when_i_visit_the_document_withdrawal_page
     and_i_click_withdraw_document
     then_i_see_an_error_to_enter_an_public_explanation
@@ -10,6 +11,12 @@ RSpec.feature "Withdrawal document requirements" do
 
   def given_there_is_a_published_edition
     @edition = create(:edition, :published)
+  end
+
+  def and_i_have_the_managing_editor_permission
+    user = User.first
+    user.update_attribute(:permissions,
+                          user.permissions + [User::MANAGING_EDITOR_PERMISSION])
   end
 
   def when_i_visit_the_document_withdrawal_page

--- a/spec/features/workflow/withdraw_spec.rb
+++ b/spec/features/workflow/withdraw_spec.rb
@@ -3,6 +3,7 @@
 RSpec.feature "Withdraw a document" do
   scenario do
     given_there_is_a_published_edition
+    and_i_have_the_managing_editor_permission
     when_i_visit_the_summary_page
     and_i_click_on_withdraw
     then_i_see_that_i_can_withdraw_the_document
@@ -17,6 +18,12 @@ RSpec.feature "Withdraw a document" do
 
   def when_i_visit_the_summary_page
     visit document_path(@edition.document)
+  end
+
+  def and_i_have_the_managing_editor_permission
+    user = User.first
+    user.update_attribute(:permissions,
+                          user.permissions + [User::MANAGING_EDITOR_PERMISSION])
   end
 
   def and_i_click_on_withdraw

--- a/spec/features/workflow/withdraw_spec.rb
+++ b/spec/features/workflow/withdraw_spec.rb
@@ -33,7 +33,8 @@ RSpec.feature "Withdraw a document" do
   end
 
   def and_click_on_withdraw_document
-    body = { type: "withdrawal", explanation: @explanation, locale: @edition.locale }
+    converted_explanation = GovspeakDocument.new(@explanation).to_html
+    body = { type: "withdrawal", explanation: converted_explanation, locale: @edition.locale }
     stub_publishing_api_unpublish(@edition.content_id, body: body)
     click_on "Withdraw document"
   end

--- a/spec/features/workflow/withdraw_spec.rb
+++ b/spec/features/workflow/withdraw_spec.rb
@@ -1,0 +1,26 @@
+# frozen_string_literal: true
+
+RSpec.feature "Withdraw a document" do
+  scenario do
+    given_there_is_a_published_edition
+    when_i_visit_the_summary_page
+    and_i_click_on_withdraw
+    then_i_see_that_i_can_withdraw_the_document
+  end
+
+  def given_there_is_a_published_edition
+    @edition = create(:edition, :published)
+  end
+
+  def when_i_visit_the_summary_page
+    visit document_path(@edition.document)
+  end
+
+  def and_i_click_on_withdraw
+    click_on "Withdraw"
+  end
+
+  def then_i_see_that_i_can_withdraw_the_document
+    expect(page).to have_content "Withdraw '#{@edition.title}'"
+  end
+end

--- a/spec/features/workflow/withdraw_spec.rb
+++ b/spec/features/workflow/withdraw_spec.rb
@@ -41,6 +41,13 @@ RSpec.feature "Withdraw a document" do
   end
 
   def then_i_see_the_document_has_been_withdrawn
+    withdrawal = Withdrawal.last
+    document_type = @edition.document.document_type.label.downcase
+
     expect(page).to have_content(I18n.t!("user_facing_states.withdrawn.name"))
+    expect(page).to have_content(I18n.t!("documents.show.withdrawn.title",
+                                         document_type: document_type,
+                                         withdrawn_date: withdrawal.created_at.strftime("%d %B %Y")))
+    expect(page).to have_content(@explanation)
   end
 end

--- a/spec/features/workflow/withdraw_spec.rb
+++ b/spec/features/workflow/withdraw_spec.rb
@@ -30,6 +30,7 @@ RSpec.feature "Withdraw a document" do
   def when_i_fill_in_the_public_explanation
     @explanation = "An explanation using [markdown](https://www.gov.uk)"
     fill_in "public_explanation", with: @explanation
+    expect(page).to have_content(I18n.t!("withdraw.new.public_explanation.guidance_title"))
   end
 
   def and_click_on_withdraw_document

--- a/spec/features/workflow/withdraw_spec.rb
+++ b/spec/features/workflow/withdraw_spec.rb
@@ -6,6 +6,9 @@ RSpec.feature "Withdraw a document" do
     when_i_visit_the_summary_page
     and_i_click_on_withdraw
     then_i_see_that_i_can_withdraw_the_document
+    when_i_fill_in_the_public_explanation
+    and_click_on_withdraw_document
+    then_i_see_the_document_has_been_withdrawn
   end
 
   def given_there_is_a_published_edition
@@ -22,5 +25,20 @@ RSpec.feature "Withdraw a document" do
 
   def then_i_see_that_i_can_withdraw_the_document
     expect(page).to have_content "Withdraw '#{@edition.title}'"
+  end
+
+  def when_i_fill_in_the_public_explanation
+    @explanation = "An explanation using [markdown](https://www.gov.uk)"
+    fill_in "public_explanation", with: @explanation
+  end
+
+  def and_click_on_withdraw_document
+    body = { type: "withdrawal", explanation: @explanation, locale: @edition.locale }
+    stub_publishing_api_unpublish(@edition.content_id, body: body)
+    click_on "Withdraw document"
+  end
+
+  def then_i_see_the_document_has_been_withdrawn
+    expect(page).to have_content(I18n.t!("user_facing_states.withdrawn.name"))
   end
 end

--- a/spec/features/workflow/withdraw_spec.rb
+++ b/spec/features/workflow/withdraw_spec.rb
@@ -41,7 +41,8 @@ RSpec.feature "Withdraw a document" do
   end
 
   def then_i_see_the_document_has_been_withdrawn
-    withdrawal = Withdrawal.last
+    status = @edition.reload.status
+    withdrawal = status.details
     document_type = @edition.document.document_type.label.downcase
 
     expect(page).to have_content(I18n.t!("user_facing_states.withdrawn.name"))
@@ -49,5 +50,6 @@ RSpec.feature "Withdraw a document" do
                                          document_type: document_type,
                                          withdrawn_date: withdrawal.created_at.strftime("%d %B %Y")))
     expect(page).to have_content(@explanation)
+    expect(page).to have_content(I18n.t!("documents.show.metadata.withdrawn_by") + ": #{status.created_by.name}")
   end
 end

--- a/spec/features/workflow/withdraw_without_managing_editor_permission_spec.rb
+++ b/spec/features/workflow/withdraw_without_managing_editor_permission_spec.rb
@@ -1,0 +1,58 @@
+# frozen_string_literal: true
+
+RSpec.feature "Withdraw without managing editor permission" do
+  background do
+    given_i_dont_have_the_managing_editor_permission
+  end
+
+  scenario "published edition" do
+    when_there_is_a_published_edition
+    and_i_visit_the_summary_page
+    and_i_click_on_withdraw
+    then_i_see_a_message_to_ask_my_managing_editor_to_withdraw_content
+  end
+
+  scenario "withdrawn edition" do
+    when_there_is_a_withdrawn_edition
+    and_i_visit_the_withdrawn_document_summary_page
+    and_i_click_on_change_public_explanation
+    then_i_see_a_message_to_ask_my_managing_editor_to_withdraw_content
+  end
+
+  def when_there_is_a_published_edition
+    @edition = create(:edition, :published)
+  end
+
+  def given_i_dont_have_the_managing_editor_permission
+    user = User.first
+    user.update_attribute(:permissions,
+                          user.permissions - [User::MANAGING_EDITOR_PERMISSION])
+  end
+
+  def and_i_visit_the_summary_page
+    visit document_path(@edition.document)
+  end
+
+  def and_i_click_on_withdraw
+    click_on "Withdraw"
+  end
+
+  def then_i_see_a_message_to_ask_my_managing_editor_to_withdraw_content
+    expect(page).to have_content(
+      I18n.t!("withdraw.no_managing_editor_permission.title"),
+    )
+  end
+
+  def when_there_is_a_withdrawn_edition
+    @withdrawn_edition = create(:edition, :withdrawn)
+    create(:timeline_entry, entry_type: :withdrawn, details: @withdrawn_edition.status.details)
+  end
+
+  def and_i_visit_the_withdrawn_document_summary_page
+    visit document_path(@withdrawn_edition.document)
+  end
+
+  def and_i_click_on_change_public_explanation
+    click_on "Change public explanation"
+  end
+end

--- a/spec/services/requirements/withdrawal_checker_spec.rb
+++ b/spec/services/requirements/withdrawal_checker_spec.rb
@@ -1,0 +1,18 @@
+# frozen_string_literal: true
+
+RSpec.describe Requirements::WithdrawalChecker do
+  describe "#pre_withdrawal_issues" do
+    it "returns no issues if there are none" do
+      public_explanation = SecureRandom.alphanumeric
+      issues = Requirements::WithdrawalChecker.new(public_explanation).pre_withdrawal_issues
+      expect(issues.items).to be_empty
+    end
+
+    it "returns an issue if there is no public explanation" do
+      issues = Requirements::WithdrawalChecker.new(nil).pre_withdrawal_issues
+
+      message = issues.items_for(:public_explanation).first[:text]
+      expect(message).to eq(I18n.t!("requirements.public_explanation.blank.form_message"))
+    end
+  end
+end

--- a/spec/services/unpublish_service_spec.rb
+++ b/spec/services/unpublish_service_spec.rb
@@ -8,6 +8,7 @@ RSpec.describe UnpublishService do
   let(:image_revision) do
     create(:image_revision, :on_asset_manager, state: :live)
   end
+  let(:user) { create(:user) }
 
   before { stub_any_publishing_api_unpublish }
 
@@ -20,26 +21,26 @@ RSpec.describe UnpublishService do
                                               body: { type: "withdrawal",
                                                       explanation: converted_public_explanation,
                                                       locale: edition.locale })
-      UnpublishService.new.withdraw(edition, public_explanation)
+      UnpublishService.new.withdraw(edition, public_explanation, user)
 
       expect(request).to have_been_requested
     end
 
     it "does not delete assets for withdrawn editions" do
       delete_request = stub_asset_manager_deletes_any_asset
-      UnpublishService.new.withdraw(edition_with_image, public_explanation)
+      UnpublishService.new.withdraw(edition_with_image, public_explanation, user)
 
       expect(delete_request).not_to have_been_requested
     end
 
     it "adds an entry in the timeline of the document" do
-      UnpublishService.new.withdraw(edition, public_explanation)
+      UnpublishService.new.withdraw(edition, public_explanation, user)
 
       expect(edition.timeline_entries.first.entry_type).to eq("withdrawn")
     end
 
     it "updates the edition status" do
-      UnpublishService.new.withdraw(edition, public_explanation)
+      UnpublishService.new.withdraw(edition, public_explanation, user)
       edition.reload
 
       expect(edition.status).to be_withdrawn
@@ -49,7 +50,7 @@ RSpec.describe UnpublishService do
     context "when the given edition is a draft" do
       it "raises an error" do
         draft_edition = create(:edition)
-        expect { UnpublishService.new.withdraw(draft_edition, public_explanation) }
+        expect { UnpublishService.new.withdraw(draft_edition, public_explanation, user) }
           .to raise_error RuntimeError, "attempted to unpublish an edition other than the live edition"
       end
     end
@@ -62,7 +63,7 @@ RSpec.describe UnpublishService do
                               current: false,
                               document: draft_edition.document)
 
-        expect { UnpublishService.new.withdraw(live_edition, public_explanation) }
+        expect { UnpublishService.new.withdraw(live_edition, public_explanation, user) }
           .to raise_error RuntimeError, "Publishing API does not support unpublishing while there is a draft"
       end
     end

--- a/spec/services/unpublish_service_spec.rb
+++ b/spec/services/unpublish_service_spec.rb
@@ -12,43 +12,43 @@ RSpec.describe UnpublishService do
   before { stub_any_publishing_api_unpublish }
 
   describe "#withdraw" do
-    let(:explanatory_note) { "The document is out of date" }
+    let(:public_explanation) { "The document is out of date" }
 
-    it "withdraws an edition in publishing-api with an explanatory note" do
+    it "withdraws an edition in publishing-api with a public explanation" do
       request = stub_publishing_api_unpublish(edition.content_id,
                                               body: { type: "withdrawal",
-                                                      explanation: explanatory_note,
+                                                      explanation: public_explanation,
                                                       locale: edition.locale })
-      UnpublishService.new.withdraw(edition, explanatory_note)
+      UnpublishService.new.withdraw(edition, public_explanation)
 
       expect(request).to have_been_requested
     end
 
     it "does not delete assets for withdrawn editions" do
       delete_request = stub_asset_manager_deletes_any_asset
-      UnpublishService.new.withdraw(edition_with_image, explanatory_note)
+      UnpublishService.new.withdraw(edition_with_image, public_explanation)
 
       expect(delete_request).not_to have_been_requested
     end
 
     it "adds an entry in the timeline of the document" do
-      UnpublishService.new.withdraw(edition, explanatory_note)
+      UnpublishService.new.withdraw(edition, public_explanation)
 
       expect(edition.timeline_entries.first.entry_type).to eq("withdrawn")
     end
 
     it "updates the edition status" do
-      UnpublishService.new.withdraw(edition, explanatory_note)
+      UnpublishService.new.withdraw(edition, public_explanation)
       edition.reload
 
       expect(edition.status).to be_withdrawn
-      expect(edition.status.details.explanatory_note).to eq(explanatory_note)
+      expect(edition.status.details.public_explanation).to eq(public_explanation)
     end
 
     context "when the given edition is a draft" do
       it "raises an error" do
         draft_edition = create(:edition)
-        expect { UnpublishService.new.withdraw(draft_edition, explanatory_note) }
+        expect { UnpublishService.new.withdraw(draft_edition, public_explanation) }
           .to raise_error RuntimeError, "attempted to unpublish an edition other than the live edition"
       end
     end
@@ -61,7 +61,7 @@ RSpec.describe UnpublishService do
                               current: false,
                               document: draft_edition.document)
 
-        expect { UnpublishService.new.withdraw(live_edition, explanatory_note) }
+        expect { UnpublishService.new.withdraw(live_edition, public_explanation) }
           .to raise_error RuntimeError, "Publishing API does not support unpublishing while there is a draft"
       end
     end

--- a/spec/services/unpublish_service_spec.rb
+++ b/spec/services/unpublish_service_spec.rb
@@ -12,12 +12,13 @@ RSpec.describe UnpublishService do
   before { stub_any_publishing_api_unpublish }
 
   describe "#withdraw" do
-    let(:public_explanation) { "The document is out of date" }
+    let(:public_explanation) { "The document is [out of date](https://www.gov.uk)" }
 
-    it "withdraws an edition in publishing-api with a public explanation" do
+    it "converts the public explanation Govspeak to HTML before sending to Publishing API" do
+      converted_public_explanation = GovspeakDocument.new(public_explanation).to_html
       request = stub_publishing_api_unpublish(edition.content_id,
                                               body: { type: "withdrawal",
-                                                      explanation: public_explanation,
+                                                      explanation: converted_public_explanation,
                                                       locale: edition.locale })
       UnpublishService.new.withdraw(edition, public_explanation)
 

--- a/spec/tasks/unpublish_rake_spec.rb
+++ b/spec/tasks/unpublish_rake_spec.rb
@@ -9,12 +9,12 @@ RSpec.describe "Unpublish rake tasks" do
     end
 
     it "runs the task to withdraw an edition" do
-      explanatory_note = "The reason the document is being withdrawn"
+      public_explanation = "The reason the document is being withdrawn"
 
       expect_any_instance_of(UnpublishService)
-        .to receive(:withdraw).with(edition, explanatory_note)
+        .to receive(:withdraw).with(edition, public_explanation)
 
-      ClimateControl.modify NOTE: explanatory_note do
+      ClimateControl.modify NOTE: public_explanation do
         Rake::Task["unpublish:withdraw"].invoke(edition.content_id)
       end
     end
@@ -31,9 +31,9 @@ RSpec.describe "Unpublish rake tasks" do
 
     it "raises an error if the document does not have a live version on GOV.uk" do
       draft = create(:edition, locale: "en")
-      explanatory_note = "The reason the document is being withdrawn"
+      public_explanation = "The reason the document is being withdrawn"
 
-      ClimateControl.modify NOTE: explanatory_note do
+      ClimateControl.modify NOTE: public_explanation do
         expect { Rake::Task["unpublish:withdraw"].invoke(draft.content_id) }
           .to raise_error("Document must have a published version before it can be withdrawn")
       end


### PR DESCRIPTION
For https://trello.com/c/GGxgDv3W/533-add-form-to-let-users-retire-a-document

- This adds a frontend interface so that users with managing editor permissions can withdraw a document.  
> <img width="1019" alt="withdraw_public_explanation_guidance_screen" src="https://user-images.githubusercontent.com/13434452/51679158-0cd10c80-1fd6-11e9-966b-471534a187d0.png">

- Users must enter a public explanation, otherwise an error will be displayed. The public explanation can contain markdown, which is converted to HTML before being sent to the Publishing API.
> <img width="1073" alt="withdraw_blank_public_explanation_screen" src="https://user-images.githubusercontent.com/13434452/51679181-1a869200-1fd6-11e9-9049-5b85f598dbe4.png">

- We display an error if the Publishing API is down when the user is trying to withdraw a document or update the public explanation
> <img width="1003" alt="publishing_api_down" src="https://user-images.githubusercontent.com/13434452/51679323-8b2dae80-1fd6-11e9-9c3c-52bc48b56638.png">

- Users without managing editor permissions will see a screen directing them to speak to their managing editor
> <img width="666" alt="no_managing_editor_permissions" src="https://user-images.githubusercontent.com/13434452/51679288-6a655900-1fd6-11e9-8870-7f3403279357.png">

- After a document has been withdrawn, a notice is displayed on the document page with the time the document was withdrawn, who withdrew it, and the public explanation.  We also display a link to change the public explanation
> <img width="1015" alt="withdrawn_document_screen" src="https://user-images.githubusercontent.com/13434452/51679460-f11a3600-1fd6-11e9-8904-459b66e01961.png">

- Clicking on the "Undo withdrawal" button takes users to a screen explaining that the feature hasn't been built yet
> <img width="639" alt="unwithdraw" src="https://user-images.githubusercontent.com/13434452/51679703-86b5c580-1fd7-11e9-9895-0e1fd12474e2.png">
