### PR TITLE
Rename lead_image flag to images

### DIFF
--- a/app/formats/document_types.yml
+++ b/app/formats/document_types.yml
@@ -6,7 +6,7 @@
     Do not include advice in news stories. Do not use to promote other content.
     Read the full [guidance on news stories](https://www.gov.uk/guidance/content-design/content-types#news-story).
   path_prefix: /government/news
-  lead_image: true
+  images: true
   topics: true
   check_path_conflict: true
   publishing_metadata:
@@ -67,7 +67,7 @@
     Do not use to promote other content. Statements to Parliament should use the Speech document type.
     Read the full [guidance on press releases](https://www.gov.uk/guidance/content-design/content-types#press-release).
   path_prefix: /government/news
-  lead_image: true
+  images: true
   topics: true
   check_path_conflict: true
   publishing_metadata:

--- a/app/models/document_type.rb
+++ b/app/models/document_type.rb
@@ -4,7 +4,7 @@ class DocumentType
   include InitializeWithHash
 
   attr_reader :contents, :id, :label, :managed_elsewhere, :publishing_metadata,
-    :path_prefix, :tags, :guidance_govspeak, :description, :hint, :lead_image, :topics, :check_path_conflict
+    :path_prefix, :tags, :guidance_govspeak, :description, :hint, :images, :topics, :check_path_conflict
 
   def self.find(id)
     item = all.find { |document_type| document_type.id == id }

--- a/app/services/publishing_api_payload.rb
+++ b/app/services/publishing_api_payload.rb
@@ -65,7 +65,7 @@ private
       details[field.id] = perform_input_type_specific_transformations(field)
     end
 
-    if document_type.lead_image && edition.lead_image_revision.present?
+    if document_type.images && edition.lead_image_revision.present?
       details["image"] = image
     end
 

--- a/app/views/documents/show/_summary_tab.html.erb
+++ b/app/views/documents/show/_summary_tab.html.erb
@@ -9,7 +9,7 @@
     <%= render "documents/show/requirements" %>
     <%= render "documents/show/contents" %>
 
-    <% if @edition.document_type.lead_image %>
+    <% if @edition.document_type.images %>
       <%= render "documents/show/lead_image" %>
     <% end %>
 

--- a/spec/features/editing_images/choose_lead_image_spec.rb
+++ b/spec/features/editing_images/choose_lead_image_spec.rb
@@ -11,7 +11,7 @@ RSpec.feature "Choose a lead image" do
   end
 
   def given_there_is_an_edition_with_images
-    document_type = build(:document_type, lead_image: true)
+    document_type = build(:document_type, images: true)
     @image_revision = create(:image_revision, :on_asset_manager)
     @edition = create(:edition,
                       document_type_id: document_type.id,

--- a/spec/features/editing_images/delete_image_spec.rb
+++ b/spec/features/editing_images/delete_image_spec.rb
@@ -10,7 +10,7 @@ RSpec.feature "Delete an image" do
   end
 
   def given_there_is_an_edition_with_images
-    document_type = build(:document_type, lead_image: true)
+    document_type = build(:document_type, images: true)
     @image_revision = create(:image_revision, :on_asset_manager)
     @edition = create(:edition,
                       document_type_id: document_type.id,

--- a/spec/features/editing_images/delete_lead_image_spec.rb
+++ b/spec/features/editing_images/delete_lead_image_spec.rb
@@ -10,7 +10,7 @@ RSpec.feature "Delete an image" do
   end
 
   def given_there_is_an_edition_with_images
-    document_type = build(:document_type, lead_image: true)
+    document_type = build(:document_type, images: true)
     @image_revision = create(:image_revision, :on_asset_manager)
     @edition = create(:edition,
                       document_type_id: document_type.id,

--- a/spec/features/editing_images/download_image_spec.rb
+++ b/spec/features/editing_images/download_image_spec.rb
@@ -9,7 +9,7 @@ RSpec.feature "Download a image" do
   end
 
   def given_there_is_an_edition_with_images
-    document_type = build(:document_type, lead_image: true)
+    document_type = build(:document_type, images: true)
     @image_revision = create(:image_revision, :on_asset_manager)
     @edition = create(:edition,
                       document_type_id: document_type.id,

--- a/spec/features/editing_images/edit_image_crop_spec.rb
+++ b/spec/features/editing_images/edit_image_crop_spec.rb
@@ -10,7 +10,7 @@ RSpec.feature "Edit image crop", js: true do
   end
 
   def given_there_is_an_edition_with_images
-    document_type = build(:document_type, lead_image: true)
+    document_type = build(:document_type, images: true)
     @image_revision = create(:image_revision,
                              :on_asset_manager,
                              crop_x: 0,

--- a/spec/features/editing_images/edit_image_metadata_requirements_spec.rb
+++ b/spec/features/editing_images/edit_image_metadata_requirements_spec.rb
@@ -9,7 +9,7 @@ RSpec.feature "Edit image metadata with requirements issues" do
   end
 
   def given_there_is_an_edition_with_images
-    document_type = build(:document_type, lead_image: true)
+    document_type = build(:document_type, images: true)
     @image_revision = create(:image_revision, :on_asset_manager)
     @edition = create(:edition,
                       document_type_id: document_type.id,

--- a/spec/features/editing_images/edit_image_metadata_spec.rb
+++ b/spec/features/editing_images/edit_image_metadata_spec.rb
@@ -10,7 +10,7 @@ RSpec.feature "Edit image metadata" do
   end
 
   def given_there_is_an_edition_with_images
-    document_type = build(:document_type, lead_image: true)
+    document_type = build(:document_type, images: true)
     @image_revision = create(:image_revision, :on_asset_manager)
     @edition = create(:edition,
                       document_type_id: document_type.id,

--- a/spec/features/editing_images/remove_lead_image_spec.rb
+++ b/spec/features/editing_images/remove_lead_image_spec.rb
@@ -9,7 +9,7 @@ RSpec.feature "Remove a lead image" do
   end
 
   def given_there_is_an_edition_with_a_lead_image
-    document_type = build(:document_type, lead_image: true)
+    document_type = build(:document_type, images: true)
     @image_revision = create(:image_revision,
                              :on_asset_manager,
                              alt_text: "image")

--- a/spec/features/editing_images/upload_inline_image_spec.rb
+++ b/spec/features/editing_images/upload_inline_image_spec.rb
@@ -9,7 +9,7 @@ RSpec.feature "Upload an inline image" do
   end
 
   def given_there_is_a_document
-    document_type = build(:document_type, lead_image: true)
+    document_type = build(:document_type, images: true)
     @edition = create(:edition, document_type_id: document_type.id)
   end
 

--- a/spec/features/editing_images/upload_lead_image_requirements_spec.rb
+++ b/spec/features/editing_images/upload_lead_image_requirements_spec.rb
@@ -9,7 +9,7 @@ RSpec.feature "Upload a lead image with requirements issues" do
   end
 
   def given_there_is_an_edition
-    document_type = build(:document_type, lead_image: true)
+    document_type = build(:document_type, images: true)
     @edition = create(:edition, document_type_id: document_type.id)
   end
 

--- a/spec/features/editing_images/upload_lead_image_spec.rb
+++ b/spec/features/editing_images/upload_lead_image_spec.rb
@@ -12,7 +12,7 @@ RSpec.feature "Upload a lead image" do
   end
 
   def given_there_is_an_edition
-    document_type = build(:document_type, lead_image: true)
+    document_type = build(:document_type, images: true)
     @edition = create(:edition, document_type_id: document_type.id)
   end
 

--- a/spec/features/workflow/preview_requirements_spec.rb
+++ b/spec/features/workflow/preview_requirements_spec.rb
@@ -13,7 +13,7 @@ RSpec.feature "Preview requirements" do
   end
 
   def given_there_is_an_edition_with_issues_to_fix
-    document_type = build(:document_type, lead_image: true)
+    document_type = build(:document_type, images: true)
     @image_revision = create(:image_revision, alt_text: "")
     @edition = create(:edition,
                       :publishable,

--- a/spec/services/publishing_api_payload_spec.rb
+++ b/spec/services/publishing_api_payload_spec.rb
@@ -107,7 +107,7 @@ RSpec.describe PublishingApiPayload do
                              caption: "image caption",
                              credit: "image credit")
 
-      document_type = build(:document_type, lead_image: true)
+      document_type = build(:document_type, images: true)
 
       edition = build(:edition,
                       document_type_id: document_type.id,


### PR DESCRIPTION
https://trello.com/c/ZYFBN0ns/560-support-rendering-inline-images

Now that we support inline images as part of the lead image workflow, it
makes sense to rename this flag, so it's not specific to lead images.