### PR TITLE
Users can set content to scheduled

### DIFF
--- a/app/controllers/schedule_controller.rb
+++ b/app/controllers/schedule_controller.rb
@@ -33,7 +33,7 @@ class ScheduleController < ApplicationController
     unless @edition.schedulable?
       # FIXME: this shouldn't be an exception but we've not worked out the
       # right response - maybe bad request or a redirect with flash?
-      raise "Scheduled publishing date and time must be in the future."
+      raise "Scheduled publishing date and time must be at least 15 minutes in the future."
     end
   end
 

--- a/app/controllers/schedule_controller.rb
+++ b/app/controllers/schedule_controller.rb
@@ -43,9 +43,7 @@ class ScheduleController < ApplicationController
       end
 
       reviewed = review_params == "reviewed"
-      scheduling = Scheduling.new(pre_scheduled_status: edition.status, reviewed: reviewed)
-      edition.assign_status(:scheduled, current_user, status_details: scheduling)
-      edition.save!
+      ScheduleService.new(edition).schedule(user: current_user, reviewed: reviewed)
 
       redirect_to scheduled_path(document)
     end

--- a/app/controllers/schedule_controller.rb
+++ b/app/controllers/schedule_controller.rb
@@ -26,6 +26,16 @@ class ScheduleController < ApplicationController
     end
   end
 
+  def confirmation
+    document = Document.with_current_edition.find_by_param(params[:id])
+    @edition = document.current_edition
+  end
+
+  def schedule
+    document = Document.with_current_edition.find_by_param(params[:id])
+    redirect_to document_path(document)
+  end
+
 private
 
   def permitted_params

--- a/app/controllers/schedule_controller.rb
+++ b/app/controllers/schedule_controller.rb
@@ -35,6 +35,13 @@ class ScheduleController < ApplicationController
     Document.transaction do
       document = Document.with_current_edition.lock!.find_by_param(params[:id])
       edition = document.current_edition
+
+      if edition.scheduled_publishing_datetime.blank?
+        # FIXME: this shouldn't be an exception but we've not worked out the
+        # right response - maybe bad request or a redirect with flash?
+        raise "Cannot schedule an edition to be published without setting a publishing date and time."
+      end
+
       reviewed = review_params == "reviewed"
       scheduling = Scheduling.new(pre_scheduled_status: edition.status, reviewed: reviewed)
       edition.assign_status(:scheduled, current_user, status_details: scheduling)

--- a/app/controllers/schedule_controller.rb
+++ b/app/controllers/schedule_controller.rb
@@ -29,6 +29,12 @@ class ScheduleController < ApplicationController
   def confirmation
     document = Document.with_current_edition.find_by_param(params[:id])
     @edition = document.current_edition
+
+    unless @edition.schedulable?
+      # FIXME: this shouldn't be an exception but we've not worked out the
+      # right response - maybe bad request or a redirect with flash?
+      raise "Scheduled publishing date and time must be in the future."
+    end
   end
 
   def schedule

--- a/app/controllers/schedule_controller.rb
+++ b/app/controllers/schedule_controller.rb
@@ -40,8 +40,13 @@ class ScheduleController < ApplicationController
       edition.assign_status(:scheduled, current_user, status_details: scheduling)
       edition.save!
 
-      redirect_to document_path(document)
+      redirect_to scheduled_path(document)
     end
+  end
+
+  def scheduled
+    document = Document.with_current_edition.find_by_param(params[:id])
+    @edition = document.current_edition
   end
 
 private

--- a/app/models/edition.rb
+++ b/app/models/edition.rb
@@ -102,6 +102,13 @@ class Edition < ApplicationRecord
     !live? && !scheduled?
   end
 
