### PR TITLE
Add a bit of vertical padding for the spinner

### DIFF
--- a/app/assets/stylesheets/components/_loading-spinner.scss
+++ b/app/assets/stylesheets/components/_loading-spinner.scss
@@ -1,6 +1,7 @@
 .app-c-loading-spinner {
   @include govuk-focusable;
   text-align: center;
+  padding: govuk-spacing(8) * 2;
 }
 
 @keyframes app-loading-spinner-opacity-0 {


### PR DESCRIPTION
This is just a quick fix so that the modal height doesn't collapse too
much in between rendering different sections.