### PR TITLE
Open image guidance in a new tab

### DIFF
--- a/config/locales/en/images/index.yml
+++ b/config/locales/en/images/index.yml
@@ -2,7 +2,7 @@ en:
   images:
     index:
       title: "Images for ‘%{title}’"
-      description_govspeak: Images can be jpg, png or gif files. Full [guidance on images](https://www.gov.uk/guidance/how-to-publish-on-gov-uk/images-and-videos).
+      description_govspeak: Images can be jpg, png or gif files. Full [guidance on images](https://www.gov.uk/guidance/how-to-publish-on-gov-uk/images-and-videos){:target="_blank"}.
       upload_image: Upload an image
       lead_image: Lead image
       other_images: Other images


### PR DESCRIPTION
https://trello.com/c/MkWywL4g/590-support-inline-images

This helps ensure the user doesn't break out of the inline image modal
accidentally, but this is equally applicable for the lead image page.