### PR TITLE
Remove live and current indexes

### DIFF
--- a/db/migrate/20190125181528_remove_versioned_editions_current_and_live_indexes.rb
+++ b/db/migrate/20190125181528_remove_versioned_editions_current_and_live_indexes.rb
@@ -1,0 +1,8 @@
+# frozen_string_literal: true
+
+class RemoveVersionedEditionsCurrentAndLiveIndexes < ActiveRecord::Migration[5.2]
+  def change
+    remove_index :versioned_editions, :current
+    remove_index :versioned_editions, :live
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2019_01_23_105011) do
+ActiveRecord::Schema.define(version: 2019_01_25_181528) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -94,13 +94,11 @@ ActiveRecord::Schema.define(version: 2019_01_23_105011) do
     t.bigint "revision_id", null: false
     t.boolean "revision_synced", default: false, null: false
     t.index ["created_by_id"], name: "index_versioned_editions_on_created_by_id"
-    t.index ["current"], name: "index_versioned_editions_on_current"
     t.index ["document_id", "current"], name: "index_versioned_editions_on_document_id_and_current", unique: true, where: "(current = true)"
     t.index ["document_id", "live"], name: "index_versioned_editions_on_document_id_and_live", unique: true, where: "(live = true)"
     t.index ["document_id", "number"], name: "index_versioned_editions_on_document_id_and_number", unique: true
     t.index ["document_id"], name: "index_versioned_editions_on_document_id"
     t.index ["last_edited_by_id"], name: "index_versioned_editions_on_last_edited_by_id"
-    t.index ["live"], name: "index_versioned_editions_on_live"
     t.index ["revision_id"], name: "index_versioned_editions_on_revision_id"
     t.index ["status_id"], name: "index_versioned_editions_on_status_id"
   end


### PR DESCRIPTION
Trello: https://trello.com/c/5JMGsuBj/581-follow-up-work-from-versioning-review

These are removed as we're not convinced these are currently adding any
value.

Initially the expectation was that the current index
provided performance benefits for the EditionFilter used on the index
page. The live index was then added to match.

However my most recent tests haven't shown a significant difference so
they may well be a drop in the bucket for the potential performance
problems on the index filter. So it's probably just simpler to remove
them now and do something if we discover a problem.

Some query plans:

<details>
<summary>With index</summary>

