### PR TITLE
Fix hover state for inline links

### DIFF
--- a/app/assets/stylesheets/core/_link.scss
+++ b/app/assets/stylesheets/core/_link.scss
@@ -22,7 +22,11 @@
   display: inline-block;
 
   @include govuk-media-query($from: tablet) {
-    padding: 8px 0 0 govuk-spacing(3);
+    padding: 8px govuk-spacing(3);
+  }
+
+  &:focus {
+    outline: none;
   }
 }
 


### PR DESCRIPTION
Add consistent padding for inline links and remove outline on focus to fit the height of the button.

### Before
![screen shot 2019-03-01 at 10 40 33](https://user-images.githubusercontent.com/788096/53633138-8e880b80-3c0e-11e9-8912-66dbcf5cc7ec.png)

### After
![screen shot 2019-03-01 at 10 40 45](https://user-images.githubusercontent.com/788096/53633140-9051cf00-3c0e-11e9-839f-e4fd5d64365d.png)
