### PR TITLE
Fix withdraw cancel link being smaller text

### DIFF
--- a/app/views/withdraw/new.html.erb
+++ b/app/views/withdraw/new.html.erb
@@ -26,8 +26,11 @@
       <%= render "govuk_publishing_components/components/button", {
         text: "Withdraw document", margin_bottom: true
       } %>
+
+      <p class="govuk-body">
+        <%= link_to "Cancel", document_path(@document), class: "govuk-link govuk-link--no-visited-state" %>
+      </p>
     <% end %>
-    <%= link_to "Cancel", document_path(@document), class: "govuk-link govuk-link--no-visited-state" %>
   </div>
   <div class="govuk-grid-column-one-third">
     <%= render "components/contextual_guidance", {


### PR DESCRIPTION
This changes the link to be within a govuk-body class so that the size
of the text matches other body content. This brings this to be visually
closer to the design Sonia prepared.

Before:
<img width="684" alt="screen shot 2019-02-07 at 10 48 42" src="https://user-images.githubusercontent.com/282717/52406654-24c08a00-2ac6-11e9-8c64-c31e91076314.png">

After:
<img width="671" alt="screen shot 2019-02-07 at 10 52 43" src="https://user-images.githubusercontent.com/282717/52406832-8ed92f00-2ac6-11e9-914e-eb091b53353e.png">

Design: https://content-publisher-prototype.cloudapps.digital/withdraw