```
content_publisher_development# EXPLAIN ANALYZE SELECT  "versioned_editions".* FROM "versioned_editions" INNER JOIN "versioned_revisions" ON "versioned_revisions"."id" = "versioned_editions"."revision_id" INNER JOIN "versioned_content_revisions" ON "versioned_content_revisions"."id" = "versioned_revisions"."content_revision_id" INNER JOIN "versioned_tags_revisions" ON "versioned_tags_revisions"."id" = "versioned_revisions"."tags_revision_id" INNER JOIN "versioned_statuses" ON "versioned_statuses"."id" = "versioned_editions"."status_id" INNER JOIN "versioned_documents" ON "versioned_documents"."id" = "versioned_editions"."document_id" WHERE "versioned_editions"."current" = true ORDER BY versioned_editions.last_edited_at desc LIMIT 50
;
┌─────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────┐
│                                                                                                         QUERY PLAN                                                                                                          │
├─────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────┤
│ Limit  (cost=6784.91..6785.03 rows=50 width=79) (actual time=52.819..52.831 rows=50 loops=1)                                                                                                                                │
│   ->  Sort  (cost=6784.91..6791.74 rows=2731 width=79) (actual time=52.818..52.824 rows=50 loops=1)                                                                                                                         │
│         Sort Key: versioned_editions.last_edited_at DESC                                                                                                                                                                    │
│         Sort Method: top-N heapsort  Memory: 39kB                                                                                                                                                                           │
│         ->  Nested Loop  (cost=2643.69..6694.19 rows=2731 width=79) (actual time=23.486..51.790 rows=2690 loops=1)                                                                                                          │
│               ->  Nested Loop  (cost=2643.40..5743.55 rows=2731 width=87) (actual time=23.480..47.801 rows=2690 loops=1)                                                                                                    │
│                     ->  Hash Join  (cost=2643.11..4739.17 rows=2731 width=95) (actual time=23.464..43.646 rows=2690 loops=1)                                                                                                │
│                           Hash Cond: (versioned_statuses.id = versioned_editions.status_id)                                                                                                                                 │
│                           ->  Seq Scan on versioned_statuses  (cost=0.00..1763.09 rows=81509 width=8) (actual time=0.008..8.165 rows=81465 loops=1)                                                                         │
│                           ->  Hash  (cost=2608.98..2608.98 rows=2731 width=95) (actual time=23.446..23.446 rows=2690 loops=1)                                                                                               │
│                                 Buckets: 4096  Batches: 1  Memory Usage: 411kB                                                                                                                                              │
│                                 ->  Hash Join  (cost=1483.09..2608.98 rows=2731 width=95) (actual time=11.639..22.743 rows=2690 loops=1)                                                                                    │
│                                       Hash Cond: (versioned_revisions.id = versioned_editions.revision_id)                                                                                                                  │
│                                       ->  Seq Scan on versioned_revisions  (cost=0.00..940.78 rows=42078 width=24) (actual time=0.006..4.637 rows=42078 loops=1)                                                            │
│                                       ->  Hash  (cost=1448.96..1448.96 rows=2731 width=79) (actual time=11.627..11.627 rows=2690 loops=1)                                                                                   │
│                                             Buckets: 4096  Batches: 1  Memory Usage: 350kB                                                                                                                                  │
│                                             ->  Hash Join  (cost=363.22..1448.96 rows=2731 width=79) (actual time=1.317..11.015 rows=2690 loops=1)                                                                          │
│                                                   Hash Cond: (versioned_documents.id = versioned_editions.document_id)                                                                                                      │
│                                                   ->  Seq Scan on versioned_documents  (cost=0.00..900.40 rows=42140 width=8) (actual time=0.006..4.475 rows=42079 loops=1)                                                 │
│                                                   ->  Hash  (cost=329.08..329.08 rows=2731 width=79) (actual time=1.306..1.306 rows=2690 loops=1)                                                                           │
│                                                         Buckets: 4096  Batches: 1  Memory Usage: 350kB                                                                                                                      │
│                                                         ->  Index Scan using index_versioned_editions_on_current on versioned_editions  (cost=0.29..329.08 rows=2731 width=79) (actual time=0.048..0.940 rows=2690 loops=1) │
│                                                               Index Cond: (current = true)                                                                                                                                  │
│                                                               Filter: current                                                                                                                                               │
│                     ->  Index Only Scan using versioned_content_revisions_pkey on versioned_content_revisions  (cost=0.29..0.37 rows=1 width=8) (actual time=0.001..0.001 rows=1 loops=2690)                                │
│                           Index Cond: (id = versioned_revisions.content_revision_id)                                                                                                                                        │
│                           Heap Fetches: 2690                                                                                                                                                                                │
│               ->  Index Only Scan using versioned_tags_revisions_pkey on versioned_tags_revisions  (cost=0.29..0.35 rows=1 width=8) (actual time=0.001..0.001 rows=1 loops=2690)                                            │
│                     Index Cond: (id = versioned_revisions.tags_revision_id)                                                                                                                                                 │
│                     Heap Fetches: 2690                                                                                                                                                                                      │
│ Planning time: 3.312 ms                                                                                                                                                                                                     │
│ Execution time: 52.927 ms                                                                                                                                                                                                   │
└─────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────┘
(32 rows)

Time: 57.087 ms
```

</details>

<details>
<summary>Without index</summary>

