### PR TITLE
Support deletion of images in a modal context

### DIFF
--- a/app/assets/javascripts/modules/inline-image-modal.js
+++ b/app/assets/javascripts/modules/inline-image-modal.js
@@ -97,6 +97,17 @@ InlineImageModal.prototype.performAction = function (item) {
           this.$multiSectionViewer.showStaticSection('error')
         }.bind(this))
     },
+    'delete': function () {
+      this.postModalForm(item)
+        .then(function (text) {
+          this.$multiSectionViewer.showDynamicSection(text)
+          this.overrideActions()
+          this.initComponents()
+        }.bind(this))
+        .catch(function (result) {
+          this.$multiSectionViewer.showStaticSection('error')
+        }.bind(this))
+    },
     'edit': function () {
       this.fetchModalContent(item.dataset.modalActionUrl)
         .then(function (text) {

--- a/app/views/images/_image.html.erb
+++ b/app/views/images/_image.html.erb
@@ -10,6 +10,19 @@
   }
 ) %>
 
+<% actions << capture do %>
+  <%= form_tag(
+    destroy_image_path(document, image.image_id),
+    method: :delete,
+    data: {
+      "modal-action": "delete",
+    },
+    class: "app-inline-block"
+  ) do %>
+    <button class="govuk-link app-link--button app-link--destructive">Delete image</button>
+  <% end %>
+<% end %>
+
 <% if rendering_context == "modal" %>
   <% actions << link_to("Insert image markdown", "#",
                         data: { "modal-action": "insert",
@@ -22,11 +35,6 @@
     <% end %>
   <% end %>
 
-  <% actions << capture do %>
-    <%= form_tag destroy_image_path(document, image.image_id), method: :delete, class: "app-inline-block" do %>
-      <button class="govuk-link app-link--button app-link--destructive">Delete image</button>
-    <% end %>
-  <% end %>
 <% end %>
 
 <% metadata_items = [

--- a/app/views/layouts/modal.html.erb
+++ b/app/views/layouts/modal.html.erb
@@ -1,3 +1,9 @@
+<% if flash["notice"] %>
+  <%= render "govuk_publishing_components/components/success_alert", {
+    message: flash["notice"]
+  } %>
+<% end %>
+
 <% if flash["alert_with_items"] %>
   <%= render "govuk_publishing_components/components/error_summary", {
     title: flash["alert_with_items"]["title"],

--- a/spec/features/editing_images/delete_image_spec.rb
+++ b/spec/features/editing_images/delete_image_spec.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
-RSpec.feature "Delete an image" do
-  scenario do
+RSpec.feature "Delete an image", js: true do
+  scenario "lead image" do
     given_there_is_an_edition_with_images
     when_i_visit_the_images_page
     and_i_delete_the_non_lead_image
@@ -9,9 +9,19 @@ RSpec.feature "Delete an image" do
     and_the_preview_creation_succeeded
   end
 
+  scenario "inline image" do
+    given_there_is_an_edition_with_images
+    when_i_insert_an_inline_image
+    and_i_delete_the_non_lead_image
+    then_i_see_the_image_is_gone
+    and_the_preview_creation_succeeded
+  end
+
   def given_there_is_an_edition_with_images
-    document_type = build(:document_type, images: true)
+    body_field = build(:field, id: "body", type: "govspeak")
+    document_type = build(:document_type, contents: [body_field], images: true)
     @image_revision = create(:image_revision, :on_asset_manager)
+
     @edition = create(:edition,
                       document_type_id: document_type.id,
                       image_revisions: [@image_revision])
@@ -19,6 +29,15 @@ RSpec.feature "Delete an image" do
 
   def when_i_visit_the_images_page
     visit images_path(@edition.document)
+  end
+
+  def when_i_insert_an_inline_image
+    visit edit_document_path(@edition.document)
+
+    within(".app-c-markdown-editor") do
+      find("markdown-toolbar details").click
+      click_on "Image"
+    end
   end
 
   def and_i_delete_the_non_lead_image
@@ -30,14 +49,16 @@ RSpec.feature "Delete an image" do
   def then_i_see_the_image_is_gone
     expect(all("#image-#{@image_revision.image_id}").count).to be_zero
     expect(page).to have_content(I18n.t!("images.index.flashes.deleted", file: @image_revision.filename))
-
-    visit document_path(@edition.document)
-    expect(page).to have_content(I18n.t!("documents.history.entry_types.image_deleted"))
   end
 
   def and_the_preview_creation_succeeded
     expect(@put_content_request).to have_been_requested
     expect(@delete_asset_request).to have_been_requested.at_least_once
+
+    visit document_path(@edition.document)
     expect(page).to have_content(I18n.t!("user_facing_states.draft.name"))
+
+    click_on "Document history"
+    expect(page).to have_content(I18n.t!("documents.history.entry_types.image_deleted"))
   end
 end


### PR DESCRIPTION
https://trello.com/c/MkWywL4g/590-support-inline-images

There's no specific card for this, but it seems to be part of the design 
and it only took 20 minutes :-).

This adds a delete action for all non-lead images in the inline-images
modal. As we only show the lead image for context, this action is not
supported for it. One slight surprise was that we actually do a POST
request for deletions, using a hidden parameter to override the method.