### PR TITLE
Filter by a users organisation by default

### DIFF
--- a/app/controllers/documents_controller.rb
+++ b/app/controllers/documents_controller.rb
@@ -2,6 +2,11 @@
 
 class DocumentsController < ApplicationController
   def index
+    if filter_params[:filters].empty? && current_user.has_permission?(User::PRE_RELEASE_FEATURES_PERMISSION)
+      redirect_to documents_path(organisation: current_user.organisation_content_id)
+      return
+    end
+
     filter = EditionFilter.new(filter_params)
     @editions = filter.editions
     @filter_params = filter.filter_params

--- a/app/services/edition_filter.rb
+++ b/app/services/edition_filter.rb
@@ -14,7 +14,7 @@ class EditionFilter
   def initialize(params)
     @filters = params[:filters].to_h.symbolize_keys
     @sort = allowed_sort?(params[:sort]) ? params[:sort] : DEFAULT_SORT
-    @page = params[:page]
+    @page = params.fetch(:page, 1).to_i
     @per_page = params[:per_page]
   end
 
@@ -29,9 +29,9 @@ class EditionFilter
   end
 
   def filter_params
-    filters.select { |_, value| value.present? }.tap do |params|
+    filters.dup.tap do |params|
       params[:sort] = sort if sort != DEFAULT_SORT
-      params[:page] = page if page != "1"
+      params[:page] = page if page > 1
     end
   end
 

--- a/app/views/documents/index/_filters.html.erb
+++ b/app/views/documents/index/_filters.html.erb
@@ -10,21 +10,23 @@
   } %>
 
   <div class="govuk-form-group">
-    <% document_type_select = DocumentType.all
-      .reject(&:managed_elsewhere)
-      .map { |d| [d.label, d.id] }
-    %>
+    <% organisation_select = begin
+      LinkablesService.new("organisation").select_options
+    rescue GdsApi::BaseError => e
+      GovukError.notify(e)
+      []
+    end %>
 
     <%= render "govuk_publishing_components/components/label", {
-      text: t("documents.index.filter.document_type"),
-      html_for: "document-type-filter",
+      text: t("documents.index.filter.organisation"),
+      html_for: "document-organisation-filter",
       bold: true
     } %>
 
-    <%= select_tag "document_type",
-      options_for_select(document_type_select, [params[:document_type]]),
+    <%= select_tag "organisation",
+      options_for_select(organisation_select, [params[:organisation]]),
       include_blank: true,
-      id: "document-type-filter",
+      id: "document-organisation-filter",
       class: "govuk-select"
     %>
   </div>
@@ -56,23 +58,21 @@
   </div>
 
   <div class="govuk-form-group">
-    <% organisation_select = begin
-      LinkablesService.new("organisation").select_options
-    rescue GdsApi::BaseError => e
-      GovukError.notify(e)
-      []
-    end %>
+    <% document_type_select = DocumentType.all
+      .reject(&:managed_elsewhere)
+      .map { |d| [d.label, d.id] }
+    %>
 
     <%= render "govuk_publishing_components/components/label", {
-      text: t("documents.index.filter.organisation"),
-      html_for: "document-organisation-filter",
+      text: t("documents.index.filter.document_type"),
+      html_for: "document-type-filter",
       bold: true
     } %>
 
-    <%= select_tag "organisation",
-      options_for_select(organisation_select, [params[:organisation]]),
+    <%= select_tag "document_type",
+      options_for_select(document_type_select, [params[:document_type]]),
       include_blank: true,
-      id: "document-organisation-filter",
+      id: "document-type-filter",
       class: "govuk-select"
     %>
   </div>
@@ -83,5 +83,9 @@
     text: "Filter"
   } %>
 
-  <p><%= link_to "Clear all filters", documents_path, class: "govuk-link govuk-link--no-visited-state" %></p>
+  <p>
+    <%= link_to "Clear all filters",
+                documents_path(organisation: ""),
+                class: "govuk-link govuk-link--no-visited-state" %>
+  </p>
 <% end %>

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -2,5 +2,7 @@
 
 user = User.find_or_create_by!(name: "publisher")
 
+gds_organisation_content_id = "af07d5a5-df63-4ddc-9383-6a666845ebe9"
+
 user.update!(permissions: [User::PRE_RELEASE_FEATURES_PERMISSION],
-            organisation_content_id: SecureRandom.uuid)
+            organisation_content_id: gds_organisation_content_id)

--- a/spec/factories/content_revision_factory.rb
+++ b/spec/factories/content_revision_factory.rb
@@ -2,8 +2,6 @@
 
 FactoryBot.define do
   factory :content_revision do
