### PR TITLE
Set scheduling date and time

### DIFF
--- a/app/controllers/schedule_controller.rb
+++ b/app/controllers/schedule_controller.rb
@@ -6,8 +6,18 @@ class ScheduleController < ApplicationController
       document = Document.with_current_edition.lock.find_by_param(params[:id])
       edition = document.current_edition
 
+      checker = Requirements::ScheduledDatetimeChecker.new(permitted_params)
+      issues = checker.pre_submit_issues
+
+      if issues.any?
+        flash[:scheduled_publishing_datetime_issues] = issues.items_for(:scheduled_datetime)
+        flash[:scheduled_publishing_params] = permitted_params
+        redirect_to document_path(document)
+        return
+      end
+
       new_revision = edition.revision.build_revision_update(
-        { scheduled_publishing_datetime: format_datetime },
+        { scheduled_publishing_datetime: checker.parsed_datetime },
         current_user,
       )
       edition.assign_revision(new_revision, current_user).save!
@@ -17,10 +27,6 @@ class ScheduleController < ApplicationController
   end
 
 private
-
-  def format_datetime
-    Time.zone.parse(permitted_params.values.join("-"))
-  end
 
   def permitted_params
     params.require(:scheduled).permit(:year, :month, :day, :time)

--- a/app/controllers/schedule_controller.rb
+++ b/app/controllers/schedule_controller.rb
@@ -1,0 +1,28 @@
+# frozen_string_literal: true
+
+class ScheduleController < ApplicationController
+  def save_scheduled_publishing_datetime
+    Document.transaction do
+      document = Document.with_current_edition.lock.find_by_param(params[:id])
+      edition = document.current_edition
+
+      new_revision = edition.revision.build_revision_update(
+        { scheduled_publishing_datetime: format_datetime },
+        current_user,
+      )
+      edition.assign_revision(new_revision, current_user).save!
+
+      redirect_to document_path(document)
+    end
+  end
+
+private
+
+  def format_datetime
+    Time.zone.parse(permitted_params.values.join("-"))
+  end
+
+  def permitted_params
+    params.require(:scheduled).permit(:year, :month, :day, :time)
+  end
+end

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -1,6 +1,8 @@
 # frozen_string_literal: true
 
 module ApplicationHelper
+  include TimeOptionsHelper
+
   def govspeak_to_html(govspeak)
     raw(Govspeak::Document.new(govspeak).to_html) # rubocop:disable Rails/OutputSafety
   end

--- a/app/helpers/time_options_helper.rb
+++ b/app/helpers/time_options_helper.rb
@@ -1,10 +1,12 @@
 # frozen_string_literal: true
 
 module TimeOptionsHelper
+  DEFAULT_PUBLISHING_TIME = "9:00am"
+
   def time_options(selected = nil)
     options = times.map { |time| { text: time, value: time } }
     options.each do |option|
-      if option[:text] == selected
+      if option[:text] == (selected || DEFAULT_PUBLISHING_TIME)
         option[:selected] = true
         break
       end

--- a/app/helpers/time_options_helper.rb
+++ b/app/helpers/time_options_helper.rb
@@ -1,0 +1,28 @@
+# frozen_string_literal: true
+
+module TimeOptionsHelper
+  def time_options(selected = nil)
+    options = times.map { |time| { text: time, value: time } }
+    options.each do |option|
+      if option[:text] == selected
+        option[:selected] = true
+        break
+      end
+    end
+    options
+  end
+
+private
+
+  def times
+    hours = [12] + (1..11).to_a
+    incremented_hours = hours.map do |hour|
+      [hour.to_s + ":00", hour.to_s + ":30"]
+    end
+
+    meridiem_hours = incremented_hours.flatten!.map { |hour| hour + "am" }
+    incremented_hours.each { |hour| meridiem_hours << hour + "pm" }
+    meridiem_hours[0] = "12:01am"
+    meridiem_hours
+  end
+end

