### PR TITLE
Inline image modal

### DIFF
--- a/app/assets/javascripts/application.js
+++ b/app/assets/javascripts/application.js
@@ -26,6 +26,7 @@
 
 //= require modules/gtm-form-listener.js
 //= require modules/gtm-track-copy.js
+//= require modules/inline-image-modal.js
 //= require modules/warn-before-unload.js
 
 // load after other components (esp. autocomplete)

--- a/app/assets/javascripts/components/markdown-editor.js
+++ b/app/assets/javascripts/components/markdown-editor.js
@@ -17,6 +17,7 @@ window.GOVUK.Modules = window.GOVUK.Modules || {};
     this.$previewBody = this.$module.querySelector('.js-markdown-preview-body')
     this.$toolbar = document.querySelector('.app-c-markdown-guidance')
     this.$editorToolbar = document.querySelector('.app-c-markdown-editor__toolbar')
+    this.$module.selectionReplace = this.handleSelectionReplace.bind(this)
 
     // Enable toggle bar
     this.$head.style.display = 'block'
@@ -30,6 +31,16 @@ window.GOVUK.Modules = window.GOVUK.Modules || {};
     this.bubbleFocusEventToComponent(this.$input)
     this.bubbleFocusEventToComponent(this.$editButton)
     this.bubbleFocusEventToComponent(this.$previewButton)
+  }
+
+  MarkdownEditor.prototype.handleSelectionReplace = function (text) {
+    var selectionStart = this.$input.selectionStart + text.length
+    this.$input.focus()
+
+    window.MarkdownToolbarElement.insertText(
+      this.$input,
+      { text: text, selectionStart: selectionStart, selectionEnd: selectionStart }
+    )
   }
 
   MarkdownEditor.prototype.handlePreviewButton = function (event) {

--- a/app/assets/javascripts/components/multi-section-viewer.js
+++ b/app/assets/javascripts/components/multi-section-viewer.js
@@ -18,6 +18,10 @@ window.GOVUK.Modules = window.GOVUK.Modules || {};
         this.showStaticSection(event.target.dataset.targetSection)
       }.bind(this))
     }.bind(this))
