### PR TITLE
Use synthetic blur/focus events in JS tests

### DIFF
--- a/spec/javascripts/components/markdown-editor-spec.js
+++ b/spec/javascripts/components/markdown-editor-spec.js
@@ -162,7 +162,7 @@ describe('Markdown editor component', function () {
 
   describe('when focusing the textarea', function () {
     it('should add focused class to container', function () {
-      document.querySelector('.js-markdown-editor-input textarea').focus()
+      document.querySelector('.js-markdown-editor-input textarea').dispatchEvent(new Event("focus"))
 
       var container = document.querySelector('.app-c-markdown-editor__container')
       expect(container).toHaveClass('app-c-markdown-editor__container--focused')
@@ -172,7 +172,7 @@ describe('Markdown editor component', function () {
       var container = document.querySelector('.app-c-markdown-editor')
       spyOnEvent(container, 'focus')
 
-      document.querySelector('.js-markdown-editor-input textarea').focus()
+      document.querySelector('.js-markdown-editor-input textarea').dispatchEvent(new Event("focus"))
 
       expect('focus').toHaveBeenTriggeredOn(container)
     })
@@ -181,9 +181,10 @@ describe('Markdown editor component', function () {
 
   describe('when blurring the textarea', function () {
     it('should remove focused class to container', function () {
-      document.querySelector('.js-markdown-editor-input textarea').blur()
-
       var container = document.querySelector('.app-c-markdown-editor__container')
+      container.classList.add('app-c-markdown-editor__container--focused')
+
+      document.querySelector('.js-markdown-editor-input textarea').dispatchEvent(new Event("blur"))
       expect(container).not.toHaveClass('app-c-markdown-editor__container--focused')
     })
   })


### PR DESCRIPTION
This is a workaround for our JS tests failing due to patchy support for
blur/focus in headless chrome. This is consistent with other synthetic
focus/blur events used in our tests see:
https://github.com/alphagov/content-publisher/blob/e077713857ffc8bc1404b9fa45e102cc582f1a18/spec/javascripts/components/url-preview-spec.js#L55

On my machine they now pass:

```
➜  content-publisher git:(fix-js-tests) ✗ rake jasmine:ci
Puma starting in single mode...
* Version 3.12.0 (ruby 2.5.3-p105), codename: Llamas in Pajamas
* Min threads: 0, max threads: 16
* Environment: development
* Listening on tcp://0.0.0.0:62320
Use Ctrl-C to stop
jasmine server started
Waiting for suite to finish in browser ...
.................................
33 specs, 0 failures
Randomized with seed 76008 (rake jasmine:ci[true,76008])
```