### PR TITLE
Release withdraw feature

### DIFF
--- a/app/controllers/unwithdraw_controller.rb
+++ b/app/controllers/unwithdraw_controller.rb
@@ -4,11 +4,6 @@ class UnwithdrawController < ApplicationController
   def confirm
     @document = Document.with_current_edition.find_by_param(params[:id])
 
-    if !current_user.has_permission?(User::PRE_RELEASE_FEATURES_PERMISSION)
-      render :non_pre_release
-      return
-    end
-
     if current_user.has_permission?(User::MANAGING_EDITOR_PERMISSION)
       redirect_to document_path(@document), confirmation: "unwithdraw/confirm"
     else

--- a/app/controllers/withdraw_controller.rb
+++ b/app/controllers/withdraw_controller.rb
@@ -7,11 +7,6 @@ class WithdrawController < ApplicationController
     @public_explanation =
       @edition.withdrawn? ? @edition.status.details.public_explanation : nil
 
-    if !current_user.has_permission?(User::PRE_RELEASE_FEATURES_PERMISSION)
-      render :withdraw
-      return
-    end
-
     if current_user.has_permission?(User::MANAGING_EDITOR_PERMISSION)
       render :new
     else
@@ -20,10 +15,10 @@ class WithdrawController < ApplicationController
   end
 
   def create
-    unless user_has_permissions?
+    unless current_user.has_permission?(User::MANAGING_EDITOR_PERMISSION)
       # FIXME: this shouldn't be an exception but we've not worked out the
       # right response - maybe bad request or a redirect with flash?
-      raise "Can't withdraw an edition without permissions"
+      raise "Can't withdraw an edition without managing editor permissions"
     end
 
     Document.transaction do
@@ -54,12 +49,5 @@ class WithdrawController < ApplicationController
           public_explanation: public_explanation
       end
     end
-  end
-
-private
-
-  def user_has_permissions?
-    current_user.has_all_permissions?([User::MANAGING_EDITOR_PERMISSION,
-                                       User::PRE_RELEASE_FEATURES_PERMISSION])
   end
 end

--- a/app/views/publisher_information/beta_capabilities.govspeak.md
+++ b/app/views/publisher_information/beta_capabilities.govspeak.md
@@ -1,4 +1,5 @@
-<span class="govuk-hint">Last updated: 1 February 2019</span>
+<span class="govuk-hint">Last updated: 12 February 2019</span>
+
 The Content Publisher beta tool can be used to publish the following document types:
 
 * News stories
@@ -6,12 +7,13 @@ The Content Publisher beta tool can be used to publish the following document ty
 
 Content created in Content Publisher cannot be edited in Whitehall publisher. Whitehall content cannot be edited in Content Publisher.
 
+It is possible to remove (unpublish) pages on request.
+
 Content created in Content Publisher can be featured on organisation homepages in Whitehall using the option to 'Feature non-GOV.UK government link'.
 
 These features are only available on request:
 
 * unpublishing content
-* withdrawing content
 
 Some features are not available yet:
 

--- a/app/views/publisher_information/publisher_updates.govspeak.md
+++ b/app/views/publisher_information/publisher_updates.govspeak.md
@@ -1,3 +1,6 @@
+### Withdrawing content <span class="govuk-caption-m">12 February 2019</span>
+Managing Editors can now [withdraw](https://www.gov.uk/guidance/content-design/gov-uk-content-retention-and-withdrawal-archiving-policy) content without raising a support request.
+
 ### Internal notes added <span class="govuk-caption-m">30 January 2019</span>
 You can now add internal notes about a document on the Document History screen.
 

--- a/app/views/unwithdraw/_confirm.html.erb
+++ b/app/views/unwithdraw/_confirm.html.erb
@@ -1,7 +1,7 @@
 <% confirmation = capture do %>
   <%= form_tag(unwithdraw_path(@document), method: :post) do %>
 
-    <p><%= t("documents.show.unwithdraw.title") %></p>
+    <p><%= t("documents.show.unwithdraw.description") %></p>
 
     <%= render "govuk_publishing_components/components/button", {
       text: t("documents.show.unwithdraw.confirm"),

--- a/app/views/unwithdraw/non_pre_release.govspeak.md
+++ b/app/views/unwithdraw/non_pre_release.govspeak.md
@@ -1,1 +1,0 @@
-If you need to undo the withdrawal of this content please [raise a support request and we’ll do it for you](https://support.publishing.service.gov.uk/unpublish_content_request/new).

--- a/app/views/unwithdraw/non_pre_release.html.erb
+++ b/app/views/unwithdraw/non_pre_release.html.erb
@@ -1,8 +1,0 @@
-<% content_for :back_link, render_back_link(href: document_path(@document)) %>
-<% content_for :title, t("unwithdraw.non_pre_release.title") %>
-
-<div class="govuk-grid-row">
-  <div class="govuk-grid-column-two-thirds">
-    <%= render_govspeak(File.read("app/views/unwithdraw/non_pre_release.govspeak.md")) %>
-  </div>
-</div>

--- a/app/views/withdraw/withdraw.html.erb
+++ b/app/views/withdraw/withdraw.html.erb
@@ -1,8 +1,0 @@
-<% content_for :back_link, render_back_link(href: document_path(@document)) %>
-<% content_for :title, t("unpublish.withdraw.title") %>
-
-<div class="govuk-grid-row">
-  <div class="govuk-grid-column-two-thirds">
-    <%= render_govspeak(File.read("app/views/unpublish/unpublish.govspeak.md")) %>
-  </div>
-</div>


### PR DESCRIPTION
This removes the pre-release flag and allows managing editors of content publisher to withdraw a document, they can also undo a withdrawal to reinstate the document to live on GOV.UK.

The following pr needs to be merged before this can be:
https://github.com/alphagov/content-publisher/pull/757

Trello:
https://trello.com/c/UAsOLgQ7/610-feature-release-master-card