### PR TITLE
Add component to show one section at a time

### DIFF
--- a/app/assets/javascripts/application.js
+++ b/app/assets/javascripts/application.js
@@ -20,6 +20,7 @@
 //= require components/input-length-suggester.js
 //= require components/markdown-editor.js
 //= require components/modal-dialogue.js
+//= require components/multi-section-viewer.js
 //= require components/url-preview.js
 //= require vendor/@alphagov/miller-columns-element/dist/index.umd.js
 

--- a/app/assets/javascripts/components/multi-section-viewer.js
+++ b/app/assets/javascripts/components/multi-section-viewer.js
@@ -1,0 +1,42 @@
+function MultiSectionViewer ($container) {
+  this.$container = $container
+  this.$dynamicSection = $container.querySelector('.js-dynamic-section')
+}
+
+MultiSectionViewer.prototype.init = function () {
+  var actions = document.querySelectorAll('[data-toggle="multi-section-viewer"][data-target="' + this.$container.id + '"]')
+  var $module = this
+
+  actions.forEach(function (action) {
+    action.addEventListener('click', function (event) {
+      event.preventDefault()
+      $module.showStaticSection(event.target.dataset.targetSection)
+    })
+  })
+}
+
+MultiSectionViewer.prototype.hideAllSections = function () {
+  var sections = this.$container.querySelectorAll('.app-c-multi-section-viewer__section')
+
+  sections.forEach(function (section) {
+    section.style.display = 'none'
+  })
+}
+
+MultiSectionViewer.prototype.showDynamicSection = function (content) {
+  this.hideAllSections()
+  this.$dynamicSection.innerHTML = content
+  this.$dynamicSection.style.display = 'block'
+}
+
+MultiSectionViewer.prototype.showStaticSection = function (name) {
+  this.hideAllSections()
+  var section = this.$container.querySelector('#' + name)
+  section.style.display = 'block'
+}
+
+var multiSectionViewers = document.querySelectorAll('[data-module="multi-section-viewer"]')
+
+multiSectionViewers.forEach(function (multiSectionViewer) {
+  new MultiSectionViewer(multiSectionViewer).init()
+})

--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -23,6 +23,7 @@
 @import "components/miller-columns";
 @import "components/input-length-suggester";
 @import "components/modal-dialogue";
+@import "components/multi-section-viewer";
 
 @import "utilities/display";
 @import "utilities/overwrites";

--- a/app/assets/stylesheets/components/_multi-section-viewer.scss
+++ b/app/assets/stylesheets/components/_multi-section-viewer.scss
@@ -1,0 +1,3 @@
+.app-c-multi-section-viewer__section {
+  display: none;
+}

--- a/app/views/components/_multi_section_viewer.html.erb
+++ b/app/views/components/_multi_section_viewer.html.erb
@@ -1,0 +1,13 @@
+<%
+  sections ||= []
+%>
+
+<div id="<%= id %>" class="app-c-multi-section-viewer" data-module="multi-section-viewer" aria-live="assertive">
+  <% sections.each do |section| %>
+    <section class="app-c-multi-section-viewer__section" id="<%= section[:id] %>">
+      <%= section[:content] %>
+    </section>
+  <% end %>
+
+  <div class="app-c-multi-section-viewer__section js-dynamic-section"></div>
+</div>

--- a/app/views/components/docs/multi_section_viewer.yml
+++ b/app/views/components/docs/multi_section_viewer.yml
@@ -1,0 +1,23 @@
+name: Multi section viewer
+description: Switches between multiple sections of HTML
+body: |
+  This component is a wrapper for multiple section blocks. It ensures only one is shown at a time.
+
+  The sections can be defined and toggled statically, as in the examples. The module also exposes an API to show dynamic content in its own section.
+accessibility_criteria: |
+  The multi selection view box must:
+
+  - Notify the user when the content changes
+examples:
+  default:
+    embed: |
+      <button class="govuk-button" data-toggle="multi-section-viewer" data-target="sections" data-target-section="section-1">Show Section 1</button>
+      <button class="govuk-button" data-toggle="multi-section-viewer" data-target="sections" data-target-section="section-2">Show Section 2</button>
+      <%= component %>
+    data:
+      id: sections
+      sections:
+        - id: section-1
+          content: Section 1
+        - id: section-2
+          content: Section 2

