### PR TITLE
Update non_managing_editor error description for withdraw workflow

### DIFF
--- a/app/views/withdraw/non_managing_editor.govspeak.md
+++ b/app/views/withdraw/non_managing_editor.govspeak.md
@@ -1,0 +1,5 @@
+You do not have permission to do this.
+
+If you think this content is not relevant anymore or that it shouldn’t be on [GOV.UK](https://www.gov.uk) you need to ask the managing editor for your organisation.
+
+Read the [full guidance on withdrawing or removing content](https://www.gov.uk/guidance/how-to-publish-on-gov-uk/unpublishing-and-archiving)).

--- a/app/views/withdraw/non_managing_editor.html.erb
+++ b/app/views/withdraw/non_managing_editor.html.erb
@@ -3,6 +3,6 @@
 
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
-    <%= render_govspeak(t("withdraw.no_managing_editor_permission.content")) %>
+    <%= render_govspeak(File.read("app/views/unwithdraw/non_managing_editor.govspeak.md")) %>
   </div>
 </div>

--- a/config/locales/en/withdraw/withdraw.yml
+++ b/config/locales/en/withdraw/withdraw.yml
@@ -16,7 +16,3 @@ en:
           description_govspeak: Something went wrong when withdrawing this document. Please try again or [raise a support request](https://support.publishing.service.gov.uk/technical_fault_report/new).
     no_managing_editor_permission:
       title: Only a managing editor can remove or withdraw a live page
-      content: |
-        If you think this content is not relevant anymore or that it shouldn’t be on GOV.UK, speak to the managing editor for your organisation.
-
-        Read the [full guidance on removing (unpublishing) and withdrawing content](https://www.gov.uk/guidance/how-to-publish-on-gov-uk/unpublishing-and-archiving)).


### PR DESCRIPTION
This change comes from a content review by Ben Hazell.

Another change being made is moving the govspeak markdown from locales to its own template
as locales should only store around one line sentences and shouldn't be used to store larger bodies of text with multiple paragraphs.

As mentioned here:
https://trello.com/c/yhcKNEWr/587-allow-users-undo-withdraw