### PR TITLE
Remove aria-labelledby attribute on modal

### DIFF
--- a/app/views/components/_modal_dialogue.html.erb
+++ b/app/views/components/_modal_dialogue.html.erb
@@ -7,7 +7,7 @@
 <div class="app-c-modal-dialogue" data-module="modal-dialogue" id="<%= id %>">
   <div class="app-c-modal-dialogue__overlay"></div>
   <dialog class="app-c-modal-dialogue__box <%= 'app-c-modal-dialogue__box--wide' if wide %>"
-    aria-modal="true" role="dialogue" aria-labelledby="<%= aria_labelledby %>" tabindex="0">
+    aria-modal="true" role="dialogue" tabindex="0">
     <div class="app-c-modal-dialogue__header">
       <svg role="presentation" focusable="false" class="app-c-modal-dialogue__logotype-crown" xmlns="http://www.w3.org/2000/svg" viewbox="0 0 132 97" height="26" width="30">
         <path fill="currentColor" fill-rule="evenodd"

--- a/app/views/components/docs/modal_dialogue.yml
+++ b/app/views/components/docs/modal_dialogue.yml
@@ -11,7 +11,7 @@ accessibility_criteria: |
 
   - receive focus on open
   - inform the user that it is a dialogue
-  - provide context on what the dialogue is about
+  - provide a heading that says what the dialogue is about
   - prevent mouse clicks outside the dialogue while open
   - prevent scrolling the page while the dialogue is open
   - prevent tabbing to outside the dialogue while open
@@ -24,10 +24,9 @@ examples:
       <button class="govuk-button" data-toggle="modal" data-target="#modal-default">Open modal</button>
       <%= component %>
     data:
-      aria_labelledby: default-title
       id: modal-default
       block: |
-        <h1 id="default-title">Modal title</h1>
+        <h1>Modal title</h1>
         <p class="govuk-body">Lorem ipsum dolor sit amet, consectetur adipiscing elit. Sed imperdiet fringilla dictum. Morbi at vehicula augue. Pellentesque varius orci et augue pellentesque, sed elementum massa posuere. Curabitur egestas consectetur arcu, in porta lorem sagittis eu. Nulla facilisi. Sed scelerisque ligula lectus. Nulla et ligula a eros laoreet lacinia nec et ipsum. Ut sagittis sapien est, ut blandit risus laoreet at. Vestibulum vitae erat sed dolor ultricies efficitur.</p>
   wide:
     description: |
@@ -36,11 +35,10 @@ examples:
       <button class="govuk-button" data-toggle="modal" data-target="#modal-wide">Open wide modal</button>
       <%= component %>
     data:
-      aria_labelledby: wide-title
       id: modal-wide
       wide: true
       block: |
-        <h1 id="wide-title">Modal title</h1>
+        <h1>Modal title</h1>
           <p class="govuk-body">Lorem ipsum dolor sit amet, consectetur adipiscing elit. Sed imperdiet fringilla dictum. Morbi at vehicula augue. Pellentesque varius orci et augue pellentesque, sed elementum massa posuere. Curabitur egestas consectetur arcu, in porta lorem sagittis eu. Nulla facilisi. Sed scelerisque ligula lectus. Nulla et ligula a eros laoreet lacinia nec et ipsum. Ut sagittis sapien est, ut blandit risus laoreet at. Vestibulum vitae erat sed dolor ultricies efficitur.</p>
   with_form:
     description: |
@@ -49,10 +47,9 @@ examples:
       <button class="govuk-button" data-toggle="modal" data-target="#modal-with-form">Open modal with form</button>
       <%= component %>
     data:
-      aria_labelledby: with-form-title
       id: modal-with-form
       block: |
-        <h1 id="with-form-title">Modal title</h1>
+        <h1>Modal title</h1>
           <label class="govuk-label govuk-visually-hidden" for="contacts">Search contacts</label>
           <div class="app-c-autocomplete govuk-form-group" data-module="autocomplete-with-hint-on-options">
             <select class="govuk-select" id="contacts-select">
@@ -71,10 +68,9 @@ examples:
       <button class="govuk-button" data-toggle="modal" data-target="#modal-with-large-content">Open modal with large content</button>
       <%= component %>
     data:
-      aria_labelledby: with-large-content-title
       id: modal-with-large-content
       block: |
-        <h1 id="with-large-content-title">Modal title</h1>
+        <h1>Modal title</h1>
           <p class="govuk-body">Lorem ipsum dolor sit amet, consectetur adipiscing elit. Sed imperdiet fringilla dictum. Morbi at vehicula augue. Pellentesque varius orci et augue pellentesque, sed elementum massa posuere. Curabitur egestas consectetur arcu, in porta lorem sagittis eu. Nulla facilisi. Sed scelerisque ligula lectus. Nulla et ligula a eros laoreet lacinia nec et ipsum. Ut sagittis sapien est, ut blandit risus laoreet at. Vestibulum vitae erat sed dolor ultricies efficitur.</p>
           <p class="govuk-body">Lorem ipsum dolor sit amet, consectetur adipiscing elit. Sed imperdiet fringilla dictum. Morbi at vehicula augue. Pellentesque varius orci et augue pellentesque, sed elementum massa posuere. Curabitur egestas consectetur arcu, in porta lorem sagittis eu. Nulla facilisi. Sed scelerisque ligula lectus. Nulla et ligula a eros laoreet lacinia nec et ipsum. Ut sagittis sapien est, ut blandit risus laoreet at. Vestibulum vitae erat sed dolor ultricies efficitur.</p>
           <p class="govuk-body">Lorem ipsum dolor sit amet, consectetur adipiscing elit. Sed imperdiet fringilla dictum. Morbi at vehicula augue. Pellentesque varius orci et augue pellentesque, sed elementum massa posuere. Curabitur egestas consectetur arcu, in porta lorem sagittis eu. Nulla facilisi. Sed scelerisque ligula lectus. Nulla et ligula a eros laoreet lacinia nec et ipsum. Ut sagittis sapien est, ut blandit risus laoreet at. Vestibulum vitae erat sed dolor ultricies efficitur.</p>


### PR DESCRIPTION
https://trello.com/c/jARJ0xxA/642-use-a-modal-to-insert-an-existing-image-as-an-inline-snippet

Previously we used the attribute to identify the function of the modal,
but testing with a screen reader shows this is redundant, as the reader
simply reads the title twice. This removes the redundant attribute, as
we believe it's sufficient that the modal content provide a heading that
describes what the modal is about; no further markup seems necessary.