### PR TITLE
Make re-initialisation for modal more efficient

### DIFF
--- a/app/assets/javascripts/modules/inline-image-modal.js
+++ b/app/assets/javascripts/modules/inline-image-modal.js
@@ -1,3 +1,5 @@
+/* global $ */
+
 function InlineImageModal ($module) {
   this.$module = $module
   this.$modal = document.getElementById('modal')
@@ -127,7 +129,7 @@ InlineImageModal.prototype.performAction = function (item) {
 }
 
 InlineImageModal.prototype.initComponents = function () {
-  window.GOVUK.modules.start()
+  window.GOVUK.modules.start($(this.$modal))
 
   // TODO: change ErrorSummary so it just focusses when it's initialised
   var $errorSummary = document.querySelector('[data-module="error-summary"]')


### PR DESCRIPTION
Previously we were trying to re-initialise all components in the app,
even though we only need to attempt this for the modal content.