### PR TITLE
Remove old draft assets from Asset Manager when they are no longer used

### DIFF
--- a/app/controllers/images_controller.rb
+++ b/app/controllers/images_controller.rb
@@ -82,8 +82,6 @@ class ImagesController < ApplicationController
           edition: current_edition,
         )
 
-        # TODO remove old images from asset manager
-
         PreviewService.new(document.current_edition).try_create_preview
       end
 
@@ -190,8 +188,6 @@ class ImagesController < ApplicationController
         entry_type: lead ? :lead_image_removed : :image_removed,
         edition: current_edition,
       )
-
-      # TODO remove images from asset manager
 
       PreviewService.new(current_edition).try_create_preview
 

--- a/app/services/draft_asset_cleanup_service.rb
+++ b/app/services/draft_asset_cleanup_service.rb
@@ -1,0 +1,31 @@
+# frozen_string_literal: true
+
+class DraftAssetCleanupService
+  def call(edition)
+    current_revision = edition.revision
+    previous_revision = current_revision.preceded_by
+
+    return unless previous_revision
+
+    current_assets = current_revision.image_revisions.flat_map(&:assets)
+    previous_assets = previous_revision.image_revisions.flat_map(&:assets)
+
+    delete_assets(previous_assets - current_assets)
+  end
+
+private
+
+  def delete_assets(assets)
+    assets.each do |asset|
+      next unless asset.draft?
+
+      begin
+        AssetManagerService.new.delete(asset)
+      rescue GdsApi::HTTPNotFound
+        Rails.logger.warn("No asset to delete for id #{asset.asset_manager_id}")
+      end
+
+      asset.absent!
+    end
+  end
+end

--- a/spec/features/editing_images/delete_image_spec.rb
+++ b/spec/features/editing_images/delete_image_spec.rb
@@ -22,7 +22,9 @@ RSpec.feature "Delete an image" do
   end
 
   def and_i_delete_the_non_lead_image
-    @request = stub_publishing_api_put_content(@edition.content_id, {})
+    @put_content_request = stub_publishing_api_put_content(@edition.content_id, {})
+    @delete_asset_request = stub_asset_manager_deletes_any_asset
+
     click_on "Delete image"
   end
 
@@ -35,7 +37,8 @@ RSpec.feature "Delete an image" do
   end
 
   def and_the_preview_creation_succeeded
-    expect(@request).to have_been_requested
+    expect(@put_content_request).to have_been_requested
+    expect(@delete_asset_request).to have_been_requested.at_least_once
     expect(page).to have_content(I18n.t!("user_facing_states.draft.name"))
   end
 end

--- a/spec/features/editing_images/delete_lead_image_spec.rb
+++ b/spec/features/editing_images/delete_lead_image_spec.rb
@@ -22,7 +22,8 @@ RSpec.feature "Delete an image" do
   end
 
   def when_i_delete_the_lead_image
-    @request = stub_publishing_api_put_content(@edition.content_id, {})
+    @put_content_request = stub_publishing_api_put_content(@edition.content_id, {})
+    @delete_asset_request = stub_asset_manager_deletes_any_asset
     click_on "Delete lead image"
   end
 
@@ -33,7 +34,8 @@ RSpec.feature "Delete an image" do
   end
 
   def and_the_preview_creation_succeeded
