### PR TITLE
Add MANAGING_EDITOR_PERMISSION to dev permissions rake task

### DIFF
--- a/lib/tasks/development_permissions.rake
+++ b/lib/tasks/development_permissions.rake
@@ -5,7 +5,10 @@ task development_permissions: :environment do
   raise "Setting development permissions outside dev environment" unless Rails.env.development?
 
   user = User.first || User.create!(name: "publisher")
-  permissions = (user.permissions + [User::PRE_RELEASE_FEATURES_PERMISSION, User::DEBUG_PERMISSION]).uniq
+  permissions = (user.permissions + [User::PRE_RELEASE_FEATURES_PERMISSION,
+                                     User::DEBUG_PERMISSION,
+                                     User::MANAGING_EDITOR_PERMISSION]).uniq
+
   user.update_attribute(:permissions, permissions)
   puts "User permissions are now #{permissions.to_sentence}"
 end


### PR DESCRIPTION
This is so devs can easily get all the permissions they need to run all parts of the app