### PR TITLE
Add toolbar dropdown component

### DIFF
--- a/app/assets/javascripts/application.js
+++ b/app/assets/javascripts/application.js
@@ -16,6 +16,7 @@
 //= require whatwg-fetch/dist/fetch.umd.js
 
 //= require components/autocomplete.js
+//= require components/toolbar-dropdown.js
 //= require components/image-cropper.js
 //= require components/input-length-suggester.js
 //= require components/markdown-editor.js

--- a/app/assets/javascripts/components/toolbar-dropdown.js
+++ b/app/assets/javascripts/components/toolbar-dropdown.js
@@ -1,0 +1,41 @@
+window.GOVUK = window.GOVUK || {}
+window.GOVUK.Modules = window.GOVUK.Modules || {};
+
+(function (Modules) {
+  function ToolbarDropdown () { }
+
+  ToolbarDropdown.prototype.start = function ($module) {
+    this.$module = $module[0]
+    this.$title = this.$module.querySelector('.app-c-toolbar-dropdown__title')
+    this.$container = this.$module.querySelector('.app-c-toolbar-dropdown__container')
+    this.$buttons = this.$module.querySelectorAll('.app-c-toolbar-dropdown__button')
+
+    this.$module.addEventListener('blur', ToolbarDropdown.prototype.handleBlur.bind(this), true)
+    this.$buttons.forEach(function ($button) {
+      $button.addEventListener('click', ToolbarDropdown.prototype.handleButtonClick.bind(this), true)
+    }, this)
+  }
+
+  ToolbarDropdown.prototype.handleBlur = function (event) {
+    var target = event.relatedTarget
+    if (!target) {
+      target = document.activeElement
+    }
+
+    if (!this.$module.contains(target)) {
+      this.closeToolbarDropdown()
+    }
+  }
+
+  ToolbarDropdown.prototype.handleButtonClick = function (event) {
+    this.closeToolbarDropdown()
+  }
+
+  ToolbarDropdown.prototype.closeToolbarDropdown = function (event) {
+    if (this.$module.hasAttribute('open')) {
+      this.$title.click()
+    }
+  }
+
+  Modules.ToolbarDropdown = ToolbarDropdown
+})(window.GOVUK.Modules)

--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -25,6 +25,7 @@
 @import "components/modal-dialogue";
 @import "components/multi-section-viewer";
 @import "components/loading-spinner";
+@import "components/toolbar-dropdown";
 
 @import "utilities/display";
 @import "utilities/overwrites";

--- a/app/assets/stylesheets/components/_toolbar-dropdown.scss
+++ b/app/assets/stylesheets/components/_toolbar-dropdown.scss
@@ -1,0 +1,92 @@
+$dropdown-arrow-size: 12px;
+$dropdown-arrow-spacing: $dropdown-arrow-size / 2;
+
+.app-c-toolbar-dropdown {
+  display: inline-block;
+  min-width: 120px;
+  position: relative;
+  text-align: left;
+  background: inherit;
+}
+
+.app-c-toolbar-dropdown--end {
+  float: right;
+  border-left: 4px solid govuk-colour('white');
+}
+
+.app-c-toolbar-dropdown__title {
+  @include govuk-font($size: 16, $weight: bold);
+  @include govuk-focusable;
+  background: inherit;
+  border: 0;
+  cursor: pointer;
+  user-select: none;
+  display: block;
+  padding: govuk-spacing(3);
+
+  &:hover {
+    background-color: govuk-colour("grey-3");
+  }
+
+  &:focus {
+    outline-offset: -$govuk-focus-width;
+  }
+
+  &::after {
+    position: relative;
+    top: 4px;
+    content: "";
+    float: right;
+    @include govuk-shape-arrow($direction: down, $base: $dropdown-arrow-size, $display: inline-block);
+  }
+
+  &::-webkit-details-marker {
+    display: none;
+  }
+}
+
+.app-c-toolbar-dropdown__container {
+  position: absolute;
+  width: 100%;
+  z-index: 100;
+}
+
+.app-c-toolbar-dropdown__list {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+}
+
+.app-c-toolbar-dropdown__list-item {
+  margin: 0;
+  padding: 0;
+}
+
+.app-c-toolbar-dropdown__button {
+  @include govuk-font($size: 16);
+  @include govuk-focusable;
+  appearance: none;
+  -webkit-appearance: none;
+
+  background: govuk-colour("grey-4");
+  color: $govuk-text-colour;
+  border: 0;
+  cursor: pointer;
+  display: block;
+  padding: govuk-spacing(3);
+  text-align: inherit;
+  width: 100%;
+
+  &:hover {
+    background-color: govuk-colour("grey-3");
+  }
+
+  &:focus {
+    outline-offset: -$govuk-focus-width;
+  }
+
+  &::-moz-focus-inner {
+    border: 0;
+    padding: 0;
+  }
+}

