### PR TITLE
Replace internal modal title with a title ID

### DIFF
--- a/app/views/components/_modal_dialogue.html.erb
+++ b/app/views/components/_modal_dialogue.html.erb
@@ -7,7 +7,7 @@
 <div class="app-c-modal-dialogue" data-module="modal-dialogue" id="<%= id %>">
   <div class="app-c-modal-dialogue__overlay"></div>
   <dialog class="app-c-modal-dialogue__box <%= 'app-c-modal-dialogue__box--wide' if wide %>"
-    aria-modal="true" role="dialogue" aria-labelledby="<%= id %>-title" tabindex="0">
+    aria-modal="true" role="dialogue" aria-labelledby="<%= aria_labelledby %>" tabindex="0">
     <div class="app-c-modal-dialogue__header">
       <svg role="presentation" focusable="false" class="app-c-modal-dialogue__logotype-crown" xmlns="http://www.w3.org/2000/svg" viewbox="0 0 132 97" height="26" width="30">
         <path fill="currentColor" fill-rule="evenodd"
@@ -16,9 +16,6 @@
       </svg>
     </div>
     <div class="app-c-modal-dialogue__content">
-      <%= content_tag("h#{heading_level}", id: "#{id}-title", class: 'app-c-modal-dialogue__title govuk-heading-m') do %>
-        <%= title %>
-      <% end %>
       <%= yield %>
     </div>
     <button class="app-c-modal-dialogue__close-button" aria-label="Close modal dialogue">&times;</button>

--- a/app/views/components/docs/modal_dialogue.yml
+++ b/app/views/components/docs/modal_dialogue.yml
@@ -21,24 +21,27 @@ accessibility_criteria: |
 examples:
   default:
     data:
-      title: Modal title
+      aria_labelledby: default-title
       block: |
+        <h1 id="default-title">Modal title</h1>
         <p class="govuk-body">Lorem ipsum dolor sit amet, consectetur adipiscing elit. Sed imperdiet fringilla dictum. Morbi at vehicula augue. Pellentesque varius orci et augue pellentesque, sed elementum massa posuere. Curabitur egestas consectetur arcu, in porta lorem sagittis eu. Nulla facilisi. Sed scelerisque ligula lectus. Nulla et ligula a eros laoreet lacinia nec et ipsum. Ut sagittis sapien est, ut blandit risus laoreet at. Vestibulum vitae erat sed dolor ultricies efficitur.</p>
   wide:
     description: |
       A wide version of the modal dialogue will provide the same width with the main container
     data:
-      title: Modal title
+      aria_labelledby: wide-title
       wide: true
       block: |
-        <p class="govuk-body">Lorem ipsum dolor sit amet, consectetur adipiscing elit. Sed imperdiet fringilla dictum. Morbi at vehicula augue. Pellentesque varius orci et augue pellentesque, sed elementum massa posuere. Curabitur egestas consectetur arcu, in porta lorem sagittis eu. Nulla facilisi. Sed scelerisque ligula lectus. Nulla et ligula a eros laoreet lacinia nec et ipsum. Ut sagittis sapien est, ut blandit risus laoreet at. Vestibulum vitae erat sed dolor ultricies efficitur.</p>
+        <h1 id="wide-title">Modal title</h1>
+          <p class="govuk-body">Lorem ipsum dolor sit amet, consectetur adipiscing elit. Sed imperdiet fringilla dictum. Morbi at vehicula augue. Pellentesque varius orci et augue pellentesque, sed elementum massa posuere. Curabitur egestas consectetur arcu, in porta lorem sagittis eu. Nulla facilisi. Sed scelerisque ligula lectus. Nulla et ligula a eros laoreet lacinia nec et ipsum. Ut sagittis sapien est, ut blandit risus laoreet at. Vestibulum vitae erat sed dolor ultricies efficitur.</p>
   with_form:
     description: |
       Modal dialogue with form elements inside to show how it prevents tabbing to outside the dialogue when open while preserving the tabindex on focusable elements
     data:
-      title: Search contacts
+      aria_labelledby: with-form-title
       block: |
-        <label class="govuk-label govuk-visually-hidden" for="contacts">Search contacts</label>
+        <h1 id="with-form-title">Modal title</h1>
+          <label class="govuk-label govuk-visually-hidden" for="contacts">Search contacts</label>
           <div class="app-c-autocomplete govuk-form-group" data-module="autocomplete-with-hint-on-options">
             <select class="govuk-select" id="contacts-select">
               <option></option>
