### PR TITLE
Clear scheduled publishing datetime

### DIFF
--- a/app/controllers/schedule_controller.rb
+++ b/app/controllers/schedule_controller.rb
@@ -82,5 +82,14 @@ private
       { scheduled_publishing_datetime: datetime }, current_user
     )
     edition.assign_revision(new_revision, current_user).save!
+    create_timeline_entry(edition, new_revision)
+  end
+
+  def create_timeline_entry(edition, revision)
+    TimelineEntry.create_for_revision(entry_type: :scheduled_publishing_datetime_set,
+                                      revision: revision,
+                                      edition: edition,
+                                      details: nil,
+                                      created_by: current_user)
   end
 end

--- a/app/controllers/schedule_controller.rb
+++ b/app/controllers/schedule_controller.rb
@@ -16,11 +16,7 @@ class ScheduleController < ApplicationController
         return
       end
 
-      new_revision = edition.revision.build_revision_update(
-        { scheduled_publishing_datetime: checker.parsed_datetime },
-        current_user,
-      )
-      edition.assign_revision(new_revision, current_user).save!
+      set_scheduled_publishing_datetime(edition, checker.parsed_datetime)
 
       redirect_to document_path(document)
     end
@@ -31,10 +27,7 @@ class ScheduleController < ApplicationController
       document = Document.with_current_edition.lock.find_by_param(params[:id])
       edition = document.current_edition
 
-      new_revision = edition.revision.build_revision_update(
-        { scheduled_publishing_datetime: nil }, current_user
-      )
-      edition.assign_revision(new_revision, current_user).save!
+      set_scheduled_publishing_datetime(edition)
 
       redirect_to document_path(document)
     end
@@ -82,5 +75,12 @@ private
 
   def review_params
     params.require(:review_status)
+  end
+
+  def set_scheduled_publishing_datetime(edition, datetime = nil)
+    new_revision = edition.revision.build_revision_update(
+      { scheduled_publishing_datetime: datetime }, current_user
+    )
+    edition.assign_revision(new_revision, current_user).save!
   end
 end

--- a/app/controllers/schedule_controller.rb
+++ b/app/controllers/schedule_controller.rb
@@ -26,6 +26,20 @@ class ScheduleController < ApplicationController
     end
   end
 
+  def clear_scheduled_publishing_datetime
+    Document.transaction do
+      document = Document.with_current_edition.lock.find_by_param(params[:id])
+      edition = document.current_edition
+
+      new_revision = edition.revision.build_revision_update(
+        { scheduled_publishing_datetime: nil }, current_user
+      )
+      edition.assign_revision(new_revision, current_user).save!
+
+      redirect_to document_path(document)
+    end
+  end
+
   def confirmation
     document = Document.with_current_edition.find_by_param(params[:id])
     @edition = document.current_edition

--- a/app/controllers/schedule_controller.rb
+++ b/app/controllers/schedule_controller.rb
@@ -78,11 +78,14 @@ private
   end
 
   def set_scheduled_publishing_datetime(edition, datetime = nil)
-    new_revision = edition.revision.build_revision_update(
+    current_revision = edition.revision
+    new_revision = current_revision.build_revision_update(
       { scheduled_publishing_datetime: datetime }, current_user
     )
-    edition.assign_revision(new_revision, current_user).save!
-    create_timeline_entry(edition, new_revision, datetime)
+    if new_revision != current_revision
+      edition.assign_revision(new_revision, current_user).save!
+      create_timeline_entry(edition, new_revision, datetime)
+    end
   end
 
   def create_timeline_entry(edition, revision, datetime)

--- a/app/controllers/schedule_controller.rb
+++ b/app/controllers/schedule_controller.rb
@@ -82,11 +82,16 @@ private
       { scheduled_publishing_datetime: datetime }, current_user
     )
     edition.assign_revision(new_revision, current_user).save!
-    create_timeline_entry(edition, new_revision)
+    create_timeline_entry(edition, new_revision, datetime)
   end
 