--- a/app/views/components/_markdown_editor.html.erb
+++ b/app/views/components/_markdown_editor.html.erb
@@ -40,13 +40,29 @@
           <md-unordered-list class="app-c-markdown-editor__toolbar-button" title="Bullets" aria-label="Bullets" data-gtm="markdown-toolbar-selection">
             <%= render "components/markdown_editor/bullets.svg" %>
           </md-unordered-list>
-          <button name="submit" type="submit" value="add_contact" class="app-c-markdown-editor__toolbar-button app-c-markdown-editor__toolbar-button--text app-c-markdown-editor__toolbar-button--end">Add contact</button>
           <% if current_user.permissions.include?(User::PRE_RELEASE_FEATURES_PERMISSION) %>
-            <button name="submit" type="submit" value="add_image" class="app-c-markdown-editor__toolbar-button app-c-markdown-editor__toolbar-button--text app-c-markdown-editor__toolbar-button--end"
-              data-module="inline-image-modal"
-              data-modal-action="open"
-              data-modal-action-url="<%= images_path(@document) %>"
-            >Insert image</button>
+            <%= render "components/toolbar_dropdown", {
+              title: "Insert...",
+              align: 'right',
+              items: [
+                {
+                  text: "Contact",
+                  value: "add_contact",
+                  name: "submit"
+                },
+                {
+                  text: "Image",
+                  value: "add_image",
+                  data_attributes: {
+                    module: "inline-image-modal",
+                    "modal-action": "open",
+                    "modal-action-url": images_path(@document)
+                  }
+                }
+              ]
+            } %>
+          <% else %>
+            <button name="submit" type="submit" value="add_contact" class="app-c-markdown-editor__toolbar-button app-c-markdown-editor__toolbar-button--text app-c-markdown-editor__toolbar-button--end">Add contact</button>
           <% end %>
         </markdown-toolbar>
       </div>

--- a/app/views/components/_toolbar_dropdown.html.erb
+++ b/app/views/components/_toolbar_dropdown.html.erb
@@ -1,0 +1,30 @@
+<%
+  id ||= "toolbar-dropdown-#{SecureRandom.hex(4)}"
+  align ||= false
+  items ||= []
+  data_attributes ||= {}
+  data_attributes[:module] = 'toolbar-dropdown'
+  css_classes = %w(app-c-toolbar-dropdown)
+  css_classes << 'app-c-toolbar-dropdown--end' if align == 'right'
+%>
+
+<%= tag.details id: id, class: css_classes, data: data_attributes do %>
+  <%= tag.summary title, class: "app-c-toolbar-dropdown__title" %>
+  <%= tag.div class: "app-c-toolbar-dropdown__container" do %>
+    <% if items.any? %>
+      <%= tag.ul class: "app-c-toolbar-dropdown__list" do %>
+        <% items.each do |item| %>
+          <%= tag.li class: "app-c-toolbar-dropdown__list-item" do %>
+            <%= tag.button item[:text],
+              class:"app-c-toolbar-dropdown__button",
+              type: "submit",
+              name: item[:name],
+              value: item[:value],
+              data: item[:data_attributes]
+            %>
+          <% end %>
+        <% end %>
+      <% end %>
+    <% end %>
+  <% end %>
+<% end %>

--- a/app/views/components/docs/toolbar_dropdown.yml
+++ b/app/views/components/docs/toolbar_dropdown.yml
@@ -1,0 +1,45 @@
+name: Toolbar dropdown
+description: Toggles a contextual overlay for displaying lists of button.
+body: |
+  Use this component to group a series of actions
+accessibility_criteria: |
+  The dropdown component must:
+
+  - be operable with a keyboard
+  - toggle the contextual overlay when clicked
+  - hide the contextual overlay on blur
+  - hide the contextual overlay when a button element within the component is being clicked
+
+examples:
+  default:
+    data:
+      title: Insert...
+      items:
+        - text: Image
+          data_attributes:
+            module: inline-image-modal
+            modal-action: open
+        - text: Contact
+          data_attributes:
+            module: inline-contact-modal
+            modal-action: open
+
+  within_markdown_editor_toolbar:
+    embed: |
+      <div class="app-c-markdown-editor__toolbar">
+        <markdown-toolbar class="app-c-markdown-editor__toolbar-group" for="markdown-editor">
+          <%= component %>
+        </markdown-toolbar>
+      </div>
+    data:
+      title: Insert...
+      align: right
+      items:
+        - text: Image
+          data_attributes:
+            module: inline-image-modal
+            modal-action: open
+        - text: Contact
+          data_attributes:
+            module: inline-contact-modal
+            modal-action: open

