### PR TITLE
Fix visited state on link to change withdrawal

### DIFF
--- a/app/views/documents/show/_withdrawn_notice.html.erb
+++ b/app/views/documents/show/_withdrawn_notice.html.erb
@@ -1,11 +1,11 @@
 <% withdrawal = @edition.status.details %>
+
 <%= render "govuk_publishing_components/components/notice", {
   title: I18n.t("documents.show.withdrawn.title",
                 document_type: @document.document_type.label.downcase,
                 withdrawn_date: withdrawal.withdrawn_at.strftime("%d %B %Y"))
 } do %>
-  <%= withdrawal.public_explanation %>
-  <p>
-  <p>
+  <%= render_govspeak(withdrawal.public_explanation) %>
+  <br>
   <%= link_to "Change public explanation", withdraw_path(@document), class: "govuk-link govuk-link--no-visited-state" %>
 <% end %>


### PR DESCRIPTION
https://trello.com/c/HcfYSpjX/634-allow-notice-component-to-accept-html

Previously the 'notice' component would accept govspeak as it's block
input, but this has changed to HTML in the most recent version, such
that the applied class now works. This manually renders the withdrawal
explanation with Govspeak to preserve the desired behaviour, as well as
replacing the <p> elements with a <br> to preserve the previous spacing.