+  def schedulable?
+    return false unless editable?
+    return false if scheduled_publishing_datetime.nil?
+
+    scheduled_publishing_datetime > Time.zone.now
+  end
+
   def resume_discarded(live_edition, user)
     revision = live_edition.revision.build_revision_update(
       { change_note: "", update_type: "major" },

--- a/app/models/edition.rb
+++ b/app/models/edition.rb
@@ -99,7 +99,7 @@ class Edition < ApplicationRecord
   end
 
   def editable?
-    !live?
+    !live? && !scheduled?
   end
 
   def resume_discarded(live_edition, user)

--- a/app/models/edition.rb
+++ b/app/models/edition.rb
@@ -64,6 +64,8 @@ class Edition < ApplicationRecord
            :scheduled_publishing_datetime,
            to: :revision
 
+  MINIMUM_SCHEDULING_TIME = { minutes: 15 }.freeze
+
   def self.create_initial(document, user = nil, tags = {})
     revision = Revision.create_initial(document, user, tags)
     status = Status.create!(created_by: user,
@@ -106,7 +108,7 @@ class Edition < ApplicationRecord
     return false unless editable?
     return false if scheduled_publishing_datetime.nil?
 
-    scheduled_publishing_datetime > Time.zone.now
+    scheduled_publishing_datetime > Time.zone.now.advance(MINIMUM_SCHEDULING_TIME)
   end
 
   def resume_discarded(live_edition, user)

--- a/app/models/edition.rb
+++ b/app/models/edition.rb
@@ -61,6 +61,7 @@ class Edition < ApplicationRecord
            :lead_image_revision,
            :image_revisions,
            :image_revisions_without_lead,
+           :scheduled_publishing_datetime,
            to: :revision
 
   def self.create_initial(document, user = nil, tags = {})

--- a/app/models/scheduling.rb
+++ b/app/models/scheduling.rb
@@ -1,0 +1,14 @@
+# frozen_string_literal: true
+
+# Stores the specific data for a scheduled status.
+#
+# This model is immutable
+class Scheduling < ApplicationRecord
+  has_one :status, as: :details
+
+  belongs_to :pre_scheduled_status, class_name: "Status"
+
+  def readonly?
+    !new_record?
+  end
+end

--- a/app/models/status.rb
+++ b/app/models/status.rb
@@ -22,5 +22,6 @@ class Status < ApplicationRecord
                 withdrawn: "withdrawn",
                 removed: "removed",
                 discarded: "discarded",
-                superseded: "superseded" }
+                superseded: "superseded",
+                scheduled: "scheduled" }
 end

--- a/app/models/timeline_entry.rb
+++ b/app/models/timeline_entry.rb
@@ -42,7 +42,8 @@ class TimelineEntry < ApplicationRecord
                      removed: "removed",
                      internal_note: "internal_note",
                      draft_discarded: "draft_discarded",
