### PR TITLE
Run factorybot linter after db has been set up

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -12,15 +12,17 @@ node {
         sh("yarn")
         sh("yarn run lint")
       }
-      stage("Lint FactoryBot") {
-        sh("bundle exec rake factorybot:lint RAILS_ENV='test'")
-      }
     },
     rubyLintDiff: false,
     rubyLintDirs: "",
     overrideTestTask: {
       stage("Run tests") {
         govuk.runTests("spec jasmine:ci")
+      }
+    },
+    afterTest: {
+      stage("Lint FactoryBot") {
+        sh("bundle exec rake factorybot:lint RAILS_ENV=test")
       }
     }
   )


### PR DESCRIPTION
This was causing test failures in CI due to the linter being ran against an
old version of the db. As rails db:reset had not been run yet and there
was still migrations pending the linter was trying to create factories
against old tables (column names) which caused the lint to fail.

Moving this to run after the tests means the db is set up correctly for
the linter.