### PR TITLE
Don't store identical withdrawal submissions and withdrawn_update timeline entry

### DIFF
--- a/app/controllers/withdraw_controller.rb
+++ b/app/controllers/withdraw_controller.rb
@@ -46,7 +46,7 @@ class WithdrawController < ApplicationController
         #FIXME We should check that the edition is withdrawable before passing
         # it to the UnpublishService
         UnpublishService.new.withdraw(@edition, public_explanation, current_user)
-        redirect_to @edition.document
+        redirect_to document_path(@edition.document)
       rescue GdsApi::BaseError => e
         GovukError.notify(e)
         redirect_to withdraw_path,

--- a/app/controllers/withdraw_controller.rb
+++ b/app/controllers/withdraw_controller.rb
@@ -2,10 +2,10 @@
 
 class WithdrawController < ApplicationController
   def new
-    @document = Document.with_current_edition.find_by_param(params[:id])
-    edition = @document.current_edition
+    document = Document.with_current_edition.find_by_param(params[:id])
+    @edition = document.current_edition
     @public_explanation =
-      edition.withdrawn? ? edition.status.details.public_explanation : nil
+      @edition.withdrawn? ? @edition.status.details.public_explanation : nil
 
     if !current_user.has_permission?(User::PRE_RELEASE_FEATURES_PERMISSION)
       render :withdraw
@@ -27,7 +27,8 @@ class WithdrawController < ApplicationController
     end
 
     Document.transaction do
-      @document = Document.with_current_edition.lock!.find_by_param(params[:id])
+      document = Document.with_current_edition.lock!.find_by_param(params[:id])
+      @edition = document.current_edition
       public_explanation = params[:public_explanation]
       issues = Requirements::WithdrawalChecker.new(public_explanation).pre_withdrawal_issues
 
@@ -38,18 +39,19 @@ class WithdrawController < ApplicationController
         }
 
         render :new
-      else
-        begin
-          #FIXME We should check that the edition is withdrawable before passing
-          # it to the UnpublishService
-          UnpublishService.new.withdraw(@document.current_edition, public_explanation, current_user)
-          redirect_to @document
-        rescue GdsApi::BaseError => e
-          GovukError.notify(e)
-          redirect_to withdraw_path,
-            alert_with_description: t("withdraw.new.flashes.publishing_api_error"),
-            public_explanation: public_explanation
-        end
+        return
+      end
+
+      begin
+        #FIXME We should check that the edition is withdrawable before passing
+        # it to the UnpublishService
+        UnpublishService.new.withdraw(@edition, public_explanation, current_user)
+        redirect_to @edition.document
+      rescue GdsApi::BaseError => e
+        GovukError.notify(e)
+        redirect_to withdraw_path,
+          alert_with_description: t("withdraw.new.flashes.publishing_api_error"),
+          public_explanation: public_explanation
       end
     end
   end

--- a/app/models/timeline_entry.rb
+++ b/app/models/timeline_entry.rb
@@ -37,6 +37,7 @@ class TimelineEntry < ApplicationRecord
                      image_removed: "image_removed",
                      new_edition: "new_edition",
                      withdrawn: "withdrawn",
+                     withdrawn_updated: "withdrawn_updated",
                      unwithdrawn: "unwithdrawn",
                      removed: "removed",
                      internal_note: "internal_note",

--- a/app/services/unpublish_service.rb
+++ b/app/services/unpublish_service.rb
@@ -21,7 +21,7 @@ class UnpublishService
       edition.save!
 
       TimelineEntry.create_for_status_change(
-        entry_type: :withdrawn,
+        entry_type: previous_withdrawal ? :withdrawn_updated : :withdrawn,
         status: edition.status,
         details: withdrawal,
       )

--- a/app/services/unpublish_service.rb
+++ b/app/services/unpublish_service.rb
@@ -7,6 +7,9 @@ class UnpublishService
       check_unpublishable(edition)
 
       previous_withdrawal = edition.withdrawn? && edition.status.details
+
+      return if withdrawn_with_public_explanation?(edition, public_explanation)
+
       withdrawal = if previous_withdrawal
                      previous_withdrawal.dup.tap do |w|
                        w.assign_attributes(public_explanation: public_explanation)
