### PR TITLE
Use a U+0020 space over a U+00A0 space

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,7 +47,7 @@ yarn install
 bundle exec rake
 ```
 
-### Permissions
+### Permissions
 
 Functionality of this application is enabled with permissions. There is a
 `pre_release_features` permission, for using functionality not yet available to


### PR DESCRIPTION
GitHub Markdown doesn't recognise non breaking spaces when rendering.