--- a/app/models/revision.rb
+++ b/app/models/revision.rb
@@ -47,6 +47,7 @@ class Revision < ApplicationRecord
            :change_note,
            :major?,
            :minor?,
+           :scheduled_publishing_datetime,
            to: :metadata_revision
 
   delegate :tags, to: :tags_revision
@@ -167,7 +168,12 @@ class Revision < ApplicationRecord
     end
 
     def metadata_revision(next_revision)
-      metadata = attributes.slice(:update_type, :change_note)
+      metadata = attributes.slice(
+        :update_type,
+        :change_note,
+        :scheduled_publishing_datetime,
+      )
+
       unless metadata.empty?
         revision = next_revision.metadata_revision
                                 .build_revision_update(metadata, user)

--- a/app/services/requirements/scheduled_datetime_checker.rb
+++ b/app/services/requirements/scheduled_datetime_checker.rb
@@ -1,0 +1,89 @@
+# frozen_string_literal: true
+
+module Requirements
+  class ScheduledDatetimeChecker
+    attr_reader :day, :month, :year, :time
+
+    FUTURE_TIME_PERIOD = { months: 14 }.freeze
+
+    def initialize(params)
+      @day = params[:day]
+      @month = params[:month]
+      @year = params[:year]
+      @time = params[:time]
+    end
+
+    def date_issues
+      issues = []
+
+      begin
+        parsed_date
+      rescue ArgumentError
+        issues << Issue.new(:scheduled_datetime, :invalid, field: "Date")
+      end
+
+      CheckerIssues.new(issues)
+    end
+
+    def time_issues
+      issues = []
+
+      if parsed_time.nil?
+        issues << Issue.new(:scheduled_datetime, :invalid, field: "Time")
+      end
+
+      CheckerIssues.new(issues)
+    end
+
+    def datetime_issues
+      issues = []
+
+      if in_the_past?
+        issues << Issue.new(:scheduled_datetime, :in_the_past)
+      end
+
+      if too_far_in_the_future?
+        time_period = FUTURE_TIME_PERIOD.map { |k, v| "#{v} #{k}" }.join(" & ")
+        issues << Issue.new(:scheduled_datetime,
+                            :too_far_in_future,
+                            time_period: time_period)
+      end
+
+      CheckerIssues.new(issues)
+    end
+
+    def pre_submit_issues
+      issues = []
+      issues += date_issues.to_a
+      issues += time_issues.to_a
+      if date_issues.items.empty? && time_issues.items.empty?
+        issues += datetime_issues.to_a
+      end
+      CheckerIssues.new(issues)
+    end
+
+    def parsed_datetime
+      @parsed_datetime ||= DateTime.parse("#{parsed_date} #{parsed_time}").in_time_zone
+    end
+
+  private
+
+    def parsed_date
+      @parsed_date ||= Date.parse("#{year}-#{month}-#{day}")
+    end
+
+    def parsed_time
+      @parsed_time ||= Time.zone.parse(time)
+    end
+
+    def in_the_past?
+      now = Time.zone.now
+      parsed_datetime <= now
+    end
+
+    def too_far_in_the_future?
+      now = Time.zone.now
+      parsed_datetime > now.advance(FUTURE_TIME_PERIOD).end_of_day
+    end
+  end
+end

--- a/app/views/documents/show/_actions.html.erb
+++ b/app/views/documents/show/_actions.html.erb
@@ -70,7 +70,7 @@
       <%= link_to "View published edition on GOV.UK", EditionUrl.new(@edition.document.live_edition).public_url, class: "govuk-link govuk-link--no-visited-state" %>
     <% end %>
 
-    <% if @edition.submitted_for_review? || @edition.draft? %>
+    <% if (@edition.submitted_for_review? || @edition.draft?) && current_user.has_permission?(User::PRE_RELEASE_FEATURES_PERMISSION) %>
       <hr class="govuk-section-break govuk-section-break--m govuk-section-break--visible" />
       <%= render "documents/show/scheduling_form" %>
     <% end %>

