### PR TITLE
Update the vendored version of markdown-toolbar-element

### DIFF
--- a/app/assets/javascripts/components/markdown-editor.js
+++ b/app/assets/javascripts/components/markdown-editor.js
@@ -1,4 +1,4 @@
-//= require vendor/@alphagov/markdown-toolbar-element/index.js
+//= require vendor/@alphagov/markdown-toolbar-element/dist/index.umd.js
 window.GOVUK = window.GOVUK || {}
 window.GOVUK.Modules = window.GOVUK.Modules || {};
 

--- a/app/assets/javascripts/vendor/@alphagov/markdown-toolbar-element/dist/index.umd.js
+++ b/app/assets/javascripts/vendor/@alphagov/markdown-toolbar-element/dist/index.umd.js
@@ -858,5 +858,7 @@
   }
 
   MarkdownToolbarElement.insertText = insertText;
+  MarkdownToolbarElement.newlinesToSurroundSelectedText = newlinesToSurroundSelectedText;
+
   exports.default = MarkdownToolbarElement;
 });


### PR DESCRIPTION
This uses the file from
https://github.com/alphagov/markdown-toolbar-element/blob/75b162c93120254fb7a081940ff4afa1e49342e8/dist/index.umd.js

I updated the path to match the vendor style used for
accessible-autocomplete since these were two distinct approaches and I
settled on one.