### PR TITLE
Revert "Merge autocomplete and its hinted variant"

### DIFF
--- a/app/assets/javascripts/components/autocomplete.js
+++ b/app/assets/javascripts/components/autocomplete.js
@@ -7,6 +7,32 @@ window.GOVUK.Modules = window.GOVUK.Modules || {};
 
   Autocomplete.prototype.start = function ($module) {
     this.$module = $module[0]
+    var type = this.$module.dataset.autocompleteType
+
+    if (type === 'with-hint-on-options') {
+      this.initAutoCompleteWithHintOnOptions()
+    } else {
+      this.initAutoComplete()
+    }
+  }
+
+  Autocomplete.prototype.initAutoComplete = function () {
+    var $select = this.$module.querySelector('select')
+
+    if (!$select) {
+      return
+    }
+
+    // disabled eslint because we can not control the name of the constructor (expected to be EnhanceSelectElement)
+    new window.accessibleAutocomplete.enhanceSelectElement({ // eslint-disable-line no-new, new-cap
+      selectElement: $select,
+      minLength: 3,
+      showNoOptionsFound: true
+    })
+  }
+
+  Autocomplete.prototype.initAutoCompleteWithHintOnOptions = function () {
+    // Read options and associated data attributes and feed that as results for inputValueTemplate
     var $select = this.$module.querySelector('select')
 
     if (!$select) {

--- a/app/views/components/_autocomplete.html.erb
+++ b/app/views/components/_autocomplete.html.erb
@@ -3,11 +3,12 @@
   options ||= []
   selected_options ||= []
   multiple ||= nil
+  type ||= nil
   size ||= nil
   hint ||= nil
 %>
 
-<div class="app-c-autocomplete govuk-form-group" data-module="autocomplete">
+<div class="app-c-autocomplete govuk-form-group" data-module="autocomplete" data-autocomplete-type="<%= type %>">
   <%= render "govuk_publishing_components/components/label", {
     html_for: id
   }.merge(label.symbolize_keys) %>

--- a/app/views/components/docs/autocomplete.yml
+++ b/app/views/components/docs/autocomplete.yml
@@ -86,9 +86,10 @@ examples:
     data:
       id: autocomplete-with-hint-on-options
       name: autocomplete-with-hint-on-options
+      type: with-hint-on-options
       label:
         text: Select your country
-      data_module: autocomplete-with-hint-on-options
+      data_module: autocomplete
       options:
         -
           -

--- a/app/views/contacts/search.html.erb
+++ b/app/views/contacts/search.html.erb
@@ -20,6 +20,7 @@
     },
     id: "contact-id",
     options: [["", ""]] + contact_options,
+    type: "with-hint-on-options"
   } %>
 
   <%= render "govuk_publishing_components/components/button", {

--- a/app/views/tags/edit.html.erb
+++ b/app/views/tags/edit.html.erb
@@ -6,16 +6,16 @@
     <p class="govuk-body"><%= t("tags.edit.description") %></p>
   </div>
 </div>
-<%= form_tag(tags_path(@document), data: { "warn-before-unload": "true" }, class: "app-c-contextual-guidance__form") do %>
 
-<% @document.document_type.tags.each do |tag_field| %>
-  <div class="govuk-grid-row">
-    <div class="govuk-grid-column-two-thirds">
-      <%= render "tags/tags/#{tag_field.type}_input",
-        tag_field: tag_field,
-        tags: @revision.tags %>
+<%= form_tag(tags_path(@document), data: { "warn-before-unload": "true" }, class: "app-c-contextual-guidance__form") do %>
+  <% @document.document_type.tags.each do |tag_field| %>
+    <div class="govuk-grid-row">
+      <div class="govuk-grid-column-two-thirds">
+        <%= render "tags/tags/#{tag_field.type}_input",
+          tag_field: tag_field,
+          tags: @revision.tags %>
+      </div>
     </div>
-  </div>
   <% end %>
 
   <%= render "govuk_publishing_components/components/button", {


### PR DESCRIPTION
This reverts commit bb8ece15ec7aab1862de6e470cad71b9faf4b991.

I've learnt my lesson and will avoid making 'simple' changes to the 
autocomplete in future. We can still remove the redundant contextual 
guidance for the autocomplete, as well as making the type switch a 
first-class attribute of the component, as opposed to a data attribute.