-    expect(@request).to have_been_requested
+    expect(@put_content_request).to have_been_requested
+    expect(@delete_asset_request).to have_been_requested.at_least_once
     expect(page).to have_content(I18n.t!("user_facing_states.draft.name"))
 
     expect(a_request(:put, /content/).with { |req|

--- a/spec/features/editing_images/edit_image_crop_spec.rb
+++ b/spec/features/editing_images/edit_image_crop_spec.rb
@@ -38,7 +38,8 @@ RSpec.feature "Edit image crop", js: true do
     bottom_right_handle.drag_to(find(".govuk-heading-l"))
 
     @publishing_api_request = stub_any_publishing_api_put_content
-    @asset_manager_requests = stub_asset_manager_receives_an_asset
+    @new_asset_requests = stub_asset_manager_receives_an_asset
+    @old_asset_requests = stub_asset_manager_deletes_any_asset
 
     click_on "Crop image"
   end
@@ -55,7 +56,8 @@ RSpec.feature "Edit image crop", js: true do
 
   def and_the_preview_creation_succeeded
     expect(@publishing_api_request).to have_been_requested
-    expect(@asset_manager_requests).to have_been_requested.at_least_once
+    expect(@new_asset_requests).to have_been_requested.at_least_once
+    expect(@old_asset_requests).to have_been_requested.at_least_once
 
     expect(a_request(:put, /content/).with { |req|
       expect(JSON.parse(req.body)["details"].keys).to_not include("image")

--- a/spec/services/draft_asset_cleanup_service_spec.rb
+++ b/spec/services/draft_asset_cleanup_service_spec.rb
@@ -1,0 +1,80 @@
+# frozen_string_literal: true
+
+RSpec.describe DraftAssetCleanupService do
+  describe "#call" do
+    context "when the previous revision has draft assets that aren't used" do
+      it "deletes the assets that aren't used" do
+        image_revision = create(:image_revision, :on_asset_manager, state: :draft)
+        preceding_revision = create(:revision, image_revisions: [image_revision])
+        current_revision = create(:revision, preceded_by: preceding_revision)
+        edition = create(:edition, revision: current_revision)
+
+        request = stub_asset_manager_deletes_any_asset
+
+        DraftAssetCleanupService.new.call(edition)
+
+        expect(request).to have_been_requested.at_least_once
+        expect(image_revision.assets.map(&:state).uniq).to match(%w[absent])
+      end
+    end
+
+    context "when the previous revision has assets that are used on the current revision" do
+      it "doesn't change the assets" do
+        image_revision = create(:image_revision, :on_asset_manager, state: :draft)
+        preceding_revision = create(:revision, image_revisions: [image_revision])
+        current_revision = create(:revision,
+                                  image_revisions: [image_revision],
+                                  preceded_by: preceding_revision)
+        edition = create(:edition, revision: current_revision)
+
+        request = stub_asset_manager_deletes_any_asset
+
+        DraftAssetCleanupService.new.call(edition)
+
+        expect(request).not_to have_been_requested
+        expect(image_revision.assets.map(&:state).uniq).to match(%w[draft])
+      end
+    end
+
+    context "when the previous revision has assets that are live" do
+      it "doesn't change the assets" do
+        image_revision = create(:image_revision, :on_asset_manager, state: :live)
+        preceding_revision = create(:revision, image_revisions: [image_revision])
+        current_revision = create(:revision, preceded_by: preceding_revision)
+        edition = create(:edition, revision: current_revision)
+
+        request = stub_asset_manager_deletes_any_asset
+
+        DraftAssetCleanupService.new.call(edition)
+
+        expect(request).not_to have_been_requested
+        expect(image_revision.assets.map(&:state).uniq).to match(%w[live])
+      end
+    end
+
+    context "when there is no previous revision" do
+      it "doesn't blow up" do
+        revision = create(:revision, preceded_by: nil)
+        edition = create(:edition, revision: revision)
+
+        expect { DraftAssetCleanupService.new.call(edition) }
+          .not_to raise_error
+      end
+    end
+
+    context "when assets to remove are not on asset manager" do
+      it "marks the assets as absent" do
+        image_revision = create(:image_revision, :on_asset_manager, state: :draft)
+        preceding_revision = create(:revision, image_revisions: [image_revision])
+        current_revision = create(:revision, preceded_by: preceding_revision)
+        edition = create(:edition, revision: current_revision)
+
+        stub_asset_manager_deletes_any_asset.to_return(status: 404)
+
+        DraftAssetCleanupService.new.call(edition)
+
+        expect(image_revision.assets.map(&:state).uniq).to match(%w[absent])
+      end
+    end
+  end
+end

--- a/spec/services/preview_service_spec.rb
+++ b/spec/services/preview_service_spec.rb
@@ -1,0 +1,126 @@
+# frozen_string_literal: true
+
+RSpec.describe PreviewService do
+  let(:draft_asset_cleanup_service) do
+    instance_double("DraftAssetCleanupService", call: nil)
+  end
+
+  before do
+    stub_any_publishing_api_put_content
+    stub_any_asset_manager_call
+    allow(DraftAssetCleanupService).to receive(:new) { draft_asset_cleanup_service }
+  end
+
+  describe "#create_preview" do
+    it "updates the Publishing API" do
+      edition = create(:edition)
+      request = stub_publishing_api_put_content(edition.content_id, {})
+      PreviewService.new(edition).create_preview
+      expect(request).to have_been_requested
+    end
+
+    it "marks the edition as 'revision_synced'" do
+      edition = create(:edition, revision_synced: false)
+      PreviewService.new(edition).create_preview
+      expect(edition.reload.revision_synced).to be(true)
+    end
+
+    it "delegates cleaning up draft assets" do
+      edition = create(:edition)
+      expect(draft_asset_cleanup_service).to receive(:call).with(edition)
+      PreviewService.new(edition).create_preview
+    end
+
+    context "when there are assets that aren't on Asset Manager" do
+      it "uploads the assets to Asset Manager" do
+        image_revision = create(:image_revision)
+        edition = create(:edition, image_revisions: [image_revision])
+
+        request = stub_asset_manager_receives_an_asset
+        PreviewService.new(edition).create_preview
+
+        expect(request).to have_been_requested.at_least_once
+        expect(image_revision.assets.map(&:state).uniq).to match(%w[draft])
+      end
+    end
+
+    context "when there are assets that are on Asset Manager" do
+      it "doesn't upload the assets to asset manager" do
+        image_revision1 = create(:image_revision, :on_asset_manager)
+        image_revision2 = create(:image_revision, :on_asset_manager, state: :live)
+        edition = create(:edition, image_revisions: [image_revision1, image_revision2])
+
+        request = stub_asset_manager_receives_an_asset
+        PreviewService.new(edition).create_preview
+
+        expect(request).not_to have_been_requested
+        expect(image_revision1.assets.map(&:state).uniq).to match(%w[draft])
+        expect(image_revision2.assets.map(&:state).uniq).to match(%w[live])
+      end
+    end
+
+    context "when Publishing API is down" do
+      it "sets revision_synced to false on the edition" do
+        stub_publishing_api_isnt_available
+        edition = create(:edition, revision_synced: true)
+
+        expect { PreviewService.new(edition).create_preview }
+          .to raise_error(GdsApi::BaseError)
+        expect(edition.revision_synced).to be(false)
+      end
+    end
+
+    context "when there are images and Asset Manager is down" do
+      it "sets revision_synced to false on the edition" do
+        stub_asset_manager_isnt_available
+        image_revision = create(:image_revision)
+        edition = create(:edition, image_revisions: [image_revision], revision_synced: true)
+
+        expect { PreviewService.new(edition).create_preview }
+          .to raise_error(GdsApi::BaseError)
+        expect(edition.revision_synced).to be(false)
+      end
+    end
+  end
+
+  describe "#try_create_preview" do
+    it "delegates to create_preview" do
+      edition = create(:edition)
+      service = PreviewService.new(edition)
+      expect(service).to receive(:create_preview)
+      service.try_create_preview
+    end
+
+    context "when an external service is down" do
+      it "sets revision_synced to false on the edition" do
+        stub_publishing_api_isnt_available
+        edition = create(:edition, revision_synced: true)
+        PreviewService.new(edition).try_create_preview
+        expect(edition.revision_synced).to be(false)
+      end
+    end
+
+    context "when there are pre-preview issues" do
+      let(:edition) { create(:edition, title: "", revision_synced: true) }
+
+      it "sets revision_synced to false on the edition" do
+        PreviewService.new(edition).try_create_preview
+
+        expect(edition.revision_synced).to be(false)
+      end
+
+      it "doesn't send to the Publishing API" do
+        request = stub_publishing_api_put_content(edition.content_id, {})
+
+        PreviewService.new(edition).try_create_preview
+
+        expect(request).not_to have_been_requested
+      end
+
+      it "delegates cleaning up draft assets" do
+        expect(draft_asset_cleanup_service).to receive(:call).with(edition)
+        PreviewService.new(edition).try_create_preview
+      end
+    end
+  end
+end


### PR DESCRIPTION
Trello: https://trello.com/c/5JMGsuBj/581-follow-up-work-from-versioning-review

This uses the point of creating a preview as a point to delete assets
from Asset Manager which are no longer used.

When an edition is sent to the preview service the previous revision
assets are compared with the current revision and any that are in a
draft state are then deleted from Asset Manager.

This doesn't feel like the most robust of solutions as if assets are not
removed at this point they will remain in draft forever. The approach
that would resolve that would be to have some form of scheduled task
that performs a cleanup of assets periodically. However since we don't
have prior art currently in scheduled tasks on this app I have not
implemented it.