### PR TITLE
Display scheduled publishing date time errors in error summary

### DIFF
--- a/app/controllers/schedule_controller.rb
+++ b/app/controllers/schedule_controller.rb
@@ -10,7 +10,10 @@ class ScheduleController < ApplicationController
       issues = checker.pre_submit_issues
 
       if issues.any?
-        flash[:scheduled_publishing_datetime_issues] = issues.items_for(:scheduled_datetime)
+        flash["alert_with_items"] = {
+          title: I18n.t!("requirements.scheduled_datetime.title"),
+          items: issues.items,
+        }
         flash[:scheduled_publishing_params] = permitted_params
         redirect_to document_path(document)
         return

--- a/app/controllers/schedule_controller.rb
+++ b/app/controllers/schedule_controller.rb
@@ -10,9 +10,10 @@ class ScheduleController < ApplicationController
       issues = checker.pre_submit_issues
 
       if issues.any?
+        href = { scheduled_datetime: "#scheduled_publishing_datetime" }
         flash["alert_with_items"] = {
           title: I18n.t!("requirements.scheduled_datetime.title"),
-          items: issues.items,
+          items: issues.items(hrefs: href),
         }
         flash[:scheduled_publishing_params] = permitted_params
         redirect_to document_path(document)

--- a/app/views/documents/show/_scheduling_form.html.erb
+++ b/app/views/documents/show/_scheduling_form.html.erb
@@ -17,7 +17,8 @@
   title: scheduling_title,
   open: submitted_values.present?,
 } do %>
-  <%= form_tag(save_scheduled_publishing_datetime_path(@edition.document)) do %>
+  <%= form_tag(save_scheduled_publishing_datetime_path(@edition.document),
+               id: "scheduled_publishing_datetime") do %>
     <%= render "govuk_publishing_components/components/input", {
       label: { text: "Day" },
       name: "scheduled[day]",

--- a/app/views/documents/show/_scheduling_form.html.erb
+++ b/app/views/documents/show/_scheduling_form.html.erb
@@ -17,13 +17,6 @@
   title: scheduling_title
 } do %>
   <%= form_tag(save_scheduled_publishing_datetime_path(@edition.document)) do %>
-    <% if flash[:scheduled_publishing_datetime_issues] %>
-      <% flash[:scheduled_publishing_datetime_issues].each do |issue| %>
-        <%= render "govuk_publishing_components/components/error_message", {
-          text: issue["text"]
-        } %>
-      <% end %>
-    <% end %>
     <%= render "govuk_publishing_components/components/input", {
       label: { text: "Day" },
       name: "scheduled[day]",

--- a/app/views/documents/show/_scheduling_form.html.erb
+++ b/app/views/documents/show/_scheduling_form.html.erb
@@ -14,7 +14,8 @@
 
 <%= render "govuk_publishing_components/components/details", {
   margin_bottom: 0,
-  title: scheduling_title
+  title: scheduling_title,
+  open: submitted_values.present?,
 } do %>
   <%= form_tag(save_scheduled_publishing_datetime_path(@edition.document)) do %>
     <%= render "govuk_publishing_components/components/input", {

--- a/config/locales/en/requirements.yml
+++ b/config/locales/en/requirements.yml
@@ -65,6 +65,7 @@ en:
       blank:
         form_message: Enter a public explanation
     scheduled_datetime:
+      title: The scheduled publishing date and time needs to be changed
       in_the_past:
         form_message: Date & time cannot be in the past
       invalid:


### PR DESCRIPTION
This moves the scheduled publishing datetime form errors to be displayed in the error summary on top of the document show page.  We also add a href so that errors link to the form, and ensure the form stays open in the event of invalid data being submitted.

**Before**
<img width="282" alt="screen shot 2019-03-04 at 10 29 19" src="https://user-images.githubusercontent.com/13434452/53731100-a1e6e100-3e71-11e9-8cbd-fc64a12f59e8.png">

**After**
<img width="1012" alt="screen shot 2019-03-04 at 10 14 16" src="https://user-images.githubusercontent.com/13434452/53731109-a4e1d180-3e71-11e9-965c-b541f66906b0.png">
