### PR TITLE
Insert a new line after the inline snippet

### DIFF
--- a/app/assets/javascripts/modules/inline-image-modal.js
+++ b/app/assets/javascripts/modules/inline-image-modal.js
@@ -77,7 +77,7 @@ InlineImageModal.prototype.renderResponse = function (response) {
 
 InlineImageModal.prototype.insertSnippet = function (item) {
   var editor = this.$module.closest('[data-module="markdown-editor"]')
-  editor.selectionReplace(item.dataset.modalData)
+  editor.selectionReplace(item.dataset.modalData + '\n')
 }
 
 InlineImageModal.prototype.performAction = function (item) {


### PR DESCRIPTION
https://trello.com/c/jsJLqcSa/667-allow-users-to-edit-image-metadata-in-the-context-of-a-modal

This is to ensure certain inline elements render correctly.