-                     draft_reset: "draft_reset" }
+                     draft_reset: "draft_reset",
+                     scheduled: "scheduled" }
 
   def self.create_for_status_change(entry_type:,
                                     status:,

--- a/app/services/schedule_service.rb
+++ b/app/services/schedule_service.rb
@@ -1,0 +1,15 @@
+# frozen_string_literal: true
+
+class ScheduleService
+  attr_reader :edition
+
+  def initialize(edition)
+    @edition = edition
+  end
+
+  def schedule(user: nil, reviewed: false)
+    scheduling = Scheduling.new(pre_scheduled_status: edition.status, reviewed: reviewed)
+    edition.assign_status(:scheduled, user, status_details: scheduling)
+    edition.save!
+  end
+end

--- a/app/services/schedule_service.rb
+++ b/app/services/schedule_service.rb
@@ -9,7 +9,22 @@ class ScheduleService
 
   def schedule(user: nil, reviewed: false)
     scheduling = Scheduling.new(pre_scheduled_status: edition.status, reviewed: reviewed)
+    set_edition_status(scheduling, user)
+    create_timeline_entry(scheduling)
+  end
+
+private
+
+  def set_edition_status(scheduling, user)
     edition.assign_status(:scheduled, user, status_details: scheduling)
     edition.save!
+  end
+
+  def create_timeline_entry(scheduling)
+    TimelineEntry.create_for_status_change(
+      entry_type: :scheduled,
+      status: edition.status,
+      details: scheduling,
+    )
   end
 end

--- a/app/views/documents/show/_actions.html.erb
+++ b/app/views/documents/show/_actions.html.erb
@@ -65,7 +65,7 @@
 
       <%= render "govuk_publishing_components/components/button", text: "Preview", href: preview_document_path(@edition.document), secondary: true %>
 
-      <% if @edition.scheduled_publishing_datetime.present? && !@edition.scheduled? %>
+      <% if @edition.schedulable? && current_user.has_permission?(User::PRE_RELEASE_FEATURES_PERMISSION) %>
         <%= link_to "Schedule", scheduling_confirmation_path(@edition.document), class: "govuk-link govuk-link--no-visited-state" %>
       <% else %>
         <%= link_to "Publish", publish_confirmation_path(@edition.document), class: "govuk-link govuk-link--no-visited-state" %>

--- a/app/views/documents/show/_actions.html.erb
+++ b/app/views/documents/show/_actions.html.erb
@@ -78,7 +78,7 @@
       <%= link_to "View published edition on GOV.UK", EditionUrl.new(@edition.document.live_edition).public_url, class: "govuk-link govuk-link--no-visited-state" %>
     <% end %>
 
-    <% if (@edition.submitted_for_review? || @edition.draft?) && current_user.has_permission?(User::PRE_RELEASE_FEATURES_PERMISSION) %>
+    <% if (@edition.editable? || @edition.scheduled?) && current_user.has_permission?(User::PRE_RELEASE_FEATURES_PERMISSION) %>
       <hr class="govuk-section-break govuk-section-break--m govuk-section-break--visible" />
       <%= render "documents/show/scheduling_form" %>
     <% end %>

--- a/app/views/documents/show/_actions.html.erb
+++ b/app/views/documents/show/_actions.html.erb
@@ -60,8 +60,11 @@
 
       <%= render "govuk_publishing_components/components/button", text: "Preview", href: preview_document_path(@edition.document), secondary: true %>
 
-      <%= link_to "Publish", publish_confirmation_path(@edition.document), class: "govuk-link govuk-link--no-visited-state" %>
-
+      <% if @edition.scheduled_publishing_datetime.present? %>
+        <%= link_to "Schedule", scheduling_confirmation_path(@edition.document), class: "govuk-link govuk-link--no-visited-state" %>
+      <% else %>
+        <%= link_to "Publish", publish_confirmation_path(@edition.document), class: "govuk-link govuk-link--no-visited-state" %>
+      <% end %>
       <%= delete_draft_link("app-link--right") %>
     <% end %>
 

--- a/app/views/documents/show/_actions.html.erb
+++ b/app/views/documents/show/_actions.html.erb
@@ -53,6 +53,11 @@
                  text: "Undo withdrawal",
                  data_attributes: { gtm: "undo-withdraw" },
                  href: unwithdraw_path(@document) %>
+    <% elsif @edition.scheduled? %>
+      <%= form_tag create_preview_path(@edition.document) do %>
+        <%= render "govuk_publishing_components/components/button", text: "Preview" %>
+      <% end %>
+      <%= delete_draft_link %>
     <% else %>
       <%= form_tag submit_document_for_2i_path(@edition.document) do %>
         <%= render "govuk_publishing_components/components/button", text: "Submit for 2i review" %>
@@ -60,7 +65,7 @@
 
       <%= render "govuk_publishing_components/components/button", text: "Preview", href: preview_document_path(@edition.document), secondary: true %>
 
-      <% if @edition.scheduled_publishing_datetime.present? %>
+      <% if @edition.scheduled_publishing_datetime.present? && !@edition.scheduled? %>
         <%= link_to "Schedule", scheduling_confirmation_path(@edition.document), class: "govuk-link govuk-link--no-visited-state" %>
       <% else %>
         <%= link_to "Publish", publish_confirmation_path(@edition.document), class: "govuk-link govuk-link--no-visited-state" %>

--- a/app/views/schedule/confirmation.html.erb
+++ b/app/views/schedule/confirmation.html.erb
@@ -1,0 +1,30 @@
+<% content_for :back_link, render_back_link(href: document_path(@edition.document)) %>
+<% content_for :title, t("schedule.confirmation.title") %>
+
+<% scheduled_time = @edition.scheduled_publishing_datetime.strftime("%l:%M%P").strip %>
+<% scheduled_date = @edition.scheduled_publishing_datetime.strftime("%-d %B %Y") %>
+
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-two-thirds">
+    <%= form_tag(scheduling_confirmation_path(@edition.document)) do %>
+      <%= render "govuk_publishing_components/components/radio", {
+        name: "review_status",
+        is_page_heading: true,
+        hint: t("schedule.confirmation.hint_text", time: scheduled_time, date: scheduled_date),
+        items: [
+          {
+            value: "reviewed",
+            text: t("schedule.confirmation.review_status.reviewed"),
+          },
+          {
+            value: "not_reviewed",
+            text: t("schedule.confirmation.review_status.not_reviewed"),
+          },
+        ]
+      } %>
+      <%= render "govuk_publishing_components/components/button", {
+        text: "Publish"
+      } %>
+    <% end %>
+  </div>
+</div>

--- a/app/views/schedule/scheduled.html.erb
+++ b/app/views/schedule/scheduled.html.erb
@@ -1,0 +1,19 @@
+<% content_for :back_link, render_back_link(text: "Return to dashboard", href: document_path(@edition.document)) %>
+<% content_for :browser_title, t("schedule.scheduled.title") %>
+<% scheduled_time = @edition.scheduled_publishing_datetime.strftime("%l:%M%P").strip %>
+<% scheduled_date = @edition.scheduled_publishing_datetime.strftime("%-d %B %Y") %>
+<% public_url = EditionUrl.new(@edition).public_url %>
+
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-two-thirds">
+    <%= render "govuk_publishing_components/components/panel", {
+      title: t("schedule.scheduled.title")
+    } %>
+    <%= render "govuk_publishing_components/components/govspeak" do %>
+      <%= govspeak_to_html t("schedule.scheduled.body_govspeak", title: @edition.title, time: scheduled_time, date: scheduled_date) %>
+    <% end %>
+    <%= render "govuk_publishing_components/components/inset_text", {
+      text: strip_scheme_from_url(public_url)
+    } %>
+  </div>
+</div>

--- a/config/locales/en/documents/history.yml
+++ b/config/locales/en/documents/history.yml
@@ -24,3 +24,4 @@ en:
         draft_discarded: "Draft discarded"
         draft_reset: "Draft reset to last published edition"
         unwithdrawn: "Unwithdrawn"
+        scheduled: "Scheduled to publish"

--- a/config/locales/en/schedule/confirmation.yml
+++ b/config/locales/en/schedule/confirmation.yml
@@ -1,0 +1,8 @@
+en:
+  schedule:
+    confirmation:
+      title: Schedule to publish
+      hint_text: "This content will be automatically published at %{time} on %{date}."
+      review_status:
+        reviewed: This content has been reviewed and approved for publication.
+        not_reviewed: This content needs to be published urgently but should be reviewed as soon as possible.

--- a/config/locales/en/schedule/scheduled.yml
+++ b/config/locales/en/schedule/scheduled.yml
@@ -1,0 +1,8 @@
+en:
+  schedule:
+    scheduled:
+      title: Content has been scheduled to publish
+      body_govspeak: |
+        ‘%{title}’ will be automatically published at %{time} on %{date}.
+
+        It may take 5 minutes to appear live.

--- a/config/locales/en/states.yml
+++ b/config/locales/en/states.yml
@@ -16,3 +16,5 @@ en:
       name: Discarded
     superseded:
       name: Superseded
+    scheduled:
+      name: Scheduled to publish

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -12,7 +12,9 @@ Rails.application.routes.draw do
   post "/documents/:id/publish" => "publish#publish"
   get "/documents/:id/published" => "publish#published", as: :published
 
-  post "documents/:id/save-scheduled-publishing-datetime" => "schedule#save_scheduled_publishing_datetime", as: :save_scheduled_publishing_datetime
+  post "/documents/:id/save-scheduled-publishing-datetime" => "schedule#save_scheduled_publishing_datetime", as: :save_scheduled_publishing_datetime
+  get "/documents/:id/schedule" => "schedule#confirmation", as: :scheduling_confirmation
+  post "/documents/:id/schedule" => "schedule#schedule"
 
   get "/documents" => "documents#index"
   get "/documents/:id/edit" => "documents#edit", as: :edit_document

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -15,6 +15,7 @@ Rails.application.routes.draw do
   post "/documents/:id/save-scheduled-publishing-datetime" => "schedule#save_scheduled_publishing_datetime", as: :save_scheduled_publishing_datetime
   get "/documents/:id/schedule" => "schedule#confirmation", as: :scheduling_confirmation
   post "/documents/:id/schedule" => "schedule#schedule"
+  get "/documents/:id/scheduled" => "schedule#scheduled", as: :scheduled
 
   get "/documents" => "documents#index"
   get "/documents/:id/edit" => "documents#edit", as: :edit_document

--- a/db/migrate/20190225133030_create_scheduling.rb
+++ b/db/migrate/20190225133030_create_scheduling.rb
@@ -1,0 +1,14 @@
+# frozen_string_literal: true
+
+class CreateScheduling < ActiveRecord::Migration[5.2]
+  def change
+    create_table :schedulings do |t|
+      t.boolean :reviewed, default: false
+      t.datetime :created_at, null: false
+      t.references :pre_scheduled_status,
+                   foreign_key: { to_table: :statuses, on_delete: :restrict },
+                   index: false,
+                   null: false
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2019_02_14_120136) do
+ActiveRecord::Schema.define(version: 2019_02_25_133030) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -201,6 +201,12 @@ ActiveRecord::Schema.define(version: 2019_02_14_120136) do
     t.index ["status_id"], name: "index_revisions_statuses_on_status_id"
   end
 
