### PR TITLE
Send user uid value to Google Tag Manager

### DIFF
--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -5,7 +5,10 @@
   <% end %>
 
   <script>
-    var dataLayer = [{ 'dimension1': '<%= current_user.organisation_slug %>' }];
+    var dataLayer = [{
+      'dimension1': '<%= current_user.organisation_slug %>',
+      'cp_uid': '<%= current_user.uid %>'
+    }];
     dataLayer.push({ 'gtm.blacklist': ['html', 'customScripts', 'nonGoogleScripts', 'customPixels'] });
   </script>
   <% if ENV["GOOGLE_TAG_MANAGER_ID"] %>


### PR DESCRIPTION
Trello: https://trello.com/c/ZhLNktSm/644-add-user-id-tracking-to-content-publisher

This is so we can monitor session behaviour of particular users and see
when they're using different browsers/devices.

According to Andy it is acceptable privacy wise to send an id that has a
meaning in our internal systems but cannot be used out of context to
identify the user. I debated whether it would be better to run this
through a one way cryptographic hash function such as SHA1 but I'm not
sure that offers any actual benefits.