### PR TITLE
Move flash messages in main container

### DIFF
--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -49,44 +49,44 @@
 
     <%= yield(:back_link) %>
 
-    <% if flash["notice"] %>
-      <%= render "govuk_publishing_components/components/success_alert", {
-        message: flash["notice"]
-      } %>
-    <% end %>
-
-    <% if flash["confirmation"] %>
-      <%= render flash["confirmation"] %>
-    <% end %>
-
-    <% if flash["alert_with_description"] %>
-      <%= render "govuk_publishing_components/components/error_alert", {
-        message: flash["alert_with_description"].fetch("title"),
-        data_attributes: { gtm: "global-alert" },
-        description: capture do
-          render "govuk_publishing_components/components/govspeak" do
-            govspeak_to_html(flash["alert_with_description"].fetch("description_govspeak"))
-          end
-        end
-      } %>
-    <% end %>
-
-    <% if flash["alert_with_items"] %>
-      <%= render "govuk_publishing_components/components/error_summary", {
-        title: flash["alert_with_items"]["title"],
-        items: flash["alert_with_items"]["items"].map(&:symbolize_keys),
-        data_attributes: { gtm: "global-alert" },
-      } %>
-    <% end %>
-
-    <% if flash["alert"] %>
-      <%= render "govuk_publishing_components/components/error_alert", {
-        message: flash["alert"],
-        data_attributes: { gtm: "global-alert" },
-      } %>
-    <% end %>
-
     <main class="govuk-main-wrapper<%= " govuk-main-wrapper--l" if yield(:back_link).blank?%>" id="main-content" role="main">
+      <% if flash["notice"] %>
+        <%= render "govuk_publishing_components/components/success_alert", {
+          message: flash["notice"]
+        } %>
+      <% end %>
+
+      <% if flash["confirmation"] %>
+        <%= render flash["confirmation"] %>
+      <% end %>
+
+      <% if flash["alert_with_description"] %>
+        <%= render "govuk_publishing_components/components/error_alert", {
+          message: flash["alert_with_description"].fetch("title"),
+          data_attributes: { gtm: "global-alert" },
+          description: capture do
+            render "govuk_publishing_components/components/govspeak" do
+              govspeak_to_html(flash["alert_with_description"].fetch("description_govspeak"))
+            end
+          end
+        } %>
+      <% end %>
+
+      <% if flash["alert_with_items"] %>
+        <%= render "govuk_publishing_components/components/error_summary", {
+          title: flash["alert_with_items"]["title"],
+          items: flash["alert_with_items"]["items"].map(&:symbolize_keys),
+          data_attributes: { gtm: "global-alert" },
+        } %>
+      <% end %>
+
+      <% if flash["alert"] %>
+        <%= render "govuk_publishing_components/components/error_alert", {
+          message: flash["alert"],
+          data_attributes: { gtm: "global-alert" },
+        } %>
+      <% end %>
+
       <% if yield(:title).present? %>
       <div class="govuk-grid-row">
         <div class="govuk-grid-column-two-thirds">


### PR DESCRIPTION
Error/flash messages are meant to sit within the main container, for layout consistency and accessibility reasons. This PR is dependent on having a consistent spacing for all error/alert components: https://github.com/alphagov/govuk_publishing_components/pull/765