### PR TITLE
Clear scheduled_publishing_datetime when new edition

### DIFF
--- a/app/models/edition.rb
+++ b/app/models/edition.rb
@@ -83,7 +83,7 @@ class Edition < ApplicationRecord
 
   def self.create_next_edition(preceding_edition, user)
     revision = preceding_edition.revision.build_revision_update(
-      { change_note: "", update_type: "major" },
+      { change_note: "", update_type: "major", scheduled_publishing_datetime: nil },
       user,
     )
 

--- a/spec/models/edition_spec.rb
+++ b/spec/models/edition_spec.rb
@@ -44,16 +44,18 @@ RSpec.describe Edition do
       expect(edition.number).to be 6
     end
 
-    it "resets the change note and update type" do
+    it "resets the change note, update type and scheduled_publishing_datetime" do
       preceding = create(:edition,
                          change_note: "Changes",
                          update_type: :minor,
-                         current: false)
+                         current: false,
+                         scheduled_publishing_datetime: Time.zone.now)
 
       edition = Edition.create_next_edition(preceding, user)
 
       expect(edition.change_note).to be_empty
       expect(edition.update_type).to eq("major")
+      expect(edition.scheduled_publishing_datetime).to be nil
     end
   end
 


### PR DESCRIPTION
This ensures that an old `scheduled_publishing_datetime` belonging to an old
edition isn't carried over to a new edition.