### PR TITLE
Add auto-generated ID to multi-section-viewer

### DIFF
--- a/app/views/components/_multi_section_viewer.html.erb
+++ b/app/views/components/_multi_section_viewer.html.erb
@@ -1,4 +1,5 @@
 <%
+  id ||= "multi-section-viewer-#{SecureRandom.hex(4)}"
   sections ||= []
 %>
 


### PR DESCRIPTION
https://trello.com/c/jARJ0xxA/642-use-a-modal-to-insert-an-existing-image-as-an-inline-snippet

Previously we required an ID to be specified for this component.
This auto-generates the ID if it's not specified, to support support a
more consistent initialisation by data-module as part of the modal work
for inline images, where the scope of the module is already isolated.