### PR TITLE
Set clear all filters link to not show visited state

### DIFF
--- a/app/views/documents/index/_filters.html.erb
+++ b/app/views/documents/index/_filters.html.erb
@@ -83,5 +83,5 @@
     text: "Filter"
   } %>
 
-  <p><%= link_to "Clear all filters", documents_path, class: "govuk-link" %></p>
+  <p><%= link_to "Clear all filters", documents_path, class: "govuk-link govuk-link--no-visited-state" %></p>
 <% end %>


### PR DESCRIPTION
Since this link is used to reset a dynamic page it doesn't make sense
for this to show a visited state as this is more of an action than a
link to a consistent resource.

Before:
<img width="349" alt="screen shot 2019-01-25 at 16 58 53" src="https://user-images.githubusercontent.com/282717/51760537-880fec80-20c2-11e9-8df5-b7144f2a5f60.png">

After:
<img width="335" alt="screen shot 2019-01-25 at 16 59 33" src="https://user-images.githubusercontent.com/282717/51760562-9bbb5300-20c2-11e9-9fa0-5e046472dc9b.png">

