### PR TITLE
Lint JavaScript test files

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,13 +5,14 @@
   "author": "Government Digital Service",
   "license": "MIT",
   "scripts": {
-    "lint": "standard app/assets/javascripts/{*,**/*}",
-    "lint:fix": "standard --fix app/javascripts/{*,**/*}"
+    "lint": "standard app/assets/javascripts/{*.js,**/*.js} spec/javascripts/{*.js,**/*.js}",
+    "lint:fix": "standard --fix app/javascripts/{*.js,**/*.js} spec/javascripts/{*.js,**/*.js}"
   },
   "standard": {
     "ignore": [
       "/app/assets/javascripts/components/markdown-toolbar.js",
-      "/app/assets/javascripts/vendor/"
+      "/app/assets/javascripts/vendor/",
+      "/spec/javascripts/helpers/jasmine-jquery.js"
     ]
   },
   "devDependencies": {

--- a/spec/javascripts/components/input-length-suggester-spec.js
+++ b/spec/javascripts/components/input-length-suggester-spec.js
@@ -1,5 +1,5 @@
-/* global describe beforeEach afterEach it expect */
-/* global InputLengthSuggester Event */
+/* eslint-env jasmine, jquery */
+/* global GOVUK */
 
 describe('Input length suggester component', function () {
   'use strict'
@@ -36,7 +36,7 @@ describe('Input length suggester component', function () {
   it('is visible when the input grows too long', function () {
     var input = document.querySelector('#document_title')
     input.value = 'a'.repeat(55)
-    input.dispatchEvent(new Event('change'))
+    input.dispatchEvent(new window.Event('change'))
 
     var suggester = document.querySelector('[data-module="input-length-suggester"]')
     expect(suggester).not.toHaveClass('app-c-input-length-suggester__hidden')
@@ -45,20 +45,20 @@ describe('Input length suggester component', function () {
   it('is hidden when the input gets smaller again', function () {
     var input = document.querySelector('#document_title')
     input.value = 'a'.repeat(55)
-    input.dispatchEvent(new Event('keyup'))
+    input.dispatchEvent(new window.Event('keyup'))
 
     var suggester = document.querySelector('[data-module="input-length-suggester"]')
     expect(suggester).not.toHaveClass('app-c-input-length-suggester__hidden')
 
     input.value = 'a'.repeat(54)
-    input.dispatchEvent(new Event('keydown'))
+    input.dispatchEvent(new window.Event('keydown'))
     expect(suggester).toHaveClass('app-c-input-length-suggester__hidden')
   })
 
   it('shows a message when the input grows too long', function () {
     var input = document.querySelector('#document_title')
     input.value = 'a'.repeat(55)
-    input.dispatchEvent(new Event('change'))
+    input.dispatchEvent(new window.Event('change'))
 
     var suggester = document.querySelector('[data-module="input-length-suggester"]')
     expect(suggester.innerHTML).toEqual('Title should be under 65 characters. Current length: 55')

--- a/spec/javascripts/components/markdown-editor-spec.js
+++ b/spec/javascripts/components/markdown-editor-spec.js
@@ -1,5 +1,5 @@
-/* global describe beforeEach afterEach it expect */
-/* global MarkdownEditor */
+/* eslint-env jasmine, jquery */
+/* global GOVUK spyOnEvent */
 
 describe('Markdown editor component', function () {
   'use strict'
@@ -162,7 +162,7 @@ describe('Markdown editor component', function () {
 
   describe('when focusing the textarea', function () {
     it('should add focused class to container', function () {
-      document.querySelector('.js-markdown-editor-input textarea').dispatchEvent(new Event("focus"))
+      document.querySelector('.js-markdown-editor-input textarea').dispatchEvent(new window.Event('focus'))
 
       var container = document.querySelector('.app-c-markdown-editor__container')
       expect(container).toHaveClass('app-c-markdown-editor__container--focused')
@@ -172,11 +172,10 @@ describe('Markdown editor component', function () {
       var container = document.querySelector('.app-c-markdown-editor')
       spyOnEvent(container, 'focus')
 
-      document.querySelector('.js-markdown-editor-input textarea').dispatchEvent(new Event("focus"))
+      document.querySelector('.js-markdown-editor-input textarea').dispatchEvent(new window.Event('focus'))
 
       expect('focus').toHaveBeenTriggeredOn(container)
     })
-
   })
 
   describe('when blurring the textarea', function () {
@@ -184,7 +183,7 @@ describe('Markdown editor component', function () {
       var container = document.querySelector('.app-c-markdown-editor__container')
       container.classList.add('app-c-markdown-editor__container--focused')
 
-      document.querySelector('.js-markdown-editor-input textarea').dispatchEvent(new Event("blur"))
+      document.querySelector('.js-markdown-editor-input textarea').dispatchEvent(new window.Event('blur'))
       expect(container).not.toHaveClass('app-c-markdown-editor__container--focused')
     })
   })

--- a/spec/javascripts/components/modal-dialogue-spec.js
+++ b/spec/javascripts/components/modal-dialogue-spec.js
@@ -1,5 +1,5 @@
-/* global describe beforeEach afterEach it expect */
-/* global ModalDialogue */
+/* eslint-env jasmine, jquery */
+/* global GOVUK */
 
 function keyPress (element, key) {
   var event = document.createEvent('Event')
@@ -72,7 +72,7 @@ describe('Modal dialogue component', function () {
 
   describe('close button', function () {
     it('should hide the modal dialogue', function () {
-      document.querySelector('.govuk-button').dispatchEvent(new Event('focus'))
+      document.querySelector('.govuk-button').dispatchEvent(new window.Event('focus'))
       document.querySelector('.govuk-button').click()
       document.querySelector('.app-c-modal-dialogue__close-button').click()
 

--- a/spec/javascripts/components/multi-section-viewer-spec.js
+++ b/spec/javascripts/components/multi-section-viewer-spec.js
@@ -1,3 +1,6 @@
+/* eslint-env jasmine, jquery */
+/* global GOVUK */
+
 describe('Multi section viewer', function () {
   'use strict'
 

--- a/spec/javascripts/components/url-preview-spec.js
+++ b/spec/javascripts/components/url-preview-spec.js
@@ -1,5 +1,5 @@
-/* global describe beforeEach afterEach it expect */
-/* global UrlPreview Event */
+/* eslint-env jasmine, jquery */
+/* global GOVUK */
 
 describe('URL preview component', function () {
   'use strict'
@@ -36,7 +36,7 @@ describe('URL preview component', function () {
   it('should only display the default message if input is empty', function () {
     // Interact with input and leave empty
     var input = document.querySelector('[data-url-preview="input"]')
-    input.dispatchEvent(new Event('blur'))
+    input.dispatchEvent(new window.Event('blur'))
 
     var defaultMessage = document.querySelector('.js-url-preview-default-message')
     expect(defaultMessage).toBeVisible()
@@ -52,7 +52,7 @@ describe('URL preview component', function () {
     // Interact with input and set value
     var input = document.querySelector('[data-url-preview="input"]')
     input.value = 'My title'
-    input.dispatchEvent(new Event('blur'))
+    input.dispatchEvent(new window.Event('blur'))
 
     var defaultMessage = document.querySelector('.js-url-preview-default-message')
     expect(defaultMessage).toBeHidden()

--- a/spec/javascripts/modules/gtm-copy-paste-listener-spec.js
+++ b/spec/javascripts/modules/gtm-copy-paste-listener-spec.js
@@ -1,5 +1,4 @@
-/* global describe beforeEach afterEach it expect */
-/* global GtmCopyListener */
+/* eslint-env jasmine */
 
 describe('Gtm copy paste listener', function () {
   'use strict'

--- a/spec/javascripts/modules/gtm-form-listener-spec.js
+++ b/spec/javascripts/modules/gtm-form-listener-spec.js
@@ -1,5 +1,4 @@
-/* global describe beforeEach afterEach it expect */
-/* global GTMFormListener */
+/* eslint-env jasmine */
 
 describe('GTM form listener', function () {
   'use strict'


### PR DESCRIPTION
These weren't being linted previously. I reduced the linting scope to be .js files as it was catching yaml files for the test configuration.