### PR TITLE
Remove download link for non-lead images

### DIFF
--- a/app/views/images/_image.html.erb
+++ b/app/views/images/_image.html.erb
@@ -1,5 +1,4 @@
 <% actions = [] %>
-<% actions << link_to("Download 960x640 image", download_image_path(document, image.image_id), class: "govuk-link") %>
 
 <% if rendering_context == "modal" %>
   <% actions << link_to("Insert image markdown", "#",

--- a/spec/features/editing_images/download_image_spec.rb
+++ b/spec/features/editing_images/download_image_spec.rb
@@ -11,9 +11,10 @@ RSpec.feature "Download a image" do
   def given_there_is_an_edition_with_images
     document_type = build(:document_type, images: true)
     @image_revision = create(:image_revision, :on_asset_manager)
+
     @edition = create(:edition,
                       document_type_id: document_type.id,
-                      image_revisions: [@image_revision])
+                      lead_image_revision: @image_revision)
   end
 
   def when_i_visit_the_image_index_page
@@ -21,9 +22,7 @@ RSpec.feature "Download a image" do
   end
 
   def and_i_click_the_link_to_download_the_image
-    within("#image-#{@image_revision.image_id}") do
-      click_on("Download 960x640 image")
-    end
+    click_on("Download 960x640 image")
   end
 
   def then_the_image_should_have_been_downloaded


### PR DESCRIPTION
https://trello.com/c/w4aI961C/440-provide-a-960x640-download-link-for-images

Previously we showed the download link for all images, but we expect
this is only needed for the lead image. This removes the download link
for non-lead images, which has the added benefit of reduces the number
of actions from the still-crowded list.