@@ -106,6 +109,13 @@ private
     if document.current_edition != document.live_edition
       raise "Publishing API does not support unpublishing while there is a draft"
     end
+  end
+
+  def withdrawn_with_public_explanation?(edition, public_explanation)
+    return false unless edition.withdrawn?
+
+    withdrawal = edition.status.details
+    withdrawal.public_explanation == public_explanation
   end
 
   def format_govspeak(text, edition)

--- a/app/views/documents/show/_history_tab.html.erb
+++ b/app/views/documents/show/_history_tab.html.erb
@@ -24,7 +24,7 @@
           <%= simple_format(escape_and_link(entry.details.body)) %>
         <% end %>
 
-        <% if entry.withdrawn? && entry.details %>
+        <% if (entry.withdrawn? || entry.withdrawn_updated?) && entry.details %>
           <%= entry.details.public_explanation %>
         <% end %>
 

--- a/app/views/withdraw/new.html.erb
+++ b/app/views/withdraw/new.html.erb
@@ -1,5 +1,5 @@
-<% content_for :back_link, render_back_link(href: document_path(@document)) %>
-<% content_for :title, t("withdraw.new.title", title: @document.current_edition.title) %>
+<% content_for :back_link, render_back_link(href: document_path(@edition.document)) %>
+<% content_for :title, t("withdraw.new.title", title: @edition.title) %>
 
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
@@ -9,7 +9,7 @@
 
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
-    <%= form_tag(withdraw_path(@document)) do %>
+    <%= form_tag(withdraw_path(@edition.document)) do %>
       <%= render "govuk_publishing_components/components/textarea", {
         label: {
           text: t("withdraw.new.public_explanation.title"),
@@ -23,12 +23,19 @@
           "contextual_guidance": "withdrawal-public-explanation-guidance",
         }
       } %>
-      <%= render "govuk_publishing_components/components/button", {
-        text: "Withdraw document", margin_bottom: true
-      } %>
+
+      <% if @edition.withdrawn? %>
+        <%= render "govuk_publishing_components/components/button", {
+          text: "Update explanation", margin_bottom: true
+        } %>
+      <% else %>
+        <%= render "govuk_publishing_components/components/button", {
+          text: "Withdraw document", margin_bottom: true
+        } %>
+      <% end %>
 
       <p class="govuk-body">
-        <%= link_to "Cancel", document_path(@document), class: "govuk-link govuk-link--no-visited-state" %>
+        <%= link_to "Cancel", document_path(@edition.document), class: "govuk-link govuk-link--no-visited-state" %>
       </p>
     <% end %>
   </div>