+  create_table "schedulings", force: :cascade do |t|
+    t.boolean "reviewed", default: false
+    t.datetime "created_at", null: false
+    t.bigint "pre_scheduled_status_id", null: false
+  end
+
   create_table "statuses", force: :cascade do |t|
     t.string "state", null: false
     t.bigint "revision_at_creation_id", null: false
@@ -293,6 +299,7 @@ ActiveRecord::Schema.define(version: 2019_02_14_120136) do
   add_foreign_key "revisions_image_revisions", "revisions", on_delete: :restrict
   add_foreign_key "revisions_statuses", "revisions", on_delete: :restrict
   add_foreign_key "revisions_statuses", "statuses", on_delete: :restrict
+  add_foreign_key "schedulings", "statuses", column: "pre_scheduled_status_id", on_delete: :restrict
   add_foreign_key "statuses", "editions", on_delete: :restrict
   add_foreign_key "statuses", "revisions", column: "revision_at_creation_id", on_delete: :restrict
   add_foreign_key "statuses", "users", column: "created_by_id", on_delete: :restrict

--- a/spec/factories/edition_factory.rb
+++ b/spec/factories/edition_factory.rb
@@ -15,6 +15,7 @@ FactoryBot.define do
       title { SecureRandom.alphanumeric(10) }
       update_type { "major" }
       change_note { "First published." }