@@ -53,9 +56,10 @@ examples:
     description: |
       Modal dialogue with a large block content to show how the modal scrolls withing the page and how it prevents scrolling the page while the dialogue is open
     data:
-      title: Modal title
+      aria_labelledby: with-large-content-title
       block: |
-        <p class="govuk-body">Lorem ipsum dolor sit amet, consectetur adipiscing elit. Sed imperdiet fringilla dictum. Morbi at vehicula augue. Pellentesque varius orci et augue pellentesque, sed elementum massa posuere. Curabitur egestas consectetur arcu, in porta lorem sagittis eu. Nulla facilisi. Sed scelerisque ligula lectus. Nulla et ligula a eros laoreet lacinia nec et ipsum. Ut sagittis sapien est, ut blandit risus laoreet at. Vestibulum vitae erat sed dolor ultricies efficitur.</p>
+        <h1 id="with-large-content-title">Modal title</h1>
+          <p class="govuk-body">Lorem ipsum dolor sit amet, consectetur adipiscing elit. Sed imperdiet fringilla dictum. Morbi at vehicula augue. Pellentesque varius orci et augue pellentesque, sed elementum massa posuere. Curabitur egestas consectetur arcu, in porta lorem sagittis eu. Nulla facilisi. Sed scelerisque ligula lectus. Nulla et ligula a eros laoreet lacinia nec et ipsum. Ut sagittis sapien est, ut blandit risus laoreet at. Vestibulum vitae erat sed dolor ultricies efficitur.</p>
           <p class="govuk-body">Lorem ipsum dolor sit amet, consectetur adipiscing elit. Sed imperdiet fringilla dictum. Morbi at vehicula augue. Pellentesque varius orci et augue pellentesque, sed elementum massa posuere. Curabitur egestas consectetur arcu, in porta lorem sagittis eu. Nulla facilisi. Sed scelerisque ligula lectus. Nulla et ligula a eros laoreet lacinia nec et ipsum. Ut sagittis sapien est, ut blandit risus laoreet at. Vestibulum vitae erat sed dolor ultricies efficitur.</p>
           <p class="govuk-body">Lorem ipsum dolor sit amet, consectetur adipiscing elit. Sed imperdiet fringilla dictum. Morbi at vehicula augue. Pellentesque varius orci et augue pellentesque, sed elementum massa posuere. Curabitur egestas consectetur arcu, in porta lorem sagittis eu. Nulla facilisi. Sed scelerisque ligula lectus. Nulla et ligula a eros laoreet lacinia nec et ipsum. Ut sagittis sapien est, ut blandit risus laoreet at. Vestibulum vitae erat sed dolor ultricies efficitur.</p>
           <p class="govuk-body">Lorem ipsum dolor sit amet, consectetur adipiscing elit. Sed imperdiet fringilla dictum. Morbi at vehicula augue. Pellentesque varius orci et augue pellentesque, sed elementum massa posuere. Curabitur egestas consectetur arcu, in porta lorem sagittis eu. Nulla facilisi. Sed scelerisque ligula lectus. Nulla et ligula a eros laoreet lacinia nec et ipsum. Ut sagittis sapien est, ut blandit risus laoreet at. Vestibulum vitae erat sed dolor ultricies efficitur.</p>

--- a/spec/javascripts/components/modal-dialogue-spec.js
+++ b/spec/javascripts/components/modal-dialogue-spec.js
@@ -22,7 +22,7 @@ describe('Modal dialogue component', function () {
       '<dialog class="app-c-modal-dialogue__box" aria-modal="true" role="dialogue" aria-labelledby="my-modal-title">' +
         '<div class="app-c-modal-dialogue__container">' +
           '<div class="app-c-modal-dialogue__content">' +
-            '<h2 id="my-modal-title" class="app-c-modal-dialogue__title">Modal title</h2>' +
+            '<h2 id="my-modal-title">Modal title</h2>' +
           '</div>' +
           '<button class="app-c-modal-dialogue__close-button" aria-label="Close modal dialogue">&times;</button>' +
         '</div>' +


### PR DESCRIPTION
https://trello.com/c/jARJ0xxA/642-use-a-modal-to-insert-an-existing-image-as-an-inline-snippet

Previously the modal had a title option and populate its own title
element that would act to describe the modal, using aria-labelledby.
Using static markup for the title makes it difficult to show existing
pages in the modal, which already contain markup for their own titles.
This removes the static title markup within the modal component and
instead adds an mandatory option to specify which title element to use.