### PR TITLE
Rename image TimelineEntry types

### DIFF
--- a/db/migrate/20190212110438_rename_image_timeline_entry_types.rb
+++ b/db/migrate/20190212110438_rename_image_timeline_entry_types.rb
@@ -1,0 +1,19 @@
+# frozen_string_literal: true
+
+class RenameImageTimelineEntryTypes < ActiveRecord::Migration[5.2]
+  def up
+    TimelineEntry.where(entry_type: "lead_image_updated")
+      .update_all(entry_type: "lead_image_selected")
+
+    TimelineEntry.where(entry_type: "image_removed")
+      .update_all(entry_type: "image_deleted")
+  end
+
+  def down
+    TimelineEntry.where(entry_type: "lead_image_selected")
+      .update_all(entry_type: "lead_image_updated")
+
+    TimelineEntry.where(entry_type: "image_deleted")
+      .update_all(entry_type: "image_removed")
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2019_02_07_183954) do
+ActiveRecord::Schema.define(version: 2019_02_12_110438) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -255,8 +255,8 @@ ActiveRecord::Schema.define(version: 2019_02_07_183954) do
   create_table "withdrawals", force: :cascade do |t|
     t.string "public_explanation", null: false
     t.datetime "created_at", null: false
-    t.datetime "withdrawn_at", null: false
     t.bigint "published_status_id", null: false
+    t.datetime "withdrawn_at", null: false
   end
 
   add_foreign_key "content_revisions", "users", column: "created_by_id", on_delete: :restrict


### PR DESCRIPTION
https://trello.com/c/JcQEznco/605-add-checkbox-to-select-unselect-a-lead-image-on-metadata-page

Previously we added support for 'lead_image_selected' and
'image_deleted' to replace 'lead_image_updated' and 'image_removed'.

This migrates the existing data to use the new entry types, after which
we will remove support for the old entry types.