--- a/app/views/documents/show/_actions.html.erb
+++ b/app/views/documents/show/_actions.html.erb
@@ -69,5 +69,10 @@
       <hr class="govuk-section-break govuk-section-break--m govuk-section-break--visible" />
       <%= link_to "View published edition on GOV.UK", EditionUrl.new(@edition.document.live_edition).public_url, class: "govuk-link govuk-link--no-visited-state" %>
     <% end %>
+
+    <% if @edition.submitted_for_review? || @edition.draft? %>
+      <hr class="govuk-section-break govuk-section-break--m govuk-section-break--visible" />
+      <%= render "documents/show/scheduling_form" %>
+    <% end %>
   </div>
 </div>

--- a/app/views/documents/show/_scheduling_form.html.erb
+++ b/app/views/documents/show/_scheduling_form.html.erb
@@ -13,16 +13,19 @@
       label: { text: "Day" },
       name: "scheduled[day]",
       maxlength: 2,
+      value: publish_datetime&.day,
     } %>
     <%= render "govuk_publishing_components/components/input", {
       label: { text: "Month" },
       name: "scheduled[month]",
       maxlength: 2,
+      value: publish_datetime&.month,
     } %>
     <%= render "govuk_publishing_components/components/input", {
       label: { text: "Year" },
       name: "scheduled[year]",
       maxlength: 4,
+      value: publish_datetime&.year,
     } %>
     <%= render "govuk_publishing_components/components/select", {
       label: "Time",

--- a/app/views/documents/show/_scheduling_form.html.erb
+++ b/app/views/documents/show/_scheduling_form.html.erb
@@ -32,8 +32,14 @@
       id: "scheduled[time]",
       options: time_options(publish_datetime&.strftime("%l:%M%P")&.strip),
     } %>
-    <%= render "govuk_publishing_components/components/button", {
-      text: "Save", margin_bottom: true
-    } %>
+    <% if publish_datetime %>
+      <%= render "govuk_publishing_components/components/button", {
+        text: "Update"
+      } %>
+    <% else %>
+      <%= render "govuk_publishing_components/components/button", {
+        text: "Save"
+      } %>
+    <% end %>
   <% end %>
 <% end %>

--- a/app/views/documents/show/_scheduling_form.html.erb
+++ b/app/views/documents/show/_scheduling_form.html.erb
@@ -1,0 +1,40 @@
+<% publish_datetime = @edition.revision.scheduled_publishing_datetime %>
+
+<%= form_tag(save_scheduled_publishing_datetime_path(@edition.document)) do %>
+  <%= render "govuk_publishing_components/components/details", {
+    title: if publish_datetime
+             simple_format("Publish date: \n" + publish_datetime.strftime("%-d %B %Y - %l:%M%P"))
+           else
+             "Schedule publishing"
+           end
+  } do %>
+    <%= render "govuk_publishing_components/components/input", {
+      label: { text: "Day" },
+      name: "scheduled[day]",
+      maxlength: 2,
+    } %>
+    <%= render "govuk_publishing_components/components/input", {
+      label: { text: "Month" },
+      name: "scheduled[month]",
+      maxlength: 2,
+    } %>
+    <%= render "govuk_publishing_components/components/input", {
+      label: { text: "Year" },
+      name: "scheduled[year]",
+      maxlength: 4,
+    } %>
+    <%= render "govuk_publishing_components/components/select", {
+      label: "Time",
+      id: "scheduled[time]",
+      options: [
+        {
+          text: "12:01am",
+          value: "12:01am"
+        }
+      ]
+    } %>
+    <%= render "govuk_publishing_components/components/button", {
+      text: "Save", margin_bottom: true
+    } %>
+  <% end %>
+<% end %>

