### PR TITLE
Remove redundant data attribute from crop page

### DIFF
--- a/app/views/images/crop.html.erb
+++ b/app/views/images/crop.html.erb
@@ -3,11 +3,9 @@
 
 <%= form_tag(
   crop_image_path(@document, @image_revision.image_id),
-  id: "image-crop",
   method: :patch,
   data: {
     "modal-action": "crop",
-    "modal-action-form": "image-crop",
   }
 ) do %>
   <%= render "/components/image_cropper", {


### PR DESCRIPTION
This is no longer required by the inline-image module.