### PR TITLE
Return govspeak in component in GovspeakPreviewController

### DIFF
--- a/app/assets/javascripts/components/markdown-editor.js
+++ b/app/assets/javascripts/components/markdown-editor.js
@@ -69,6 +69,7 @@ window.GOVUK.Modules = window.GOVUK.Modules || {};
         this.$preview.innerHTML = text
         this.setTargetBlank(this.$preview)
         this.$preview.classList.add('app-c-markdown-editor__govspeak--rendered')
+        window.GOVUK.modules.start()
       }.bind(this))
       .catch(function () {
         this.$preview.innerHTML = 'Error previewing content'

--- a/app/controllers/govspeak_preview_controller.rb
+++ b/app/controllers/govspeak_preview_controller.rb
@@ -6,6 +6,8 @@ class GovspeakPreviewController < ApplicationController
   def to_html
     @document = Document.with_current_edition.find_by_param(params[:id])
     current_edition = @document.current_edition
-    render plain: GovspeakDocument.new(params[:govspeak], current_edition).in_app_html
+    govspeak_html = GovspeakDocument.new(params[:govspeak], current_edition).in_app_html
+    render partial: "govuk_publishing_components/components/govspeak",
+           locals: { content: govspeak_html.html_safe } # rubocop:disable Rails/OutputSafety
   end
 end

--- a/app/views/components/_markdown_editor.html.erb
+++ b/app/views/components/_markdown_editor.html.erb
@@ -73,9 +73,7 @@
     </div>
 
     <div class="app-c-markdown-editor__preview js-markdown-preview-body">
-      <%= render "govuk_publishing_components/components/govspeak", { } do %>
-        <div class="govuk-textarea"></div>
-      <% end %>
+      <div class="govuk-textarea"></div>
     </div>
   </div>
 <% end %>


### PR DESCRIPTION
Trello: https://trello.com/c/VDgVNurM/544-extract-govspeak-javascript-functionality-to-govukpublishingcomponents

This allows for the govspeak component to be initialised each time we
preview govspeak and therefore show videos and barcharts.

Previously this did not work as we were changing HTML inside the
component. This component then ignored any calls to initialise as it was
already initialised.

This won't work properly until https://github.com/alphagov/govuk_publishing_components/pull/775 is released and used by this app.