### PR TITLE
Fix accidental submit when choosing images

### DIFF
--- a/app/assets/javascripts/modules/inline-image-modal.js
+++ b/app/assets/javascripts/modules/inline-image-modal.js
@@ -32,8 +32,7 @@ InlineImageModal.prototype.fetchModalContent = function (url) {
     })
 }
 
-InlineImageModal.prototype.postModalForm = function (formId) {
-  var form = document.getElementById(formId)
+InlineImageModal.prototype.postModalForm = function (form) {
   var controller = new window.AbortController()
   setTimeout(function () { controller.abort() }, 10000)
 
@@ -77,7 +76,7 @@ InlineImageModal.prototype.performAction = function (item) {
       editor.selectionReplace(item.dataset.modalData)
     },
     'upload': function () {
-      this.postModalForm(item.dataset.modalActionForm)
+      this.postModalForm(item)
         .then(function (text) {
           this.$multiSectionViewer.showDynamicSection(text)
           this.overrideActions()
@@ -106,14 +105,17 @@ InlineImageModal.prototype.initComponents = function () {
 }
 
 InlineImageModal.prototype.overrideActions = function () {
-  var items = this.$modal.querySelectorAll('[data-modal-action]')
+  var formItems = this.$modal.querySelectorAll('form[data-modal-action]')
+  var linkItems = this.$modal.querySelectorAll('a[data-modal-action]')
 
-  items.forEach(function (item) {
+  linkItems.forEach(function (item) {
     item.addEventListener('click', function (event) {
       event.preventDefault()
       this.performAction(item)
     }.bind(this))
+  }.bind(this))
 
+  formItems.forEach(function (item) {
     item.addEventListener('submit', function (event) {
       event.preventDefault()
       this.performAction(item)

--- a/app/views/images/index.html.erb
+++ b/app/views/images/index.html.erb
@@ -12,12 +12,10 @@
 
       <%= form_tag(
         create_image_path(@document),
-        id: "image-upload",
         multipart: true,
         data: {
           gtm: "image-upload-submit",
           "modal-action": "upload",
-          "modal-action-form": "image-upload",
         }
       ) do %>
         <%= render "govuk_publishing_components/components/file_upload", {


### PR DESCRIPTION
https://trello.com/c/QDEuNPgp/653-allow-users-to-upload-an-inline-image-in-the-context-of-a-modal

Previously we moved some of the override behaviour of the inline image
modal to apply to the 'submit' form, instead of the 'click' event of
the submit button of the form.  However, the 'click' event was still
being handled on the form, which was interfering with its other inputs.

This separates the events we override for modal content: 'submit' for
forms and 'click' for links. It also removes the (now) redundant data
attribute to specify the ID of the form element, as this is now the same
as the action item (element) being performed.