### PR TITLE
Begin replacing model build methods with updaters

### DIFF
--- a/app/services/versioning/base_updater.rb
+++ b/app/services/versioning/base_updater.rb
@@ -1,0 +1,40 @@
+# frozen_string_literal: true
+
+module Versioning
+  class BaseUpdater
+    attr_reader :revision, :user
+
+    def initialize(revision, user)
+      @revision = revision
+      @user = user
+    end
+
+    def column_names
+      raise "Not implemented"
+    end
+
+    def changed?(field = nil)
+      field ? changes.key?(field) : changes.any?
+    end
+
+    def next_revision
+      changed? ? dup_revision : revision
+    end
+
+    def changes
+      raise "Not implemented"
+    end
+
+  protected
+
+    def changed_columns
+      old_key_vals = column_names.map { |c| [c, revision.public_send(c)] }
+      new_key_vals = column_names.map { |c| [c, dup_revision.public_send(c)] }
+      Hash[new_key_vals - old_key_vals]
+    end
+
+    def dup_revision
+      raise "Not implemented"
+    end
+  end
+end

--- a/app/services/versioning/image_revision_updater.rb
+++ b/app/services/versioning/image_revision_updater.rb
@@ -1,0 +1,38 @@
+# frozen_string_literal: true
+
+module Versioning
+  class ImageRevisionUpdater < BaseUpdater
+    def column_names
+      sub_updaters.keys
+    end
+
+    def assign(fields)
+      fields = fields.to_h.symbolize_keys
+
+      sub_updaters.map do |column_name, updater|
+        updater.assign(fields.slice(*updater.column_names))
+        dup_revision.assign_attributes(column_name => updater.next_revision)
+      end
+
+      sub_columns = sub_updaters.values.flat_map(&:column_names)
+      dup_revision.assign_attributes(fields.except(*sub_columns))
+    end
+
+    def changes
+      changed_columns.merge(*sub_updaters.values.map(&:changes))
+    end
+
+  private
+
+    def dup_revision
+      @dup_revision ||= revision.dup.tap { |r| r.created_by = user }
+    end
+
+    def sub_updaters
+      @sub_updaters ||= {
+        metadata_revision: SubRevisionUpdater.new(revision.metadata_revision, user),
+        file_revision: SubRevisionUpdater.new(revision.file_revision, user),
+      }
+    end
+  end
+end

--- a/app/services/versioning/revision_updater.rb
+++ b/app/services/versioning/revision_updater.rb
@@ -2,6 +2,8 @@
 
 module Versioning
   class RevisionUpdater < BaseUpdater
+    include RevisionUpdater::Image
+
     def column_names
       sub_updaters.keys + %i[lead_image_revision]
     end

--- a/app/services/versioning/revision_updater.rb
+++ b/app/services/versioning/revision_updater.rb
@@ -1,0 +1,56 @@
+# frozen_string_literal: true
+
+module Versioning
+  class RevisionUpdater < BaseUpdater
+    def column_names
+      sub_updaters.keys + %i[lead_image_revision]
+    end
+
+    def collection_names
+      %i[image_revisions]
+    end
+
+    def assign(fields)
+      fields = fields.to_h.symbolize_keys
+
+      sub_updaters.map do |column_name, updater|
+        updater.assign(fields.slice(*updater.column_names))
+        dup_revision.assign_attributes(column_name => updater.next_revision)
+      end
+
+      sub_columns = sub_updaters.values.flat_map(&:column_names)
+      dup_revision.assign_attributes(fields.except(*sub_columns))
+    end
+
+    def changes
+      changed_columns
+        .merge(*sub_updaters.values.map(&:changes))
+        .merge(changed_collections)
+    end
+
+  private
+
+    def changed_collections
+      old_key_vals = collection_names.map { |c| [c, revision.public_send(c).to_a] }
+      new_key_vals = collection_names.map { |c| [c, dup_revision.public_send(c).to_a] }
+      Hash[new_key_vals - old_key_vals]
+    end
+
+    def dup_revision
+      @dup_revision ||= revision.dup.tap do |r|
+        r.created_by = user
+        r.number = revision.document.next_revision_number
+        r.image_revisions = revision.image_revisions
+        r.preceded_by = revision
+      end
+    end
+
+    def sub_updaters
+      @sub_updaters ||= {
+        metadata_revision: SubRevisionUpdater.new(revision.metadata_revision, user),
+        content_revision: SubRevisionUpdater.new(revision.content_revision, user),
+        tags_revision: SubRevisionUpdater.new(revision.tags_revision, user),
+      }
+    end
+  end
+end

