### PR TITLE
Add user ID to context for Sentry errors

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -4,6 +4,7 @@ class ApplicationController < ActionController::Base
   include GDS::SSO::ControllerMethods
 
   before_action :authenticate_user!
+  before_action { Raven.user_context(id: current_user&.uid) }
 
   add_flash_types :alert_with_description, :alert_with_items, :confirmation, :tried_to_publish, :tried_to_preview
 end


### PR DESCRIPTION
https://sentry.io/govuk/app-content-publisher/issues/882726330/events/45d88c2a6e914dd4a5c2206d628d95b9/

Previously we've seen errors arising with multiple users interacting
with the same document. Having the user ID associated with the error
will help us to better debug these issues.