### PR TITLE
Clean up css for govuk-link

### DIFF
--- a/app/assets/stylesheets/core/_link.scss
+++ b/app/assets/stylesheets/core/_link.scss
@@ -19,3 +19,12 @@
 .app-link--right {
   float: right;
 }
+
+.app-link--inline {
+  padding: govuk-spacing(3) 0;
+  display: inline-block;
+
+  @include govuk-media-query($from: tablet) {
+    padding: 8px 0 0 govuk-spacing(3);
+  }
+}

--- a/app/assets/stylesheets/utilities/_overwrites.scss
+++ b/app/assets/stylesheets/utilities/_overwrites.scss
@@ -13,18 +13,6 @@
   height: 100%;
 }
 
-.govuk-link {
-  @extend %govuk-link;
-  @extend %govuk-body-m;
-  margin: 0;
-  padding: 0;
-  border: 0;
-  color: $govuk-link-colour;
-  background: transparent;
-  text-decoration: underline;
-  cursor: pointer;
-}
-
 .govuk-table {
   .gem-c-document-list__item {
     margin: 0;

--- a/app/views/documents/show/_delete_draft.html.erb
+++ b/app/views/documents/show/_delete_draft.html.erb
@@ -9,9 +9,9 @@
       destructive: true
     } %>
 
-    <div style="display: inline-block; padding-left: 15px; padding-top: 8px">
-      <%= link_to "Cancel", document_path(@edition.document), class: "govuk-link" %>
-    </div>
+  <%= link_to "Cancel",
+              document_path(@edition.document),
+              class: "govuk-link govuk-link--no-visited-state app-link--inline" %>
   <% end %>
 
 <% end %>


### PR DESCRIPTION
This removes the duplicated .govuk-link class from the overwrites and
moves the css styling from the `delete_draft` html template to the
link.css file.

While doing this the styling has also been modified to accommodate
mobile / tablet and functions have been used instead of hard coded
values.