--- a/app/services/versioning/revision_updater/image.rb
+++ b/app/services/versioning/revision_updater/image.rb
@@ -1,0 +1,43 @@
+# frozen_string_literal: true
+
+module Versioning
+  class RevisionUpdater
+    module Image
+      def update_image(image_revision, selected = false)
+        assign(
+          image_revisions: other_images(image_revision) + [image_revision],
+          lead_image_revision: next_lead_image(image_revision, selected),
+        )
+      end
+
+      def remove_image(image_revision)
+        assign(
+          image_revisions: other_images(image_revision),
+          lead_image_revision: next_lead_image(image_revision),
+        )
+      end
+
+      def selected_lead_image?
+        changes[:lead_image_revision].present?
+      end
+
+      def removed_lead_image?
+        changed?(:lead_image_revision) && changes[:lead_image_revision].nil?
+      end
+
+    private
+
+      def other_images(image_revision)
+        revision.image_revisions.reject { |ir| ir.image_id == image_revision.image_id }
+      end
+
+      def next_lead_image(image_revision, selected = false)
+        currently_lead = revision.lead_image_revision&.image_id == image_revision.image_id
+        return image_revision if selected
+        return if currently_lead
+
+        revision.lead_image_revision
+      end
+    end
+  end
+end

--- a/app/services/versioning/revision_updater/image.rb
+++ b/app/services/versioning/revision_updater/image.rb
@@ -18,7 +18,8 @@ module Versioning
       end
 
       def selected_lead_image?
-        changes[:lead_image_revision].present?
+        changes[:lead_image_revision].present? &&
+          revision.lead_image_revision&.image_id != changes[:lead_image_revision].image_id
       end
 
       def removed_lead_image?

--- a/app/services/versioning/sub_revision_updater.rb
+++ b/app/services/versioning/sub_revision_updater.rb
@@ -1,0 +1,24 @@
+# frozen_string_literal: true
+
+module Versioning
+  class SubRevisionUpdater < BaseUpdater
+    def column_names
+      revision.class.column_names.map(&:to_sym) -
+        %i[id created_by created_at created_by_id]
+    end
+
+    def assign(fields)
+      dup_revision.assign_attributes(fields)
+    end
+
+    def changes
+      changed_columns
+    end
+
+  private
+
+    def dup_revision
+      @dup_revision ||= revision.dup.tap { |r| r.created_by = user }
+    end
+  end
+end

--- a/spec/services/versioning/image_revision_updater_spec.rb
+++ b/spec/services/versioning/image_revision_updater_spec.rb
@@ -1,0 +1,81 @@
+# frozen_string_literal: true
+
+RSpec.describe Versioning::ImageRevisionUpdater do
+  describe "#assign" do
+    let(:user) { create :user }
+
+    let(:revision) do
+      create(
+        :image_revision,
+        alt_text: "old alt text",
+        crop_x: 1,
+      )
+    end
+
+    it "raises an error for unexpected attributes" do
+      updater = Versioning::ImageRevisionUpdater.new(revision, user)
+      expect { updater.assign(foo: "bar") }.to raise_error ActiveModel::UnknownAttributeError
+    end
+
+    it "creates a new revision when a value changes" do
+      updater = Versioning::ImageRevisionUpdater.new(revision, user)
+      updater.assign(alt_text: "new alt text")
+
+      next_revision = updater.next_revision
+      expect(next_revision).to_not eq revision
+      expect(next_revision.created_by).to eq user
+    end
+
+    it "updates and reports changes to the fields" do
+      updater = Versioning::ImageRevisionUpdater.new(revision, user)
+
+      new_fields = {
+        alt_text: "new alt text",
+        crop_x: 2,
+      }
+
+      updater.assign(new_fields)
+      next_revision = updater.next_revision
+
+      expect(updater.changed?).to be_truthy
+      expect(updater.changes).to include(new_fields)
+
+      new_fields.each do |name, value|
+        expect(updater.changed?(name)).to be_truthy
+        expect(next_revision.public_send(name)).to eq value
+      end
+    end
+
+    it "preserves the current revision if no change" do
+      updater = Versioning::ImageRevisionUpdater.new(revision, user)
+
+      old_fields = {
+        alt_text: revision.alt_text,
+        crop_x: revision.crop_x,
+      }
+
+      updater.assign(old_fields)
+      expect(updater.changed?).to be_falsey
+      expect(updater.changes).to be_empty
+      expect(updater.next_revision).to eq revision
+    end
+
+    it "preserves existing values when others change" do
+      updater = Versioning::ImageRevisionUpdater.new(revision, user)
+
+      old_fields = {
+        alt_text: revision.alt_text,
+        crop_x: revision.crop_x,
+      }
+
+      updater.assign(credit: "new credit")
+      next_revision = updater.next_revision
+
+      expect(next_revision).to_not eq revision
+
+      old_fields.each do |name, value|
+        expect(next_revision.public_send(name)).to eq value
+      end
+    end
+  end
+end

