### PR TITLE
Fix styling for image button actions

### DIFF
--- a/app/assets/stylesheets/core/_link.scss
+++ b/app/assets/stylesheets/core/_link.scss
@@ -28,3 +28,14 @@
     padding: 8px 0 0 govuk-spacing(3);
   }
 }
+
+.app-link--button {
+  @extend %govuk-body-m;
+  margin: 0;
+  padding: 0;
+  border: 0;
+  color: $govuk-link-colour;
+  background: transparent;
+  text-decoration: underline;
+  cursor: pointer;
+}

--- a/app/views/images/_image.html.erb
+++ b/app/views/images/_image.html.erb
@@ -6,13 +6,13 @@
 
 <% actions << capture do %>
   <%= form_tag choose_lead_image_path(document, image.image_id), class: "app-inline-block" do %>
-    <button class="govuk-link">Select as lead image</button>
+    <button class="govuk-link app-link--button">Select as lead image</button>
   <% end %>
 <% end %>
 
 <% actions << capture do %>
   <%= form_tag destroy_image_path(document, image.image_id), method: :delete, class: "app-inline-block" do %>
-    <button class="govuk-link app-link--destructive">Delete image</button>
+    <button class="govuk-link app-link--button app-link--destructive">Delete image</button>
   <% end %>
 <% end %>
 

--- a/app/views/images/_lead_image.html.erb
+++ b/app/views/images/_lead_image.html.erb
@@ -9,14 +9,14 @@
 
 <% actions << capture do %>
   <%= form_tag remove_lead_image_path(document), method: :delete, class: "app-inline-block" do %>
-    <button class="govuk-link">Remove lead image</button>
+    <button class="govuk-link app-link--button">Remove lead image</button>
   <% end %>
 <% end %>
 
 <% actions << capture do %>
   <%= form_tag destroy_image_path(document, lead_image.image_id), method: :delete, class: "app-inline-block" do %>
     <%= hidden_field_tag :wizard, "lead_image" %>
-    <button class="govuk-link app-link--destructive">Delete lead image</button>
+    <button class="govuk-link app-link--button app-link--destructive">Delete lead image</button>
   <% end %>
 <% end %>
 


### PR DESCRIPTION
Previously we overwrote govuk-link to style any links as buttons, but
the behaviour was lost in a recent PR. This re-instates the behaviour
using a specific class to complement govuk-link, so that the behaviour
is better documented, and only applied where it's actually necessary.