### PR TITLE
Merge autocomplete and its hinted variant

### DIFF
--- a/app/assets/javascripts/components/autocomplete.js
+++ b/app/assets/javascripts/components/autocomplete.js
@@ -7,40 +7,6 @@ window.GOVUK.Modules = window.GOVUK.Modules || {};
 
   Autocomplete.prototype.start = function ($module) {
     this.$module = $module[0]
-    var type = this.$module.dataset.autocompleteType
-
-    if (type === 'with-hint-on-options') {
-      this.initAutoCompleteWithHintOnOptions()
-    } else {
-      this.initAutoComplete()
-    }
-  }
-
-  Autocomplete.prototype.initAutoComplete = function () {
-    var customAttributes = {}
-    var $select = this.$module.querySelector('select')
-
-    if (!$select) {
-      return
-    }
-
-    if ($select.attributes['data-contextual-guidance']) {
-      customAttributes = {
-        'data-contextual-guidance': $select.attributes['data-contextual-guidance'].value
-      }
-    }
-
-    // disabled eslint because we can not control the name of the constructor (expected to be EnhanceSelectElement)
-    new window.accessibleAutocomplete.enhanceSelectElement({ // eslint-disable-line no-new, new-cap
-      selectElement: $select,
-      minLength: 3,
-      showNoOptionsFound: true,
-      customAttributes: customAttributes
-    })
-  }
-
-  Autocomplete.prototype.initAutoCompleteWithHintOnOptions = function () {
-    // Read options and associated data attributes and feed that as results for inputValueTemplate
     var $select = this.$module.querySelector('select')
 
     if (!$select) {

--- a/app/views/components/_autocomplete.html.erb
+++ b/app/views/components/_autocomplete.html.erb
@@ -4,12 +4,10 @@
   selected_options ||= []
   multiple ||= nil
   size ||= nil
-  data ||= nil
   hint ||= nil
-  data_module ||= "autocomplete"
 %>
 
-<div class="app-c-autocomplete govuk-form-group" data-module="<%= data_module %>">
+<div class="app-c-autocomplete govuk-form-group" data-module="autocomplete">
   <%= render "govuk_publishing_components/components/label", {
     html_for: id
   }.merge(label.symbolize_keys) %>
@@ -27,7 +25,6 @@
       options_for_select(options, selected_options),
       id: id,
       class: "govuk-select",
-      data: data,
       size: size,
       multiple: multiple
     %>

--- a/app/views/contacts/search.html.erb
+++ b/app/views/contacts/search.html.erb
@@ -20,10 +20,6 @@
     },
     id: "contact-id",
     options: [["", ""]] + contact_options,
-    data: {
-      module: "autocomplete",
-      "autocomplete-type": "with-hint-on-options"
-    }
   } %>
 
   <%= render "govuk_publishing_components/components/button", {

--- a/app/views/tags/edit.html.erb
+++ b/app/views/tags/edit.html.erb
@@ -16,16 +16,6 @@
         tags: @revision.tags,
         contextual_guidance_id: "#{tag_field.id}-guidance" %>
     </div>
-    <% if @document.document_type.guidance_for(tag_field.id) %>
-    <div class="govuk-grid-column-one-third">
-      <%= render "components/contextual_guidance", {
-        id: "#{tag_field.id}-guidance",
-        title: @document.document_type.guidance_for(tag_field.id).title
-      } do %>
-        <p class="govuk-body"><%= @document.document_type.guidance_for(tag_field.id).body %></p>
-      <% end %>
-    </div>
-    <% end %>
   </div>
   <% end %>
 

--- a/app/views/tags/tags/_multi_tag_input.html.erb
+++ b/app/views/tags/tags/_multi_tag_input.html.erb
@@ -10,7 +10,4 @@
   selected_options: tags[tag_field.id],
   multiple: true,
   size: 10,
-  data: {
-    "contextual-guidance": contextual_guidance_id
-  }
 } %>

--- a/app/views/tags/tags/_single_tag_input.html.erb
+++ b/app/views/tags/tags/_single_tag_input.html.erb
@@ -8,7 +8,4 @@
   hint: tag_field.hint,
   options: LinkablesService.new(tag_field.document_type).select_options,
   selected_options: tags[tag_field.id],
-  data: {
-    "contextual-guidance": contextual_guidance_id
-  }
 } %>


### PR DESCRIPTION
Previously we had a flag that would change the autocomplete to add hint
text to each entry. The hinted variant is only used for contacts, and
was broken due to a misplaced data attribute.

This merges the hinted variant with the normal non-hinted autocomplete,
which fixes the issue with contacts and removes some duplicated code,
noting that the hinted variant also supports not using a hint.

This also removes support for contextual guidance, since this is not
currently being used with the autocomplete, and in any case was only
implemented for the non-hinted variant.