+      scheduled_publishing_datetime { nil }
       summary { nil }
       base_path { title ? "/prefix/#{title.parameterize}" : nil }
       contents { {} }
@@ -55,6 +56,7 @@ FactoryBot.define do
           tags: evaluator.tags,
           update_type: evaluator.update_type,
           change_note: evaluator.change_note,
+          scheduled_publishing_datetime: evaluator.scheduled_publishing_datetime,
           lead_image_revision: evaluator.lead_image_revision,
           image_revisions: image_revisions,
         )

--- a/spec/factories/revision_factory.rb
+++ b/spec/factories/revision_factory.rb
@@ -15,6 +15,7 @@ FactoryBot.define do
       tags { {} }
       update_type { "major" }
       change_note { "First published." }
+      scheduled_publishing_datetime { nil }
     end
 
     after(:build) do |revision, evaluator|
@@ -37,6 +38,7 @@ FactoryBot.define do
           update_type: evaluator.update_type,
           change_note: evaluator.change_note,
           created_by: revision.created_by,
+          scheduled_publishing_datetime: evaluator.scheduled_publishing_datetime,
         )
       end
 

--- a/spec/features/workflow/schedule_set_datetime_passes_spec.rb
+++ b/spec/features/workflow/schedule_set_datetime_passes_spec.rb
@@ -1,0 +1,22 @@
+# frozen_string_literal: true
+
+RSpec.feature "Set scheduled publishing date and time passes before scheduling" do
+  scenario do
+    given_there_is_an_edition_with_past_scheduled_publishing_datetime
+    when_i_visit_the_summary_page
+    then_i_cannot_see_a_schedule_link
+  end
+
+  def given_there_is_an_edition_with_past_scheduled_publishing_datetime
+    datetime = Time.zone.now - 1
+    @edition = create(:edition, scheduled_publishing_datetime: datetime)
+  end
+
+  def when_i_visit_the_summary_page
+    visit document_path(@edition.document)
+  end
+
+  def then_i_cannot_see_a_schedule_link
+    expect(page).not_to have_button("Schedule")
+  end
+end

