### PR TITLE
Expose function to re-focus the modal dialog box

### DIFF
--- a/app/assets/javascripts/components/modal-dialogue.js
+++ b/app/assets/javascripts/components/modal-dialogue.js
@@ -12,6 +12,7 @@ ModalDialogue.prototype.init = function () {
 
   this.$module.open = this.handleOpen.bind(this)
   this.$module.close = this.handleClose.bind(this)
+  this.$module.focusDialog = this.handleFocusDialog.bind(this)
   this.$module.boundKeyDown = this.handleKeyDown.bind(this)
 
   var $triggerElement = document.querySelector('[data-toggle="modal"][data-target="#' + this.$module.id + '"]')
@@ -47,6 +48,10 @@ ModalDialogue.prototype.handleClose = function (event) {
   this.$focusedElementBeforeOpen.focus()
 
   document.removeEventListener('keydown', this.$module.boundKeyDown, true)
+}
+
+ModalDialogue.prototype.handleFocusDialog = function () {
+  this.$dialogBox.focus()
 }
 
 // while open, prevent tabbing to outside the dialogue


### PR DESCRIPTION
https://trello.com/c/jARJ0xxA/642-use-a-modal-to-insert-an-existing-image-as-an-inline-snippet

This exposes a function to manually focus the dialog box of the modal,
in case the content changes dynamically and lose the previously focussed
element. Because the code uses the focus() function to achieve this,
it's not possible to verify this behaviour in our headless JS tests :-(.