### PR TITLE
Enable factory bot linting

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -12,6 +12,9 @@ node {
         sh("yarn")
         sh("yarn run lint")
       }
+      stage("Lint FactoryBot") {
+        sh("bundle exec rake factorybot:lint RAILS_ENV='test'")
+      }
     },
     rubyLintDiff: false,
     rubyLintDirs: "",

--- a/Rakefile
+++ b/Rakefile
@@ -6,4 +6,4 @@
 require_relative "config/application"
 
 Rails.application.load_tasks
-task default: %i(spec jasmine:ci lint brakeman)
+task default: %i(jasmine:ci lint brakeman)

--- a/lib/tasks/factorybot.rake
+++ b/lib/tasks/factorybot.rake
@@ -1,0 +1,16 @@
+# frozen_string_literal: true
+
+desc "Run FactoryBot linter"
+namespace :factorybot do
+  task lint: :environment do
+    if Rails.env.test?
+      ActiveRecord::Base.transaction do
+        FactoryBot.lint(traits: true)
+        raise ActiveRecord::Rollback
+      end
+    else
+      system("bundle exec rake factorybot:lint RAILS_ENV='test'")
+      fail if $?.exitstatus.nonzero?
+    end
+  end
+end

--- a/lib/tasks/lint.rake
+++ b/lib/tasks/lint.rake
@@ -1,8 +1,9 @@
 # frozen_string_literal: true
 
-desc "lint Ruby, Sass and Javascript"
+desc "lint Ruby, FactoryBot, Sass and Javascript"
 task "lint" do
   sh "govuk-lint-ruby --format clang"
+  sh "bundle exec rake factorybot:lint RAILS_ENV='test'"
   sh "govuk-lint-sass app/assets/stylesheets"
   sh "yarn run lint"
 end

--- a/spec/factories/document_type_factory.rb
+++ b/spec/factories/document_type_factory.rb
@@ -2,6 +2,8 @@
 
 FactoryBot.define do
   factory :document_type do
+    skip_create
+
     id { SecureRandom.hex(4) }
     label { SecureRandom.alphanumeric(8) }
     contents { [] }

--- a/spec/factories/field_factory.rb
+++ b/spec/factories/field_factory.rb
@@ -2,6 +2,8 @@
 
 FactoryBot.define do
   factory :field, class: DocumentType::Field do
+    skip_create
+
     id { SecureRandom.hex(4) }
     label { SecureRandom.alphanumeric(4) }
     initialize_with { new(attributes) }

--- a/spec/factories/guidance_factory.rb
+++ b/spec/factories/guidance_factory.rb
@@ -2,6 +2,8 @@
 
 FactoryBot.define do
   factory :guidance, class: Hash do
+    skip_create
+
     title { SecureRandom.alphanumeric(8) }
     body { SecureRandom.alphanumeric(8) }
     initialize_with { attributes.stringify_keys }

--- a/spec/factories/tag_field_factory.rb
+++ b/spec/factories/tag_field_factory.rb
@@ -2,6 +2,8 @@
 
 FactoryBot.define do
   factory :tag_field, class: DocumentType::TagField do
+    skip_create
+
     id { SecureRandom.hex(4) }
     document_type { SecureRandom.alphanumeric(8) }
     initialize_with { new(attributes) }


### PR DESCRIPTION
FactoryBot offers a lint method to check the validity of each of the factories we have. This should be enabled to run as part of the default rake task and as part of our Jenkins build.

Trello:
https://trello.com/c/J48ZqCto/593-enable-factorybot-linting