-    title { SecureRandom.alphanumeric(10) }
-    base_path { title ? "/prefix/#{title.parameterize}" : nil }
     association :created_by, factory: :user
   end
 end

--- a/spec/factories/edition_factory.rb
+++ b/spec/factories/edition_factory.rb
@@ -8,18 +8,12 @@ FactoryBot.define do
     revision_synced { true }
     association :created_by, factory: :user
 
+    revision_fields
+
     transient do
       content_id { SecureRandom.uuid }
       locale { I18n.available_locales.sample }
       document_type_id { build(:document_type, path_prefix: "/prefix").id }
-      title { SecureRandom.alphanumeric(10) }
-      update_type { "major" }
-      change_note { "First published." }
-      scheduled_publishing_datetime { nil }
-      summary { nil }
-      base_path { title ? "/prefix/#{title.parameterize}" : nil }
-      contents { {} }
-      tags { {} }
       state { "draft" }
       lead_image_revision { nil }
       image_revisions { [] }

--- a/spec/factories/revision_factory.rb
+++ b/spec/factories/revision_factory.rb
@@ -7,7 +7,16 @@ FactoryBot.define do
       base_path { title ? "/prefix/#{title.parameterize}" : nil }
       summary { nil }
       contents { {} }
-      tags { {} }
+      tags do
+        if created_by&.organisation_content_id
+          {
+            primary_publishing_organisation: [created_by.organisation_content_id],
+            organisations: [created_by.organisation_content_id],
+          }
+        else
+          {}
+        end
+      end
       update_type { "major" }
       change_note { "First published." }
       scheduled_publishing_datetime { nil }

--- a/spec/factories/revision_factory.rb
+++ b/spec/factories/revision_factory.rb
@@ -1,12 +1,7 @@
 # frozen_string_literal: true
 
 FactoryBot.define do
-  factory :revision do
-    association :created_by, factory: :user
-    document
-    association :lead_image_revision, factory: :image_revision
-    image_revisions { lead_image_revision ? [lead_image_revision] : [] }
-
+  trait :revision_fields do
     transient do
       title { SecureRandom.alphanumeric(10) }
       base_path { title ? "/prefix/#{title.parameterize}" : nil }
@@ -17,6 +12,15 @@ FactoryBot.define do
       change_note { "First published." }
       scheduled_publishing_datetime { nil }
     end
+  end
+
+  factory :revision do
+    association :created_by, factory: :user
+    document
+    association :lead_image_revision, factory: :image_revision
+    image_revisions { lead_image_revision ? [lead_image_revision] : [] }
+
+    revision_fields
 
     after(:build) do |revision, evaluator|
       revision.number = revision.document&.next_revision_number unless revision.number

--- a/spec/factories/user_factory.rb
+++ b/spec/factories/user_factory.rb
@@ -4,5 +4,9 @@ FactoryBot.define do
   factory :user do
     name { "John Smith" }
     uid { SecureRandom.uuid }
+
+    trait :managing_editor do
+      permissions { [User::MANAGING_EDITOR_PERMISSION] }
+    end
   end
 end