--- a/app/views/withdraw/non_managing_editor.govspeak.md
+++ b/app/views/withdraw/non_managing_editor.govspeak.md
@@ -2,4 +2,4 @@ You do not have permission to do this.
 
 If you think this content is not relevant anymore or that it shouldn’t be on [GOV.UK](https://www.gov.uk) you need to ask the managing editor for your organisation.
 
-Read the [full guidance on withdrawing or removing content](https://www.gov.uk/guidance/how-to-publish-on-gov-uk/unpublishing-and-archiving)).
+Read the [full guidance on withdrawing or removing content](https://www.gov.uk/guidance/how-to-publish-on-gov-uk/unpublishing-and-archiving).

--- a/app/views/withdraw/non_managing_editor.html.erb
+++ b/app/views/withdraw/non_managing_editor.html.erb
@@ -1,4 +1,4 @@
-<% content_for :back_link, render_back_link(href: document_path(@document)) %>
+<% content_for :back_link, render_back_link(href: document_path(@edition.document)) %>
 <% content_for :title, t("withdraw.no_managing_editor_permission.title") %>
 
 <div class="govuk-grid-row">

--- a/config/locales/en/documents/history.yml
+++ b/config/locales/en/documents/history.yml
@@ -18,6 +18,7 @@ en:
         new_edition: "New edition"
         create_preview: "Create preview"
         withdrawn: "Withdrawn"
+        withdrawn_updated: "Updated withdrawal explanation"
         removed: "Removed"
         internal_note: "Internal note"
         draft_discarded: "Draft discarded"

--- a/spec/factories/edition_factory.rb
+++ b/spec/factories/edition_factory.rb
@@ -93,6 +93,7 @@ FactoryBot.define do
       live { true }
 
       transient do
+        public_explanation { SecureRandom.alphanumeric }
         withdrawn_at { Time.current }
       end
 
@@ -105,6 +106,7 @@ FactoryBot.define do
           state: :withdrawn,
           revision_at_creation: edition.revision,
           withdrawn_at: evaluator.withdrawn_at,
+          public_explanation: evaluator.public_explanation,
         )
       end
     end

--- a/spec/factories/edition_factory.rb
+++ b/spec/factories/edition_factory.rb
@@ -93,8 +93,7 @@ FactoryBot.define do
       live { true }
 
       transient do
-        public_explanation { SecureRandom.alphanumeric }
-        withdrawn_at { Time.current }
+        withdrawal { nil }
       end
 
       after(:build) do |edition, evaluator|
@@ -105,8 +104,7 @@ FactoryBot.define do
           created_by: edition.created_by,
           state: :withdrawn,
           revision_at_creation: edition.revision,
-          withdrawn_at: evaluator.withdrawn_at,
-          public_explanation: evaluator.public_explanation,
+          withdrawal: evaluator.withdrawal,
         )
       end
     end

--- a/spec/factories/status_factory.rb
+++ b/spec/factories/status_factory.rb
@@ -10,17 +10,11 @@ FactoryBot.define do
       state { :withdrawn }
 
       transient do
-        public_explanation { SecureRandom.alphanumeric }
-        withdrawn_at { Time.current }
+        withdrawal { nil }
       end
 
-      association :details, factory: :withdrawal
       after(:build) do |status, evaluator|
-        status.details = evaluator.association(
-          :withdrawal,
-          withdrawn_at: evaluator.withdrawn_at,
-          public_explanation: evaluator.public_explanation,
-        )
+        status.details = evaluator.withdrawal || evaluator.association(:withdrawal)
       end
     end
 

--- a/spec/factories/status_factory.rb
+++ b/spec/factories/status_factory.rb
@@ -10,6 +10,7 @@ FactoryBot.define do
       state { :withdrawn }
 
       transient do
+        public_explanation { SecureRandom.alphanumeric }
         withdrawn_at { Time.current }
       end
 
@@ -18,6 +19,7 @@ FactoryBot.define do
         status.details = evaluator.association(
           :withdrawal,
           withdrawn_at: evaluator.withdrawn_at,
+          public_explanation: evaluator.public_explanation,
         )
       end
     end

--- a/spec/features/workflow/edit_withdrawal_spec.rb
+++ b/spec/features/workflow/edit_withdrawal_spec.rb
@@ -7,7 +7,8 @@ RSpec.feature "Edit a withdrawal" do
     when_i_visit_the_summary_page
     and_i_click_to_change_the_public_explanation
     then_i_can_see_the_existing_public_explanation
-    and_i_can_edit_the_public_explanation
+    when_i_edit_the_public_explanation
+    then_i_can_see_the_updated_explanation
   end
 
   def given_there_is_a_withdrawn_edition
@@ -32,15 +33,20 @@ RSpec.feature "Edit a withdrawal" do
     expect(page).to have_field("public_explanation", with: @edition.status.details.public_explanation)
   end
 
-  def and_i_can_edit_the_public_explanation
-    new_explanation = "Another explanation"
-    converted_explanation = GovspeakDocument.new(new_explanation, @edition).payload_html
+  def when_i_edit_the_public_explanation
+    @new_explanation = "Another explanation"
+    converted_explanation = GovspeakDocument.new(@new_explanation, @edition).payload_html
     body = { type: "withdrawal", explanation: converted_explanation, locale: @edition.locale }
     stub_publishing_api_unpublish(@edition.content_id, body: body)
 
-    fill_in "public_explanation", with: new_explanation
-    click_on "Withdraw document"
+    fill_in "public_explanation", with: @new_explanation
+    click_on "Update explanation"
+  end
 
-    expect(@edition.reload.status.details.public_explanation).to eq(new_explanation)
+  def then_i_can_see_the_updated_explanation
+    expect(page).to have_content(@new_explanation)
+
+    click_on "Document history"
+    expect(page).to have_content(I18n.t!("documents.history.entry_types.withdrawn_updated"))
   end
 end

--- a/spec/services/unpublish_service_spec.rb
+++ b/spec/services/unpublish_service_spec.rb
@@ -36,9 +36,12 @@ RSpec.describe UnpublishService do
     end
 
     it "adds an entry in the timeline of the document" do
-      UnpublishService.new.withdraw(edition, public_explanation, user)
+      expect { UnpublishService.new.withdraw(edition, public_explanation, user) }
+        .to change { edition.reload.timeline_entries.count }
+        .by(1)
 
-      expect(edition.timeline_entries.first.entry_type).to eq("withdrawn")
+      timeline_entry = edition.timeline_entries.last
+      expect(timeline_entry.entry_type).to eq("withdrawn")
     end
 
     it "updates the edition status to withdrawn" do
@@ -110,6 +113,16 @@ RSpec.describe UnpublishService do
         expect { UnpublishService.new.withdraw(edition, public_explanation, user) }
           .not_to change { edition.reload.status.details.withdrawn_at }
           .from(withdrawn_at)
+      end
+
+      it "creates a withdrawn_updated timeline entry" do
+        withdrawn_edition = create(:edition, :withdrawn)
+        expect { UnpublishService.new.withdraw(withdrawn_edition, public_explanation, user) }
+          .to change { withdrawn_edition.reload.timeline_entries.count }
+          .by(1)
+
+        timeline_entry = withdrawn_edition.timeline_entries.last
+        expect(timeline_entry.entry_type).to eq("withdrawn_updated")
       end
     end
   end

--- a/spec/services/unpublish_service_spec.rb
+++ b/spec/services/unpublish_service_spec.rb
@@ -101,7 +101,8 @@ RSpec.describe UnpublishService do
 
     context "when an edition is already withdrawn and public_explanation is the same" do
       let!(:withdrawn_edition) do
-        create(:edition, :withdrawn, public_explanation: public_explanation)
+        withdrawal = build(:withdrawal, public_explanation: public_explanation)
+        create(:edition, :withdrawn, withdrawal: withdrawal)
       end
 
       it "doesn't update the Publishing API" do
@@ -131,7 +132,8 @@ RSpec.describe UnpublishService do
 
       it "maintains the withdrawn timestamp" do
         withdrawn_at = 10.days.ago.midnight
-        withdrawn_edition = create(:edition, :withdrawn, withdrawn_at: withdrawn_at)
+        withdrawal = build(:withdrawal, withdrawn_at: withdrawn_at)
+        withdrawn_edition = create(:edition, :withdrawn, withdrawal: withdrawal)
         expect { UnpublishService.new.withdraw(withdrawn_edition, public_explanation, user) }
           .not_to change { withdrawn_edition.reload.status.details.withdrawn_at }
           .from(withdrawn_at)


### PR DESCRIPTION
Trello: https://trello.com/c/GGxgDv3W/533-add-form-to-let-users-withdraw-a-document

This addresses comments raised by Ben in: https://github.com/alphagov/content-publisher/pull/749#pullrequestreview-201081495

It redirects when a user submits the same explanation for updating a withdrawal.

It updates the button on the form to update an explanation. 

See:
<img width="677" alt="screen shot 2019-02-07 at 16 40 37" src="https://user-images.githubusercontent.com/282717/52429082-4b4ce800-2afb-11e9-88e3-949ad68ffa20.png">

And changes what's shown on the timeline entry:

See:
<img width="539" alt="screen shot 2019-02-07 at 16 42 48" src="https://user-images.githubusercontent.com/282717/52429185-71728800-2afb-11e9-9ed1-53be0ee95a3f.png">

There's a secondary issue I noticed while doing this that the withdrawal date can go wrong so I'm going to fix that in a separate PR.