--- a/spec/services/versioning/revision_updater/image_spec.rb
+++ b/spec/services/versioning/revision_updater/image_spec.rb
@@ -1,0 +1,119 @@
+# frozen_string_literal: true
+
+RSpec.describe Versioning::RevisionUpdater::Image do
+  let(:user) { create :user }
+  let(:image_revision) { create :image_revision }
+
+  describe "#update_image" do
+    it "extends image revisions with a new image" do
+      revision = create :revision, image_revisions: [image_revision]
+      new_image = create :image_revision
+
+      updater = Versioning::RevisionUpdater.new(revision, user)
+      updater.update_image(new_image)
+
+      next_revision = updater.next_revision
+      expect(next_revision.image_revisions).to match_array [image_revision, new_image]
+    end
+
+    it "updates an existing image with a new revision" do
+      revision = create :revision, image_revisions: [image_revision]
+      updated_image = create :image_revision, image_id: image_revision.image_id
+
+      updater = Versioning::RevisionUpdater.new(revision, user)
+      updater.update_image(updated_image)
+
+      next_revision = updater.next_revision
+      expect(next_revision.image_revisions).to match_array [updated_image]
+    end
+
+    it "preserves another existing image as the lead" do
+      revision = create :revision, lead_image_revision: image_revision
+
+      updater = Versioning::RevisionUpdater.new(revision, user)
+      updater.update_image(create(:image_revision))
+
+      next_revision = updater.next_revision
+      expect(next_revision.lead_image_revision).to eq image_revision
+      expect(updater.selected_lead_image?).to be_falsey
+      expect(updater.removed_lead_image?).to be_falsey
+    end
+
+    it "preserves the given image as the lead if selected" do
+      revision = create :revision, lead_image_revision: image_revision
+      updated_image = create :image_revision, image_id: image_revision.image_id
+
+      updater = Versioning::RevisionUpdater.new(revision, user)
+      updater.update_image(updated_image, true)
+
+      next_revision = updater.next_revision
+      expect(next_revision.lead_image_revision).to eq updated_image
+      expect(updater.selected_lead_image?).to be_falsey
+      expect(updater.removed_lead_image?).to be_falsey
+    end
+
+    it "sets the given image as the lead if selected" do
+      revision = create :revision
+      updated_image = create :image_revision
+
+      updater = Versioning::RevisionUpdater.new(revision, user)
+      updater.update_image(updated_image, true)
+
+      next_revision = updater.next_revision
+      expect(next_revision.lead_image_revision).to eq updated_image
+      expect(updater.selected_lead_image?).to be_truthy
+      expect(updater.removed_lead_image?).to be_falsey
+    end
+
+    it "unsets the given image as the lead if not selected" do
+      revision = create :revision, lead_image_revision: image_revision
+      updated_image = create :image_revision, image_id: image_revision.image_id
+
+      updater = Versioning::RevisionUpdater.new(revision, user)
+      updater.update_image(updated_image)
+
+      next_revision = updater.next_revision
+      expect(next_revision.lead_image_revision).to be_nil
+      expect(updater.selected_lead_image?).to be_falsey
+      expect(updater.removed_lead_image?).to be_truthy
+    end
+  end
+
+  describe "#remove_image" do
+    it "removes the image from the image revisions" do
+      other_image_revision = create :image_revision
+      revision = create :revision, image_revisions: [other_image_revision, image_revision]
+
+      updater = Versioning::RevisionUpdater.new(revision, user)
+      updater.remove_image(image_revision)
+
+      next_revision = updater.next_revision
+      expect(next_revision.image_revisions).to match_array [other_image_revision]
+    end
+
+    it "preserves another existing image as the lead" do
+      other_image_revision = create :image_revision
+      revision = create :revision, lead_image_revision: other_image_revision
+
+      updater = Versioning::RevisionUpdater.new(revision, user)
+      updater.remove_image(image_revision)
+
+      next_revision = updater.next_revision
+      expect(next_revision.lead_image_revision).to eq other_image_revision
+      expect(updater.selected_lead_image?).to be_falsey
+      expect(updater.removed_lead_image?).to be_falsey
+    end
+
+    it "unsets the given image if it was the lead" do
+      revision = create :revision, lead_image_revision: image_revision
+
+      updater = Versioning::RevisionUpdater.new(revision, user)
+      updater.remove_image(image_revision)
+
+      next_revision = updater.next_revision
+      expect(next_revision.lead_image_revision).to be_nil
+      expect(updater.selected_lead_image?).to be_falsey
+      expect(updater.removed_lead_image?).to be_truthy
+    end
+  end
+end

