### PR TITLE
Amend editions current and live migration

### DIFF
--- a/db/migrate/20190125181528_remove_editions_current_and_live_indexes.rb
+++ b/db/migrate/20190125181528_remove_editions_current_and_live_indexes.rb
@@ -1,0 +1,8 @@
+# frozen_string_literal: true
+
+class RemoveEditionsCurrentAndLiveIndexes < ActiveRecord::Migration[5.2]
+  def change
+    remove_index :editions, :current
+    remove_index :editions, :live
+  end
+end

--- a/db/migrate/20190125181528_remove_versioned_editions_current_and_live_indexes.rb
+++ b/db/migrate/20190125181528_remove_versioned_editions_current_and_live_indexes.rb
@@ -1,8 +1,0 @@
-# frozen_string_literal: true
-
-class RemoveVersionedEditionsCurrentAndLiveIndexes < ActiveRecord::Migration[5.2]
-  def change
-    remove_index :versioned_editions, :current
-    remove_index :versioned_editions, :live
-  end
-end


### PR DESCRIPTION
This change removes the `versioned_` prefix from this migration.