--- a/spec/features/workflow/schedule_set_datetime_too_close_to_now_spec.rb
+++ b/spec/features/workflow/schedule_set_datetime_too_close_to_now_spec.rb
@@ -1,0 +1,22 @@
+# frozen_string_literal: true
+
+RSpec.feature "Set scheduled publishing date and time passes is too close to now" do
+  scenario do
+    given_there_is_an_edition_with_a_scheduled_publishing_date_and_time_set_too_close_to_now
+    when_i_visit_the_summary_page
+    then_i_cannot_see_a_schedule_link
+  end
+
+  def given_there_is_an_edition_with_a_scheduled_publishing_date_and_time_set_too_close_to_now
+    datetime = Time.zone.now.advance(Edition::MINIMUM_SCHEDULING_TIME)
+    @edition = create(:edition, scheduled_publishing_datetime: datetime)
+  end
+
+  def when_i_visit_the_summary_page
+    visit document_path(@edition.document)
+  end
+
+  def then_i_cannot_see_a_schedule_link
+    expect(page).not_to have_button("Schedule")
+  end
+end

--- a/spec/features/workflow/schedule_spec.rb
+++ b/spec/features/workflow/schedule_spec.rb
@@ -12,6 +12,7 @@ RSpec.feature "Schedule an edition" do
     when_i_visit_the_summary_page
     then_i_see_the_edition_has_been_scheduled
     and_i_can_no_longer_see_a_schedule_action
+    and_i_can_no_longer_edit_the_content
   end
 
   def given_there_is_an_edition_with_set_scheduled_publishing_datetime
@@ -45,5 +46,9 @@ RSpec.feature "Schedule an edition" do
 
   def and_i_can_no_longer_see_a_schedule_action
     expect(page).not_to have_link("Schedule")
+  end
+
+  def and_i_can_no_longer_edit_the_content
+    expect(page).not_to have_link("Change Content")
   end
 end

--- a/spec/features/workflow/schedule_spec.rb
+++ b/spec/features/workflow/schedule_spec.rb
@@ -11,6 +11,7 @@ RSpec.feature "Schedule an edition" do
 
     when_i_visit_the_summary_page
     then_i_see_the_edition_has_been_scheduled
+    and_i_can_no_longer_see_a_schedule_action
   end
 
   def given_there_is_an_edition_with_set_scheduled_publishing_datetime
@@ -40,5 +41,9 @@ RSpec.feature "Schedule an edition" do
 
   def then_i_see_the_edition_has_been_scheduled
     expect(page).to have_content(I18n.t!("user_facing_states.scheduled.name"))
+  end
+
+  def and_i_can_no_longer_see_a_schedule_action
+    expect(page).not_to have_link("Schedule")
   end
 end

--- a/spec/features/workflow/schedule_spec.rb
+++ b/spec/features/workflow/schedule_spec.rb
@@ -1,69 +1,37 @@
 # frozen_string_literal: true
 
-RSpec.feature "Scheduling an edition" do
+RSpec.feature "Schedule an edition" do
   scenario do
-    given_there_is_an_edition
+    given_there_is_an_edition_with_set_scheduled_publishing_datetime
     when_i_visit_the_summary_page
-    and_i_click_on_schedule_publishing
-    then_i_see_a_default_date_and_time_selected
-
-    when_i_choose_a_scheduled_date_and_time
-    and_i_click_save
-    then_i_see_the_edition_has_a_set_scheduled_publishing_date_and_time
+    and_i_click_on_schedule
+    and_i_select_the_content_has_been_reviewed_option
+    and_i_click_on_publish
+    then_i_see_the_edition_has_been_scheduled
   end
 
-  def given_there_is_an_edition
-    @edition = create(:edition)
+  def given_there_is_an_edition_with_set_scheduled_publishing_datetime
+    datetime = Time.zone.tomorrow
+    @edition = create(:edition, scheduled_publishing_datetime: datetime)
   end
 
   def when_i_visit_the_summary_page
     visit document_path(@edition.document)
   end
 
-  def and_i_click_on_schedule_publishing
-    find(".govuk-details__summary-text", text: "Schedule publishing").click
+  def and_i_click_on_schedule
+    click_on "Schedule"
   end
 
-  def then_i_see_a_default_date_and_time_selected
-    default_date = Time.zone.tomorrow
-    expect(page).to have_selector(
-      "[@name='scheduled[day]'][@value='#{default_date.day}']",
-    )
-    expect(page).to have_selector(
-      "[@name='scheduled[month]'][@value='#{default_date.month}']",
-    )
-    expect(page).to have_selector(
-      "[@name='scheduled[year]'][@value='#{default_date.year}']",
-    )
-    expect(page).to have_select(
-      "scheduled[time]", selected: "9:00am"
-    )
+  def and_i_select_the_content_has_been_reviewed_option
+    choose I18n.t!("schedule.confirmation.review_status.reviewed")
   end
 
