### PR TITLE
Update contextual guidance

### DIFF
--- a/app/assets/javascripts/components/contextual-guidance.js
+++ b/app/assets/javascripts/components/contextual-guidance.js
@@ -22,7 +22,7 @@ window.GOVUK.Modules = window.GOVUK.Modules || {};
   }
 
   ContextualGuidance.prototype.hideAllGuidance = function () {
-    var guidances = document.querySelectorAll('.app-c-contextual-guidance-wrapper')
+    var guidances = document.querySelectorAll('[data-module="contextual-guidance"]')
 
     guidances.forEach(function (guidance) {
       guidance.style.display = 'none'

--- a/app/assets/javascripts/components/contextual-guidance.js
+++ b/app/assets/javascripts/components/contextual-guidance.js
@@ -18,7 +18,9 @@ window.GOVUK.Modules = window.GOVUK.Modules || {};
 
   ContextualGuidance.prototype.handleFocus = function (event) {
     this.hideAllGuidance()
-    this.$module.style.display = 'block'
+    if (!event.target.dataset.contextualGuidanceHideOnly) {
+      this.$module.style.display = 'block'
+    }
   }
 
   ContextualGuidance.prototype.hideAllGuidance = function () {

--- a/app/assets/stylesheets/components/_contextual-guidance.scss
+++ b/app/assets/stylesheets/components/_contextual-guidance.scss
@@ -1,5 +1,5 @@
 .app-c-contextual-guidance-wrapper {
-  position: absolute;
+  position: relative;
 
   @include govuk-font(19);
 
@@ -10,13 +10,18 @@
   }
 }
 
-.app-c-contextual-guidance-wrapper--relative {
+.app-c-contextual-guidance__form .govuk-grid-row:last-of-type .app-c-contextual-guidance__wrapper {
   position: relative;
 }
 
 .js-enabled {
-  .app-c-contextual-guidance-wrapper {
+  .app-c-contextual-guidance__wrapper {
     display: none;
+
+    @include govuk-media-query($from: tablet) {
+      position: absolute;
+      margin-right: govuk-spacing(3);
+    }
   }
 }
 

--- a/app/assets/stylesheets/components/_contextual-guidance.scss
+++ b/app/assets/stylesheets/components/_contextual-guidance.scss
@@ -1,4 +1,15 @@
-.app-c-contextual-guidance-wrapper {
+.app-c-contextual-guidance__form {
+  .govuk-grid-column-one-third,
+  .govuk-grid-column-two-thirds {
+    position: relative;
+  }
+
+  .govuk-grid-row:last-of-type .app-c-contextual-guidance__wrapper {
+    position: relative;
+  }
+}
+
+.app-c-contextual-guidance__wrapper {
   position: relative;
 
   @include govuk-font(19);
@@ -8,10 +19,6 @@
   @include govuk-media-query($from: tablet) {
     padding-top: govuk-spacing(6);
   }
-}
-
-.app-c-contextual-guidance__form .govuk-grid-row:last-of-type .app-c-contextual-guidance__wrapper {
-  position: relative;
 }
 
 .js-enabled {

--- a/app/assets/stylesheets/utilities/_overwrites.scss
+++ b/app/assets/stylesheets/utilities/_overwrites.scss
@@ -68,11 +68,6 @@
   }
 }
 
-.govuk-grid-column-one-third,
-.govuk-grid-column-two-thirds {
-  position: relative;
-}
-
 .app-selected-topics {
   .govuk-breadcrumbs {
     @include govuk-font(19);

--- a/app/views/components/_contextual_guidance.html.erb
+++ b/app/views/components/_contextual_guidance.html.erb
@@ -1,11 +1,8 @@
 <%
   id ||= "input-#{SecureRandom.hex(4)}"
   title ||= nil
-  relative ||= false
 %>
-<div id="<%= id %>"
-     class="app-c-contextual-guidance-wrapper<%= " app-c-contextual-guidance-wrapper--relative" if relative %>"
-     data-module="contextual-guidance">
+<div id="<%= id %>" class="app-c-contextual-guidance__wrapper" data-module="contextual-guidance">
   <div class="app-c-contextual-guidance">
     <h2 class="govuk-heading-s"><%= title %></h2>
     <%= yield %>

--- a/app/views/components/docs/contextual_guidance.yml
+++ b/app/views/components/docs/contextual_guidance.yml
@@ -27,24 +27,3 @@ examples:
       id: news-title-guidance
       block: |
         The title must make clear what the content offers users. Use the words your users do to help them find this. Avoid wordplay or teases.
-
-  relative_position:
-    description: Reveals a contextul guidance on the side expaning the height of the container
-    embed: |
-      <div class="govuk-grid-row">
-        <div class="govuk-grid-column-two-thirds">
-          <div class="govuk-form-group">
-            <label for="title-relative" class="govuk-label govuk-label--s">Title</label>
-            <input class="govuk-input" id="title-relative" data-contextual-guidance="news-title-guidance-relative" placeholder="Focus to reveal">
-          </div>
-        </div>
-        <div class="govuk-grid-column-one-third">
-          <%= component %>
-        </div>
-      </div>
-    data:
-      title: Writing a news title
-      id: news-title-guidance-relative
-      relative: true
-      block: |
-        The title must make clear what the content offers users. Use the words your users do to help them find this. Avoid wordplay or teases.

--- a/app/views/documents/edit.html.erb
+++ b/app/views/documents/edit.html.erb
@@ -8,7 +8,7 @@
 
 <%= form_for(
   @document,
-  html: { "autocomplete": "off" },
+  html: { "autocomplete": "off", class: "app-c-contextual-guidance__form" },
   data: {
     module: "edit-document-form",
     "url-preview-path": generate_path_path,

--- a/app/views/documents/edit/_change_notes.html.erb
+++ b/app/views/documents/edit/_change_notes.html.erb
@@ -27,11 +27,13 @@
             text: t("documents.edit.update_type.major_name"),
             conditional: textarea,
             checked: @revision.major?,
+            data_attributes: { "contextual-guidance": "change-note-guidance" }
           },
           {
             value: "minor",
             text: t("documents.edit.update_type.minor_name"),
             checked: @revision.minor?,
+            data_attributes: { "contextual-guidance": "change-note-guidance", "contextual-guidance-hide-only": "true" }
           }
         ]
       } %>

--- a/app/views/images/edit.html.erb
+++ b/app/views/images/edit.html.erb
@@ -93,8 +93,7 @@
     <div class="govuk-grid-column-one-third">
       <%= render "components/contextual_guidance", {
         id: "credit-guidance",
-        title: t("images.edit.form_labels.credit"),
-        relative: true
+        title: t("images.edit.form_labels.credit")
       } do %>
         <%= render_govspeak(t("images.edit.guidance.credit_govspeak")) %>
       <% end %>

--- a/app/views/images/edit.html.erb
+++ b/app/views/images/edit.html.erb
@@ -17,6 +17,7 @@
 <%= form_tag(
   update_image_path(@document, @image_revision.image_id, wizard: params[:wizard]),
   method: :patch,
+  class: "app-c-contextual-guidance__form",
   data: {
     "warn-before-unload": true,
     "modal-action": "meta",

--- a/app/views/tags/edit.html.erb
+++ b/app/views/tags/edit.html.erb
@@ -6,7 +6,7 @@
     <p class="govuk-body"><%= t("tags.edit.description") %></p>
   </div>
 </div>
-<%= form_tag(tags_path(@document), data: { "warn-before-unload": "true" }) do %>
+<%= form_tag(tags_path(@document), data: { "warn-before-unload": "true" }, class: "app-c-contextual-guidance__form") do %>
 
 <% @document.document_type.tags.each do |tag_field| %>
   <div class="govuk-grid-row">

--- a/spec/javascripts/components/contextual-guidance-spec.js
+++ b/spec/javascripts/components/contextual-guidance-spec.js
@@ -1,5 +1,5 @@
 /* global describe beforeEach afterEach it expect */
-/* global ContextualGuidance Event */
+/* global $, GOVUK */
 
 describe('Contextual guidance component', function () {
   'use strict'
@@ -11,7 +11,7 @@ describe('Contextual guidance component', function () {
     container.innerHTML =
       '<input id="document-title" type="text" class="gem-c-input govuk-input" data-contextual-guidance="document-title-guidance"></textarea>' +
 
-      '<div id="document-title-guidance" class="app-c-contextual-guidance-wrapper">' +
+      '<div id="document-title-guidance" class="app-c-contextual-guidance__wrapper" data-module="contextual-guidance">' +
         '<div class="app-c-contextual-guidance">' +
         '<h2 class="govuk-heading-s">Title</h2>' +
         'The title should be unique and specific. It must make clear what the content offers users. Use the words your users do to help them find this. Avoid wordplay or teases.' +
@@ -20,13 +20,14 @@ describe('Contextual guidance component', function () {
 
       '<textarea id="document-summary" class="gem-c-textarea govuk-textarea" data-contextual-guidance="document-summary-guidance"></textarea>' +
 
-      '<div id="document-summary-guidance" class="app-c-contextual-guidance-wrapper">' +
+      '<div id="document-summary-guidance" class="app-c-contextual-guidance__wrapper" data-module="contextual-guidance">' +
         '<div class="app-c-contextual-guidance">' +
         '<h2 class="govuk-heading-s">Summary</h2>' +
         'The summary should explain the main point of the story. It is the first line of the story so don’t repeat it in the body and end with a full stop.' +
         '</div>' +
       '</div>'
 
+    document.body.classList.add('js-enabled')
     document.body.appendChild(container)
     var titleContextualGuidance = document.getElementById('document-title-guidance')
     var summaryContextualGuidance = document.getElementById('document-summary-guidance')
@@ -42,10 +43,9 @@ describe('Contextual guidance component', function () {
     var title = document.querySelector('#document-title')
     var titleGuidance = document.querySelector('#document-title-guidance')
 
-    var summary = document.querySelector('#document-summary')
     var summaryGuidance = document.querySelector('#document-summary-guidance')
 
-    title.dispatchEvent(new Event('focus'))
+    title.dispatchEvent(new window.Event('focus'))
 
     expect(titleGuidance.style.display).toEqual('block')
     expect(summaryGuidance.style.display).toEqual('none')
@@ -58,8 +58,8 @@ describe('Contextual guidance component', function () {
     var summary = document.querySelector('#document-summary')
     var summaryGuidance = document.querySelector('#document-summary-guidance')
 
-    title.dispatchEvent(new Event('focus'))
-    summary.dispatchEvent(new Event('focus'))
+    title.dispatchEvent(new window.Event('focus'))
+    summary.dispatchEvent(new window.Event('focus'))
 
     expect(titleGuidance.style.display).toEqual('none')
     expect(summaryGuidance.style.display).toEqual('block')


### PR DESCRIPTION
This PR refactors the contextual guidance as follows:
- remove relative option on contextual guidance and position the last guidance on the page as relative using CSS selectors.
- fix contextual guidance overflowing horizontally [Trello card](https://trello.com/c/FlW8s7G7)
- add 'hide only' support for contextual guidance triggers based on additional data attribute [Trello card](https://trello.com/c/pcbHvl7B)


### Before
<img width="1437" alt="screen shot 2019-03-01 at 15 31 22" src="https://user-images.githubusercontent.com/788096/53648242-51843f00-3c37-11e9-9534-c5755375362d.png">

### After
<img width="1439" alt="screen shot 2019-03-01 at 15 30 35" src="https://user-images.githubusercontent.com/788096/53648250-56e18980-3c37-11e9-8f97-a24252d66afb.png">