--- a/spec/services/versioning/revision_updater_spec.rb
+++ b/spec/services/versioning/revision_updater_spec.rb
@@ -1,0 +1,96 @@
+# frozen_string_literal: true
+
+RSpec.describe Versioning::RevisionUpdater do
+  describe "#assign" do
+    let(:user) { create :user }
+
+    let(:revision) do
+      create(
+        :revision,
+        number: 1,
+        title: "old title",
+        tags: { old: "tag" },
+        change_note: "old change note",
+        lead_image_revision: (create :image_revision),
+        image_revisions: [create(:image_revision)],
+      )
+    end
+
+    it "raises an error for unexpected attributes" do
+      updater = Versioning::RevisionUpdater.new(revision, user)
+      expect { updater.assign(foo: "bar") }.to raise_error ActiveModel::UnknownAttributeError
+    end
+
+    it "creates a new revision when a value changes" do
+      updater = Versioning::RevisionUpdater.new(revision, user)
+      updater.assign(title: "new title")
+
+      next_revision = updater.next_revision
+      expect(next_revision).to_not eq revision
+      expect(next_revision.created_by).to eq user
+      expect(next_revision.number).to eq 2
+      expect(next_revision.preceded_by).to eq revision
+    end
+
+    it "updates and reports changes to the fields" do
+      updater = Versioning::RevisionUpdater.new(revision, user)
+
+      new_fields = {
+        title: "new title",
+        tags: { "new_tag" => [] },
+        change_note: "new change note",
+        lead_image_revision: nil,
+        image_revisions: [],
+      }
+
+      updater.assign(new_fields)
+      next_revision = updater.next_revision
+
+      expect(updater.changed?).to be_truthy
+      expect(updater.changes).to include(new_fields)
+
+      new_fields.each do |name, value|
+        expect(updater.changed?(name)).to be_truthy
+        expect(next_revision.public_send(name)).to eq value
+      end
+    end
+
+    it "preserves the current revision if no change" do
+      updater = Versioning::RevisionUpdater.new(revision, user)
+
+      old_fields = {
+        title: revision.title,
+        tags: revision.tags,
+        change_note: revision.change_note,
+        lead_image_revision: revision.lead_image_revision,
+        image_revisions: revision.image_revisions,
+      }
+
+      updater.assign(old_fields)
+      expect(updater.changed?).to be_falsey
+      expect(updater.changes).to be_empty
+      expect(updater.next_revision).to eq revision
+    end
+
+    it "preserves existing values when others change" do
+      updater = Versioning::RevisionUpdater.new(revision, user)
+
+      old_fields = {
+        title: revision.title,
+        tags: revision.tags,
+        change_note: revision.change_note,
+        lead_image_revision: revision.lead_image_revision,
+        image_revisions: revision.image_revisions,
+      }
+
+      updater.assign(summary: "new summary")
+      next_revision = updater.next_revision
+
+      expect(next_revision).to_not eq revision
+
+      old_fields.each do |name, value|
+        expect(next_revision.public_send(name)).to eq value
+      end
+    end
+  end
+end


### PR DESCRIPTION
https://trello.com/c/pAjSCymq/746-its-hard-to-follow-how-we-build-a-revision-and-to-see-whats-changed

To some extent I think I've tried to avoid making the ImagesController 
even longer, but this may have made it less readable and some more 
question methods somewhere might be beneficial. I've outlined an 
idea for doing this below, but I worry that it's just disguising a bunch of 
single-use code through a convenient interface...

Previously we used a tree of 'build_revision_update' methods on each
model, which has lead to some duplication between models and quite a lot
of extra code in the model classes. This makes a start at extracting
this logic into a set of 'updater' classes with some helper methods.

The updaters take a hash of 'fields', which can include columns,
collections and sub-fields for sub-revisions. I've used inheritance to
DRY-up some of this logic, as well as create a clear interface for the
updater classes that derive from it.

Some of the existing code doesn't fit very well into the updater
classes, as it's specific to a single use-case and doesn't make sense to
share centrally. This does mean the ImagesController now has a bit more
code in it than before. A nice compromise that would avoid bloating the
existing controller and the new RevisionUpdater, would be to use an
'include' pattern to add more image-specific methods to RevisionUpdater.