```
content_publisher_development# EXPLAIN ANALYZE SELECT  "versioned_editions".* FROM "versioned_editions" INNER JOIN "versioned_revisions" ON "versioned_revisions"."id" = "versioned_editions"."revision_id" INNER JOIN "versioned_content_revisions" ON "versioned_content_revisions"."id" = "versioned_revisions"."content_revision_id" INNER JOIN "versioned_tags_revisions" ON "versioned_tags_revisions"."id" = "versioned_revisions"."tags_revision_id" INNER JOIN "versioned_statuses" ON "versioned_statuses"."id" = "versioned_editions"."status_id" INNER JOIN "versioned_documents" ON "versioned_documents"."id" = "versioned_editions"."document_id" WHERE "versioned_editions"."current" = true ORDER BY versioned_editions.last_edited_at desc LIMIT 50
;
┌──────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────┐
│                                                                                          QUERY PLAN                                                                                          │
├──────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────┤
│ Limit  (cost=9423.59..9423.71 rows=50 width=79) (actual time=68.958..68.971 rows=50 loops=1)                                                                                                 │
│   ->  Sort  (cost=9423.59..9430.41 rows=2731 width=79) (actual time=68.957..68.964 rows=50 loops=1)                                                                                          │
│         Sort Key: versioned_editions.last_edited_at DESC                                                                                                                                     │
│         Sort Method: top-N heapsort  Memory: 39kB                                                                                                                                            │
│         ->  Nested Loop  (cost=5282.37..9332.86 rows=2731 width=79) (actual time=37.339..67.957 rows=2690 loops=1)                                                                           │
│               ->  Nested Loop  (cost=5282.08..8382.23 rows=2731 width=87) (actual time=37.332..64.009 rows=2690 loops=1)                                                                     │
│                     ->  Hash Join  (cost=5281.79..7377.85 rows=2731 width=95) (actual time=37.316..59.914 rows=2690 loops=1)                                                                 │
│                           Hash Cond: (versioned_statuses.id = versioned_editions.status_id)                                                                                                  │
│                           ->  Seq Scan on versioned_statuses  (cost=0.00..1763.09 rows=81509 width=8) (actual time=0.007..9.150 rows=81465 loops=1)                                          │
│                           ->  Hash  (cost=5247.65..5247.65 rows=2731 width=95) (actual time=37.268..37.268 rows=2690 loops=1)                                                                │
│                                 Buckets: 4096  Batches: 1  Memory Usage: 411kB                                                                                                               │
│                                 ->  Hash Join  (cost=4121.77..5247.65 rows=2731 width=95) (actual time=25.192..36.242 rows=2690 loops=1)                                                     │
│                                       Hash Cond: (versioned_revisions.id = versioned_editions.revision_id)                                                                                   │
│                                       ->  Seq Scan on versioned_revisions  (cost=0.00..940.78 rows=42078 width=24) (actual time=0.005..4.757 rows=42078 loops=1)                             │
│                                       ->  Hash  (cost=4087.63..4087.63 rows=2731 width=79) (actual time=25.159..25.159 rows=2690 loops=1)                                                    │
│                                             Buckets: 4096  Batches: 1  Memory Usage: 350kB                                                                                                   │
│                                             ->  Hash Join  (cost=3001.90..4087.63 rows=2731 width=79) (actual time=13.638..24.214 rows=2690 loops=1)                                         │
│                                                   Hash Cond: (versioned_documents.id = versioned_editions.document_id)                                                                       │
│                                                   ->  Seq Scan on versioned_documents  (cost=0.00..900.40 rows=42140 width=8) (actual time=0.005..4.581 rows=42079 loops=1)                  │
│                                                   ->  Hash  (cost=2967.76..2967.76 rows=2731 width=79) (actual time=13.601..13.601 rows=2690 loops=1)                                        │
│                                                         Buckets: 4096  Batches: 1  Memory Usage: 350kB                                                                                       │
│                                                         ->  Seq Scan on versioned_editions  (cost=0.00..2967.76 rows=2731 width=79) (actual time=1.619..13.044 rows=2690 loops=1)            │
│                                                               Filter: current                                                                                                                │
│                                                               Rows Removed by Filter: 39386                                                                                                  │
│                     ->  Index Only Scan using versioned_content_revisions_pkey on versioned_content_revisions  (cost=0.29..0.37 rows=1 width=8) (actual time=0.001..0.001 rows=1 loops=2690) │
│                           Index Cond: (id = versioned_revisions.content_revision_id)                                                                                                         │
│                           Heap Fetches: 2690                                                                                                                                                 │
│               ->  Index Only Scan using versioned_tags_revisions_pkey on versioned_tags_revisions  (cost=0.29..0.35 rows=1 width=8) (actual time=0.001..0.001 rows=1 loops=2690)             │
│                     Index Cond: (id = versioned_revisions.tags_revision_id)                                                                                                                  │
│                     Heap Fetches: 2690                                                                                                                                                       │
│ Planning time: 2.655 ms                                                                                                                                                                      │
│ Execution time: 69.116 ms                                                                                                                                                                    │
└──────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────┘
(32 rows)

Time: 72.684 ms
```

</details>