### PR TITLE
[WIP] Modify when change note guidance appears

### DIFF
--- a/app/views/documents/edit/_change_notes.html.erb
+++ b/app/views/documents/edit/_change_notes.html.erb
@@ -27,11 +27,13 @@
             text: t("documents.edit.update_type.major_name"),
             conditional: textarea,
             checked: @revision.major?,
+            data_attributes: { "contextual-guidance": "change-note-guidance" },
           },
           {
             value: "minor",
             text: t("documents.edit.update_type.minor_name"),
             checked: @revision.minor?,
+            data_attributes: { "contextual-guidance": "no-change-note-guidance" },
           }
         ]
       } %>


### PR DESCRIPTION
This passes a data_attribute for contextual guidance to the radio button
component, this means that change note guidance will only appear when a
user selects a major change and will disappear if the user selects a
minor change.

JS for contextual guidance adds event listeners to all elements with
data attribute of `data-contextual-guidance` to handle displaying
and hiding a components guidance, this enables the minor / major change
note radio button to benefit from this functionality, instead of before
where only focusing on the textarea would display the guidance.

Dependant on this for govuk_publishing_components:
alphagov/govuk_publishing_components#766

Trello:
https://trello.com/c/pcbHvl7B/636-change-note-guidance