+
+    this.$module.hideAllSections = this.hideAllSections.bind(this)
+    this.$module.showDynamicSection = this.showDynamicSection.bind(this)
+    this.$module.showStaticSection = this.showStaticSection.bind(this)
   }
 
   MultiSectionViewer.prototype.hideAllSections = function () {

--- a/app/assets/javascripts/modules/inline-image-modal.js
+++ b/app/assets/javascripts/modules/inline-image-modal.js
@@ -19,7 +19,7 @@ InlineImageModal.prototype.init = function () {
 
 InlineImageModal.prototype.fetchModalContent = function (url) {
   var controller = new window.AbortController()
-  var headers = { 'X-Requested-With': 'XMLHttpRequest' }
+  var headers = { 'Content-Publisher-Rendering-Context': 'modal' }
   var options = { credentials: 'include', signal: controller.signal, headers: headers }
   setTimeout(function () { controller.abort() }, 5000)
 

--- a/app/assets/javascripts/modules/inline-image-modal.js
+++ b/app/assets/javascripts/modules/inline-image-modal.js
@@ -1,0 +1,73 @@
+function InlineImageModal ($module) {
+  this.$module = $module
+  this.$modal = document.getElementById('modal')
+}
+
+InlineImageModal.prototype.init = function () {
+  if (!this.$module || !this.$modal) {
+    return
+  }
+
+  this.$multiSectionViewer = this.$modal
+    .querySelector('[data-module="multi-section-viewer"]')
+
+  this.$module.addEventListener('click', function (event) {
+    event.preventDefault()
+    this.performAction(this.$module)
+  }.bind(this))
+}
+
+InlineImageModal.prototype.fetchModalContent = function (url) {
+  var controller = new window.AbortController()
+  var headers = { 'X-Requested-With': 'XMLHttpRequest' }
+  var options = { credentials: 'include', signal: controller.signal, headers: headers }
+  setTimeout(function () { controller.abort() }, 5000)
+
+  return window.fetch(url, options)
+    .then(function (response) {
+      if (!response.ok) {
+        return window.Promise.reject('Unable to render the content.')
+      }
+      return response.text()
+    })
+}
+
+InlineImageModal.prototype.performAction = function (item) {
+  var handlers = {
+    'open': function () {
+      this.$modal.open()
+
+      this.fetchModalContent(item.dataset.modalActionUrl)
+        .then(function (text) {
+          this.$multiSectionViewer.showDynamicSection(text)
+          this.overrideActions()
+        }.bind(this))
+        .catch(function (result) {
+          this.$multiSectionViewer.showStaticSection('error')
+        }.bind(this))
+    },
+    'insert': function () {
+      var editor = this.$module.closest('[data-module="markdown-editor"]')
+      this.$modal.close()
+      editor.selectionReplace(item.dataset.modalData)
+    }
+  }
+
+  this.$modal.focusDialog()
+  this.$multiSectionViewer.showStaticSection('loading')
+  handlers[item.dataset.modalAction].bind(this)()
+}
+
+InlineImageModal.prototype.overrideActions = function () {
+  var items = this.$modal.querySelectorAll('[data-modal-action]')
+
+  items.forEach(function (item) {
+    item.addEventListener('click', function (event) {
+      event.preventDefault()
+      this.performAction(item)
+    }.bind(this))
+  }.bind(this))
+}
+
+var element = document.querySelector('[data-module="inline-image-modal"]')
+new InlineImageModal(element).init()

--- a/app/assets/javascripts/vendor/@alphagov/markdown-toolbar-element/index.js
+++ b/app/assets/javascripts/vendor/@alphagov/markdown-toolbar-element/index.js
@@ -857,5 +857,6 @@
     }
   }
 
+  MarkdownToolbarElement.insertText = insertText;
   exports.default = MarkdownToolbarElement;
 });

--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -24,6 +24,7 @@
 @import "components/input-length-suggester";
 @import "components/modal-dialogue";
 @import "components/multi-section-viewer";
+@import "components/loading-spinner";
 
 @import "utilities/display";
 @import "utilities/overwrites";

--- a/app/assets/stylesheets/components/_loading-spinner.scss
+++ b/app/assets/stylesheets/components/_loading-spinner.scss
@@ -1,0 +1,6 @@
+$loading-spinner-container-padding: govuk-spacing(8) + govuk-spacing(8);
+
+.app-c-loading-spinner {
+  text-align: center;
+  padding: $loading-spinner-container-padding;
+}

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -3,8 +3,14 @@
 class ApplicationController < ActionController::Base
   include GDS::SSO::ControllerMethods
 
+  helper_method :rendering_context
+
   before_action :authenticate_user!
   before_action { Raven.user_context(id: current_user&.uid) }
 
   add_flash_types :alert_with_description, :alert_with_items, :confirmation, :tried_to_publish, :tried_to_preview
+
+  def rendering_context
+    request.headers["Content-Publisher-Rendering-Context"] || "application"
+  end
 end

--- a/app/controllers/images_controller.rb
+++ b/app/controllers/images_controller.rb
@@ -8,6 +8,7 @@ class ImagesController < ApplicationController
 
   def index
     @document = Document.with_current_edition.find_by_param(params[:document_id])
+    render layout: (@context = "modal") if request.xhr?
   end
 
   def create

--- a/app/controllers/images_controller.rb
+++ b/app/controllers/images_controller.rb
@@ -8,7 +8,7 @@ class ImagesController < ApplicationController
 
   def index
     @document = Document.with_current_edition.find_by_param(params[:document_id])
-    render layout: (@context = "modal") if request.xhr?
+    render layout: rendering_context
   end
 
   def create

--- a/app/views/components/_loading_spinner.html.erb
+++ b/app/views/components/_loading_spinner.html.erb
@@ -1,0 +1,1 @@
+<p class="govuk-body app-c-loading-spinner">Loading...</p>

