### PR TITLE
Modular components

### DIFF
--- a/app/assets/javascripts/components/autocomplete.js
+++ b/app/assets/javascripts/components/autocomplete.js
@@ -1,10 +1,29 @@
 //= require vendor/accessible-autocomplete/dist/accessible-autocomplete.min.js
+window.GOVUK = window.GOVUK || {}
+window.GOVUK.Modules = window.GOVUK.Modules || {};
 
-var $autocompletes = document.querySelectorAll('[data-module="autocomplete"]')
-if ($autocompletes) {
-  $autocompletes.forEach(function ($el) {
+(function (Modules) {
+  function Autocomplete () { }
+
+  Autocomplete.prototype.start = function ($module) {
+    this.$module = $module[0]
+    var type = this.$module.dataset.autocompleteType
+
+    if (type === 'with-hint-on-options') {
+      this.initAutoCompleteWithHintOnOptions()
+    } else {
+      this.initAutoComplete()
+    }
+  }
+
+  Autocomplete.prototype.initAutoComplete = function () {
     var customAttributes = {}
-    var $select = $el.querySelector('select')
+    var $select = this.$module.querySelector('select')
+
+    if (!$select) {
+      return
+    }
+
     if ($select.attributes['data-contextual-guidance']) {
       customAttributes = {
         'data-contextual-guidance': $select.attributes['data-contextual-guidance'].value
@@ -18,54 +37,60 @@ if ($autocompletes) {
       showNoOptionsFound: true,
       customAttributes: customAttributes
     })
-  })
-}
+  }
 
-var $autocompleteWithHintOnOptions = document.querySelector('[data-module="autocomplete-with-hint-on-options"]')
-if ($autocompleteWithHintOnOptions) {
-  // Read options and associated data attributes and feed that as results for inputValueTemplate
-  var $select = $autocompleteWithHintOnOptions.querySelector('select')
-  var $options = $select.querySelectorAll('option')
+  Autocomplete.prototype.initAutoCompleteWithHintOnOptions = function () {
+    // Read options and associated data attributes and feed that as results for inputValueTemplate
+    var $select = this.$module.querySelector('select')
 
-  new window.accessibleAutocomplete({ // eslint-disable-line no-new, new-cap
-    element: $autocompleteWithHintOnOptions,
-    id: $select.id,
-    source: function (query, syncResults) {
-      var results = []
-      $options.forEach(function ($el) {
-        results.push({text: $el.textContent, hint: $el.dataset.hint || '', value: $el.value})
-      })
-      syncResults(query
-        ? results.filter(function (result) {
-          var valueContains = result.text.toLowerCase().indexOf(query.toLowerCase()) !== -1
-          var hintContains = result.hint.toLowerCase().indexOf(query.toLowerCase()) !== -1
-          return valueContains || hintContains
-        }) : []
-      )
-    },
-    minLength: 3,
-    autoselect: true,
-    showNoOptionsFound: true,
-    templates: {
-      inputValue: function (result) {
-        return result && result.text
-      },
-      suggestion: function (result) {
-        return result && result.text + '<span class="autocomplete__option-hint">' + result.hint + '</span>'
-      }
-    },
-    onConfirm: function (result) {
-      var value = result && result.value
-      var options = [].filter.call($select.options, function (option) {
-        return option.value === value
-      })
-
-      if (options.length) {
-        options[0].selected = true
-      }
+    if (!$select) {
+      return
     }
-  })
 
-  $select.style.display = 'none'
-  $select.id = $select.id + '-select'
-}
+    var $options = $select.querySelectorAll('option')
+
+    new window.accessibleAutocomplete({ // eslint-disable-line no-new, new-cap
+      element: this.$module,
+      id: $select.id,
+      source: function (query, syncResults) {
+        var results = []
+        $options.forEach(function ($el) {
+          results.push({text: $el.textContent, hint: $el.dataset.hint || '', value: $el.value})
+        })
+        syncResults(query
+          ? results.filter(function (result) {
+            var valueContains = result.text.toLowerCase().indexOf(query.toLowerCase()) !== -1
+            var hintContains = result.hint.toLowerCase().indexOf(query.toLowerCase()) !== -1
+            return valueContains || hintContains
+          }) : []
+        )
+      },
+      minLength: 3,
+      autoselect: true,
+      showNoOptionsFound: true,
+      templates: {
+        inputValue: function (result) {
+          return result && result.text
+        },
+        suggestion: function (result) {
+          return result && result.text + '<span class="autocomplete__option-hint">' + result.hint + '</span>'
+        }
+      },
+      onConfirm: function (result) {
+        var value = result && result.value
+        var options = [].filter.call($select.options, function (option) {
+          return option.value === value
+        })
+
+        if (options.length) {
+          options[0].selected = true
+        }
+      }
+    })
+
+    $select.style.display = 'none'
+    $select.id = $select.id + '-select'
+  }
+
+  Modules.Autocomplete = Autocomplete
+})(window.GOVUK.Modules)

--- a/app/assets/javascripts/components/contextual-guidance.js
+++ b/app/assets/javascripts/components/contextual-guidance.js
@@ -1,57 +1,33 @@
-function ContextualGuidance ($module) {
-  if (!$module) $module = document
-  this.$module = $module
-  this.$fields = $module.querySelectorAll('[data-contextual-guidance]')
-}
+window.GOVUK = window.GOVUK || {}
+window.GOVUK.Modules = window.GOVUK.Modules || {};
 
-ContextualGuidance.prototype.handleFocus = function (event) {
-  // Get the target element
-  var target = event.target
-  var guidanceId = ContextualGuidance.prototype.getGuidanceId(target)
+(function (Modules) {
+  function ContextualGuidance () { }
 
-  // If we have guidance for the field
-  if (guidanceId) {
-    var guidance = document.querySelector('#' + guidanceId)
-    ContextualGuidance.prototype.hideAllGuidance()
-    ContextualGuidance.prototype.showGuidance(guidance)
+  ContextualGuidance.prototype.start = function ($module) {
+    this.$module = $module[0]
+
+    var fields = document.querySelectorAll(
+      '[data-contextual-guidance="' + this.$module.id + '"]'
+    )
+
+    fields.forEach(function (field) {
+      field.addEventListener('focus', this.handleFocus.bind(this))
+    }, this)
   }
-}
 
-ContextualGuidance.prototype.showGuidance = function (element) {
-  if (element) {
-    element.style.display = 'block'
+  ContextualGuidance.prototype.handleFocus = function (event) {
+    this.hideAllGuidance()
+    this.$module.style.display = 'block'
   }
-}
 
-ContextualGuidance.prototype.hideAllGuidance = function () {
-  var $guidances = document.querySelectorAll('.app-c-contextual-guidance-wrapper')
-  $guidances.forEach(function ($guidance) {
-    $guidance.style.display = 'none'
-  })
-}
+  ContextualGuidance.prototype.hideAllGuidance = function () {
+    var guidances = document.querySelectorAll('.app-c-contextual-guidance-wrapper')
 
-ContextualGuidance.prototype.getGuidanceId = function (element) {
-  var guidanceId = element.getAttribute('data-contextual-guidance')
-  return guidanceId
-}
+    guidances.forEach(function (guidance) {
+      guidance.style.display = 'none'
+    })
+  }
 
-ContextualGuidance.prototype.init = function () {
-  var $fields = this.$fields
-
-  /**
-  * Loop over all items with [data-contextual-guidance]
-  * Check if they have a matching contextual guidance
-  * If they do, add event listener on focus
-  **/
-  $fields.forEach(function ($field) {
-    var guidanceId = ContextualGuidance.prototype.getGuidanceId($field)
-    if (!guidanceId) {
-      return
-    }
-    $field.addEventListener('focus', ContextualGuidance.prototype.handleFocus)
-  })
-}
-
-// Initialise guidance at document level
-var guidance = new ContextualGuidance()
-guidance.init(document)
+  Modules.ContextualGuidance = ContextualGuidance
+})(window.GOVUK.Modules)

--- a/app/assets/javascripts/components/image-cropper.js
+++ b/app/assets/javascripts/components/image-cropper.js
@@ -1,101 +1,120 @@
 //= require cropperjs/dist/cropper.js
+window.GOVUK = window.GOVUK || {}
+window.GOVUK.Modules = window.GOVUK.Modules || {};
 
-var $imageCroppers = document.querySelectorAll('[data-module="image-cropper"]')
+(function (Modules) {
+  function ImageCropper () { }
 
-if ($imageCroppers) {
-  $imageCroppers.forEach(function ($imageCropper) {
-    var $image = $imageCropper.querySelector('.app-c-image-cropper__image')
+  ImageCropper.prototype.start = function ($imageCropper) {
+    this.$imageCropper = $imageCropper[0]
+    this.$image = this.$imageCropper.querySelector('.app-c-image-cropper__image')
 
-    window.onload = function () {
-      var $inputX = $imageCropper.querySelector('.js-image-cropper-x')
-      var $inputY = $imageCropper.querySelector('.js-image-cropper-y')
-      var $inputWidth = $imageCropper.querySelector('.js-image-cropper-width')
-      var $inputHeight = $imageCropper.querySelector('.js-image-cropper-height')
+    // This only runs if the image isn't cached
+    this.$image.addEventListener('load', function () {
+      this.initCropper()
+    }.bind(this))
 
-      var width = $image.clientWidth
-      var height = $image.clientHeight
-      var naturalWidth = $image.naturalWidth
-      var naturalHeight = $image.naturalHeight
-      var scaledRatio = 1
-      var minCropWidth = 960
-      var minCropHeight = 640
-
-      // Set the crop box limits
-      var minCropBoxWidth = minCropWidth
-      var minCropBoxHeight = minCropHeight
-
-      // Read existing crop box data
-      var cropBoxX = $inputX.value
-      var cropBoxY = $inputY.value
-      var cropBoxWidth = $inputWidth.value
-      var cropBoxHeight = $inputHeight.value
-
-      if (width < naturalWidth || height < naturalHeight) {
-        // Determine the scale ratio of the resized image
-        scaledRatio = width / naturalWidth
-
-        // Adjust the crop box limits to the scaled image
-        minCropBoxWidth = Math.round(minCropBoxWidth * scaledRatio)
-        minCropBoxHeight = Math.round(minCropBoxHeight * scaledRatio)
-
-        // Adjust the crop box to the scaled image
-        cropBoxX = cropBoxX * scaledRatio
-        cropBoxY = cropBoxY * scaledRatio
-        cropBoxWidth = cropBoxWidth * scaledRatio
-        cropBoxHeight = cropBoxHeight * scaledRatio
-
-        // Ensure the cropbox doesn't exceed the canvas
-        if (cropBoxWidth + cropBoxX > width) cropBoxX = width - cropBoxWidth
-        if (cropBoxHeight + cropBoxY > height) cropBoxY = height - cropBoxHeight
-      }
-
-      if ($image) {
-        new window.Cropper($image, { // eslint-disable-line
-          viewMode: 2,
-          aspectRatio: 3 / 2,
-          autoCrop: true,
-          autoCropArea: 1,
-          guides: false,
-          zoomable: false,
-          highlight: false,
-          minCropBoxWidth: minCropBoxWidth,
-          minCropBoxHeight: minCropBoxHeight,
-          rotatable: false,
-          scalable: false,
-          ready: function () {
-            // Get canvas data
-            var canvasData = this.cropper.getCanvasData()
-
-            // Set crop box data
-            this.cropper.setCropBoxData({
-              left: cropBoxX + canvasData.left,
-              top: cropBoxY + canvasData.top,
-              width: cropBoxWidth,
-              height: cropBoxHeight
-            })
-          },
-          crop: function () {
-            // Get crop data
-            var cropData = this.cropper.getData({rounded: true})
-
-            // Ensure the crop size is not smaller than the minimum values
-            if (cropData.width < minCropWidth) {
-              cropData.width = minCropWidth
-              cropData.x -= minCropWidth - cropData.width
-            }
-            if (cropData.height < minCropHeight) {
-              cropData.height = minCropHeight
-              cropData.y -= minCropHeight - cropData.height
-            }
-
-            // Set crop data in inputs
-            $inputX.value = cropData.x
-            $inputY.value = cropData.y
-            $inputWidth.value = cropData.width
-            $inputHeight.value = cropData.height
-          }
-        })
-      }
+    // This should only run if the image is cached
+    if (this.$image.complete) {
+      this.initCropper()
     }
-  })
-}
+  }
+
+  ImageCropper.prototype.initCropper = function () {
+    if (!this.$image.complete) {
+      return
+    }
+
+    var $inputX = this.$imageCropper.querySelector('.js-image-cropper-x')
+    var $inputY = this.$imageCropper.querySelector('.js-image-cropper-y')
+    var $inputWidth = this.$imageCropper.querySelector('.js-image-cropper-width')
+    var $inputHeight = this.$imageCropper.querySelector('.js-image-cropper-height')
+
+    var width = this.$image.clientWidth
+    var height = this.$image.clientHeight
+    var naturalWidth = this.$image.naturalWidth
+    var naturalHeight = this.$image.naturalHeight
+    var scaledRatio = 1
+    var minCropWidth = 960
+    var minCropHeight = 640
+
+    // Set the crop box limits
+    var minCropBoxWidth = minCropWidth
+    var minCropBoxHeight = minCropHeight
+
+    // Read existing crop box data
+    var cropBoxX = $inputX.value
+    var cropBoxY = $inputY.value
+    var cropBoxWidth = $inputWidth.value
+    var cropBoxHeight = $inputHeight.value
+
+    if (width < naturalWidth || height < naturalHeight) {
+      // Determine the scale ratio of the resized image
+      scaledRatio = width / naturalWidth
+
+      // Adjust the crop box limits to the scaled image
+      minCropBoxWidth = Math.round(minCropBoxWidth * scaledRatio)
+      minCropBoxHeight = Math.round(minCropBoxHeight * scaledRatio)
+
+      // Adjust the crop box to the scaled image
+      cropBoxX = cropBoxX * scaledRatio
+      cropBoxY = cropBoxY * scaledRatio
+      cropBoxWidth = cropBoxWidth * scaledRatio
+      cropBoxHeight = cropBoxHeight * scaledRatio
+
+      // Ensure the cropbox doesn't exceed the canvas
+      if (cropBoxWidth + cropBoxX > width) cropBoxX = width - cropBoxWidth
+      if (cropBoxHeight + cropBoxY > height) cropBoxY = height - cropBoxHeight
+    }
+
+    if (this.$image) {
+      new window.Cropper(this.$image, { // eslint-disable-line
+        viewMode: 2,
+        aspectRatio: 3 / 2,
+        autoCrop: true,
+        autoCropArea: 1,
+        guides: false,
+        zoomable: false,
+        highlight: false,
+        minCropBoxWidth: minCropBoxWidth,
+        minCropBoxHeight: minCropBoxHeight,
+        rotatable: false,
+        scalable: false,
+        ready: function () {
+          // Get canvas data
+          var canvasData = this.cropper.getCanvasData()
+
+          // Set crop box data
+          this.cropper.setCropBoxData({
+            left: cropBoxX + canvasData.left,
+            top: cropBoxY + canvasData.top,
+            width: cropBoxWidth,
+            height: cropBoxHeight
+          })
+        },
+        crop: function () {
+          // Get crop data
+          var cropData = this.cropper.getData({rounded: true})
+
+          // Ensure the crop size is not smaller than the minimum values
+          if (cropData.width < minCropWidth) {
+            cropData.width = minCropWidth
+            cropData.x -= minCropWidth - cropData.width
+          }
+          if (cropData.height < minCropHeight) {
+            cropData.height = minCropHeight
+            cropData.y -= minCropHeight - cropData.height
+          }
+
+          // Set crop data in inputs
+          $inputX.value = cropData.x
+          $inputY.value = cropData.y
+          $inputWidth.value = cropData.width
+          $inputHeight.value = cropData.height
+        }
+      })
+    }
+  }
+
+  Modules.ImageCropper = ImageCropper
+})(window.GOVUK.Modules)

--- a/app/assets/javascripts/components/input-length-suggester.js
+++ b/app/assets/javascripts/components/input-length-suggester.js
@@ -1,55 +1,57 @@
-function InputLengthSuggester ($module) {
-  this.$module = $module
-  this.$target = document.getElementById($module.getAttribute('data-for'))
-  this.messageTemplate = $module.getAttribute('data-message')
-  var showFrom = parseInt($module.getAttribute('data-show-from'), 10)
-  this.showFrom = showFrom > 0 ? showFrom : 0
-  this.pollInterval = null
-}
+window.GOVUK = window.GOVUK || {}
+window.GOVUK.Modules = window.GOVUK.Modules || {};
 
-InputLengthSuggester.prototype.init = function () {
-  if (!this.$target || !this.messageTemplate) {
-    return
-  }
-  this.update()
+(function (Modules) {
+  function InputLengthSuggester () { }
 
-  // these 3 cover most bases for a consistent experience
-  this.$target.addEventListener('keydown', this.update.bind(this))
-  this.$target.addEventListener('keyup', this.update.bind(this))
-  this.$target.addEventListener('change', this.update.bind(this))
-
-  // set-up polling
-  this.$target.addEventListener('focus', this.handleFocus.bind(this))
-  this.$target.addEventListener('blur', this.handleBlur.bind(this))
-}
-
-InputLengthSuggester.prototype.update = function () {
-  var count = this.$target.value.length
-  this.$module.textContent = this.messageTemplate.replace(/{count}/g, count)
-  if (count >= this.showFrom) {
-    this.$module.classList.remove('app-c-input-length-suggester__hidden')
-  } else {
-    this.$module.classList.add('app-c-input-length-suggester__hidden')
-  }
-}
-
-InputLengthSuggester.prototype.handleFocus = function () {
-  if (!this.pollInterval) {
-    // according to https://github.com/alphagov/govuk-frontend/blob/29c50367474396a090b31b66bc9a2de3046ed816/src/components/character-count/character-count.js#L119-L121
-    // screen readers may modify the input value directly via JS so we have to
-    // poll to catch those updates
-    this.pollInterval = setInterval(this.update.bind(this), 1000)
-  }
-}
-
-InputLengthSuggester.prototype.handleBlur = function () {
-  if (this.pollInterval) {
-    clearInterval(this.pollInterval)
+  InputLengthSuggester.prototype.start = function ($module) {
+    this.$module = $module[0]
+    this.$target = document.getElementById(this.$module.getAttribute('data-for'))
+    this.messageTemplate = this.$module.getAttribute('data-message')
+    var showFrom = parseInt(this.$module.getAttribute('data-show-from'), 10)
+    this.showFrom = showFrom > 0 ? showFrom : 0
     this.pollInterval = null
-  }
-}
 
-var inputLengthSuggesters = document.querySelectorAll('[data-module="input-length-suggester"]')
-for (var i = 0; i < inputLengthSuggesters.length; i++) {
-  new InputLengthSuggester(inputLengthSuggesters[i]).init()
-}
+    if (!this.$target || !this.messageTemplate) {
+      return
+    }
+    this.update()
+
+    // these 3 cover most bases for a consistent experience
+    this.$target.addEventListener('keydown', this.update.bind(this))
+    this.$target.addEventListener('keyup', this.update.bind(this))
+    this.$target.addEventListener('change', this.update.bind(this))
+
+    // set-up polling
+    this.$target.addEventListener('focus', this.handleFocus.bind(this))
+    this.$target.addEventListener('blur', this.handleBlur.bind(this))
+  }
+
+  InputLengthSuggester.prototype.update = function () {
+    var count = this.$target.value.length
+    this.$module.textContent = this.messageTemplate.replace(/{count}/g, count)
+    if (count >= this.showFrom) {
+      this.$module.classList.remove('app-c-input-length-suggester__hidden')
+    } else {
+      this.$module.classList.add('app-c-input-length-suggester__hidden')
+    }
+  }
+
+  InputLengthSuggester.prototype.handleFocus = function () {
+    if (!this.pollInterval) {
+      // according to https://github.com/alphagov/govuk-frontend/blob/29c50367474396a090b31b66bc9a2de3046ed816/src/components/character-count/character-count.js#L119-L121
+      // screen readers may modify the input value directly via JS so we have to
+      // poll to catch those updates
+      this.pollInterval = setInterval(this.update.bind(this), 1000)
+    }
+  }
+
+  InputLengthSuggester.prototype.handleBlur = function () {
+    if (this.pollInterval) {
+      clearInterval(this.pollInterval)
+      this.pollInterval = null
+    }
+  }
+
+  Modules.InputLengthSuggester = InputLengthSuggester
+})(window.GOVUK.Modules)

--- a/app/assets/javascripts/components/markdown-editor.js
+++ b/app/assets/javascripts/components/markdown-editor.js
@@ -1,156 +1,149 @@
 //= require vendor/@alphagov/markdown-toolbar-element/index.js
+window.GOVUK = window.GOVUK || {}
+window.GOVUK.Modules = window.GOVUK.Modules || {};
 
-function MarkdownEditor ($module) {
-  this.$module = $module
-  this.$head = $module.querySelector('.js-markdown-editor__head')
-  this.$container = $module.querySelector('.js-markdown-editor__container')
-  this.$input = $module.querySelector('textarea')
-  this.$preview = $module.querySelector('.js-markdown-preview-body .govuk-textarea')
-  this.$previewButton = $module.querySelector('.js-markdown-preview-button')
-  this.$editButton = $module.querySelector('.js-markdown-edit-button')
-  this.$editorInput = $module.querySelector('.js-markdown-editor-input')
-  this.$previewBody = $module.querySelector('.js-markdown-preview-body')
-  this.$toolbar = document.querySelector('.app-c-markdown-guidance')
-  this.$editorToolbar = document.querySelector('.app-c-markdown-editor__toolbar')
-}
+(function (Modules) {
+  function MarkdownEditor () { }
 
-MarkdownEditor.prototype.init = function () {
-  var $module = this.$module
+  MarkdownEditor.prototype.start = function ($module) {
+    this.$module = $module[0]
+    this.$head = this.$module.querySelector('.js-markdown-editor__head')
+    this.$container = this.$module.querySelector('.js-markdown-editor__container')
+    this.$input = this.$module.querySelector('textarea')
+    this.$preview = this.$module.querySelector('.js-markdown-preview-body .govuk-textarea')
+    this.$previewButton = this.$module.querySelector('.js-markdown-preview-button')
+    this.$editButton = this.$module.querySelector('.js-markdown-edit-button')
+    this.$editorInput = this.$module.querySelector('.js-markdown-editor-input')
+    this.$previewBody = this.$module.querySelector('.js-markdown-preview-body')
+    this.$toolbar = document.querySelector('.app-c-markdown-guidance')
+    this.$editorToolbar = document.querySelector('.app-c-markdown-editor__toolbar')
 
-  // Save bounded functions to use when removing event listeners during teardown
-  $module.boundPreviewButtonClick = this.handlePreviewButton.bind(this)
-  $module.boundEditButtonClick = this.handleEditButton.bind(this)
+    // Enable toggle bar
+    this.$head.style.display = 'block'
 
-  // Enable toggle bar
-  this.$head.style.display = 'block'
+    // Handle button events
+    this.$previewButton.addEventListener('click', this.handlePreviewButton.bind(this))
+    this.$editButton.addEventListener('click', this.handleEditButton.bind(this))
 
-  // Handle button events
-  this.$previewButton.addEventListener('click', $module.boundPreviewButtonClick)
-  this.$editButton.addEventListener('click', $module.boundEditButtonClick)
-
-  // Reflect focus events
-  this.reflectFocusStateToContainer(this.$input, this.$container)
-  this.bubbleFocusEventToComponent(this.$input)
-  this.bubbleFocusEventToComponent(this.$editButton)
-  this.bubbleFocusEventToComponent(this.$previewButton)
-}
-
-MarkdownEditor.prototype.handlePreviewButton = function (event) {
-  event.preventDefault()
-
-  // Disable action if muted
-  if (this.$previewButton.classList.contains('app-c-markdown-editor__button--muted')) {
-    return
+    // Reflect focus events
+    this.reflectFocusStateToContainer(this.$input, this.$container)
+    this.bubbleFocusEventToComponent(this.$input)
+    this.bubbleFocusEventToComponent(this.$editButton)
+    this.bubbleFocusEventToComponent(this.$previewButton)
   }
 
-  // Mirror textarea's height
-  this.$preview.style.height = this.$input.offsetHeight + this.$editorToolbar.offsetHeight + 'px'
+  MarkdownEditor.prototype.handlePreviewButton = function (event) {
+    event.preventDefault()
 
-  // Clear previous preview
-  this.$preview.innerHTML = ''
-  this.$preview.classList.remove('app-c-markdown-editor__govspeak--rendered')
+    // Disable action if muted
+    if (this.$previewButton.classList.contains('app-c-markdown-editor__button--muted')) {
+      return
+    }
 
-  if (!this.$input.value) {
-    this.$preview.innerHTML = 'Nothing to preview'
+    // Mirror textarea's height
+    this.$preview.style.height = this.$input.offsetHeight + this.$editorToolbar.offsetHeight + 'px'
+
+    // Clear previous preview
+    this.$preview.innerHTML = ''
+    this.$preview.classList.remove('app-c-markdown-editor__govspeak--rendered')
+
+    if (!this.$input.value) {
+      this.$preview.innerHTML = 'Nothing to preview'
+      this.toggleElements()
+      return
+    }
+
+    this.fetchGovspeakPreview(this.$input.value)
+      .then(function (text) {
+        this.$preview.innerHTML = text
+        this.setTargetBlank(this.$preview)
+        this.$preview.classList.add('app-c-markdown-editor__govspeak--rendered')
+      }.bind(this))
+      .catch(function () {
+        this.$preview.innerHTML = 'Error previewing content'
+        this.$preview.classList.add('app-c-markdown-editor__govspeak--rendered')
+      }.bind(this))
+
     this.toggleElements()
-    return
   }
 
-  var $preview = this.$preview
+  MarkdownEditor.prototype.fetchGovspeakPreview = function (text) {
+    var path = this.$module.getAttribute('data-govspeak-path')
+    var url = new URL(document.location.origin + path)
 
-  this.fetchGovspeakPreview(this.$input.value)
-    .then(function (text) {
-      $preview.innerHTML = text
-      MarkdownEditor.prototype.setTargetBlank($preview)
-      $preview.classList.add('app-c-markdown-editor__govspeak--rendered')
-    })
-    .catch(function () {
-      $preview.innerHTML = 'Error previewing content'
-      $preview.classList.add('app-c-markdown-editor__govspeak--rendered')
-    })
+    var formData = new window.FormData()
+    formData.append('govspeak', text)
 
-  this.toggleElements()
-}
+    var controller = new window.AbortController()
+    var options = { credentials: 'include', signal: controller.signal, method: 'POST', body: formData }
+    setTimeout(function () { controller.abort() }, 5000)
 
-MarkdownEditor.prototype.fetchGovspeakPreview = function (text) {
-  var path = this.$module.getAttribute('data-govspeak-path')
-  var url = new URL(document.location.origin + path)
-
-  var formData = new window.FormData()
-  formData.append('govspeak', text)
-
-  var controller = new window.AbortController()
-  var options = { credentials: 'include', signal: controller.signal, method: 'POST', body: formData }
-  setTimeout(function () { controller.abort() }, 5000)
-
-  return window.fetch(url, options).then(function (response) { return response.text() })
-}
-
-MarkdownEditor.prototype.handleEditButton = function (event) {
-  event.preventDefault()
-
-  // Disable action if muted
-  if (this.$editButton.classList.contains('app-c-markdown-editor__button--muted')) {
-    return
+    return window.fetch(url, options).then(function (response) { return response.text() })
   }
 
-  this.toggleElements()
-}
+  MarkdownEditor.prototype.handleEditButton = function (event) {
+    event.preventDefault()
 
-MarkdownEditor.prototype.toggleElements = function () {
-  this.$editButton.classList.toggle('app-c-markdown-editor__button--muted')
-  this.$previewButton.classList.toggle('app-c-markdown-editor__button--muted')
-  this.toggle(this.$editorInput)
-  this.toggle(this.$previewBody)
-  if (this.$toolbar) {
-    this.toggle(this.$toolbar)
+    // Disable action if muted
+    if (this.$editButton.classList.contains('app-c-markdown-editor__button--muted')) {
+      return
+    }
+
+    this.toggleElements()
   }
-  if (this.$editorToolbar) {
-    this.toggle(this.$editorToolbar)
+
+  MarkdownEditor.prototype.toggleElements = function () {
+    this.$editButton.classList.toggle('app-c-markdown-editor__button--muted')
+    this.$previewButton.classList.toggle('app-c-markdown-editor__button--muted')
+    this.toggle(this.$editorInput)
+    this.toggle(this.$previewBody)
+    if (this.$toolbar) {
+      this.toggle(this.$toolbar)
+    }
+    if (this.$editorToolbar) {
+      this.toggle(this.$editorToolbar)
+    }
   }
-}
 
-MarkdownEditor.prototype.toggle = function (element) {
-  // Evaluate `display` property coming from either CSS or JavaScript
-  if (element.ownerDocument.defaultView.getComputedStyle(element, null).display === 'none') {
-    element.style.display = 'block'
-  } else {
-    element.style.display = 'none'
+  MarkdownEditor.prototype.toggle = function (element) {
+    // Evaluate `display` property coming from either CSS or JavaScript
+    if (element.ownerDocument.defaultView.getComputedStyle(element, null).display === 'none') {
+      element.style.display = 'block'
+    } else {
+      element.style.display = 'none'
+    }
   }
-}
 
-// Set target="_blank" to anchors inside the container
-MarkdownEditor.prototype.setTargetBlank = function (container) {
-  if (container) {
-    var anchors = container.querySelectorAll('a')
-    anchors.forEach(function (anchor) {
-      anchor.setAttribute('target', '_blank')
-    })
+  // Set target="_blank" to anchors inside the container
+  MarkdownEditor.prototype.setTargetBlank = function (container) {
+    if (container) {
+      var anchors = container.querySelectorAll('a')
+      anchors.forEach(function (anchor) {
+        anchor.setAttribute('target', '_blank')
+      })
+    }
   }
-}
 
-// Reflect focus and blur events to component
-MarkdownEditor.prototype.bubbleFocusEventToComponent = function (element) {
-  var $module = this.$module
-  element.addEventListener('focus', function (event) {
-    $module.dispatchEvent(new window.Event('focus'))
-  }, true)
-  element.addEventListener('blur', function (event) {
-    $module.dispatchEvent(new window.Event('blur'))
-  }, true)
-}
+  // Reflect focus and blur events to component
+  MarkdownEditor.prototype.bubbleFocusEventToComponent = function (element) {
+    var $module = this.$module
+    element.addEventListener('focus', function (event) {
+      $module.dispatchEvent(new window.Event('focus'))
+    }, true)
+    element.addEventListener('blur', function (event) {
+      $module.dispatchEvent(new window.Event('blur'))
+    }, true)
+  }
 
-// Reflect focus and blur element state to container
-MarkdownEditor.prototype.reflectFocusStateToContainer = function (element, container) {
-  element.addEventListener('focus', function (event) {
-    container && container.classList.add('app-c-markdown-editor__container--focused')
-  }, true)
-  element.addEventListener('blur', function (event) {
-    container && container.classList.remove('app-c-markdown-editor__container--focused')
-  }, true)
-}
+  // Reflect focus and blur element state to container
+  MarkdownEditor.prototype.reflectFocusStateToContainer = function (element, container) {
+    element.addEventListener('focus', function (event) {
+      container && container.classList.add('app-c-markdown-editor__container--focused')
+    }, true)
+    element.addEventListener('blur', function (event) {
+      container && container.classList.remove('app-c-markdown-editor__container--focused')
+    }, true)
+  }
 
-var $govspeak = document.querySelector('[data-module="markdown-editor"]')
-if ($govspeak) {
-  new MarkdownEditor($govspeak).init()
-}
+  Modules.MarkdownEditor = MarkdownEditor
+})(window.GOVUK.Modules)

--- a/app/assets/javascripts/components/modal-dialogue.js
+++ b/app/assets/javascripts/components/modal-dialogue.js
@@ -1,91 +1,92 @@
-function ModalDialogue ($module) {
-  this.$module = $module
-  this.$dialogBox = $module.querySelector('.app-c-modal-dialogue__box')
-  this.$closeButton = $module.querySelector('.app-c-modal-dialogue__close-button')
-  this.$body = document.querySelector('body')
-}
+window.GOVUK = window.GOVUK || {}
+window.GOVUK.Modules = window.GOVUK.Modules || {};
 
-ModalDialogue.prototype.init = function () {
-  if (!this.$module) {
-    return
+(function (Modules) {
+  function ModalDialogue () { }
+
+  ModalDialogue.prototype.start = function ($module) {
+    this.$module = $module[0]
+    this.$dialogBox = this.$module.querySelector('.app-c-modal-dialogue__box')
+    this.$closeButton = this.$module.querySelector('.app-c-modal-dialogue__close-button')
+    this.$body = document.querySelector('body')
+
+    this.$module.open = this.handleOpen.bind(this)
+    this.$module.close = this.handleClose.bind(this)
+    this.$module.focusDialog = this.handleFocusDialog.bind(this)
+    this.$module.boundKeyDown = this.handleKeyDown.bind(this)
+
+    var $triggerElement = document.querySelector(
+      '[data-toggle="modal"][data-target="' + this.$module.id + '"]'
+    )
+
+    if ($triggerElement) {
+      $triggerElement.addEventListener('click', this.$module.open)
+    }
+
+    if (this.$closeButton) {
+      this.$closeButton.addEventListener('click', this.$module.close)
+    }
   }
 
-  this.$module.open = this.handleOpen.bind(this)
-  this.$module.close = this.handleClose.bind(this)
-  this.$module.focusDialog = this.handleFocusDialog.bind(this)
-  this.$module.boundKeyDown = this.handleKeyDown.bind(this)
+  ModalDialogue.prototype.handleOpen = function (event) {
+    if (event) {
+      event.preventDefault()
+    }
 
-  var $triggerElement = document.querySelector('[data-toggle="modal"][data-target="' + this.$module.id + '"]')
-  if ($triggerElement) {
-    $triggerElement.addEventListener('click', this.$module.open)
+    this.$body.classList.add('app-o-template__body--modal')
+    this.$body.classList.add('app-o-template__body--blur')
+    this.$focusedElementBeforeOpen = document.activeElement
+    this.$module.style.display = 'block'
+    this.$dialogBox.focus()
+
+    document.addEventListener('keydown', this.$module.boundKeyDown, true)
   }
 
-  if (this.$closeButton) {
-    this.$closeButton.addEventListener('click', this.$module.close)
+  ModalDialogue.prototype.handleClose = function (event) {
+    if (event) {
+      event.preventDefault()
+    }
+
+    this.$body.classList.remove('app-o-template__body--modal')
+    this.$body.classList.remove('app-o-template__body--blur')
+    this.$module.style.display = 'none'
+    this.$focusedElementBeforeOpen.focus()
+
+    document.removeEventListener('keydown', this.$module.boundKeyDown, true)
   }
-}
 
-ModalDialogue.prototype.handleOpen = function (event) {
-  if (event) {
-    event.preventDefault()
+  ModalDialogue.prototype.handleFocusDialog = function () {
+    this.$dialogBox.focus()
   }
-  this.$body.classList.add('app-o-template__body--modal')
-  this.$body.classList.add('app-o-template__body--blur')
-  this.$focusedElementBeforeOpen = document.activeElement
-  this.$module.style.display = 'block'
-  this.$dialogBox.focus()
 
-  document.addEventListener('keydown', this.$module.boundKeyDown, true)
-}
+  // while open, prevent tabbing to outside the dialogue
+  // and listen for ESC key to close the dialogue
+  ModalDialogue.prototype.handleKeyDown = function (event) {
+    var KEY_TAB = 9
+    var KEY_ESC = 27
 
-ModalDialogue.prototype.handleClose = function (event) {
-  if (event) {
-    event.preventDefault()
-  }
-  this.$body.classList.remove('app-o-template__body--modal')
-  this.$body.classList.remove('app-o-template__body--blur')
-  this.$module.style.display = 'none'
-  this.$focusedElementBeforeOpen.focus()
-
-  document.removeEventListener('keydown', this.$module.boundKeyDown, true)
-}
-
-ModalDialogue.prototype.handleFocusDialog = function () {
-  this.$dialogBox.focus()
-}
-
-// while open, prevent tabbing to outside the dialogue
-// and listen for ESC key to close the dialogue
-ModalDialogue.prototype.handleKeyDown = function (event) {
-  var KEY_TAB = 9
-  var KEY_ESC = 27
-
-  switch (event.keyCode) {
-    case KEY_TAB:
-      if (event.shiftKey) {
-        if (document.activeElement === this.$dialogBox) {
-          event.preventDefault()
-          this.$closeButton.focus()
+    switch (event.keyCode) {
+      case KEY_TAB:
+        if (event.shiftKey) {
+          if (document.activeElement === this.$dialogBox) {
+            event.preventDefault()
+            this.$closeButton.focus()
+          }
+        } else {
+          if (document.activeElement === this.$closeButton) {
+            event.preventDefault()
+            this.$dialogBox.focus()
+          }
         }
-      } else {
-        if (document.activeElement === this.$closeButton) {
-          event.preventDefault()
-          this.$dialogBox.focus()
-        }
-      }
 
-      break
-    case KEY_ESC:
-      this.$module.close()
-      break
-    default:
-      break
+        break
+      case KEY_ESC:
+        this.$module.close()
+        break
+      default:
+        break
+    }
   }
-}
 
-// Initialise modals
-var $modalDialogues = document.querySelectorAll('[data-module="modal-dialogue"]')
-$modalDialogues.forEach(function ($el) {
-  var $modalDialogue = new ModalDialogue($el)
-  $modalDialogue.init()
-})
+  Modules.ModalDialogue = ModalDialogue
+})(window.GOVUK.Modules)

--- a/app/assets/javascripts/components/multi-section-viewer.js
+++ b/app/assets/javascripts/components/multi-section-viewer.js
@@ -1,42 +1,44 @@
-function MultiSectionViewer ($container) {
-  this.$container = $container
-  this.$dynamicSection = $container.querySelector('.js-dynamic-section')
-}
+window.GOVUK = window.GOVUK || {}
+window.GOVUK.Modules = window.GOVUK.Modules || {};
 
-MultiSectionViewer.prototype.init = function () {
-  var actions = document.querySelectorAll('[data-toggle="multi-section-viewer"][data-target="' + this.$container.id + '"]')
-  var $module = this
+(function (Modules) {
+  function MultiSectionViewer () { }
 
-  actions.forEach(function (action) {
-    action.addEventListener('click', function (event) {
-      event.preventDefault()
-      $module.showStaticSection(event.target.dataset.targetSection)
+  MultiSectionViewer.prototype.start = function ($module) {
+    this.$module = $module[0]
+    this.$dynamicSection = this.$module.querySelector('.js-dynamic-section')
+
+    var actions = document.querySelectorAll(
+      '[data-toggle="multi-section-viewer"][data-target="' + this.$module.id + '"]'
+    )
+
+    actions.forEach(function (action) {
+      action.addEventListener('click', function (event) {
+        event.preventDefault()
+        this.showStaticSection(event.target.dataset.targetSection)
+      }.bind(this))
+    }.bind(this))
+  }
+
+  MultiSectionViewer.prototype.hideAllSections = function () {
+    var sections = this.$module.querySelectorAll('.app-c-multi-section-viewer__section')
+
+    sections.forEach(function (section) {
+      section.style.display = 'none'
     })
-  })
-}
+  }
 
-MultiSectionViewer.prototype.hideAllSections = function () {
-  var sections = this.$container.querySelectorAll('.app-c-multi-section-viewer__section')
+  MultiSectionViewer.prototype.showDynamicSection = function (content) {
+    this.hideAllSections()
+    this.$dynamicSection.innerHTML = content
+    this.$dynamicSection.style.display = 'block'
+  }
 
-  sections.forEach(function (section) {
-    section.style.display = 'none'
-  })
-}
+  MultiSectionViewer.prototype.showStaticSection = function (id) {
+    this.hideAllSections()
+    var section = this.$module.querySelector('#' + id)
+    section.style.display = 'block'
+  }
 
-MultiSectionViewer.prototype.showDynamicSection = function (content) {
-  this.hideAllSections()
-  this.$dynamicSection.innerHTML = content
-  this.$dynamicSection.style.display = 'block'
-}
-
-MultiSectionViewer.prototype.showStaticSection = function (name) {
-  this.hideAllSections()
-  var section = this.$container.querySelector('#' + name)
-  section.style.display = 'block'
-}
-
-var multiSectionViewers = document.querySelectorAll('[data-module="multi-section-viewer"]')
-
-multiSectionViewers.forEach(function (multiSectionViewer) {
-  new MultiSectionViewer(multiSectionViewer).init()
-})
+  Modules.MultiSectionViewer = MultiSectionViewer
+})(window.GOVUK.Modules)

--- a/app/assets/javascripts/components/url-preview.js
+++ b/app/assets/javascripts/components/url-preview.js
@@ -1,74 +1,71 @@
-function UrlPreview ($module) {
-  this.$module = $module
+window.GOVUK = window.GOVUK || {}
+window.GOVUK.Modules = window.GOVUK.Modules || {};
 
-  this.urlPreview = this.$module.querySelector('.js-url-preview-url')
-  this.basePath = this.$module.querySelector('.js-url-preview-path')
-  this.defaultMessage = this.$module.querySelector('.js-url-preview-default-message')
-  this.errorMessage = this.$module.querySelector('.js-url-preview-error-message')
-  this.input = document.querySelector('[data-url-preview="input"]')
-  this.form = document.querySelector('[data-url-preview-path]')
-  this.path = this.form.getAttribute('data-url-preview-path')
-}
+(function (Modules) {
+  function UrlPreview () { }
 
-UrlPreview.prototype.init = function () {
-  var $module = this.$module
-  if (!$module || !this.input || !this.path) {
-    return
+  UrlPreview.prototype.start = function ($module) {
+    this.$module = $module[0]
+
+    this.urlPreview = this.$module.querySelector('.js-url-preview-url')
+    this.basePath = this.$module.querySelector('.js-url-preview-path')
+    this.defaultMessage = this.$module.querySelector('.js-url-preview-default-message')
+    this.errorMessage = this.$module.querySelector('.js-url-preview-error-message')
+    this.input = document.querySelector('[data-url-preview="input"]')
+    this.form = document.querySelector('[data-url-preview-path]')
+    this.path = this.form.getAttribute('data-url-preview-path')
+    this.input.addEventListener('blur', this.handleBlur.bind(this))
   }
 
-  this.input.addEventListener('blur', this.handleBlur.bind(this))
-}
-
-UrlPreview.prototype.showErrorMessage = function () {
-  this.urlPreview.classList.add('app-c-url-preview__url--hidden')
-  this.defaultMessage.classList.add('app-c-url-preview__default-message--hidden')
-  this.errorMessage.classList.remove('app-c-url-preview__error-message--hidden')
-}
-
-UrlPreview.prototype.showNoTitleMessage = function () {
-  this.urlPreview.classList.add('app-c-url-preview__url--hidden')
-  this.defaultMessage.classList.remove('app-c-url-preview__default-message--hidden')
-  this.errorMessage.classList.add('app-c-url-preview__error-message--hidden')
-}
-
-UrlPreview.prototype.showPathPreview = function (path) {
-  this.urlPreview.classList.remove('app-c-url-preview__url--hidden')
-  this.defaultMessage.classList.add('app-c-url-preview__default-message--hidden')
-  this.errorMessage.classList.add('app-c-url-preview__error-message--hidden')
-  this.basePath.innerHTML = path
-}
-
-UrlPreview.prototype.fetchPathPreview = function (path, input) {
-  var url = new URL(document.location.origin + path)
-  url.searchParams.append('title', input.value)
-
-  var controller = new window.AbortController()
-  var options = { credentials: 'include', signal: controller.signal }
-  setTimeout(function () { controller.abort() }, 5000)
-
-  return window.fetch(url, options)
-    .then(function (response) {
-      if (!response.ok) {
-        throw Error('Unable to generate response.')
-      }
-
-      return response.text()
-    })
-}
-
-UrlPreview.prototype.handleBlur = function (event) {
-  var input = event.target
-
-  if (!input.value) {
-    this.showNoTitleMessage()
-    return
+  UrlPreview.prototype.showErrorMessage = function () {
+    this.urlPreview.classList.add('app-c-url-preview__url--hidden')
+    this.defaultMessage.classList.add('app-c-url-preview__default-message--hidden')
+    this.errorMessage.classList.remove('app-c-url-preview__error-message--hidden')
   }
-  UrlPreview.prototype.fetchPathPreview(this.path, this.input)
-    .then(this.showPathPreview.bind(this))
-    .catch(this.showErrorMessage.bind(this))
-}
 
-var $urlPreview = document.querySelector('[data-module="url-preview"]')
-if ($urlPreview) {
-  new UrlPreview($urlPreview).init()
-}
+  UrlPreview.prototype.showNoTitleMessage = function () {
+    this.urlPreview.classList.add('app-c-url-preview__url--hidden')
+    this.defaultMessage.classList.remove('app-c-url-preview__default-message--hidden')
+    this.errorMessage.classList.add('app-c-url-preview__error-message--hidden')
+  }
+
+  UrlPreview.prototype.showPathPreview = function (path) {
+    this.urlPreview.classList.remove('app-c-url-preview__url--hidden')
+    this.defaultMessage.classList.add('app-c-url-preview__default-message--hidden')
+    this.errorMessage.classList.add('app-c-url-preview__error-message--hidden')
+    this.basePath.innerHTML = path
+  }
+
+  UrlPreview.prototype.fetchPathPreview = function (path, input) {
+    var url = new URL(document.location.origin + path)
+    url.searchParams.append('title', input.value)
+
+    var controller = new window.AbortController()
+    var options = { credentials: 'include', signal: controller.signal }
+    setTimeout(function () { controller.abort() }, 5000)
+
+    return window.fetch(url, options)
+      .then(function (response) {
+        if (!response.ok) {
+          throw Error('Unable to generate response.')
+        }
+
+        return response.text()
+      })
+  }
+
+  UrlPreview.prototype.handleBlur = function (event) {
+    var input = event.target
+
+    if (!input.value) {
+      this.showNoTitleMessage()
+      return
+    }
+
+    this.fetchPathPreview(this.path, this.input)
+      .then(this.showPathPreview.bind(this))
+      .catch(this.showErrorMessage.bind(this))
+  }
+
+  Modules.UrlPreview = UrlPreview
+})(window.GOVUK.Modules)

--- a/app/views/components/_contextual_guidance.html.erb
+++ b/app/views/components/_contextual_guidance.html.erb
@@ -3,7 +3,9 @@
   title ||= nil
   relative ||= false
 %>
-<div id="<%= id %>" class="app-c-contextual-guidance-wrapper<%= " app-c-contextual-guidance-wrapper--relative" if relative %>">
+<div id="<%= id %>"
+     class="app-c-contextual-guidance-wrapper<%= " app-c-contextual-guidance-wrapper--relative" if relative %>"
+     data-module="contextual-guidance">
   <div class="app-c-contextual-guidance">
     <h2 class="govuk-heading-s"><%= title %></h2>
     <%= yield %>

--- a/app/views/contacts/search.html.erb
+++ b/app/views/contacts/search.html.erb
@@ -20,7 +20,10 @@
     },
     id: "contact-id",
     options: [["", ""]] + contact_options,
-    data_module: "autocomplete-with-hint-on-options",
+    data: {
+      module: "autocomplete",
+      "autocomplete-type": "with-hint-on-options"
+    }
   } %>
 
   <%= render "govuk_publishing_components/components/button", {

--- a/spec/javascripts/components/contextual-guidance-spec.js
+++ b/spec/javascripts/components/contextual-guidance-spec.js
@@ -28,7 +28,10 @@ describe('Contextual guidance component', function () {
       '</div>'
 
     document.body.appendChild(container)
-    new ContextualGuidance().init(document)
+    var titleContextualGuidance = document.getElementById('document-title-guidance')
+    var summaryContextualGuidance = document.getElementById('document-summary-guidance')
+    new GOVUK.Modules.ContextualGuidance().start($(titleContextualGuidance))
+    new GOVUK.Modules.ContextualGuidance().start($(summaryContextualGuidance))
   })
 
   afterEach(function () {

--- a/spec/javascripts/components/input-length-suggester-spec.js
+++ b/spec/javascripts/components/input-length-suggester-spec.js
@@ -21,7 +21,7 @@ describe('Input length suggester component', function () {
 
     document.body.appendChild(container)
     var element = document.querySelector('[data-module="input-length-suggester"]')
-    new InputLengthSuggester(element).init()
+    new GOVUK.Modules.InputLengthSuggester().start($(element))
   })
 
   afterEach(function () {

--- a/spec/javascripts/components/markdown-editor-spec.js
+++ b/spec/javascripts/components/markdown-editor-spec.js
@@ -61,7 +61,7 @@ describe('Markdown editor component', function () {
 
     document.body.appendChild(container)
     var element = document.querySelector('[data-module="markdown-editor"]')
-    new MarkdownEditor(element).init()
+    new GOVUK.Modules.MarkdownEditor().start($(element))
   })
 
   afterEach(function () {

--- a/spec/javascripts/components/modal-dialogue-spec.js
+++ b/spec/javascripts/components/modal-dialogue-spec.js
@@ -33,7 +33,7 @@ describe('Modal dialogue component', function () {
     document.body.classList.add('js-enabled')
     document.body.appendChild(container)
     var element = document.querySelector('[data-module="modal-dialogue"]')
-    new ModalDialogue(element).init()
+    new GOVUK.Modules.ModalDialogue().start($(element))
   })
 
   afterEach(function () {

--- a/spec/javascripts/components/multi-section-viewer-spec.js
+++ b/spec/javascripts/components/multi-section-viewer-spec.js
@@ -21,8 +21,8 @@ describe('Multi section viewer', function () {
 
     document.body.appendChild(container)
     var element = document.querySelector('[data-module="multi-section-viewer"]')
-    module = new MultiSectionViewer(element)
-    module.init()
+    module = new GOVUK.Modules.MultiSectionViewer()
+    module.start($(element))
   })
 
   afterEach(function () {

--- a/spec/javascripts/components/url-preview-spec.js
+++ b/spec/javascripts/components/url-preview-spec.js
@@ -26,7 +26,7 @@ describe('URL preview component', function () {
 
     document.body.appendChild(container)
     var element = document.querySelector('[data-module="url-preview"]')
-    new UrlPreview(element).init()
+    new GOVUK.Modules.UrlPreview().start($(element))
   })
 
   afterEach(function () {


### PR DESCRIPTION
https://trello.com/c/5qBQd1ko/654-allow-users-to-crop-inline-images-in-the-context-of-a-modal

Please see the commits for more detail about how some of the components have changed. In general, the current JS for our local components has been written to look like this:

```
function MyComponent($module) {
  // init stuff
}

MyComponent.prototype.myfunction = function ...

var components = document.querySelectorAll('[data-module="my-component"]')
components.forEach(function (component) {
  new MyComponent(component).init()
}
```

The above is neither consistent with govuk-frontend or govuk_publishing_components, and also means that this JS can only run when the page loads, which is incompatible with the dynamic content we load into a modal (e.g. the images index page). This rewrites our local component JS to use the pattern in govuk_publishing_components, which looks like this:

```
window.GOVUK = window.GOVUK || {};
window.GOVUK.Modules = window.GOVUK.Modules || {};

(function (Modules) {
  Modules.MyComponent = function () {
    this.start = function ($module) {
      this.$module = $module[0]
      // init code (formerly the constructor and init() function)
    }

   this.myfunction = function ...
})(GOVUK.Modules)
```

The framework in govuk_publishing_components will then auto-match HTML with `data-module="my-component"` against the `MyComponent` module, which removes some of the repetitive boilerplate that used to go at the bottom, and also means we can ask our components to re-scan for new HTML by doing `GOVUK.modules.start()`.

Unfortunately, the framework in govuk_publishing_components is based on jQuery, so we have to do `this.$module = $module[0]` to get the component HTML out of the nasty jQuery wrapper. This is something we expect to improve in govuk_publishing_components in general.