-  def when_i_choose_a_scheduled_date_and_time
-    @date = Time.zone.now.advance(days: 2)
-    fill_in "scheduled[day]", with: @date.day
-    fill_in "scheduled[month]", with: @date.month
-    fill_in "scheduled[year]", with: @date.year
-    select "11:00pm", from: "scheduled[time]"
+  def and_i_click_on_publish
+    click_on "Publish"
   end
 
-  def and_i_click_save
-    click_on "Save"
-  end
-
-  def then_i_see_the_edition_has_a_set_scheduled_publishing_date_and_time
-    scheduled_date = @date.strftime("%-d %B %Y - 11:00pm")
-    expect(page).to have_content("Publish date: #{scheduled_date}")
-    expect(page).to have_selector(
-      "[@name='scheduled[day]'][@value='#{@date.day}']",
-    )
-    expect(page).to have_selector(
-      "[@name='scheduled[month]'][@value='#{@date.month}']",
-    )
-    expect(page).to have_selector(
-      "[@name='scheduled[year]'][@value='#{@date.year}']",
-    )
-    expect(find_field("scheduled[time]").value).to eq("11:00pm")
+  def then_i_see_the_edition_has_been_scheduled
+    expect(page).to have_content(I18n.t!("user_facing_states.scheduled.name"))
   end
 end

--- a/spec/features/workflow/schedule_spec.rb
+++ b/spec/features/workflow/schedule_spec.rb
@@ -7,6 +7,9 @@ RSpec.feature "Schedule an edition" do
     and_i_click_on_schedule
     and_i_select_the_content_has_been_reviewed_option
     and_i_click_on_publish
+    then_i_see_a_confirmation_that_the_edition_has_been_scheduled
+
+    when_i_visit_the_summary_page
     then_i_see_the_edition_has_been_scheduled
   end
 
@@ -29,6 +32,10 @@ RSpec.feature "Schedule an edition" do
 
   def and_i_click_on_publish
     click_on "Publish"
+  end
+
+  def then_i_see_a_confirmation_that_the_edition_has_been_scheduled
+    expect(page).to have_content(I18n.t!("schedule.scheduled.title"))
   end
 
   def then_i_see_the_edition_has_been_scheduled

--- a/spec/features/workflow/scheduled_publishing_datetime_requirements_spec.rb
+++ b/spec/features/workflow/scheduled_publishing_datetime_requirements_spec.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-RSpec.feature "Scheduling requirements" do
+RSpec.feature "Scheduled publishing datetime requirements" do
   scenario do
     given_there_is_an_edition
     when_i_visit_the_summary_page

--- a/spec/features/workflow/set_scheduled_publishing_datetime_spec.rb
+++ b/spec/features/workflow/set_scheduled_publishing_datetime_spec.rb
@@ -1,0 +1,69 @@
+# frozen_string_literal: true
+
+RSpec.feature "Set scheduled publishing datetime" do
+  scenario do
+    given_there_is_an_edition
+    when_i_visit_the_summary_page
+    and_i_click_on_schedule_publishing
+    then_i_see_a_default_date_and_time_selected
+
+    when_i_choose_a_scheduled_date_and_time
+    and_i_click_save
+    then_i_see_the_edition_has_a_set_scheduled_publishing_date_and_time
+  end
+
+  def given_there_is_an_edition
+    @edition = create(:edition)
+  end
+
+  def when_i_visit_the_summary_page
+    visit document_path(@edition.document)
+  end
+
+  def and_i_click_on_schedule_publishing
+    find(".govuk-details__summary-text", text: "Schedule publishing").click
+  end
+
+  def then_i_see_a_default_date_and_time_selected
+    default_date = Time.zone.tomorrow
+    expect(page).to have_selector(
+      "[@name='scheduled[day]'][@value='#{default_date.day}']",
+    )
+    expect(page).to have_selector(
+      "[@name='scheduled[month]'][@value='#{default_date.month}']",
+    )
+    expect(page).to have_selector(
+      "[@name='scheduled[year]'][@value='#{default_date.year}']",
+    )
+    expect(page).to have_select(
+      "scheduled[time]", selected: "9:00am"
+    )
+  end
+
+  def when_i_choose_a_scheduled_date_and_time
+    @date = Time.zone.now.advance(days: 2)
+    fill_in "scheduled[day]", with: @date.day
+    fill_in "scheduled[month]", with: @date.month
+    fill_in "scheduled[year]", with: @date.year
+    select "11:00pm", from: "scheduled[time]"
+  end
+
+  def and_i_click_save
+    click_on "Save"
+  end
+
+  def then_i_see_the_edition_has_a_set_scheduled_publishing_date_and_time
+    scheduled_date = @date.strftime("%-d %B %Y - 11:00pm")
+    expect(page).to have_content("Publish date: #{scheduled_date}")
+    expect(page).to have_selector(
+      "[@name='scheduled[day]'][@value='#{@date.day}']",
+    )
+    expect(page).to have_selector(
+      "[@name='scheduled[month]'][@value='#{@date.month}']",
+    )
+    expect(page).to have_selector(
+      "[@name='scheduled[year]'][@value='#{@date.year}']",
+    )
+    expect(find_field("scheduled[time]").value).to eq("11:00pm")
+  end
+end