--- a/app/views/components/_markdown_editor.html.erb
+++ b/app/views/components/_markdown_editor.html.erb
@@ -41,6 +41,11 @@
             <%= render "components/markdown_editor/bullets.svg" %>
           </md-unordered-list>
           <button name="submit" type="submit" value="add_contact" class="app-c-markdown-editor__toolbar-button app-c-markdown-editor__toolbar-button--text app-c-markdown-editor__toolbar-button--end">Add contact</button>
+          <button name="submit" type="submit" value="add_image" class="app-c-markdown-editor__toolbar-button app-c-markdown-editor__toolbar-button--text app-c-markdown-editor__toolbar-button--end"
+            data-module="inline-image-modal"
+            data-modal-action="open"
+            data-modal-action-url="<%= images_path(@document) %>"
+          >Insert image</button>
         </markdown-toolbar>
       </div>
     </div>

--- a/app/views/components/_markdown_editor.html.erb
+++ b/app/views/components/_markdown_editor.html.erb
@@ -41,11 +41,13 @@
             <%= render "components/markdown_editor/bullets.svg" %>
           </md-unordered-list>
           <button name="submit" type="submit" value="add_contact" class="app-c-markdown-editor__toolbar-button app-c-markdown-editor__toolbar-button--text app-c-markdown-editor__toolbar-button--end">Add contact</button>
-          <button name="submit" type="submit" value="add_image" class="app-c-markdown-editor__toolbar-button app-c-markdown-editor__toolbar-button--text app-c-markdown-editor__toolbar-button--end"
-            data-module="inline-image-modal"
-            data-modal-action="open"
-            data-modal-action-url="<%= images_path(@document) %>"
-          >Insert image</button>
+          <% if current_user.permissions.include?(User::PRE_RELEASE_FEATURES_PERMISSION) %>
+            <button name="submit" type="submit" value="add_image" class="app-c-markdown-editor__toolbar-button app-c-markdown-editor__toolbar-button--text app-c-markdown-editor__toolbar-button--end"
+              data-module="inline-image-modal"
+              data-modal-action="open"
+              data-modal-action-url="<%= images_path(@document) %>"
+            >Insert image</button>
+          <% end %>
         </markdown-toolbar>
       </div>
     </div>

--- a/app/views/components/docs/loading_spinner.yml
+++ b/app/views/components/docs/loading_spinner.yml
@@ -1,0 +1,4 @@
+name: Loading spinner
+description: Displays an animated graphic to indicate loading activity
+examples:
+  default:

--- a/app/views/images/_image.html.erb
+++ b/app/views/images/_image.html.erb
@@ -1,7 +1,7 @@
 <% actions = [] %>
 <% actions << link_to("Download 960x640 image", download_image_path(document, image.image_id), class: "govuk-link") %>
 
