### PR TITLE
Fix details components

### DIFF
--- a/app/views/components/_markdown_guidance.html.erb
+++ b/app/views/components/_markdown_guidance.html.erb
@@ -1,7 +1,8 @@
 <div class="app-c-markdown-guidance">
   <%= render "govuk_publishing_components/components/details", {
         title: "Acronyms",
-        data_attributes: { gtm: "markdown-guidance-details" }
+        data_attributes: { gtm: "markdown-guidance-details" },
+        margin_bottom: 0
   } do %>
     <p>Definitions for acronyms that will appear if the user hovers the mouse over it.</p>
     <p>Add each definition in its own paragraph at the end of the body copy.</p>
@@ -12,7 +13,8 @@
 
   <%= render "govuk_publishing_components/components/details", {
         title: "Addresses",
-        data_attributes: { gtm: "markdown-guidance-details" }
+        data_attributes: { gtm: "markdown-guidance-details" },
+        margin_bottom: 0
   } do %>
     <p>Add $A before and after an address to inset it.</p>
     <pre class="app-c-markdown-guidance__code-snippet">
@@ -25,7 +27,8 @@
 
   <%= render "govuk_publishing_components/components/details", {
         title: "Call to action",
-        data_attributes: { gtm: "markdown-guidance-details" }
+        data_attributes: { gtm: "markdown-guidance-details" },
+        margin_bottom: 0
   } do %>
     <p>Add $CTA before and after a paragraph to highlight an action for the user.</p>
     <pre class="app-c-markdown-guidance__code-snippet">
@@ -37,7 +40,8 @@
 
   <%= render "govuk_publishing_components/components/details", {
         title: "Email links",
-        data_attributes: { gtm: "markdown-guidance-details" }
+        data_attributes: { gtm: "markdown-guidance-details" },
+        margin_bottom: 0
   } do %>
     <p>Add < and > brackets around email addresses to make them a link.</p>
     <pre class="app-c-markdown-guidance__code-snippet">
@@ -47,7 +51,8 @@
 
   <%= render "govuk_publishing_components/components/details", {
         title: "Tables",
-        data_attributes: { gtm: "markdown-guidance-details" }
+        data_attributes: { gtm: "markdown-guidance-details" },
+        margin_bottom: 0
   } do %>
     <p>Add | to separate data into columns and put each row on a new line.</p>
     <pre class="app-c-markdown-guidance__code-snippet">
@@ -68,7 +73,8 @@
 
   <%= render "govuk_publishing_components/components/details", {
         title: "Bar charts",
-        data_attributes: { gtm: "markdown-guidance-details" }
+        data_attributes: { gtm: "markdown-guidance-details" },
+        margin_bottom: 0
   } do %>
     <p>Add {barchart} at the end of numeric tables to display a simple bar chart.</p>
     <pre class="app-c-markdown-guidance__code-snippet">

--- a/app/views/documents/show/_scheduling_form.html.erb
+++ b/app/views/documents/show/_scheduling_form.html.erb
@@ -4,12 +4,17 @@
 <% submitted_values = flash[:scheduled_publishing_params] %>
 <% selected_time = submitted_values&.fetch("time") ||  current_scheduled_publish_datetime&.strftime("%l:%M%P")&.strip %>
 
+<% scheduling_title = capture do %>
+  <% if current_scheduled_publish_datetime %>
+    Publish date: <br><%= current_scheduled_publish_datetime.strftime("%-d %B %Y - %l:%M%P") %>
+  <% else %>
+    Schedule publishing
+  <% end %>
+<% end %>
+
 <%= render "govuk_publishing_components/components/details", {
-  title: if current_scheduled_publish_datetime
-           simple_format("Publish date: \n" + current_scheduled_publish_datetime.strftime("%-d %B %Y - %l:%M%P"))
-         else
-           "Schedule publishing"
-         end
+  margin_bottom: 0,
+  title: scheduling_title
 } do %>
   <%= form_tag(save_scheduled_publishing_datetime_path(@edition.document)) do %>
     <% if flash[:scheduled_publishing_datetime_issues] %>


### PR DESCRIPTION
This fixes instances of details component after #811 introduced the default spacing.
Tries to deal with excessive padding and markup on the scheduling details element.

### Before
![screen shot 2019-03-01 at 10 44 18](https://user-images.githubusercontent.com/788096/53633341-179f4280-3c0f-11e9-9db6-2a2f69d27a69.png)

### After
![screen shot 2019-03-01 at 10 44 38](https://user-images.githubusercontent.com/788096/53633349-1a9a3300-3c0f-11e9-9814-681aebf907d2.png)


@emmabeynon: will rebase after #826 
