### PR TITLE
Remove explicit scss imports

### DIFF
--- a/app/assets/stylesheets/components/_autocomplete.scss
+++ b/app/assets/stylesheets/components/_autocomplete.scss
@@ -1,4 +1,3 @@
-@import "govuk-frontend/helpers/typography";
 @import "vendor/accessible-autocomplete/dist/accessible-autocomplete.min";
 
 .autocomplete__option {

--- a/app/assets/stylesheets/components/_contextual-guidance.scss
+++ b/app/assets/stylesheets/components/_contextual-guidance.scss
@@ -1,6 +1,3 @@
-@import "govuk-frontend/settings/all";
-@import "govuk-frontend/helpers/all";
-
 .app-c-contextual-guidance-wrapper {
   position: absolute;
 

--- a/app/assets/stylesheets/components/_formatted-text.scss
+++ b/app/assets/stylesheets/components/_formatted-text.scss
@@ -1,5 +1,3 @@
-@import "govuk-frontend/helpers/all";
-
 .app-c-formatted-text {
   @include govuk-font(19);
 

--- a/app/assets/stylesheets/components/_image-cropper.scss
+++ b/app/assets/stylesheets/components/_image-cropper.scss
@@ -1,5 +1,3 @@
-@import "govuk-frontend/settings/all";
-@import "govuk-frontend/helpers/all";
 @import "vendor/cropperjs/dist/cropper";
 
 $cropper-point-size: 20px;

--- a/app/assets/stylesheets/components/_image-meta.scss
+++ b/app/assets/stylesheets/components/_image-meta.scss
@@ -1,8 +1,3 @@
-@import "govuk-frontend/settings/all";
-@import "govuk-frontend/helpers/all";
-@import "govuk-frontend/objects/grid";
-@import "govuk-frontend/utilities/clearfix";
-
 .app-c-image-meta {
   @include govuk-font(19);
 

--- a/app/assets/stylesheets/components/_markdown-editor.scss
+++ b/app/assets/stylesheets/components/_markdown-editor.scss
@@ -1,7 +1,3 @@
-@import "govuk-frontend/helpers/all";
-@import "govuk-frontend/settings/all";
-@import "govuk-frontend/core/links";
-
 $toolbar-button-size: 50px;
 
 .app-c-markdown-editor {

--- a/app/assets/stylesheets/components/_markdown-guidance.scss
+++ b/app/assets/stylesheets/components/_markdown-guidance.scss
@@ -1,7 +1,3 @@
-@import "govuk-frontend/helpers/all";
-@import "govuk-frontend/settings/all";
-@import "govuk-frontend/core/lists";
-
 .app-c-markdown-guidance {
   @include govuk-font(19);
 

--- a/app/assets/stylesheets/components/_metadata.scss
+++ b/app/assets/stylesheets/components/_metadata.scss
@@ -1,6 +1,3 @@
-@import "govuk-frontend/helpers/all";
-@import "govuk-frontend/utilities/clearfix";
-
 .app-c-metadata {
   @include govuk-font(19);
 }

--- a/app/assets/stylesheets/components/_side-navigation.scss
+++ b/app/assets/stylesheets/components/_side-navigation.scss
@@ -1,7 +1,3 @@
-@import "govuk-frontend/helpers/all";
-@import "govuk-frontend/settings/all";
-@import "govuk-frontend/core/lists";
-
 .app-c-side-navigation {
   @include govuk-responsive-margin(6, "bottom");
 

--- a/app/assets/stylesheets/components/_summary.scss
+++ b/app/assets/stylesheets/components/_summary.scss
@@ -1,11 +1,6 @@
 // Recommended styles from the check your answers pattern
 // https://design-system.service.gov.uk/patterns/check-answers/
 
-@import "govuk-frontend/helpers/all";
-@import "govuk-frontend/settings/all";
-@import "govuk-frontend/tools/all";
-@import "govuk-frontend/core/links";
-
 .app-c-summary {
   @include govuk-font(19);
   position: relative;

--- a/app/assets/stylesheets/components/_url-preview.scss
+++ b/app/assets/stylesheets/components/_url-preview.scss
@@ -1,6 +1,3 @@
-@import "govuk-frontend/settings/all";
-@import "govuk-frontend/helpers/all";
-
 .app-c-url-preview {
   @include govuk-font(19);
 

--- a/app/assets/stylesheets/components/_warning-summary.scss
+++ b/app/assets/stylesheets/components/_warning-summary.scss
@@ -1,6 +1,3 @@
-@import "govuk-frontend/helpers/all";
-@import "govuk-frontend/settings/all";
-
 $govuk-notice-border-color: govuk-colour("grey-1");
 $govuk-notice-background-color: govuk-colour("grey-4");
 

--- a/app/assets/stylesheets/core/_link.scss
+++ b/app/assets/stylesheets/core/_link.scss
@@ -1,6 +1,3 @@
-@import "govuk-frontend/helpers/all";
-@import "govuk-frontend/settings/all";
-
 // TODO: support this modifier in govuk-frontend
 .govuk-link.app-link--destructive {
   color: $govuk-error-colour;

--- a/app/assets/stylesheets/objects/_pane.scss
+++ b/app/assets/stylesheets/objects/_pane.scss
@@ -1,8 +1,3 @@
-@import "govuk-frontend/helpers/all";
-@import "govuk-frontend/settings/all";
-@import "govuk-frontend/tools/all";
-@import "govuk-frontend/utilities/clearfix";
-
 .app-pane {
   @include govuk-responsive-margin(6, "bottom");
   @include govuk-clearfix;

--- a/app/assets/stylesheets/objects/_side.scss
+++ b/app/assets/stylesheets/objects/_side.scss
@@ -1,8 +1,3 @@
-@import "govuk-frontend/helpers/all";
-@import "govuk-frontend/settings/all";
-@import "govuk-frontend/tools/all";
-@import "govuk-frontend/utilities/clearfix";
-
 .app-side {
   @include govuk-responsive-margin(6, "bottom");
   @include govuk-clearfix;

--- a/app/assets/stylesheets/utilities/_overwrites.scss
+++ b/app/assets/stylesheets/utilities/_overwrites.scss
@@ -1,6 +1,3 @@
-@import "govuk-frontend/core/links";
-@import "govuk-frontend/core/typography";
-
 .gem-c-success-alert__message {
   margin: 0;
 }


### PR DESCRIPTION
We're currently [importing govuk-frontend/all via govuk_publishing_components](https://github.com/alphagov/govuk_publishing_components/blob/master/app/assets/stylesheets/govuk_publishing_components/_all_components.scss#L9) since [#683](https://github.com/alphagov/govuk_publishing_components/pull/683), so there's no point in continuing to explicitly import only the needed dependencies as they're all available.