### PR TITLE
Image copy changes

### DIFF
--- a/app/views/images/crop.html.erb
+++ b/app/views/images/crop.html.erb
@@ -1,4 +1,7 @@
-<% content_for :title, t("images.crop.title", title: @document.current_edition.title_or_fallback) %>
+<%
+title_key = rendering_context == "modal" ? "images.crop.title_modal" : "images.crop.title"
+content_for :title,t(title_key, title: @document.current_edition.title_or_fallback)
+%>
 
 <% content_for :back_link, render_back_link(
   href: images_path(@document),

--- a/app/views/images/edit.html.erb
+++ b/app/views/images/edit.html.erb
@@ -1,4 +1,7 @@
-<% content_for :title, t("images.edit.title", title: @document.current_edition.title_or_fallback) %>
+<%
+title_key = rendering_context == "modal" ? "images.edit.title_modal" : "images.edit.title"
+content_for :title,t(title_key, title: @document.current_edition.title_or_fallback)
+%>
 
 <% content_for :back_link, render_back_link(
   href: crop_image_path(@document, @image_revision.image_id, wizard: params[:wizard]),

--- a/app/views/images/index.html.erb
+++ b/app/views/images/index.html.erb
@@ -1,4 +1,7 @@
-<% content_for :title, t("images.index.title", title: @document.current_edition.title_or_fallback) %>
+<%
+title_key = rendering_context == "modal" ? "images.index.title_modal" : "images.index.title"
+content_for :title,t(title_key, title: @document.current_edition.title_or_fallback)
+%>
 
 <% unless rendering_context == "modal" %>
   <% content_for :back_link, render_back_link(href: document_path(@document)) %>

--- a/config/locales/en/images/crop.yml
+++ b/config/locales/en/images/crop.yml
@@ -2,3 +2,4 @@ en:
   images:
     crop:
       title: "Crop image for ‘%{title}’"
+      title_modal: "Crop image"

--- a/config/locales/en/images/edit.yml
+++ b/config/locales/en/images/edit.yml
@@ -1,7 +1,7 @@
 en:
   images:
     edit:
-      title: "Edit image for ‘%{title}’"
+      title: "Image details for ‘%{title}’"
       title_modal: "Image details"
       form_labels:
         alt_text: Alt text

--- a/config/locales/en/images/edit.yml
+++ b/config/locales/en/images/edit.yml
@@ -2,6 +2,7 @@ en:
   images:
     edit:
       title: "Edit image for ‘%{title}’"
+      title_modal: "Image details"
       form_labels:
         alt_text: Alt text
         caption: Image caption

--- a/config/locales/en/images/index.yml
+++ b/config/locales/en/images/index.yml
@@ -2,6 +2,7 @@ en:
   images:
     index:
       title: "Images for ‘%{title}’"
+      title_modal: "Insert image"
       description_govspeak: Images can be jpg, png or gif files. Full [guidance on images](https://www.gov.uk/guidance/how-to-publish-on-gov-uk/images-and-videos){:target="_blank"}.
       upload_image: Upload an image
       lead_image: Lead image


### PR DESCRIPTION
Trello: https://trello.com/c/MkWywL4g/590-support-inline-images

This is DNM as it is pending chats between @benhazell and @soniaturcotte.

This implements some of the changes @benhazell raised in the linked trello card for copy changes - the other changes suggested looked to require further discussion. Though to do these consistently I had to refer back to designs for some copy where there were gaps in Ben's suggestions.

Things that have changed:

Before:

![screen shot 2019-03-07 at 12 48 47](https://user-images.githubusercontent.com/282717/53958429-f0e27f80-40d8-11e9-968c-16ffa00e6129.png)

After:

![screen shot 2019-03-07 at 12 49 44](https://user-images.githubusercontent.com/282717/53958468-08ba0380-40d9-11e9-8172-60e4eadf93e5.png)

Before: 

![screen shot 2019-03-07 at 12 49 16](https://user-images.githubusercontent.com/282717/53958445-f8098d80-40d8-11e9-9fda-8fc60fc6b112.png)

After:

![screen shot 2019-03-07 at 12 51 02](https://user-images.githubusercontent.com/282717/53958539-356e1b00-40d9-11e9-9b07-121ad96e69d3.png)

Before:

![screen shot 2019-03-07 at 12 49 24](https://user-images.githubusercontent.com/282717/53958453-0061c880-40d9-11e9-9eef-4e0e399ef27c.png)

After:

![screen shot 2019-03-07 at 12 51 08](https://user-images.githubusercontent.com/282717/53958538-34d58480-40d9-11e9-97d5-b596a0199285.png)

Before:

![screen shot 2019-03-07 at 12 52 35](https://user-images.githubusercontent.com/282717/53958536-34d58480-40d9-11e9-8a74-cbb11fc806f2.png)

After:

![screen shot 2019-03-07 at 12 52 01](https://user-images.githubusercontent.com/282717/53958537-34d58480-40d9-11e9-86af-13df0ca45e78.png)