### PR TITLE
Resolve issue where withdrawal time changes

### DIFF
--- a/app/views/documents/show/_withdrawn_notice.html.erb
+++ b/app/views/documents/show/_withdrawn_notice.html.erb
@@ -1,9 +1,10 @@
+<% withdrawal = @edition.status.details %>
 <%= render "govuk_publishing_components/components/notice", {
   title: I18n.t("documents.show.withdrawn.title",
                 document_type: @document.document_type.label.downcase,
-                withdrawn_date: @edition.status.created_at.strftime("%d %B %Y"))
+                withdrawn_date: withdrawal.withdrawn_at.strftime("%d %B %Y"))
 } do %>
-  <%= @edition.status.details.public_explanation %>
+  <%= withdrawal.public_explanation %>
   <p>
   <p>
   <%= link_to "Change public explanation", withdraw_path(@document), class: "govuk-link govuk-link--no-visited-state" %>

--- a/db/migrate/20190207183954_add_withdrawn_at_to_withdrawal.rb
+++ b/db/migrate/20190207183954_add_withdrawn_at_to_withdrawal.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+class AddWithdrawnAtToWithdrawal < ActiveRecord::Migration[5.2]
+  def change
+    add_column :withdrawals, :withdrawn_at, :datetime, null: false # rubocop:disable Rails/NotNullColumn
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2019_01_30_100821) do
+ActiveRecord::Schema.define(version: 2019_02_07_183954) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -255,6 +255,7 @@ ActiveRecord::Schema.define(version: 2019_01_30_100821) do
   create_table "withdrawals", force: :cascade do |t|
     t.string "public_explanation", null: false
     t.datetime "created_at", null: false
+    t.datetime "withdrawn_at", null: false
   end
 
   add_foreign_key "content_revisions", "users", column: "created_by_id", on_delete: :restrict

--- a/spec/factories/edition_factory.rb
+++ b/spec/factories/edition_factory.rb
@@ -92,6 +92,10 @@ FactoryBot.define do
       summary { SecureRandom.alphanumeric(10) }
       live { true }
 
+      transient do
+        withdrawn_at { Time.current }
+      end
+
       after(:build) do |edition, evaluator|
         edition.revision = evaluator.association(:revision)
         edition.status = evaluator.association(
@@ -100,6 +104,7 @@ FactoryBot.define do
           created_by: edition.created_by,
           state: :withdrawn,
           revision_at_creation: edition.revision,
+          withdrawn_at: evaluator.withdrawn_at,
         )
       end
     end

--- a/spec/factories/status_factory.rb
+++ b/spec/factories/status_factory.rb
@@ -8,12 +8,18 @@ FactoryBot.define do
 
     trait :withdrawn do
       state { :withdrawn }
-      association :details, factory: :withdrawal
-    end
-  end
 
-  trait :withdrawn do
-    state { :withdrawn }
-    association :details, factory: :withdrawal
+      transient do
+        withdrawn_at { Time.current }
+      end
+
+      association :details, factory: :withdrawal
+      after(:build) do |status, evaluator|
+        status.details = evaluator.association(
+          :withdrawal,
+          withdrawn_at: evaluator.withdrawn_at,
+        )
+      end
+    end
   end
 end

--- a/spec/factories/withdrawal_factory.rb
+++ b/spec/factories/withdrawal_factory.rb
@@ -3,5 +3,6 @@
 FactoryBot.define do
   factory :withdrawal do
     public_explanation { SecureRandom.alphanumeric }
+    withdrawn_at { Time.current }
   end
 end


### PR DESCRIPTION
Trello: https://trello.com/c/GGxgDv3W/533-add-form-to-let-users-withdraw-a-document

We previously used the time a status was created to show a user when a
piece of content was withdrawn, however this is not accurate if you
update the explanation of a withdrawal as this creates a new status.

Thus the way I've approached resolving this is by passing a timestamp
among the details of Withdrawal objects so that this data is persisted.
If a user undoes a withdraw and re-withdraws this timestamp will be
reset.

Note: this migration relies on there not being any withdrawal records persisted, as is the case in production. In a dev environment it may well require a db:reset. For integration it should be straightforward if the data sync has ran, if not it’ll need any documents that have been withdrawn to be deleted or statuses changed