### PR TITLE
Improve quality of errors when debugging

### DIFF
--- a/app/assets/javascripts/modal/modal-fetch.js
+++ b/app/assets/javascripts/modal/modal-fetch.js
@@ -10,6 +10,7 @@ window.ModalFetch.getLink = function (item) {
   return window.fetch(url, options)
     .then(function (response) {
       if (!response.ok) {
+        window.ModalFetch.debug(response)
         return window.Promise.reject('Unable to render the content.')
       }
 
@@ -36,6 +37,7 @@ window.ModalFetch.postForm = function (form) {
   return window.fetch(form.action, options)
     .then(function (response) {
       if (!response.ok) {
+        window.ModalFetch.debug(response)
         return window.Promise.reject('Unable to render the content.')
       }
 
@@ -44,4 +46,14 @@ window.ModalFetch.postForm = function (form) {
           return { body: text, done: response.redirected }
         })
     })
+}
+
+window.ModalFetch.debug = function (response) {
+  var envMeta = document.querySelector('meta[name="app-environment"]')
+
+  if (envMeta.content !== 'production') {
+    return
+  }
+
+  response.text().then(console.debug)
 }

--- a/app/assets/javascripts/modules/inline-image-modal.js
+++ b/app/assets/javascripts/modules/inline-image-modal.js
@@ -25,6 +25,8 @@ InlineImageModal.prototype.render = function (response) {
 }
 
 InlineImageModal.prototype.renderError = function (result) {
+  window.Raven.captureException(result)
+  console.error(result)
   this.$multiSectionViewer.showStaticSection('error')
 }
 

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -18,6 +18,8 @@
       gtm_preview: ENV["GOOGLE_TAG_MANAGER_PREVIEW"]
     } %>
   <% end %>
+
+  <meta name="app-environment" content"<%= Rails.env %>"
 <% end %>
 
 <%= render 'govuk_publishing_components/components/layout_for_admin',


### PR DESCRIPTION
https://trello.com/c/jsJLqcSa/667-allow-users-to-edit-image-metadata-in-the-context-of-a-modal

It didn't take long to track down the pain-points when debugging with 
the modal, but I'm happy to break this out into another card if we feel 
it deserves some more thorough attention.

This adds a 'console.error' to ensure we don't swallow errors that we
don't hide errors caused by things like syntax issues with JavaScript.
I've also added a couple of 'console.debug' statements to help inspect
server errors when they occur - these won't be shown in production.