### PR TITLE
Reorder schedule publishing form when new edition

### DIFF
--- a/app/views/documents/show/_actions.html.erb
+++ b/app/views/documents/show/_actions.html.erb
@@ -73,14 +73,14 @@
       <%= delete_draft_link("app-link--right") %>
     <% end %>
 
-    <% if @edition.document.live_edition %>
-      <hr class="govuk-section-break govuk-section-break--m govuk-section-break--visible" />
-      <%= link_to "View published edition on GOV.UK", EditionUrl.new(@edition.document.live_edition).public_url, class: "govuk-link govuk-link--no-visited-state" %>
-    <% end %>
-
     <% if (@edition.editable? || @edition.scheduled?) && current_user.has_permission?(User::PRE_RELEASE_FEATURES_PERMISSION) %>
       <hr class="govuk-section-break govuk-section-break--m govuk-section-break--visible" />
       <%= render "documents/show/scheduling_form" %>
+    <% end %>
+
+    <% if @edition.document.live_edition %>
+      <hr class="govuk-section-break govuk-section-break--m govuk-section-break--visible" />
+      <%= link_to "View published edition on GOV.UK", EditionUrl.new(@edition.document.live_edition).public_url, class: "govuk-link govuk-link--no-visited-state" %>
     <% end %>
   </div>
 </div>


### PR DESCRIPTION
When a new edition is created then the schedule publishing form appears above
the "View published edition" link.

**Before**
<img width="325" alt="screen shot 2019-02-28 at 15 22 39" src="https://user-images.githubusercontent.com/13434452/53577221-2f25ef00-3b6d-11e9-9576-94f2db652bdf.png">

**After**
<img width="326" alt="screen shot 2019-02-28 at 15 23 13" src="https://user-images.githubusercontent.com/13434452/53577236-351bd000-3b6d-11e9-8d9c-8f4da01a15bb.png">
