### PR TITLE
Fix inserting inline image snippet after upload

### DIFF
--- a/app/views/images/edit.html.erb
+++ b/app/views/images/edit.html.erb
@@ -20,7 +20,7 @@
   class: "app-c-contextual-guidance__form",
   data: {
     "warn-before-unload": true,
-    "modal-action": "meta",
+    "modal-action": (params[:wizard] == "upload") ? "metaInsert": "meta",
     "modal-data": I18n.t("images.index.meta.inline_code.value", filename: @image_revision.filename),
   }
 ) do %>

--- a/spec/features/editing_content/insert_inline_image_spec.rb
+++ b/spec/features/editing_content/insert_inline_image_spec.rb
@@ -36,9 +36,7 @@ RSpec.feature "Insert inline image", js: true do
   end
 
   def then_i_see_the_snippet_is_inserted
-    snippet = I18n.t("images.index.meta.inline_code.value",
-                     filename: @image_revision.filename)
-
+    snippet = I18n.t("images.index.meta.inline_code.value", filename: @image_revision.filename)
     expect(find("#body").value).to match snippet
   end
 end

--- a/spec/features/editing_images/upload_image_spec.rb
+++ b/spec/features/editing_images/upload_image_spec.rb
@@ -17,7 +17,7 @@ RSpec.feature "Upload an image", js: true do
     and_i_upload_a_new_image
     and_i_crop_the_image
     and_i_fill_in_the_metadata
-    then_i_see_the_new_image
+    then_i_see_the_snippet_is_inserted
     and_the_preview_creation_succeeded
   end
 
@@ -80,6 +80,12 @@ RSpec.feature "Upload an image", js: true do
       expect(find("img")["src"]).to include("1000x1000.jpg")
       expect(find("img")["alt"]).to eq("Some alt text")
     end
+  end
+
+  def then_i_see_the_snippet_is_inserted
+    expect(page).to_not have_selector(".app-c-modal-dialogue")
+    snippet = I18n.t("images.index.meta.inline_code.value", filename: @image_filename)
+    expect(find("#body").value).to match snippet
   end
 
   def and_the_preview_creation_succeeded


### PR DESCRIPTION
https://trello.com/c/jsJLqcSa/667-allow-users-to-edit-image-metadata-in-the-context-of-a-modal

This adds the missing behaviour and test, which seems to have been
accidentally removed from the original branch for the metadata page.