--- a/spec/javascripts/components/multi-section-viewer-spec.js
+++ b/spec/javascripts/components/multi-section-viewer-spec.js
@@ -1,0 +1,115 @@
+describe('Multi section viewer', function () {
+  'use strict'
+
+  var container, module
+
+  beforeEach(function () {
+    container = document.createElement('div')
+    container.innerHTML =
+      '<button class="govuk-button" data-toggle="multi-section-viewer" data-target="sections" data-target-section="section-1">Show Section 1</button>' +
+      '<button class="govuk-button" data-toggle="multi-section-viewer" data-target="sections" data-target-section="section-2">Show Section 2</button>' +
+      '<div id="sections" data-module="multi-section-viewer">' +
+        '<div class="app-c-multi-section-viewer__section" id="section-1">' +
+          'Section 1' +
+        '</div>' +
+        '<div class="app-c-multi-section-viewer__section" id="section-2">' +
+          'Section 2' +
+        '</div>' +
+        '<div class="app-c-multi-section-viewer__section js-dynamic-section">' +
+        '</div>' +
+      '</div>'
+
+    document.body.appendChild(container)
+    var element = document.querySelector('[data-module="multi-section-viewer"]')
+    module = new MultiSectionViewer(element)
+    module.init()
+  })
+
+  afterEach(function () {
+    document.body.removeChild(container)
+  })
+
+  it('hides all the sections', function () {
+    var section1 = document.querySelector('#section-1')
+    var section2 = document.querySelector('#section-2')
+    var dynamicSection = document.querySelector('.js-dynamic-section')
+
+    expect(section1).toBeHidden()
+    expect(section2).toBeHidden()
+    expect(dynamicSection).toBeHidden()
+  })
+
+  describe('section buttons', function () {
+    it('shows only a single section at a time', function () {
+      var section1 = document.querySelector('#section-1')
+      var section2 = document.querySelector('#section-2')
+      var dynamicSection = document.querySelector('.js-dynamic-section')
+
+      var section1Button = document.querySelector('[data-target-section="section-1"]')
+      section1Button.click()
+
+      expect(section1).toBeVisible()
+      expect(section2).toBeHidden()
+      expect(dynamicSection).toBeHidden()
+
+      var section2Button = document.querySelector('[data-target-section="section-2"]')
+      section2Button.click()
+
+      expect(section2).toBeVisible()
+      expect(section1).toBeHidden()
+      expect(dynamicSection).toBeHidden()
+    })
+  })
+
+  describe('showStaticSection', function () {
+    it('shows only a single section at a time', function () {
+      var section1 = document.querySelector('#section-1')
+      var section2 = document.querySelector('#section-2')
+      var dynamicSection = document.querySelector('.js-dynamic-section')
+
+      dynamicSection.style.display = 'block'
+
+      module.showStaticSection('section-1')
+      expect(section1).toBeVisible()
+      expect(section2).toBeHidden()
+      expect(dynamicSection).toBeHidden()
+
+      module.showStaticSection('section-2')
+      expect(section2).toBeVisible()
+      expect(section1).toBeHidden()
+      expect(dynamicSection).toBeHidden()
+    })
+  })
+
+  describe('showDynamicSection', function () {
+    it('shows only the dynamic section', function () {
+      var dynamicSection = document.querySelector('.js-dynamic-section')
+      var section1 = document.querySelector('#section-1')
+
+      section1.style.display = 'block'
+      module.showDynamicSection('<div>Dynamic</div>')
+      expect(dynamicSection).toBeVisible()
+      expect(section1).toBeHidden()
+    })
+
+    it('sets the content of the dynamic section', function () {
+      var dynamicSection = document.querySelector('.js-dynamic-section')
+      module.showDynamicSection('<div>Dynamic</div>')
+      expect(dynamicSection.innerHTML).toEqual('<div>Dynamic</div>')
+    })
+  })
+
+  describe('hideAllSections', function () {
+    it('hides all sections', function () {
+      var section1 = document.querySelector('#section-1')
+      var dynamicSection = document.querySelector('.js-dynamic-section')
+
+      section1.style.display = 'block'
+      dynamicSection.style.display = 'block'
+
+      module.hideAllSections()
+      expect(section1).toBeHidden()
+      expect(dynamicSection).toBeHidden()
+    })
+  })
+})


### PR DESCRIPTION
https://trello.com/c/jARJ0xxA/642-use-a-modal-to-insert-an-existing-image-as-an-inline-snippet

    Add component to show one section at a time
    
    This component is intended to show a single block of HTML (a 'section').
    Sections can be specified in the config, or dyanmic content can be shown
    in a special section, using the API exposed by the component's module.
    
    This component has been created to support the modal work on inline
    images, which involves replacing the entire content of the modal
    multiple times, either with a static screen, such as a loading screen,
    or with dynamic content that forms part of the inline image workflow.
    
    In order to avoid any flickering, the content of each section is wrapped
    with a class to hide it by default, using styles to override this. Since
    the point of this component is to only show a single section, if JS is
    not available, the component shouldn't be used and shows nothing.
    
    Because the content of this component can change, we set
    aria-live="assertive" in order to notify any assistive tech, much like
    when a browser page reloads. The downside is that any section with a
    'noisy' component will require work to ensure it doesn't annoy the user.