--- a/spec/features/creating_documents/create_document_spec.rb
+++ b/spec/features/creating_documents/create_document_spec.rb
@@ -57,8 +57,8 @@ RSpec.feature "Create a document" do
   def content_body
     {
       "links" => {
-        "organisations" => [User.first.organisation_content_id],
-        "primary_publishing_organisation" => [User.first.organisation_content_id],
+        "organisations" => [current_user.organisation_content_id],
+        "primary_publishing_organisation" => [current_user.organisation_content_id],
       },
       "title" => "A title",
       "document_type" => @document_type.id,

--- a/spec/features/debug_spec.rb
+++ b/spec/features/debug_spec.rb
@@ -23,9 +23,7 @@ RSpec.feature "Viewing debug information" do
   end
 
   def when_i_dont_have_the_debug_permission
-    user = User.first
-    user.update_attribute(:permissions,
-                          user.permissions - [User::DEBUG_PERMISSION])
+    login_as(create(:user))
   end
 
   def then_i_see_an_error_page
@@ -35,9 +33,7 @@ RSpec.feature "Viewing debug information" do
   end
 
   def when_im_given_debug_permission
-    user = User.first
-    user.update_attribute(:permissions,
-                          user.permissions + [User::DEBUG_PERMISSION])
+    current_user.update_attribute(:permissions, [User::DEBUG_PERMISSION])
   end
 
   def then_i_see_the_debug_page

--- a/spec/features/documentation_spec.rb
+++ b/spec/features/documentation_spec.rb
@@ -11,9 +11,7 @@ RSpec.feature "Viewing documentation" do
   end
 
   def when_i_dont_have_the_debug_permission
-    user = User.first
-    user.update_attribute(:permissions,
-                          user.permissions - [User::DEBUG_PERMISSION])
+    login_as(create(:user))
   end
 
   def and_i_visit_the_documentation_page
@@ -27,9 +25,7 @@ RSpec.feature "Viewing documentation" do
   end
 
   def when_im_given_debug_permission
-    user = User.first
-    user.update_attribute(:permissions,
-                          user.permissions + [User::DEBUG_PERMISSION])
+    current_user.update_attribute(:permissions, [User::DEBUG_PERMISSION])
   end
 
   def then_i_see_the_documentation_page

--- a/spec/features/editing_content/edit_edition_spec.rb
+++ b/spec/features/editing_content/edit_edition_spec.rb
@@ -47,7 +47,7 @@ RSpec.feature "Edit an edition" do
   end
 
   def and_i_see_i_was_the_last_user_to_edit_the_edition
-    editor = User.first.name
+    editor = current_user.name
     last_edited = I18n.t!("documents.show.metadata.last_edited_by") + ": #{editor}"
     expect(page).to have_content(last_edited)
   end

--- a/spec/features/finding/index_details_spec.rb
+++ b/spec/features/finding/index_details_spec.rb
@@ -4,36 +4,25 @@ RSpec.feature "Index details" do
   scenario do
     given_there_is_an_edition
     when_i_visit_the_index_page
-    then_i_can_see_the_title
-    and_i_can_see_the_document_type
-    and_i_can_see_the_state
-    and_i_can_see_who_last_edited_it
+    then_i_can_see_the_edition
   end
 
   def given_there_is_an_edition
-    @editor = create(:user)
-    @edition = create(:edition, last_edited_by: @editor)
+    @edition = create(:edition,
+                      last_edited_by: current_user,
+                      created_by: current_user)
   end
 
   def when_i_visit_the_index_page
     visit documents_path
   end
 
-  def then_i_can_see_the_title
+  def then_i_can_see_the_edition
     expect(page).to have_content(@edition.title)
-  end
-
-  def and_i_can_see_the_document_type
     expect(page).to have_content(@edition.document_type.label)
-  end
-
-  def and_i_can_see_the_state
     expect(page).to have_content(I18n.t!("user_facing_states.draft.name"))
-  end
-
-  def and_i_can_see_who_last_edited_it
     expect(page).to have_content(
-      I18n.t!("documents.index.search_results.last_edited_by", user: @editor.name),
+      I18n.t!("documents.index.search_results.last_edited_by", user: current_user.name),
     )
   end
 end

--- a/spec/features/finding/index_filtering_spec.rb
+++ b/spec/features/finding/index_filtering_spec.rb
@@ -4,21 +4,20 @@ RSpec.feature "Index filtering" do
   scenario do
     given_there_are_some_editions
     when_i_visit_the_index_page
-    and_i_filter_by_title
-    then_i_see_just_the_ones_that_match
+    then_i_only_see_my_organisations_editions
 
     when_i_clear_the_filters
-    then_i_see_all_the_editions
+    then_i_see_all_editions
+
+    when_i_clear_the_filters
+    and_i_filter_by_title
+    then_i_see_just_the_ones_that_match
 
     when_i_filter_by_document_type
     then_i_see_just_the_ones_that_match
 
     when_i_clear_the_filters
     and_i_filter_by_state
-    then_i_see_just_the_ones_that_match
-
-    when_i_clear_the_filters
-    and_i_filter_by_primary_organisation
     then_i_see_just_the_ones_that_match
 
     when_i_clear_the_filters
@@ -30,21 +29,36 @@ RSpec.feature "Index filtering" do
   end
 
   def given_there_are_some_editions
-    create(:edition, :published, title: "Totally irrelevant")
-    @primary_organisation = { "content_id" => SecureRandom.uuid, "internal_name" => "Organisation 1" }
-    @organisation = { "content_id" => SecureRandom.uuid, "internal_name" => "Organisation 2" }
+    @primary_organisation = { "content_id" => current_user.organisation_content_id,
+                              "internal_name" => "Organisation 1" }
+    @other_organisation = { "content_id" => SecureRandom.uuid,
+                            "internal_name" => "Organisation 2" }
 
     @relevant_edition = create(:edition,
                                title: "Super relevant",
                                tags: {
                                  primary_publishing_organisation: [@primary_organisation["content_id"]],
-                                 organisations: [@organisation["content_id"]],
+                                 organisations: [
+                                   @primary_organisation["content_id"],
+                                   @other_organisation["content_id"],
+                                 ],
                                })
+    create(:edition,
+           :published,
+           title: "Irrelevant but my organistion",
+           tags: {
+             primary_publishing_organisation: [@primary_organisation["content_id"]],
+             organisations: [@primary_organisation["content_id"]],
+           })
+
+    create(:edition, :published, title: "Not even my organisation")
   end
 
   def when_i_visit_the_index_page
-    stub_publishing_api_has_linkables([@primary_organisation, @organisation],
-                                      document_type: "organisation")
+    stub_publishing_api_has_linkables(
+      [@primary_organisation, @other_organisation],
+      document_type: "organisation",
+    )
 
     visit documents_path
   end
@@ -63,8 +77,17 @@ RSpec.feature "Index filtering" do
     click_on "Clear all filters"
   end
 
-  def then_i_see_all_the_editions
+  def then_i_only_see_my_organisations_editions
     expect(page).to have_content("2 documents")
+  end
+
+  def when_i_filter_by_all_organisations
+    select "", from: "organisation"
+    click_on "Filter"
+  end
+
+  def then_i_see_all_editions
+    expect(page).to have_content("3 documents")
   end
 
   def when_i_filter_by_document_type
@@ -77,13 +100,8 @@ RSpec.feature "Index filtering" do
     click_on "Filter"
   end
 
-  def and_i_filter_by_primary_organisation
-    select @primary_organisation["internal_name"], from: "organisation"
-    click_on "Filter"
-  end
-
   def and_i_filter_by_organisation
-    select @organisation["internal_name"], from: "organisation"
+    select @other_organisation["internal_name"], from: "organisation"
     click_on "Filter"
   end
 

--- a/spec/features/finding/index_ordering_spec.rb
+++ b/spec/features/finding/index_ordering_spec.rb
@@ -12,8 +12,14 @@ RSpec.feature "Index ordering" do
   end
 
   def given_there_are_some_editions
-    @most_recent = create(:edition, title: "Most recent", last_edited_at: 1.minute.ago)
-    @least_recent = create(:edition, title: "Least recent", last_edited_at: 2.minutes.ago)
+    @most_recent = create(:edition,
+                          title: "Most recent",
+                          last_edited_at: 1.minute.ago,
+                          created_by: current_user)
+    @least_recent = create(:edition,
+                           title: "Least recent",
+                           last_edited_at: 2.minutes.ago,
+                           created_by: current_user)
   end
 
   def when_i_visit_the_index_page

--- a/spec/features/finding/index_pagination_spec.rb
+++ b/spec/features/finding/index_pagination_spec.rb
@@ -12,7 +12,7 @@ RSpec.feature "User pages through a list of editions" do
   end
 
   def given_there_are_lots_of_editions
-    create_list(:edition, 51)
+    create_list(:edition, 51, created_by: current_user)
   end
 
   def when_i_visit_the_index_page

--- a/spec/features/workflow/delete_draft_after_publishing_spec.rb
+++ b/spec/features/workflow/delete_draft_after_publishing_spec.rb
@@ -12,7 +12,7 @@ RSpec.feature "Delete draft after publishing" do
   end
 
   def given_there_is_a_edition
-    @edition = create(:edition, :publishable)
+    @edition = create(:edition, :publishable, created_by: current_user)
   end
 
   def when_i_visit_the_summary_page
@@ -50,7 +50,7 @@ RSpec.feature "Delete draft after publishing" do
   end
 
   def then_i_see_the_draft_is_gone
-    expect(page).to have_current_path(documents_path)
+    expect(page).to have_current_path(documents_path, ignore_query: true)
     expect(page).to_not have_content @new_title
     expect(page).to have_content @edition.title
   end

--- a/spec/features/workflow/delete_draft_asset_manager_down_spec.rb
+++ b/spec/features/workflow/delete_draft_asset_manager_down_spec.rb
@@ -13,7 +13,9 @@ RSpec.feature "Delete draft with Asset Manager down" do
 
   def given_there_is_an_edition
     @image_revision = create(:image_revision, :on_asset_manager)
-    @edition = create(:edition, lead_image_revision: @image_revision)
+    @edition = create(:edition,
+                      lead_image_revision: @image_revision,
+                      created_by: current_user)
   end
 
   def when_i_visit_the_summary_page
@@ -42,7 +44,7 @@ RSpec.feature "Delete draft with Asset Manager down" do
   end
 
   def then_i_see_the_edition_is_gone
-    expect(page).to have_current_path(documents_path)
+    expect(page).to have_current_path(documents_path, ignore_query: true)
     expect(page).to_not have_content @edition.title
   end
 end

--- a/spec/features/workflow/delete_draft_publishing_api_down_spec.rb
+++ b/spec/features/workflow/delete_draft_publishing_api_down_spec.rb
@@ -12,7 +12,7 @@ RSpec.feature "Delete draft when the Publishing API is down" do
   end
 
   def given_there_is_an_edition
-    @edition = create(:edition, :publishable)
+    @edition = create(:edition, created_by: current_user)
   end
 
   def when_i_visit_the_summary_page
@@ -40,7 +40,7 @@ RSpec.feature "Delete draft when the Publishing API is down" do
   end
 
   def then_i_see_the_edition_is_gone
-    expect(page).to have_current_path(documents_path)
+    expect(page).to have_current_path(documents_path, ignore_query: true)
     expect(page).to_not have_content @edition.title
   end
 end

--- a/spec/features/workflow/delete_draft_spec.rb
+++ b/spec/features/workflow/delete_draft_spec.rb
@@ -11,7 +11,9 @@ RSpec.feature "Delete draft" do
 
   def given_there_is_an_edition
     @image_revision = create(:image_revision, :on_asset_manager)
-    @edition = create(:edition, lead_image_revision: @image_revision)
+    @edition = create(:edition,
+                      lead_image_revision: @image_revision,
+                      created_by: current_user)
   end
 
   def when_i_visit_the_summary_page
@@ -27,7 +29,7 @@ RSpec.feature "Delete draft" do
   end
 
   def then_i_see_the_edition_is_gone
-    expect(page).to have_current_path(documents_path)
+    expect(page).to have_current_path(documents_path, ignore_query: true)
     expect(page).to_not have_content @edition.title
   end
 

--- a/spec/features/workflow/edit_withdrawal_spec.rb
+++ b/spec/features/workflow/edit_withdrawal_spec.rb
@@ -3,7 +3,7 @@
 RSpec.feature "Edit a withdrawal" do
   scenario do
     given_there_is_a_withdrawn_edition
-    and_i_have_the_managing_editor_permission
+    and_i_am_a_managing_editor
     when_i_visit_the_summary_page
     and_i_click_to_change_the_public_explanation
     then_i_can_see_the_existing_public_explanation
@@ -15,10 +15,8 @@ RSpec.feature "Edit a withdrawal" do
     @edition = create(:edition, :withdrawn)
   end
 
-  def and_i_have_the_managing_editor_permission
-    user = User.first
-    user.update_attribute(:permissions,
-                          user.permissions + [User::MANAGING_EDITOR_PERMISSION])
+  def and_i_am_a_managing_editor
+    login_as(create(:user, :managing_editor))
   end
 
   def when_i_visit_the_summary_page

--- a/spec/features/workflow/show_with_creator_spec.rb
+++ b/spec/features/workflow/show_with_creator_spec.rb
@@ -9,8 +9,9 @@ RSpec.feature "Viewing a document with a creator" do
   end
 
   def given_there_is_a_document_with_a_creator
-    @user = create(:user, name: "Joe Bloggs")
-    @document = create(:document, :with_current_edition, created_by: @user)
+    @edition = create(:edition,
+                      document: build(:document, created_by: current_user),
+                      created_by: current_user)
   end
 
   def when_i_visit_the_index_page
@@ -18,12 +19,12 @@ RSpec.feature "Viewing a document with a creator" do
   end
 
   def and_i_click_on_the_document_title
-    click_on @document.current_edition.title
+    click_on @edition.title
   end
 
   def then_i_see_who_created_the_document
     expect(page).to have_content(
-      I18n.t!("documents.show.metadata.created_by") + ": " + @user.name,
+      I18n.t!("documents.show.metadata.created_by") + ": " + current_user.name,
     )
   end
 end

--- a/spec/features/workflow/show_with_no_creator_or_editor_spec.rb
+++ b/spec/features/workflow/show_with_no_creator_or_editor_spec.rb
@@ -11,8 +11,10 @@ RSpec.feature "Viewing a document with no creator or editor" do
   end
 
   def given_there_is_a_document_with_no_creator
-    document = create(:document, created_by: nil)
-    @edition = create(:edition, document: document, last_edited_by: nil)
+    @edition = create(:edition,
+                      document: build(:document, created_by: nil),
+                      last_edited_by: nil,
+                      created_by: current_user)
   end
 
   def when_i_visit_the_index_page

--- a/spec/features/workflow/unwithdraw_publishing_api_down_spec.rb
+++ b/spec/features/workflow/unwithdraw_publishing_api_down_spec.rb
@@ -3,7 +3,7 @@
 RSpec.feature "Unwithdraw a document when Publishing API is down" do
   scenario do
     given_there_is_a_withdrawn_edition
-    and_i_have_the_managing_editor_permission
+    and_i_am_a_managing_editor
     and_the_publishing_api_is_down
     when_i_visit_the_summary_page
     and_i_click_on_undo_withdraw_and_confirm
@@ -15,10 +15,8 @@ RSpec.feature "Unwithdraw a document when Publishing API is down" do
     @edition = create(:edition, :withdrawn)
   end
 
-  def and_i_have_the_managing_editor_permission
-    user = User.first
-    user.update_attribute(:permissions,
-                          user.permissions + [User::MANAGING_EDITOR_PERMISSION])
+  def and_i_am_a_managing_editor
+    login_as(create(:user, :managing_editor))
   end
 
   def and_the_publishing_api_is_down

--- a/spec/features/workflow/unwithdraw_spec.rb
+++ b/spec/features/workflow/unwithdraw_spec.rb
@@ -3,21 +3,19 @@
 RSpec.feature "Unwithdraw a document" do
   scenario do
     given_there_is_a_withdrawn_document
-    and_i_have_the_managing_editor_permission
+    and_i_am_a_managing_editor
     when_i_visit_the_summary_page
     then_i_see_the_documents_withdrawn_banner
     and_i_click_on_undo_withdrawal_and_confirm
     then_i_see_the_document_is_now_unwithdrawn
   end
 
-  def and_i_have_the_managing_editor_permission
-    user = User.first
-    user.update_attribute(:permissions,
-                          user.permissions + [User::MANAGING_EDITOR_PERMISSION])
-  end
-
   def given_there_is_a_withdrawn_document
     @withdrawn_edition = create(:edition, :withdrawn)
+  end
+
+  def and_i_am_a_managing_editor
+    login_as(create(:user, :managing_editor))
   end
 
   def when_i_visit_the_summary_page

--- a/spec/features/workflow/unwithdraw_without_managing_editor_permissions.spec.rb
+++ b/spec/features/workflow/unwithdraw_without_managing_editor_permissions.spec.rb
@@ -2,15 +2,10 @@
 
 RSpec.feature "Undo a withdraw without managing editor permission" do
   scenario "withdrawn edition" do
-    given_i_am_not_a_managing_editor
     when_there_is_a_withdrawn_edition
     and_i_visit_the_withdrawn_document_summary_page
     and_i_click_on_undo_withdrawal
     then_i_see_a_message_to_ask_my_managing_editor_to_unwithdraw_content
-  end
-
-  def given_i_am_not_a_managing_editor
-    login_as(create(:user))
   end
 
   def when_there_is_a_withdrawn_edition

--- a/spec/features/workflow/unwithdraw_without_managing_editor_permissions.spec.rb
+++ b/spec/features/workflow/unwithdraw_without_managing_editor_permissions.spec.rb
@@ -2,10 +2,15 @@
 
 RSpec.feature "Undo a withdraw without managing editor permission" do
   scenario "withdrawn edition" do
+    given_i_am_not_a_managing_editor
     when_there_is_a_withdrawn_edition
     and_i_visit_the_withdrawn_document_summary_page
     and_i_click_on_undo_withdrawal
     then_i_see_a_message_to_ask_my_managing_editor_to_unwithdraw_content
+  end
+
+  def given_i_am_not_a_managing_editor
+    login_as(create(:user))
   end
 
   def when_there_is_a_withdrawn_edition

--- a/spec/features/workflow/withdraw_publishing_api_down_spec.rb
+++ b/spec/features/workflow/withdraw_publishing_api_down_spec.rb
@@ -3,7 +3,7 @@
 RSpec.feature "Withdraw a document when Publishing API is down" do
   scenario do
     given_there_is_a_published_edition
-    and_i_have_the_managing_editor_permission
+    and_i_am_a_managing_editor
     when_i_visit_the_withdraw_document_page
     and_the_publishing_api_is_down
     when_i_fill_in_the_public_explanation
@@ -16,10 +16,8 @@ RSpec.feature "Withdraw a document when Publishing API is down" do
     @edition = create(:edition, :published)
   end
 
-  def and_i_have_the_managing_editor_permission
-    user = User.first
-    user.update_attribute(:permissions,
-                          user.permissions + [User::MANAGING_EDITOR_PERMISSION])
+  def and_i_am_a_managing_editor
+    login_as(create(:user, :managing_editor))
   end
 
   def when_i_visit_the_withdraw_document_page

--- a/spec/features/workflow/withdraw_requirements_spec.rb
+++ b/spec/features/workflow/withdraw_requirements_spec.rb
@@ -3,7 +3,7 @@
 RSpec.feature "Withdrawal document requirements" do
   scenario do
     given_there_is_a_published_edition
-    and_i_have_the_managing_editor_permission
+    and_i_am_a_managing_editor
     when_i_visit_the_document_withdrawal_page
     and_i_click_withdraw_document
     then_i_see_an_error_to_enter_an_public_explanation
@@ -13,10 +13,8 @@ RSpec.feature "Withdrawal document requirements" do
     @edition = create(:edition, :published)
   end
 
-  def and_i_have_the_managing_editor_permission
-    user = User.first
-    user.update_attribute(:permissions,
-                          user.permissions + [User::MANAGING_EDITOR_PERMISSION])
+  def and_i_am_a_managing_editor
+    login_as(create(:user, :managing_editor))
   end
 
   def when_i_visit_the_document_withdrawal_page

--- a/spec/features/workflow/withdraw_spec.rb
+++ b/spec/features/workflow/withdraw_spec.rb
@@ -3,7 +3,7 @@
 RSpec.feature "Withdraw a document" do
   scenario do
     given_there_is_a_published_edition
-    and_i_have_the_managing_editor_permission
+    and_i_am_a_managing_editor
     when_i_visit_the_summary_page
     and_i_click_on_withdraw
     then_i_see_that_i_can_withdraw_the_document
@@ -16,14 +16,12 @@ RSpec.feature "Withdraw a document" do
     @edition = create(:edition, :published)
   end
 
-  def when_i_visit_the_summary_page
-    visit document_path(@edition.document)
+  def and_i_am_a_managing_editor
+    login_as(create(:user, :managing_editor))
   end
 
-  def and_i_have_the_managing_editor_permission
-    user = User.first
-    user.update_attribute(:permissions,
-                          user.permissions + [User::MANAGING_EDITOR_PERMISSION])
+  def when_i_visit_the_summary_page
+    visit document_path(@edition.document)
   end
 
   def and_i_click_on_withdraw

--- a/spec/features/workflow/withdraw_without_managing_editor_permission_spec.rb
+++ b/spec/features/workflow/withdraw_without_managing_editor_permission_spec.rb
@@ -1,10 +1,6 @@
 # frozen_string_literal: true
 
 RSpec.feature "Withdraw without managing editor permission" do
-  background do
-    given_i_am_not_a_managing_editor
-  end
-
   scenario "published edition" do
     when_there_is_a_published_edition
     and_i_visit_the_summary_page
@@ -17,10 +13,6 @@ RSpec.feature "Withdraw without managing editor permission" do
     and_i_visit_the_withdrawn_document_summary_page
     and_i_click_on_change_public_explanation
     then_i_see_a_message_to_ask_my_managing_editor_to_withdraw_content
-  end
-
-  def given_i_am_not_a_managing_editor
-    login_as(create(:user))
   end
 
   def when_there_is_a_published_edition

--- a/spec/features/workflow/withdraw_without_managing_editor_permission_spec.rb
+++ b/spec/features/workflow/withdraw_without_managing_editor_permission_spec.rb
@@ -2,7 +2,7 @@
 
 RSpec.feature "Withdraw without managing editor permission" do
   background do
-    given_i_dont_have_the_managing_editor_permission
+    given_i_am_not_a_managing_editor
   end
 
   scenario "published edition" do
@@ -19,14 +19,12 @@ RSpec.feature "Withdraw without managing editor permission" do
     then_i_see_a_message_to_ask_my_managing_editor_to_withdraw_content
   end
 
-  def when_there_is_a_published_edition
-    @edition = create(:edition, :published)
+  def given_i_am_not_a_managing_editor
+    login_as(create(:user))
   end
 
-  def given_i_dont_have_the_managing_editor_permission
-    user = User.first
-    user.update_attribute(:permissions,
-                          user.permissions - [User::MANAGING_EDITOR_PERMISSION])
+  def when_there_is_a_published_edition
+    @edition = create(:edition, :published)
   end
 
   def and_i_visit_the_summary_page

--- a/spec/services/edition_filter_spec.rb
+++ b/spec/services/edition_filter_spec.rb
@@ -99,4 +99,26 @@ RSpec.describe EditionFilter do
       expect(editions).to eq([edition2])
     end
   end
+
+  describe "#filter_params" do
+    it "returns the params used to filter" do
+      params = EditionFilter.new(filters: { title_or_url: "title" }).filter_params
+      expect(params).to eq(title_or_url: "title")
+    end
+
+    it "maintains empty params" do
+      params = EditionFilter.new(filters: { organisation: "" }).filter_params
+      expect(params).to eq(organisation: "")
+    end
+
+    it "includes sort and page if they are different to default" do
+      params = EditionFilter.new(sort: "last_updated", page: 5).filter_params
+      expect(params).to eq(sort: "last_updated", page: 5)
+    end
+
+    it "rejects page parameters less than 1" do
+      params = EditionFilter.new(page: 0).filter_params
+      expect(params).to eq({})
+    end
+  end
 end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -41,6 +41,7 @@ RSpec.configure do |config|
   config.include GdsApi::TestHelpers::PublishingApiV2
   config.include GdsApi::TestHelpers::AssetManager
   config.include GovukSchemas::RSpecMatchers
+  config.include AuthenticationHelper, type: :feature
 
   config.fixture_path = "#{::Rails.root}/spec/fixtures"
 
@@ -51,6 +52,10 @@ RSpec.configure do |config|
   config.before :each, type: :feature do
     # This is required by lots of specs when visiting the index page
     stub_publishing_api_has_linkables([], document_type: "organisation")
+  end
+
+  config.after :each, type: :feature do
+    reset_authentication
   end
 
   config.after :each, type: :feature, js: true do

--- a/spec/support/authentication_helper.rb
+++ b/spec/support/authentication_helper.rb
@@ -1,0 +1,15 @@
+# frozen_string_literal: true
+
+module AuthenticationHelper
+  def login_as(user)
+    GDS::SSO.test_user = user
+  end
+
+  def current_user
+    GDS::SSO.test_user || User.first
+  end
+
+  def reset_authentication
+    GDS::SSO.test_user = nil
+  end
+end


### PR DESCRIPTION
Trello: https://trello.com/c/RAspjwep/673-set-default-view-to-filter-by-organisation

This is a draft PR - my first one 🌮 - as there are still design decisions to be made in the trello card and there's a couple of aspects of this PR I want to open to discussion first.

This changes the default behaviour of the `/documents` of Content Publisher to redirect to `/documents?organisation#{current_user.organisation.content_id}` when requested without an organisation parameter.

This is done so that documents are filtered by the current users organisation and so that the URL used to browse documents is not personalised towards a particular session - as per [this trello comment](https://trello.com/c/RAspjwep/673-set-default-view-to-filter-by-organisation#comment-5c790b2694ca0d8b930b48e8).

This has led to this containing a few things that I'm not super duper happy about and I thought I'd open it open for feedback/suggestions.

### Whether to still link to `documents_path` or link to organisation filtered path

It feels a bit annoying to link users to `documents_path` when they'll only be served a redirect we can anticipate but it doesn't feel great to be typing `documents_path(organisation: current_user.organisation_content_id)` all over the place too and that feels a bit fragile. I also wondered if this could mean lost flash messages, but I believe that won't be the case.

Currently I've gone with just linking to `documents_path`. Although setting `documents_path(organisation: current_user.organisation_content_id)` isn't actually much different to most route parameters but it does feel a bit strange since it's an optional rather than a required parameter.

My ideal would have been to set up a proc in the routes.rb file which automatically adds this as part of writing the route using the warden config, but I don't know how to do that. 

Finally another option would be a helper function, but I feel like this would be a bit of a wtf since it's not really that complex and it'd be tricky to make that distinguishable from routes.rb paths yet still be clearly a path.

### Usage of current user in tests

I think this is one of the first features where we're making references to the object of the current user. I've gone with using `User.first` to access them, since I know how gds-sso mock mode works. 

This does feel a bit opaque though. I wonder if a `current_user` helper in tests could be easier. It could also be good to embrace `Warden::Test::Helpers` per https://github.com/plataformatec/devise/wiki/How-To:-Test-with-Capybara although it's probably overkill at this point.

### Coupling of index filtering behaviour to other tests

The other pain point I hit here was that I had to change tests where a user ended up being redirect to the documents page, see https://github.com/alphagov/content-publisher/commit/f999b1ad2632530404ad28fe9afd7e77909e47a8. It's ended up with these tests being rather coupled to this index change which again doesn't feel great. 

I decided against pursing ideas that removed the index filtering in those cases, as they'd no longer be representative as integration tests. One option I considered was specifying the User as the creator edition and having that automatically set the organisation tag, but that's maybe somewhat opaque.

Any thoughts/suggestions?