--- a/app/views/documents/show/_scheduling_form.html.erb
+++ b/app/views/documents/show/_scheduling_form.html.erb
@@ -1,4 +1,5 @@
 <% publish_datetime = @edition.revision.scheduled_publishing_datetime %>
+<% default_date = Time.zone.now.tomorrow %>
 
 <%= form_tag(save_scheduled_publishing_datetime_path(@edition.document)) do %>
   <%= render "govuk_publishing_components/components/details", {
@@ -26,12 +27,7 @@
     <%= render "govuk_publishing_components/components/select", {
       label: "Time",
       id: "scheduled[time]",
-      options: [
-        {
-          text: "12:01am",
-          value: "12:01am"
-        }
-      ]
+      options: time_options(publish_datetime&.strftime("%l:%M%P")&.strip),
     } %>
     <%= render "govuk_publishing_components/components/button", {
       text: "Save", margin_bottom: true

--- a/app/views/documents/show/_scheduling_form.html.erb
+++ b/app/views/documents/show/_scheduling_form.html.erb
@@ -1,38 +1,48 @@
-<% publish_datetime = @edition.revision.scheduled_publishing_datetime %>
+<% current_scheduled_publish_datetime = @edition.revision.scheduled_publishing_datetime %>
 <% default_date = Time.zone.now.tomorrow %>
+<% publish_date = current_scheduled_publish_datetime || default_date %>
+<% submitted_values = flash[:scheduled_publishing_params] %>
+<% selected_time = submitted_values&.fetch("time") ||  current_scheduled_publish_datetime&.strftime("%l:%M%P")&.strip %>
 
 <%= form_tag(save_scheduled_publishing_datetime_path(@edition.document)) do %>
   <%= render "govuk_publishing_components/components/details", {
-    title: if publish_datetime
-             simple_format("Publish date: \n" + publish_datetime.strftime("%-d %B %Y - %l:%M%P"))
+    title: if current_scheduled_publish_datetime
+             simple_format("Publish date: \n" + current_scheduled_publish_datetime.strftime("%-d %B %Y - %l:%M%P"))
            else
              "Schedule publishing"
            end
   } do %>
+    <% if flash[:scheduled_publishing_datetime_issues] %>
+      <% flash[:scheduled_publishing_datetime_issues].each do |issue| %>
+        <%= render "govuk_publishing_components/components/error_message", {
+          text: issue["text"]
+        } %>
+      <% end %>
+    <% end %>
     <%= render "govuk_publishing_components/components/input", {
       label: { text: "Day" },
       name: "scheduled[day]",
       maxlength: 2,
-      value: publish_datetime&.day,
+      value: submitted_values&.fetch("day") || publish_date&.day,
     } %>
     <%= render "govuk_publishing_components/components/input", {
       label: { text: "Month" },
       name: "scheduled[month]",
       maxlength: 2,
-      value: publish_datetime&.month,
+      value: submitted_values&.fetch("month") || publish_date&.month,
     } %>
     <%= render "govuk_publishing_components/components/input", {
       label: { text: "Year" },
       name: "scheduled[year]",
       maxlength: 4,
-      value: publish_datetime&.year,
+      value: submitted_values&.fetch("year") || publish_date&.year,
     } %>
     <%= render "govuk_publishing_components/components/select", {
       label: "Time",
       id: "scheduled[time]",
-      options: time_options(publish_datetime&.strftime("%l:%M%P")&.strip),
+      options: time_options(selected_time),
     } %>
-    <% if publish_datetime %>
+    <% if current_scheduled_publish_datetime %>
       <%= render "govuk_publishing_components/components/button", {
         text: "Update"
       } %>

--- a/config/locales/en/requirements.yml
+++ b/config/locales/en/requirements.yml
@@ -64,3 +64,10 @@ en:
     public_explanation:
       blank:
         form_message: Enter a public explanation
+    scheduled_datetime:
+      in_the_past:
+        form_message: Date & time cannot be in the past
+      invalid:
+        form_message: "%{field} is invalid"
+      too_far_in_future:
+        form_message: "Please select a date within the next %{time_period}"

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -12,6 +12,8 @@ Rails.application.routes.draw do
   post "/documents/:id/publish" => "publish#publish"
   get "/documents/:id/published" => "publish#published", as: :published
 
+  post "documents/:id/save-scheduled-publishing-datetime" => "schedule#save_scheduled_publishing_datetime", as: :save_scheduled_publishing_datetime
+
   get "/documents" => "documents#index"
   get "/documents/:id/edit" => "documents#edit", as: :edit_document
   patch "/documents/:id" => "documents#update", as: :document

--- a/db/migrate/20190214120136_add_schedule_date_to_metadata_revision.rb
+++ b/db/migrate/20190214120136_add_schedule_date_to_metadata_revision.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+class AddScheduleDateToMetadataRevision < ActiveRecord::Migration[5.2]
+  def change
+    add_column :metadata_revisions, :scheduled_publishing_datetime, :datetime
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2019_02_12_110438) do
+ActiveRecord::Schema.define(version: 2019_02_14_120136) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -154,6 +154,7 @@ ActiveRecord::Schema.define(version: 2019_02_12_110438) do
     t.text "change_note"
     t.datetime "created_at"
     t.bigint "created_by_id"
+    t.datetime "scheduled_publishing_datetime"
   end
 
   create_table "removals", force: :cascade do |t|
@@ -255,8 +256,8 @@ ActiveRecord::Schema.define(version: 2019_02_12_110438) do
   create_table "withdrawals", force: :cascade do |t|
     t.string "public_explanation", null: false
     t.datetime "created_at", null: false
-    t.bigint "published_status_id", null: false
     t.datetime "withdrawn_at", null: false
+    t.bigint "published_status_id", null: false
   end
 
   add_foreign_key "content_revisions", "users", column: "created_by_id", on_delete: :restrict

--- a/spec/features/workflow/schedule_requirements_spec.rb
+++ b/spec/features/workflow/schedule_requirements_spec.rb
@@ -1,0 +1,41 @@
+# frozen_string_literal: true
+
+RSpec.feature "Scheduling requirements" do
+  scenario do
+    given_there_is_an_edition
+    when_i_visit_the_summary_page
+    and_i_click_on_schedule_publishing
+    and_i_enter_invalid_date_fields
+    and_i_click_save
+    then_i_see_an_error_about_the_date_being_invalid
+  end
+
+  def given_there_is_an_edition
+    @edition = create(:edition)
+  end
+
+  def when_i_visit_the_summary_page
+    visit document_path(@edition.document)
+  end
+
+  def and_i_click_on_schedule_publishing
+    find(".govuk-details__summary-text", text: "Schedule publishing").click
+  end
+
+  def and_i_enter_invalid_date_fields
+    fill_in "scheduled[day]", with: ""
+    fill_in "scheduled[month]", with: ""
+    fill_in "scheduled[year]", with: ""
+  end
+
+  def and_i_click_save
+    click_on "Save"
+  end
+
+  def then_i_see_an_error_about_the_date_being_invalid
+    expect(page).to have_content(
+      I18n.t!("requirements.scheduled_datetime.invalid.form_message",
+      field: "Date"),
+    )
+  end
+end

--- a/spec/features/workflow/schedule_spec.rb
+++ b/spec/features/workflow/schedule_spec.rb
@@ -5,7 +5,9 @@ RSpec.feature "Scheduling an edition" do
     given_there_is_an_edition
     when_i_visit_the_summary_page
     and_i_click_on_schedule_publishing
-    and_i_choose_a_scheduled_date_and_time
+    then_i_see_a_default_date_and_time_selected
+
+    when_i_choose_a_scheduled_date_and_time
     and_i_click_save
     then_i_see_the_edition_has_a_set_scheduled_publishing_date_and_time
   end
@@ -22,8 +24,24 @@ RSpec.feature "Scheduling an edition" do
     find(".govuk-details__summary-text", text: "Schedule publishing").click
   end
 
-  def and_i_choose_a_scheduled_date_and_time
-    @date = Time.zone.now.tomorrow
+  def then_i_see_a_default_date_and_time_selected
+    default_date = Time.zone.tomorrow
+    expect(page).to have_selector(
+      "[@name='scheduled[day]'][@value='#{default_date.day}']",
+    )
+    expect(page).to have_selector(
+      "[@name='scheduled[month]'][@value='#{default_date.month}']",
+    )
+    expect(page).to have_selector(
+      "[@name='scheduled[year]'][@value='#{default_date.year}']",
+    )
+    expect(page).to have_select(
+      "scheduled[time]", selected: "9:00am"
+    )
+  end
+
+  def when_i_choose_a_scheduled_date_and_time
+    @date = Time.zone.now.advance(days: 2)
     fill_in "scheduled[day]", with: @date.day
     fill_in "scheduled[month]", with: @date.month
     fill_in "scheduled[year]", with: @date.year
@@ -37,9 +55,15 @@ RSpec.feature "Scheduling an edition" do
   def then_i_see_the_edition_has_a_set_scheduled_publishing_date_and_time
     scheduled_date = @date.strftime("%-d %B %Y - 11:00pm")
     expect(page).to have_content("Publish date: #{scheduled_date}")
-    expect(page).to have_selector("[@name='scheduled[day]'][@value='#{@date.day}']")
-    expect(page).to have_selector("[@name='scheduled[month]'][@value='#{@date.month}']")
-    expect(page).to have_selector("[@name='scheduled[year]'][@value='#{@date.year}']")
-    expect(page).to have_select("scheduled[time]", selected: "11:00pm")
+    expect(page).to have_selector(
+      "[@name='scheduled[day]'][@value='#{@date.day}']",
+    )
+    expect(page).to have_selector(
+      "[@name='scheduled[month]'][@value='#{@date.month}']",
+    )
+    expect(page).to have_selector(
+      "[@name='scheduled[year]'][@value='#{@date.year}']",
+    )
+    expect(find_field("scheduled[time]").value).to eq("11:00pm")
   end
 end

--- a/spec/features/workflow/schedule_spec.rb
+++ b/spec/features/workflow/schedule_spec.rb
@@ -27,7 +27,7 @@ RSpec.feature "Scheduling an edition" do
     fill_in "scheduled[day]", with: @date.day
     fill_in "scheduled[month]", with: @date.month
     fill_in "scheduled[year]", with: @date.year
-    select "12:01am", from: "scheduled[time]"
+    select "11:00pm", from: "scheduled[time]"
   end
 
   def and_i_click_save
@@ -35,7 +35,11 @@ RSpec.feature "Scheduling an edition" do
   end
 
   def then_i_see_the_edition_has_a_set_scheduled_publishing_date_and_time
-    scheduled_date = @date.strftime("%-d %B %Y - 12:01am")
+    scheduled_date = @date.strftime("%-d %B %Y - 11:00pm")
     expect(page).to have_content("Publish date: #{scheduled_date}")
+    expect(page).to have_selector("[@name='scheduled[day]'][@value='#{@date.day}']")
+    expect(page).to have_selector("[@name='scheduled[month]'][@value='#{@date.month}']")
+    expect(page).to have_selector("[@name='scheduled[year]'][@value='#{@date.year}']")
+    expect(page).to have_select("scheduled[time]", selected: "11:00pm")
   end
 end

--- a/spec/features/workflow/schedule_spec.rb
+++ b/spec/features/workflow/schedule_spec.rb
@@ -1,0 +1,41 @@
+# frozen_string_literal: true
+
+RSpec.feature "Scheduling an edition" do
+  scenario do
+    given_there_is_an_edition
+    when_i_visit_the_summary_page
+    and_i_click_on_schedule_publishing
+    and_i_choose_a_scheduled_date_and_time
+    and_i_click_save
+    then_i_see_the_edition_has_a_set_scheduled_publishing_date_and_time
+  end
+
+  def given_there_is_an_edition
+    @edition = create(:edition)
+  end
+
+  def when_i_visit_the_summary_page
+    visit document_path(@edition.document)
+  end
+
+  def and_i_click_on_schedule_publishing
+    find(".govuk-details__summary-text", text: "Schedule publishing").click
+  end
+
+  def and_i_choose_a_scheduled_date_and_time
+    @date = Time.zone.now.tomorrow
+    fill_in "scheduled[day]", with: @date.day
+    fill_in "scheduled[month]", with: @date.month
+    fill_in "scheduled[year]", with: @date.year
+    select "12:01am", from: "scheduled[time]"
+  end
+
+  def and_i_click_save
+    click_on "Save"
+  end
+
+  def then_i_see_the_edition_has_a_set_scheduled_publishing_date_and_time
+    scheduled_date = @date.strftime("%-d %B %Y - 12:01am")
+    expect(page).to have_content("Publish date: #{scheduled_date}")
+  end
+end

--- a/spec/services/requirements/scheduled_datetime_checker_spec.rb
+++ b/spec/services/requirements/scheduled_datetime_checker_spec.rb
@@ -1,0 +1,127 @@
+# frozen_string_literal: true
+
+RSpec.describe Requirements::ScheduledDatetimeChecker do
+  let(:valid_datetime) { Time.zone.now.tomorrow }
+  let(:datetime_params) do
+    {
+      day: valid_datetime.day,
+      month: valid_datetime.month,
+      year: valid_datetime.year,
+      time: "11:00am",
+    }
+  end
+
+  describe "#date_issues" do
+    it "returns no issues if there are none" do
+      issues = Requirements::ScheduledDatetimeChecker.new(datetime_params).date_issues
+      expect(issues.items).to be_empty
+    end
+
+    it "returns an issue if the date is invalid" do
+      datetime_params[:day] = ""
+      datetime_params[:month] = ""
+      datetime_params[:year] = ""
+
+      invalid_date = I18n.t!(
+        "requirements.scheduled_datetime.invalid.form_message",
+        field: "Date",
+      )
+
+      issues = Requirements::ScheduledDatetimeChecker.new(datetime_params).date_issues
+      expect(issues.items_for(:scheduled_datetime))
+        .to include(a_hash_including(text: invalid_date))
+    end
+  end
+
+  describe "#time_issues" do
+    it "returns no issues if there are none" do
+      issues = Requirements::ScheduledDatetimeChecker.new(datetime_params).time_issues
+      expect(issues.items).to be_empty
+    end
+
+    it "returns an issue if the time values are invalid" do
+      datetime_params[:time] = ""
+
+      issues = Requirements::ScheduledDatetimeChecker.new(datetime_params).time_issues
+      time_issue = I18n.t!(
+        "requirements.scheduled_datetime.invalid.form_message",
+        field: "Time",
+      )
+
+      expect(issues.items_for(:scheduled_datetime))
+        .to include(a_hash_including(text: time_issue))
+    end
+  end
+
+  describe "#datetime_issues" do
+    it "returns no issues if the datetime is in the future within the limit" do
+      issues = Requirements::ScheduledDatetimeChecker.new(datetime_params).datetime_issues
+      expect(issues.items).to be_empty
+    end
+
+    it "returns an issue if the datetime is in the past" do
+      datetime_params[:day] -= 2
+      issues = Requirements::ScheduledDatetimeChecker.new(datetime_params).datetime_issues
+      datetime_issue = I18n.t!("requirements.scheduled_datetime.in_the_past.form_message")
+
+      expect(issues.items_for(:scheduled_datetime))
+        .to include(a_hash_including(text: datetime_issue))
+    end
+
+    it "returns an issues if the datetime is too far in the future" do
+      allowed_time_period = Requirements::ScheduledDatetimeChecker::FUTURE_TIME_PERIOD
+      period = { day: 1 }.merge(allowed_time_period)
+      future_date_time = valid_datetime.advance(period)
+
+      datetime_params[:day] = future_date_time.day.to_i
+      datetime_params[:month] = future_date_time.month.to_i
+      datetime_params[:year] = future_date_time.year.to_i
+
+      issues = Requirements::ScheduledDatetimeChecker.new(datetime_params).datetime_issues
+      datetime_issue = I18n.t!("requirements.scheduled_datetime.too_far_in_future.form_message",
+                               time_period: allowed_time_period.map { |k, v| "#{v} #{k}" }.join(" & "))
+
+      expect(issues.items_for(:scheduled_datetime))
+        .to include(a_hash_including(text: datetime_issue))
+    end
+  end
+
+  describe "#pre_submit_issues" do
+    it "returns no issues if there are none" do
+      issues = Requirements::ScheduledDatetimeChecker.new(datetime_params).pre_submit_issues
+      expect(issues.items).to be_empty
+    end
+
+    it "returns datetime issues if any are present" do
+      datetime_params[:day] -= 2
+      datetime_issue = I18n.t!("requirements.scheduled_datetime.in_the_past.form_message")
+
+      issues = Requirements::ScheduledDatetimeChecker.new(datetime_params).pre_submit_issues
+
+      expect(issues.items_for(:scheduled_datetime))
+        .to include(a_hash_including(text: datetime_issue))
+    end
+
+    it "returns date and time issues if any are present" do
+      datetime_params[:day] = ""
+      datetime_params[:time] = ""
+
+      date_issue = I18n.t!(
+        "requirements.scheduled_datetime.invalid.form_message",
+        field: "Date",
+      )
+
+      time_issue = I18n.t!(
+        "requirements.scheduled_datetime.invalid.form_message",
+        field: "Time",
+      )
+
+      issues = Requirements::ScheduledDatetimeChecker.new(datetime_params).pre_submit_issues
+
+      expect(issues.items_for(:scheduled_datetime))
+      .to include(a_hash_including(text: date_issue))
+      expect(issues.items_for(:scheduled_datetime))
+        .to include(a_hash_including(text: time_issue))
+    end
+  end
+end


### PR DESCRIPTION
For https://trello.com/c/4Ycdjj3C/640-allow-users-to-set-a-future-date-and-time-for-content-to-be-published

This PR enables users to set a scheduled date and time for content to be published.  A default time appears in the form and users can set and update their chosen scheduled date and time.  The input users choose is validated using the ScheduledDateTimeChecker service and errors are displayed in the event a user inputs invalid data.  

This PR does not handle the process of scheduling itself, which will be covered in a subsequent card.

The current usage of input fields for the date is a temporary measure.  There is a card in the backlog that will look at creating a date input component to replace these.  It is also expected that the time selection dropdown will eventually be replaced by a more dynamic component that will allow users to select a more granular minutes value.

<img width="306" alt="screen shot 2019-02-19 at 11 51 11" src="https://user-images.githubusercontent.com/13434452/53013212-174bbe00-343d-11e9-947b-54dc8ce95984.png">

<img width="287" alt="screen shot 2019-02-21 at 15 53 02" src="https://user-images.githubusercontent.com/13434452/53182210-ee6c2a00-35f0-11e9-9625-18dab280ddba.png">

<img width="306" alt="screen shot 2019-02-19 at 11 52 33" src="https://user-images.githubusercontent.com/13434452/53013268-3c403100-343d-11e9-81aa-2eaad956c9bf.png">