--- a/spec/features/editing_content/insert_contact_publishing_api_down_spec.rb
+++ b/spec/features/editing_content/insert_contact_publishing_api_down_spec.rb
@@ -25,7 +25,8 @@ RSpec.feature "Insert contact when the Publishing API down" do
     # thus we want the put content API call to succeed before contacts being
     # unavailable
     stub_publishing_api_put_content(@edition.content_id, {})
-    click_on "Add contact"
+    find("markdown-toolbar details").click
+    click_on "Contact"
   end
 
   def then_i_should_see_an_error_message

--- a/spec/features/editing_content/insert_contact_spec.rb
+++ b/spec/features/editing_content/insert_contact_spec.rb
@@ -38,7 +38,8 @@ RSpec.feature "Insert contact", js: true do
 
   def and_i_go_to_add_a_contact
     @request = stub_publishing_api_put_content(@edition.content_id, {})
-    click_on "Add contact"
+    find("markdown-toolbar details").click
+    click_on "Contact"
   end
 
   def when_i_select_a_contact

--- a/spec/features/editing_content/insert_inline_image_spec.rb
+++ b/spec/features/editing_content/insert_inline_image_spec.rb
@@ -26,7 +26,8 @@ RSpec.feature "Insert inline image", js: true do
 
   def and_i_click_to_insert_an_image
     within(".app-c-markdown-editor") do
-      click_on "Insert image"
+      find("markdown-toolbar details").click
+      click_on "Image"
     end
   end
 

--- a/spec/javascripts/components/dropdown-spec.js
+++ b/spec/javascripts/components/dropdown-spec.js
@@ -1,0 +1,53 @@
+/* global describe beforeEach afterEach it expect */
+/* global GOVUK, $ */
+
+describe('Toolbar dropdown component', function () {
+  'use strict'
+
+  var container
+
+  beforeEach(function () {
+    container = document.createElement('div')
+    container.innerHTML =
+    '<details class="app-c-toolbar-dropdown" data-module="toolbar-dropdown" role="group">' +
+      '<summary class="app-c-toolbar-dropdown__title" role="button">Insert...</summary>' +
+      '<div class="app-c-toolbar-dropdown__container">' +
+        '<ul class="app-c-toolbar-dropdown__list">' +
+          '<li class="app-c-toolbar-dropdown__list-item">' +
+            '<button class="app-c-toolbar-dropdown__button">Image</button>' +
+          '</li>' +
+          '<li class="app-c-toolbar-dropdown__list-item">' +
+            '<button class="app-c-toolbar-dropdown__button">Contact</button>' +
+          '</li>' +
+        '</ul>' +
+      '</div>' +
+    '</details>'
+
+    document.body.classList.add('js-enabled')
+    document.body.appendChild(container)
+    var element = document.querySelector('[data-module="toolbar-dropdown"]')
+    new GOVUK.Modules.ToolbarDropdown().start($(element))
+  })
+
+  afterEach(function () {
+    document.body.removeChild(container)
+  })
+
+  it('should hide the overlay container', function () {
+    var overlay = document.querySelector('.app-c-toolbar-dropdown__container')
+    expect(overlay).toBeHidden()
+  })
+
+  it('should show the overlay container on title click', function () {
+    document.querySelector('.app-c-toolbar-dropdown__title').click()
+    var overlay = document.querySelector('.app-c-toolbar-dropdown__container')
+    expect(overlay).toBeVisible()
+  })
+
+  it('should hide the overlay container on button click', function () {
+    document.querySelector('.app-c-toolbar-dropdown__title').click()
+    document.querySelector('.app-c-toolbar-dropdown__button').click()
+    var overlay = document.querySelector('.app-c-toolbar-dropdown__container')
+    expect(overlay).toBeHidden()
+  })
+})


### PR DESCRIPTION
This PR adds a [toolbar dropdown component](https://content-publisher-revie-pr-803.herokuapp.com/component-guide/toolbar_dropdown) ✨ to be used within the markdown toolbar to group "insert" action buttons (such as images and contacts).

This component does not require JavaScript to be toggled, so the actions will be accessible in a no-js experience.

This implementation is purely functional. Have had a chat with @soniaturcotte and we'll iterate the style of this component.

Another PR will follow this one to use the component in the markdown toolbar to launch a modal dialogue for each of these two "insert" actions.

### Dropdown in markdown toolbar - default
![screenshot-content-publisher-revie-pr-803 herokuapp com-2019 02 21-15-52-52](https://user-images.githubusercontent.com/788096/53182209-ee6c2a00-35f0-11e9-845c-213eb8d14b38.png)

### Dropdown in markdown toolbar - opened
![screenshot-content-publisher-revie-pr-803 herokuapp com-2019 02 21-15-53-09](https://user-images.githubusercontent.com/788096/53182220-f330de00-35f0-11e9-8f77-cc7c6d2209cc.png)

[Trello card](https://trello.com/c/Wf0A8zsq)
