### PR TITLE
Add Scheduled Publishing worker

### DIFF
--- a/app/workers/scheduled_publishing_worker.rb
+++ b/app/workers/scheduled_publishing_worker.rb
@@ -14,6 +14,11 @@ class ScheduledPublishingWorker
         return
       end
 
+      unless edition.scheduled?
+        logger.warn("Cannot schedule an edition that is not in a scheduled state")
+        return
+      end
+
       user = edition.status.created_by
       reviewed = edition.status.details.reviewed
 

--- a/app/workers/scheduled_publishing_worker.rb
+++ b/app/workers/scheduled_publishing_worker.rb
@@ -1,0 +1,16 @@
+# frozen_string_literal: true
+
+class ScheduledPublishingWorker
+  include Sidekiq::Worker
+
+  def perform(id)
+    Edition.transaction do
+      edition = Edition.lock.find_by(id: id, current: true)
+      user = edition.status.created_by
+      reviewed = edition.status.details.reviewed
+
+      PublishService.new(edition.document)
+                    .publish(user: user, with_review: reviewed)
+    end
+  end
+end

--- a/app/workers/scheduled_publishing_worker.rb
+++ b/app/workers/scheduled_publishing_worker.rb
@@ -19,11 +19,22 @@ class ScheduledPublishingWorker
         return
       end
 
+      if scheduled_publishing_datetime_in_the_future?(edition)
+        logger.warn("Cannot schedule an edition whose scheduled publishing datetime is in the future")
+        return
+      end
+
       user = edition.status.created_by
       reviewed = edition.status.details.reviewed
 
       PublishService.new(edition.document)
                     .publish(user: user, with_review: reviewed)
     end
+  end
+
+private
+
+  def scheduled_publishing_datetime_in_the_future?(edition)
+    edition.scheduled_publishing_datetime >= Time.current
   end
 end

--- a/app/workers/scheduled_publishing_worker.rb
+++ b/app/workers/scheduled_publishing_worker.rb
@@ -2,6 +2,9 @@
 
 class ScheduledPublishingWorker
   include Sidekiq::Worker
+  # We want to retry for up to 5 minutes. 10 retries x 30s intervals = 5 minutes.
+  sidekiq_options retry: 10
+  sidekiq_retry_in { 30 }
 
   def perform(id)
     Edition.transaction do

--- a/app/workers/scheduled_publishing_worker.rb
+++ b/app/workers/scheduled_publishing_worker.rb
@@ -9,6 +9,11 @@ class ScheduledPublishingWorker
   def perform(id)
     Edition.transaction do
       edition = Edition.lock.find_by(id: id, current: true)
+      if edition.nil?
+        logger.warn("Could not find edition id #{id} for scheduled publishing")
+        return
+      end
+
       user = edition.status.created_by
       reviewed = edition.status.details.reviewed
 

--- a/spec/factories/edition_factory.rb
+++ b/spec/factories/edition_factory.rb
@@ -110,5 +110,24 @@ FactoryBot.define do
         )
       end
     end
+
+    trait :scheduled do
+      summary { SecureRandom.alphanumeric(10) }
+
+      transient do
+        scheduling { nil }
+      end
+
+      after(:build) do |edition, evaluator|
+        edition.status = evaluator.association(
+          :status,
+          :scheduled,
+          created_by: edition.created_by,
+          state: :scheduled,
+          revision_at_creation: edition.revision,
+          scheduling: evaluator.scheduling,
+        )
+      end
+    end
   end
 end

--- a/spec/factories/scheduling_factory.rb
+++ b/spec/factories/scheduling_factory.rb
@@ -1,0 +1,8 @@
+# frozen_string_literal: true
+
+FactoryBot.define do
+  factory :scheduling do
+    reviewed { false }
+    association :pre_scheduled_status, factory: :status
+  end
+end

--- a/spec/factories/status_factory.rb
+++ b/spec/factories/status_factory.rb
@@ -21,5 +21,17 @@ FactoryBot.define do
     trait :published do
       state { :published }
     end
+
+    trait :scheduled do
+      state { :scheduled }
+
+      transient do
+        scheduling { nil }
+      end
+
+      after(:build) do |status, evaluator|
+        status.details = evaluator.scheduling || evaluator.association(:scheduling)
+      end
+    end
   end
 end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -27,6 +27,8 @@ Capybara::Chromedriver::Logger.filters = [
   /the server responded with a status of 422/i,
 ]
 
+Sidekiq::Logging.logger = nil
+
 RSpec.configure do |config|
   config.expose_dsl_globally = false
   config.infer_spec_type_from_file_location!

--- a/spec/workers/scheduled_publishing_worker_spec.rb
+++ b/spec/workers/scheduled_publishing_worker_spec.rb
@@ -19,5 +19,12 @@ RSpec.describe ScheduledPublishingWorker, type: :worker do
       expect_any_instance_of(PublishService).not_to receive(:publish)
       ScheduledPublishingWorker.new.perform(100)
     end
+
+    it "aborts the worker and does not call Publish Service if the edition is not scheduled" do
+      edition = create(:edition)
+      expect_any_instance_of(PublishService).not_to receive(:publish)
+
+      ScheduledPublishingWorker.new.perform(edition.id)
+    end
   end
 end

--- a/spec/workers/scheduled_publishing_worker_spec.rb
+++ b/spec/workers/scheduled_publishing_worker_spec.rb
@@ -14,5 +14,10 @@ RSpec.describe ScheduledPublishingWorker, type: :worker do
 
       ScheduledPublishingWorker.new.perform(edition.id)
     end
+
+    it "aborts the worker and does not call Publish Service if edition id cannot be found" do
+      expect_any_instance_of(PublishService).not_to receive(:publish)
+      ScheduledPublishingWorker.new.perform(100)
+    end
   end
 end

--- a/spec/workers/scheduled_publishing_worker_spec.rb
+++ b/spec/workers/scheduled_publishing_worker_spec.rb
@@ -26,5 +26,14 @@ RSpec.describe ScheduledPublishingWorker, type: :worker do
 
       ScheduledPublishingWorker.new.perform(edition.id)
     end
+
+    it "aborts the worker and does not call Publish Service if the edition's scheduled publishing datetime is in the future" do
+      edition = create(:edition,
+                       :scheduled,
+                       scheduled_publishing_datetime: Time.current.tomorrow)
+      expect_any_instance_of(PublishService).not_to receive(:publish)
+
+      ScheduledPublishingWorker.new.perform(edition.id)
+    end
   end
 end

--- a/spec/workers/scheduled_publishing_worker_spec.rb
+++ b/spec/workers/scheduled_publishing_worker_spec.rb
@@ -1,0 +1,18 @@
+# frozen_string_literal: true
+
+RSpec.describe ScheduledPublishingWorker, type: :worker do
+  describe "#perform" do
+    it "calls PublishService if edition can be published" do
+      edition = create(:edition,
+                       :scheduled,
+                       scheduled_publishing_datetime: Time.current)
+      user = edition.status.created_by
+
+      expect_any_instance_of(PublishService)
+        .to receive(:publish)
+        .with(user: user, with_review: edition.status.details.reviewed)
+
+      ScheduledPublishingWorker.new.perform(edition.id)
+    end
+  end
+end


### PR DESCRIPTION
For https://trello.com/c/rXTLvzSu/685-scheduling-is-sent-to-the-publishing-api

This PR creates a Scheduled Publishing worker using Sidekiq.