-<% if context == "modal" %>
+<% if rendering_context == "modal" %>
   <% actions << link_to("Insert image markdown", "#",
                         data: { "modal-action": "insert",
                                 "modal-data": I18n.t("images.index.meta.inline_code.value", filename: image.filename) },

--- a/app/views/images/_image.html.erb
+++ b/app/views/images/_image.html.erb
@@ -1,17 +1,24 @@
 <% actions = [] %>
-
-<% actions << link_to("Edit image", crop_image_path(document, image.image_id), class: "govuk-link") %>
 <% actions << link_to("Download 960x640 image", download_image_path(document, image.image_id), class: "govuk-link") %>
 
-<% actions << capture do %>
-  <%= form_tag choose_lead_image_path(document, image.image_id), class: "app-inline-block" do %>
-    <button class="govuk-link app-link--button">Select as lead image</button>
-  <% end %>
-<% end %>
+<% if context == "modal" %>
+  <% actions << link_to("Insert image markdown", "#",
+                        data: { "modal-action": "insert",
+                                "modal-data": I18n.t("images.index.meta.inline_code.value", filename: image.filename) },
+                        class: "govuk-link govuk-link--no-visited-state") %>
+<% else %>
+  <% actions << link_to("Edit image", crop_image_path(document, image.image_id), class: "govuk-link") %>
 
-<% actions << capture do %>
-  <%= form_tag destroy_image_path(document, image.image_id), method: :delete, class: "app-inline-block" do %>
-    <button class="govuk-link app-link--button app-link--destructive">Delete image</button>
+  <% actions << capture do %>
+    <%= form_tag choose_lead_image_path(document, image.image_id), class: "app-inline-block" do %>
+      <button class="govuk-link app-link--button">Select as lead image</button>
+    <% end %>
+  <% end %>
+
+  <% actions << capture do %>
+    <%= form_tag destroy_image_path(document, image.image_id), method: :delete, class: "app-inline-block" do %>
+      <button class="govuk-link app-link--button app-link--destructive">Delete image</button>
+    <% end %>
   <% end %>
 <% end %>
 

--- a/app/views/images/_lead_image.html.erb
+++ b/app/views/images/_lead_image.html.erb
@@ -3,18 +3,21 @@
 </h2>
 
 <% actions = [] %>
-<% actions << link_to("Edit image", crop_image_path(document, lead_image.image_id), class: "govuk-link") %>
 <% actions << link_to("Download 960x640 image", download_image_path(document, lead_image.image_id), class: "govuk-link") %>
 
-<% actions << capture do %>
-  <%= form_tag remove_lead_image_path(document), method: :delete, class: "app-inline-block" do %>
-    <button class="govuk-link app-link--button">Remove lead image</button>
-  <% end %>
-<% end %>
+<% unless context == "modal" %>
+  <% actions << link_to("Edit image", crop_image_path(document, lead_image.image_id), class: "govuk-link") %>
 
-<% actions << capture do %>
-  <%= form_tag destroy_image_path(document, lead_image.image_id), method: :delete, class: "app-inline-block" do %>
-    <button class="govuk-link app-link--button app-link--destructive">Delete lead image</button>
+  <% actions << capture do %>
+    <%= form_tag remove_lead_image_path(document), method: :delete, class: "app-inline-block" do %>
+      <button class="govuk-link app-link--button">Remove lead image</button>
+    <% end %>
+  <% end %>
+
+  <% actions << capture do %>
+    <%= form_tag destroy_image_path(document, lead_image.image_id), method: :delete, class: "app-inline-block" do %>
+      <button class="govuk-link app-link--button app-link--destructive">Delete lead image</button>
+    <% end %>
   <% end %>
 <% end %>
 

--- a/app/views/images/_lead_image.html.erb
+++ b/app/views/images/_lead_image.html.erb
@@ -5,7 +5,7 @@
 <% actions = [] %>
 <% actions << link_to("Download 960x640 image", download_image_path(document, lead_image.image_id), class: "govuk-link") %>
 
-<% unless context == "modal" %>
+<% unless rendering_context == "modal" %>
   <% actions << link_to("Edit image", crop_image_path(document, lead_image.image_id), class: "govuk-link") %>
 
   <% actions << capture do %>

--- a/app/views/images/index.html.erb
+++ b/app/views/images/index.html.erb
@@ -3,35 +3,38 @@
 
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
-    <div class="app-pane">
-      <% upload_image_heading = capture do %>
-        <h2 class="govuk-heading-m">
-          <%= t("images.index.upload_image") %>
-        </h2>
-      <% end %>
 
-      <%= form_tag(
-        create_image_path(@document),
-        multipart: true,
-        data: { gtm: "image-upload-submit" },
-      ) do %>
-        <%= render "govuk_publishing_components/components/file_upload", {
-          label: {
-            text: upload_image_heading,
-          },
-          name: "image"
-        } %>
+    <% unless @context == 'modal' %>
+      <div class="app-pane">
+        <% upload_image_heading = capture do %>
+          <h2 class="govuk-heading-m">
+            <%= t("images.index.upload_image") %>
+          </h2>
+        <% end %>
 
-        <%= render_govspeak(t("images.index.description_govspeak")) %>
+        <%= form_tag(
+          create_image_path(@document),
+          multipart: true,
+          data: { gtm: "image-upload-submit" },
+        ) do %>
+          <%= render "govuk_publishing_components/components/file_upload", {
+            label: {
+              text: upload_image_heading,
+            },
+            name: "image"
+          } %>
 
-        <%= render "govuk_publishing_components/components/button", {
-          text: "Upload"
-        } %>
-      <% end %>
-    </div>
+          <%= render_govspeak(t("images.index.description_govspeak")) %>
+
+          <%= render "govuk_publishing_components/components/button", {
+            text: "Upload",
+          } %>
+        <% end %>
+      </div>
+    <% end %>
 
     <% if lead_image = @document.current_edition.lead_image_revision %>
-      <%= render "lead_image", lead_image: lead_image, document: @document %>
+      <%= render "lead_image", lead_image: lead_image, document: @document, context: @context %>
     <% end %>
 
     <% images = @document.current_edition.image_revisions_without_lead %>
@@ -42,7 +45,7 @@
       </h2>
 
       <% images.each do |image| %>
-        <%= render "image", image: image, document: @document %>
+        <%= render "image", image: image, document: @document, context: @context %>
       <% end %>
     <% end %>
   </div>

--- a/app/views/images/index.html.erb
+++ b/app/views/images/index.html.erb
@@ -4,7 +4,7 @@
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
 
-    <% unless @context == 'modal' %>
+    <% unless rendering_context == 'modal' %>
       <div class="app-pane">
         <% upload_image_heading = capture do %>
           <h2 class="govuk-heading-m">
@@ -34,7 +34,7 @@
     <% end %>
 
     <% if lead_image = @document.current_edition.lead_image_revision %>
-      <%= render "lead_image", lead_image: lead_image, document: @document, context: @context %>
+      <%= render "lead_image", lead_image: lead_image, document: @document %>
     <% end %>
 
     <% images = @document.current_edition.image_revisions_without_lead %>
@@ -45,7 +45,7 @@
       </h2>
 
       <% images.each do |image| %>
-        <%= render "image", image: image, document: @document, context: @context %>
+        <%= render "image", image: image, document: @document %>
       <% end %>
     <% end %>
   </div>

--- a/app/views/layouts/_modal_error.html.erb
+++ b/app/views/layouts/_modal_error.html.erb
@@ -1,0 +1,2 @@
+<h1 class="govuk-heading-l"><%= t("application.modal_error.title") %></h1>
+<%= render_govspeak(t("application.modal_error.description_govspeak")) %>

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -165,4 +165,19 @@
       },
     ]
   } %>
