### PR TITLE
Support upload and display of new images

### DIFF
--- a/app/assets/javascripts/modules/inline-image-modal.js
+++ b/app/assets/javascripts/modules/inline-image-modal.js
@@ -65,6 +65,7 @@ InlineImageModal.prototype.performAction = function (item) {
         .then(function (text) {
           this.$multiSectionViewer.showDynamicSection(text)
           this.overrideActions()
+          this.initComponents()
         }.bind(this))
         .catch(function (result) {
           this.$multiSectionViewer.showStaticSection('error')
@@ -80,6 +81,7 @@ InlineImageModal.prototype.performAction = function (item) {
         .then(function (text) {
           this.$multiSectionViewer.showDynamicSection(text)
           this.overrideActions()
+          this.initComponents()
         }.bind(this))
         .catch(function (result) {
           this.$multiSectionViewer.showStaticSection('error')
@@ -93,12 +95,14 @@ InlineImageModal.prototype.performAction = function (item) {
 }
 
 InlineImageModal.prototype.initComponents = function () {
-  // TODO: change govuk-frontend so we can do GOVUKFrontend.initAll(dynamicSection)
+  // TODO: change ErrorSummary so it just focusses when it's initialised
   var $errorSummary = document.querySelector('[data-module="error-summary"]')
-  new GOVUKFrontend.ErrorSummary($errorSummary).init()
 
-  // TODO: change ErrorSummary to listen on the scoped element (not static window)
-  window.dispatchEvent(new window.Event('load'))
+  if (!$errorSummary) {
+    return
+  }
+
+  $errorSummary.focus()
 }
 
 InlineImageModal.prototype.overrideActions = function () {

--- a/app/assets/javascripts/modules/inline-image-modal.js
+++ b/app/assets/javascripts/modules/inline-image-modal.js
@@ -113,6 +113,11 @@ InlineImageModal.prototype.overrideActions = function () {
       event.preventDefault()
       this.performAction(item)
     }.bind(this))
+
+    item.addEventListener('submit', function (event) {
+      event.preventDefault()
+      this.performAction(item)
+    }.bind(this))
   }.bind(this))
 }
 

--- a/app/controllers/images_controller.rb
+++ b/app/controllers/images_controller.rb
@@ -23,7 +23,7 @@ class ImagesController < ApplicationController
           "items" => @issues.items,
         }
 
-        render :index
+        render :index, layout: rendering_context
         return
       end
 
@@ -38,7 +38,12 @@ class ImagesController < ApplicationController
 
       current_edition.assign_revision(next_revision, current_user).save!
       PreviewService.new(current_edition).try_create_preview
-      redirect_to crop_image_path(params[:document_id], image_revision.image_id)
+
+      if rendering_context == "modal"
+        redirect_to images_path(params[:document_id])
+      else
+        redirect_to crop_image_path(params[:document_id], image_revision.image_id)
+      end
     end
   end
 

--- a/app/views/images/index.html.erb
+++ b/app/views/images/index.html.erb
@@ -3,35 +3,37 @@
 
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
+    <div class="app-pane">
+      <% upload_image_heading = capture do %>
+        <h2 class="govuk-heading-m">
+          <%= t("images.index.upload_image") %>
+        </h2>
+      <% end %>
 
-    <% unless rendering_context == 'modal' %>
-      <div class="app-pane">
-        <% upload_image_heading = capture do %>
-          <h2 class="govuk-heading-m">
-            <%= t("images.index.upload_image") %>
-          </h2>
-        <% end %>
+      <%= form_tag(
+        create_image_path(@document),
+        id: "image-upload",
+        multipart: true,
+        data: { gtm: "image-upload-submit" },
+      ) do %>
+        <%= render "govuk_publishing_components/components/file_upload", {
+          label: {
+            text: upload_image_heading,
+          },
+          name: "image"
+        } %>
 
-        <%= form_tag(
-          create_image_path(@document),
-          multipart: true,
-          data: { gtm: "image-upload-submit" },
-        ) do %>
-          <%= render "govuk_publishing_components/components/file_upload", {
-            label: {
-              text: upload_image_heading,
-            },
-            name: "image"
-          } %>
+        <%= render_govspeak(t("images.index.description_govspeak")) %>
 
-          <%= render_govspeak(t("images.index.description_govspeak")) %>
-
-          <%= render "govuk_publishing_components/components/button", {
-            text: "Upload",
-          } %>
-        <% end %>
-      </div>
-    <% end %>
+        <%= render "govuk_publishing_components/components/button", {
+          text: "Upload",
+          data_attributes: {
+            "modal-action": "upload",
+            "modal-action-form": "image-upload",
+          }
+        } %>
+      <% end %>
+    </div>
 
     <% if lead_image = @document.current_edition.lead_image_revision %>
       <%= render "lead_image", lead_image: lead_image, document: @document %>

--- a/app/views/images/index.html.erb
+++ b/app/views/images/index.html.erb
@@ -14,7 +14,11 @@
         create_image_path(@document),
         id: "image-upload",
         multipart: true,
-        data: { gtm: "image-upload-submit" },
+        data: {
+          gtm: "image-upload-submit",
+          "modal-action": "upload",
+          "modal-action-form": "image-upload",
+        }
       ) do %>
         <%= render "govuk_publishing_components/components/file_upload", {
           label: {
@@ -27,10 +31,6 @@
 
         <%= render "govuk_publishing_components/components/button", {
           text: "Upload",
-          data_attributes: {
-            "modal-action": "upload",
-            "modal-action-form": "image-upload",
-          }
         } %>
       <% end %>
     </div>

--- a/app/views/layouts/modal.html.erb
+++ b/app/views/layouts/modal.html.erb
@@ -1,3 +1,11 @@
+<% if flash["alert_with_items"] %>
+  <%= render "govuk_publishing_components/components/error_summary", {
+    title: flash["alert_with_items"]["title"],
+    items: flash["alert_with_items"]["items"].map(&:symbolize_keys),
+    data_attributes: { gtm: "global-alert" },
+  } %>
+<% end %>
+
 <h1 class="govuk-heading-l"><%= yield(:title) %></h1>
 
 <%= yield %>

--- a/spec/features/editing_images/upload_image_modal_requirements_spec.rb
+++ b/spec/features/editing_images/upload_image_modal_requirements_spec.rb
@@ -1,0 +1,37 @@
+# frozen_string_literal: true
+
+RSpec.feature "Upload image in a modal with requirements issues", js: true do
+  scenario do
+    given_there_is_an_edition
+    when_i_go_to_edit_the_edition
+    and_i_click_to_insert_an_image
+    and_i_upload_an_invalid_image
+    then_i_should_see_an_error
+  end
+
+  def given_there_is_an_edition
+    body_field = build(:field, id: "body", type: "govspeak")
+    document_type = build(:document_type, contents: [body_field], images: true)
+    @edition = create(:edition, document_type_id: document_type.id)
+  end
+
+  def when_i_go_to_edit_the_edition
+    visit edit_document_path(@edition.document)
+  end
+
+  def and_i_click_to_insert_an_image
+    within(".app-c-markdown-editor") do
+      find("markdown-toolbar details").click
+      click_on "Image"
+    end
+  end
+
+  def and_i_upload_an_invalid_image
+    find('form input[type="file"]').set(Rails.root.join(file_fixture("text-file.txt")))
+    click_on "Upload"
+  end
+
+  def then_i_should_see_an_error
+    expect(page).to have_content(I18n.t!("requirements.image_upload.unsupported_type.form_message"))
+  end
+end

--- a/spec/features/editing_images/upload_image_modal_spec.rb
+++ b/spec/features/editing_images/upload_image_modal_spec.rb
@@ -1,0 +1,43 @@
+# frozen_string_literal: true
+
+RSpec.feature "Upload image in a modal", js: true do
+  scenario do
+    given_there_is_an_edition
+    when_i_go_to_edit_the_edition
+    and_i_click_to_insert_an_image
+    and_i_pick_and_upload_an_image
+    then_i_see_the_uploaded_image
+  end
+
+  def given_there_is_an_edition
+    body_field = build(:field, id: "body", type: "govspeak")
+    document_type = build(:document_type, contents: [body_field], images: true)
+    @edition = create(:edition, document_type_id: document_type.id)
+  end
+
+  def when_i_go_to_edit_the_edition
+    visit edit_document_path(@edition.document)
+  end
+
+  def and_i_click_to_insert_an_image
+    within(".app-c-markdown-editor") do
+      find("markdown-toolbar details").click
+      click_on "Image"
+    end
+  end
+
+  def and_i_pick_and_upload_an_image
+    @image_filename = "1000x1000.jpg"
+    find('form input[type="file"]').set(Rails.root.join(file_fixture(@image_filename)))
+    click_on "Upload"
+  end
+
+  def then_i_see_the_uploaded_image
+    expect(page).to have_selector(".app-c-image-meta")
+
+    within("#image-#{Image.first.id}") do
+      expect(find("img")["src"]).to include("1000x1000.jpg")
+      expect(page).to have_link("Insert image markdown")
+    end
+  end
+end

--- a/spec/features/editing_images/upload_image_spec.rb
+++ b/spec/features/editing_images/upload_image_spec.rb
@@ -23,7 +23,7 @@ RSpec.feature "Upload an image" do
   def and_i_upload_a_new_image
     @image_filename = "1000x1000.jpg"
 
-    find('form input[type="file"]').set(Rails.root.join(file_fixture(@image_filename)))
+    find('form input[type="file"]').set(file_fixture(@image_filename))
     click_on "Upload"
   end
 


### PR DESCRIPTION
https://trello.com/c/QDEuNPgp/653-allow-users-to-upload-an-inline-image-in-the-context-of-a-modal

This exposes the upload form in the modal context of the images index
page, and overrides the 'Upload' button to post the form data i.e. upload
the image. Depending on the form data, we may need to render the
response HTML to display requirements issues, or follow a redirect.

The API of the FormData class means we can support posting a form
generically, which is handled using a new 'postModalForm' function in
the existing 'glue' module called 'inline-image-modal'. We also follow
any redirects automatically, to avoid unnecessary boilerplate '.fetch's.

In future work we will implement the rest of the upload workflow, so
that the modal loads the crop page after the image is uploaded.