--- a/spec/services/schedule_service_spec.rb
+++ b/spec/services/schedule_service_spec.rb
@@ -17,6 +17,13 @@ RSpec.describe ScheduleService do
       expect(edition.status.details.pre_scheduled_status).to eq(pre_scheduling_status)
     end
 
+    it "creates a timeline entry" do
+      edition = create(:edition)
+      ScheduleService.new(edition).schedule
+
+      expect(edition.timeline_entries.first.entry_type).to eq("scheduled")
+    end
+
     context "when the edition has been reviewed" do
       it "sets the scheduling reviewed state to true" do
         edition = create(:edition)

--- a/spec/services/schedule_service_spec.rb
+++ b/spec/services/schedule_service_spec.rb
@@ -1,0 +1,38 @@
+# frozen_string_literal: true
+
+RSpec.describe ScheduleService do
+  describe "#schedule" do
+    it "sets an edition's state to 'scheduled'" do
+      edition = create(:edition)
+      ScheduleService.new(edition).schedule
+
+      expect(edition).to be_scheduled
+    end
+
+    it "saves the edition's pre-scheduling status" do
+      edition = create(:edition)
+      pre_scheduling_status = edition.status
+      ScheduleService.new(edition).schedule
+
+      expect(edition.status.details.pre_scheduled_status).to eq(pre_scheduling_status)
+    end
+
+    context "when the edition has been reviewed" do
+      it "sets the scheduling reviewed state to true" do
+        edition = create(:edition)
+        ScheduleService.new(edition).schedule(reviewed: true)
+
+        expect(edition.status.details.reviewed).to be true
+      end
+    end
+
+    context "when the edition has not been reviewed" do
+      it "sets the scheduling reviewed state to false" do
+        edition = create(:edition)
+        ScheduleService.new(edition).schedule(reviewed: false)
+
+        expect(edition.status.details.reviewed).to be false
+      end
+    end
+  end
+end


### PR DESCRIPTION
For https://trello.com/c/t0mha6An/649-schedule-content-for-publication

This PR allows users to set content to a `scheduled` state in the application.  Enabling scheduled publishing functionality via the Publishing API will be tackled in a separate PR.

Content must be in an editable state in order to be scheduled; it cannot be in a live state.  It must also have a `scheduled_publishing_datetime` set.  There is some existing validation for `scheduled_publishing_datetime`, and this PR introduces a check that this value is not in the past or too close to now when the user goes to schedule the content for publication.  There isn't a clear decision on how to handle this check failing, so for now failure will result in the "Schedule" button not displaying.  However in edge cases where users may access the scheduling confirmation page regardless, we raise an error.

__Schedule button__
<img width="316" alt="screen shot 2019-02-27 at 14 32 12" src="https://user-images.githubusercontent.com/13434452/53500432-32a07400-3aa2-11e9-8e36-d2a02c11866d.png">

**Review options**
<img width="683" alt="screen shot 2019-02-27 at 14 34 24" src="https://user-images.githubusercontent.com/13434452/53500469-42b85380-3aa2-11e9-9f6d-87290af9d5ff.png">

**Scheduling confirmation**
<img width="698" alt="screen shot 2019-02-27 at 14 34 36" src="https://user-images.githubusercontent.com/13434452/53500487-4a77f800-3aa2-11e9-9713-dcd97fe608de.png">

**Scheduled status**
<img width="337" alt="screen shot 2019-02-27 at 14 31 28" src="https://user-images.githubusercontent.com/13434452/53500498-55328d00-3aa2-11e9-9d79-5d1686c38e33.png">
