### PR TITLE
Fix input length suggester spacing

### DIFF
--- a/app/assets/stylesheets/components/_input-length-suggester.scss
+++ b/app/assets/stylesheets/components/_input-length-suggester.scss
@@ -1,3 +1,7 @@
+.app-c-input-length-suggester {
+  margin-top: govuk-spacing(1);
+}
+
 .app-c-input-length-suggester__hidden {
   visibility: hidden;
 }


### PR DESCRIPTION
Because we're injecting this element inside the textarea component, the margin-bottom is being applied after the message instead of before the 'input length suggester' component. This adds margin to the injected element.

### Before
<img width="651" alt="screen shot 2019-02-28 at 17 39 29" src="https://user-images.githubusercontent.com/788096/53586338-da3fa400-3b7f-11e9-83df-7cee78b3ef60.png">

### After
<img width="645" alt="screen shot 2019-02-28 at 17 39 07" src="https://user-images.githubusercontent.com/788096/53586339-dd3a9480-3b7f-11e9-9a56-eb7a7408cefe.png">