-  def create_timeline_entry(edition, revision)
-    TimelineEntry.create_for_revision(entry_type: :scheduled_publishing_datetime_set,
+  def create_timeline_entry(edition, revision, datetime)
+    entry_type = if datetime
+                   :scheduled_publishing_datetime_set
+                 else
+                   :scheduled_publishing_datetime_cleared
+                 end
+    TimelineEntry.create_for_revision(entry_type: entry_type,
                                       revision: revision,
                                       edition: edition,
                                       details: nil,

--- a/app/models/timeline_entry.rb
+++ b/app/models/timeline_entry.rb
@@ -44,7 +44,8 @@ class TimelineEntry < ApplicationRecord
                      draft_discarded: "draft_discarded",
                      draft_reset: "draft_reset",
                      scheduled: "scheduled",
-                     scheduled_publishing_datetime_set: "scheduled_publishing_datetime_set" }
+                     scheduled_publishing_datetime_set: "scheduled_publishing_datetime_set",
+                     scheduled_publishing_datetime_cleared: "scheduled_publishing_datetime_cleared" }
 
   def self.create_for_status_change(entry_type:,
                                     status:,

--- a/app/models/timeline_entry.rb
+++ b/app/models/timeline_entry.rb
@@ -43,7 +43,8 @@ class TimelineEntry < ApplicationRecord
                      internal_note: "internal_note",
                      draft_discarded: "draft_discarded",
                      draft_reset: "draft_reset",
-                     scheduled: "scheduled" }
+                     scheduled: "scheduled",
+                     scheduled_publishing_datetime_set: "scheduled_publishing_datetime_set" }
 
   def self.create_for_status_change(entry_type:,
                                     status:,

--- a/app/views/documents/show/_scheduling_form.html.erb
+++ b/app/views/documents/show/_scheduling_form.html.erb
@@ -4,14 +4,14 @@
 <% submitted_values = flash[:scheduled_publishing_params] %>
 <% selected_time = submitted_values&.fetch("time") ||  current_scheduled_publish_datetime&.strftime("%l:%M%P")&.strip %>
 
-<%= form_tag(save_scheduled_publishing_datetime_path(@edition.document)) do %>
-  <%= render "govuk_publishing_components/components/details", {
-    title: if current_scheduled_publish_datetime
-             simple_format("Publish date: \n" + current_scheduled_publish_datetime.strftime("%-d %B %Y - %l:%M%P"))
-           else
-             "Schedule publishing"
-           end
-  } do %>
+<%= render "govuk_publishing_components/components/details", {
+  title: if current_scheduled_publish_datetime
+           simple_format("Publish date: \n" + current_scheduled_publish_datetime.strftime("%-d %B %Y - %l:%M%P"))
+         else
+           "Schedule publishing"
+         end
+} do %>
+  <%= form_tag(save_scheduled_publishing_datetime_path(@edition.document)) do %>
     <% if flash[:scheduled_publishing_datetime_issues] %>
       <% flash[:scheduled_publishing_datetime_issues].each do |issue| %>
         <%= render "govuk_publishing_components/components/error_message", {
@@ -50,6 +50,11 @@
       <%= render "govuk_publishing_components/components/button", {
         text: "Save"
       } %>
+    <% end %>
+  <% end %>
+  <% if current_scheduled_publish_datetime %>
+    <%= form_tag clear_scheduled_publishing_datetime_path(@edition.document), class: "app-inline-block" do %>
+      <button class="govuk-link app-link--button">Clear date</button>
     <% end %>
   <% end %>
 <% end %>

--- a/config/locales/en/documents/history.yml
+++ b/config/locales/en/documents/history.yml
@@ -25,3 +25,4 @@ en:
         draft_reset: "Draft reset to last published edition"
         unwithdrawn: "Unwithdrawn"
         scheduled: "Scheduled to publish"
+        scheduled_publishing_datetime_set: "Scheduled publishing date and time set"

--- a/config/locales/en/documents/history.yml
+++ b/config/locales/en/documents/history.yml
@@ -26,3 +26,4 @@ en:
         unwithdrawn: "Unwithdrawn"
         scheduled: "Scheduled to publish"
         scheduled_publishing_datetime_set: "Scheduled publishing date and time set"
+        scheduled_publishing_datetime_cleared: "Scheduled publishing date and time cleared"

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -13,6 +13,8 @@ Rails.application.routes.draw do
   get "/documents/:id/published" => "publish#published", as: :published
 
   post "/documents/:id/save-scheduled-publishing-datetime" => "schedule#save_scheduled_publishing_datetime", as: :save_scheduled_publishing_datetime
+  post "/documents/:id/clear-scheduled-publishing-datetime" => "schedule#clear_scheduled_publishing_datetime", as: :clear_scheduled_publishing_datetime
+
   get "/documents/:id/schedule" => "schedule#confirmation", as: :scheduling_confirmation
   post "/documents/:id/schedule" => "schedule#schedule"
   get "/documents/:id/scheduled" => "schedule#scheduled", as: :scheduled

--- a/spec/features/workflow/clear_scheduled_publishing_datetime_spec.rb
+++ b/spec/features/workflow/clear_scheduled_publishing_datetime_spec.rb
@@ -1,0 +1,59 @@
+# frozen_string_literal: true
+
+RSpec.feature "Clear scheduled publishing datetime" do
+  scenario do
+    given_there_is_an_edition_with_a_set_scheduled_publishing_datetime
+    when_i_visit_the_summary_page
+    and_i_click_on_publish_date
+    then_i_see_the_existing_scheduled_publishing_date_and_time
+    when_i_click_clear_date
+    then_i_see_the_default_scheduled_publishing_date_and_time
+  end
+
+  def given_there_is_an_edition_with_a_set_scheduled_publishing_datetime
+    @datetime = Time.zone.now.advance(days: 2).midday
+    @edition = create(:edition, scheduled_publishing_datetime: @datetime)
+  end
+
+  def when_i_visit_the_summary_page
+    visit document_path(@edition.document)
+  end
+
+  def and_i_click_on_publish_date
+    scheduled_date = @datetime.strftime("%-d %B %Y - 12:00pm")
+    find(".govuk-details__summary-text", text: "Publish date: #{scheduled_date}").click
+  end
+
+  def then_i_see_the_existing_scheduled_publishing_date_and_time
+    expect(page).to have_selector(
+      "[@name='scheduled[day]'][@value='#{@datetime.day}']",
+    )
+    expect(page).to have_selector(
+      "[@name='scheduled[month]'][@value='#{@datetime.month}']",
+    )
+    expect(page).to have_selector(
+      "[@name='scheduled[year]'][@value='#{@datetime.year}']",
+    )
+    expect(page).to have_select("scheduled[time]", selected: "12:00pm")
+  end
+
+  def when_i_click_clear_date
+    click_on "Clear date"
+  end
+
+  def then_i_see_the_default_scheduled_publishing_date_and_time
+    default_date = Time.zone.tomorrow
+
+    expect(page).to have_content("Schedule publishing")
+    expect(page).to have_selector(
+      "[@name='scheduled[day]'][@value='#{default_date.day}']",
+    )
+    expect(page).to have_selector(
+      "[@name='scheduled[month]'][@value='#{default_date.month}']",
+    )
+    expect(page).to have_selector(
+      "[@name='scheduled[year]'][@value='#{default_date.year}']",
+    )
+    expect(page).to have_select("scheduled[time]", selected: "9:00am")
+  end
+end

--- a/spec/features/workflow/clear_scheduled_publishing_datetime_spec.rb
+++ b/spec/features/workflow/clear_scheduled_publishing_datetime_spec.rb
@@ -55,5 +55,9 @@ RSpec.feature "Clear scheduled publishing datetime" do
       "[@name='scheduled[year]'][@value='#{default_date.year}']",
     )
     expect(page).to have_select("scheduled[time]", selected: "9:00am")
+
+    within first(".app-timeline-entry") do
+      expect(page).to have_content I18n.t!("documents.history.entry_types.scheduled_publishing_datetime_cleared")
+    end
   end
 end

--- a/spec/features/workflow/set_scheduled_publishing_datetime_spec.rb
+++ b/spec/features/workflow/set_scheduled_publishing_datetime_spec.rb
@@ -65,5 +65,9 @@ RSpec.feature "Set scheduled publishing datetime" do
       "[@name='scheduled[year]'][@value='#{@date.year}']",
     )
     expect(find_field("scheduled[time]").value).to eq("11:00pm")
+
+    within first(".app-timeline-entry") do
+      expect(page).to have_content I18n.t!("documents.history.entry_types.scheduled_publishing_datetime_set")
+    end
   end
 end


### PR DESCRIPTION
For https://trello.com/c/UJa3cgqL/678-users-can-clear-scheduled-publishing-datetime

This allows users to clear a set `scheduled_publishing_datetime`.  We also create a Timeline entry when `scheduled_publishing_datetime` is set or cleared.

<img width="289" alt="screen shot 2019-03-01 at 12 03 18" src="https://user-images.githubusercontent.com/13434452/53637048-090a5880-3c1a-11e9-8c30-aa61edf8b7a4.png">

<img width="402" alt="screen shot 2019-03-01 at 12 01 21" src="https://user-images.githubusercontent.com/13434452/53637021-f55ef200-3c19-11e9-85e0-f28e9fec2fba.png">