### PR TITLE
Counter proposal on current_status and current_revision

### DIFF
--- a/app/models/edition.rb
+++ b/app/models/edition.rb
@@ -18,9 +18,12 @@ class Edition < ApplicationRecord
     # Used to keep an audit trail of statuses a revision has held
     revision.statuses << status unless revision.statuses.include?(status)
 
-    # Used to keep an audit trail of all the revisions that have been
-    # associated with an edition
-    revisions << revision unless revisions.include?(revision)
+    # An edition points to a single revision, however we want to mantain a log
+    # of all joins between revision and edition. Revision has a many-to-many
+    # edition association that we use for storing this (to avoid the complexity
+    # of an edition having revision and revsions methods). Typically a revision
+    # would only be associated with a single edition.
+    revision.editions << self unless revision.editions.include?(self)
   end
 
   attr_readonly :number, :document_id
@@ -35,13 +38,9 @@ class Edition < ApplicationRecord
 
   belongs_to :status
 
-  has_many :statuses
-
   has_many :timeline_entries
 
   has_many :internal_notes
-
-  has_and_belongs_to_many :revisions, -> { order("revisions.number DESC") }
 
   delegate :content_id, :locale, :document_type, :topics, to: :document
 


### PR DESCRIPTION
Trello: https://trello.com/c/5JMGsuBj/581-follow-up-work-from-versioning-review

Off the back of https://github.com/alphagov/content-publisher/pull/709 I went down the road of trying out current_revision and current_status in https://github.com/alphagov/content-publisher/compare/make-names-verbose-and-current-repetitive

Doing that actually increased my concerns. But do have a look through and see if you feel that is actually a benefit or makes the code easier to understand.

The reasons I think adding the current prefix isn't a good idea are:

- It's implied and superfluous
- It starts a spread of increasing use of "current_" in various parts of an edition
  - renames assign_status to assign_current_status
  - renamed assign_revision to assign_current_revision
  - should then rename revision_synced to current_revision_synced
  - should rename status's revision_created_at to current_revision_created_at
- Causes things to seem a bit confusing when you compare `document.current_edition.current_status` and `document.live_edition.current_status`
- It involves making a lot of changes to disambiguate from something that is an audit trail.

Since the concerns seemed to be related to the naming clash of revision / revisions and status / statuses and that since the many's are used as an audit trail I felt it might be simpler to just remove the collection equivalents.

If/when we determine that these may be called on an edition I think options we could follow are:

- See if we can find a better name than all_*
- Call them past_statuses, past_revisions and use a lambda scope to cut out the current one.

Anyway, see what you think.