### PR TITLE
Support a surroundWithNewLines option when inserting text

### DIFF
--- a/app/assets/javascripts/components/markdown-editor.js
+++ b/app/assets/javascripts/components/markdown-editor.js
@@ -33,9 +33,22 @@ window.GOVUK.Modules = window.GOVUK.Modules || {};
     this.bubbleFocusEventToComponent(this.$previewButton)
   }
 
-  MarkdownEditor.prototype.handleSelectionReplace = function (text) {
+  MarkdownEditor.prototype.handleSelectionReplace = function (text, options) {
+    options = Object.assign({
+      surroundWithNewLines: false
+    }, options)
+
     var selectionStart = this.$input.selectionStart + text.length
     this.$input.focus()
+
+    if (options.surroundWithNewLines) {
+      var newlines = window.MarkdownToolbarElement.newlinesToSurroundSelectedText(this.$input)
+      // despite what logic might tell you, this is supposed to be append as a
+      // prefix and prepend as a suffix. Perhaps the github logic was that you
+      // append new lines to the text before selection and prepend it to text
+      // after selection.
+      text = newlines.newlinesToAppend + text + newlines.newlinesToPrepend
+    }
 
     window.MarkdownToolbarElement.insertText(
       this.$input,

--- a/app/assets/javascripts/modules/inline-image-modal.js
+++ b/app/assets/javascripts/modules/inline-image-modal.js
@@ -38,7 +38,7 @@ InlineImageModal.prototype.renderSuccess = function (result) {
 
 InlineImageModal.prototype.insertSnippet = function (item) {
   var editor = this.$module.closest('[data-module="markdown-editor"]')
-  editor.selectionReplace(item.dataset.modalData)
+  editor.selectionReplace(item.dataset.modalData, { surroundWithNewLines: true })
 }
 
 InlineImageModal.prototype.performAction = function (item) {


### PR DESCRIPTION
This resurrects https://github.com/alphagov/content-publisher/pull/838
since we've now had this issue caught by other people and it's about to
become invalid markdown to have image within a paragraph from govspeak
5.9.1 (https://github.com/alphagov/govspeak/pull/142).

/cc @benthorner 