+
+  <%= render "components/modal_dialogue", { id: "modal", wide: true } do %>
+    <% render "components/multi_section_viewer", {
+      sections: [
+        {
+          id: "loading",
+          content: render("components/loading_spinner")
+        },
+        {
+          id: "error",
+          content: render("layouts/modal_error")
+        }
+      ]
+    } %>
+  <% end %>
 <% end %>

--- a/app/views/layouts/modal.html.erb
+++ b/app/views/layouts/modal.html.erb
@@ -1,0 +1,3 @@
+<h1 class="govuk-heading-l"><%= yield(:title) %></h1>
+
+<%= yield %>

--- a/config/locales/en/application.yml
+++ b/config/locales/en/application.yml
@@ -1,5 +1,8 @@
 en:
   application:
+    modal_error:
+      title: Something has gone wrong
+      description_govspeak: Something went wrong with your request. Please try again or [raise a support request](https://support.publishing.service.gov.uk/technical_fault_report/new).
     phase_banner:
       raise_a_support_request: Raise a support request
       send_us_feedback: Send us feedback

--- a/spec/features/editing_content/insert_inline_image_spec.rb
+++ b/spec/features/editing_content/insert_inline_image_spec.rb
@@ -1,0 +1,43 @@
+# frozen_string_literal: true
+
+RSpec.feature "Insert inline image", js: true do
+  scenario do
+    given_there_is_an_edition_with_images
+    when_i_go_to_edit_the_edition
+    and_i_click_to_insert_an_image
+    and_i_choose_one_of_the_images
+    then_i_see_the_snippet_is_inserted
+  end
+
+  def given_there_is_an_edition_with_images
+    body_field = build(:field, id: "body", type: "govspeak")
+    document_type = build(:document_type, contents: [body_field], images: true)
+    @image_revision = create(:image_revision,
+                             :on_asset_manager,
+                             filename: "foo.jpg")
+    @edition = create(:edition,
+                      document_type_id: document_type.id,
+                      image_revisions: [@image_revision])
+  end
+
+  def when_i_go_to_edit_the_edition
+    visit edit_document_path(@edition.document)
+  end
+
+  def and_i_click_to_insert_an_image
+    within(".app-c-markdown-editor") do
+      click_on "Insert image"
+    end
+  end
+
+  def and_i_choose_one_of_the_images
+    click_on "Insert image markdown"
+  end
+
+  def then_i_see_the_snippet_is_inserted
+    snippet = I18n.t("images.index.meta.inline_code.value",
+                     filename: @image_revision.filename)
+
+    expect(find("#body").value).to match snippet
+  end
+end

--- a/spec/javascripts/components/multi-section-viewer-spec.js
+++ b/spec/javascripts/components/multi-section-viewer-spec.js
@@ -1,7 +1,7 @@
 describe('Multi section viewer', function () {
   'use strict'
 
-  var container, module
+  var container, element
 
   beforeEach(function () {
     container = document.createElement('div')
@@ -20,9 +20,8 @@ describe('Multi section viewer', function () {
       '</div>'
 
     document.body.appendChild(container)
-    var element = document.querySelector('[data-module="multi-section-viewer"]')
-    module = new GOVUK.Modules.MultiSectionViewer()
-    module.start($(element))
+    element = document.querySelector('[data-module="multi-section-viewer"]')
+    new GOVUK.Modules.MultiSectionViewer().start($(element))
   })
 
   afterEach(function () {
@@ -69,12 +68,12 @@ describe('Multi section viewer', function () {
 
       dynamicSection.style.display = 'block'
 
-      module.showStaticSection('section-1')
+      element.showStaticSection('section-1')
       expect(section1).toBeVisible()
       expect(section2).toBeHidden()
       expect(dynamicSection).toBeHidden()
 
-      module.showStaticSection('section-2')
+      element.showStaticSection('section-2')
       expect(section2).toBeVisible()
       expect(section1).toBeHidden()
       expect(dynamicSection).toBeHidden()
@@ -87,14 +86,14 @@ describe('Multi section viewer', function () {
       var section1 = document.querySelector('#section-1')
 
       section1.style.display = 'block'
-      module.showDynamicSection('<div>Dynamic</div>')
+      element.showDynamicSection('<div>Dynamic</div>')
       expect(dynamicSection).toBeVisible()
       expect(section1).toBeHidden()
     })
 
     it('sets the content of the dynamic section', function () {
       var dynamicSection = document.querySelector('.js-dynamic-section')
-      module.showDynamicSection('<div>Dynamic</div>')
+      element.showDynamicSection('<div>Dynamic</div>')
       expect(dynamicSection.innerHTML).toEqual('<div>Dynamic</div>')
     })
   })
@@ -107,7 +106,7 @@ describe('Multi section viewer', function () {
       section1.style.display = 'block'
       dynamicSection.style.display = 'block'
 
-      module.hideAllSections()
+      element.hideAllSections()
       expect(section1).toBeHidden()
       expect(dynamicSection).toBeHidden()
     })


### PR DESCRIPTION
https://trello.com/c/jARJ0xxA/642-use-a-modal-to-insert-an-existing-image-as-an-inline-snippet

This adds a 'glue' module to operate a modal for the purpose of inserting inline images. Please see the commits for further details.