### PR TITLE
Fix IE11 image insert issues / return 422 on forms with issues

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -34,7 +34,9 @@ end
 
 group :development, :test do
   gem "byebug", "~> 11"
-  gem "capybara-chromedriver-logger"
+  # Using this fork until https://github.com/dbalatero/capybara-chromedriver-logger/issues/6
+  # is resolved and released
+  gem "capybara-chromedriver-logger", git: "https://github.com/ThriveTRM/capybara-chromedriver-logger", ref: "77b9c9a"
   gem "climate_control"
   gem "factory_bot_rails", "~> 5"
   gem "govuk-lint", "~> 3"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,3 +1,12 @@
+GIT
+  remote: https://github.com/ThriveTRM/capybara-chromedriver-logger
+  revision: 77b9c9a11d8ed18719fb2288dd74952bb87b4c44
+  ref: 77b9c9a
+  specs:
+    capybara-chromedriver-logger (0.3.0)
+      capybara
+      colorize
+
 GEM
   remote: https://rubygems.org/
   specs:
@@ -78,9 +87,6 @@ GEM
       rack-test (>= 0.6.3)
       regexp_parser (~> 1.2)
       xpath (~> 3.2)
-    capybara-chromedriver-logger (0.2.1)
-      capybara
-      colorize
     childprocess (0.9.0)
       ffi (~> 1.0, >= 1.0.11)
     chromedriver-helper (2.1.0)
@@ -444,7 +450,7 @@ DEPENDENCIES
   bootsnap (~> 1)
   brakeman (~> 4)
   byebug (~> 11)
-  capybara-chromedriver-logger
+  capybara-chromedriver-logger!
   climate_control
   factory_bot_rails (~> 5)
   foreman (~> 0.85)

--- a/app/assets/javascripts/modal/modal-fetch.js
+++ b/app/assets/javascripts/modal/modal-fetch.js
@@ -36,14 +36,14 @@ window.ModalFetch.postForm = function (form) {
 
   return window.fetch(form.action, options)
     .then(function (response) {
-      if (!response.ok) {
+      if (!response.ok && response.status !== 422) {
         window.ModalFetch.debug(response)
         return window.Promise.reject('Unable to fetch modal content')
       }
 
       return response.text()
         .then(function (text) {
-          return { body: text, done: response.redirected }
+          return { body: text, unprocessableEntity: response.status === 422 }
         })
     })
 }

--- a/app/assets/javascripts/modules/inline-image-modal.js
+++ b/app/assets/javascripts/modules/inline-image-modal.js
@@ -75,11 +75,11 @@ InlineImageModal.prototype.performAction = function (item) {
     'metaInsert': function () {
       window.ModalFetch.postForm(item)
         .then(function (result) {
-          if (result.done) {
+          if (result.unprocessableEntity) {
+            this.renderSuccess(result)
+          } else {
             this.$modal.close()
             this.insertSnippet(item)
-          } else {
-            this.renderSuccess(result)
           }
         }.bind(this))
         .catch(this.renderError.bind(this))

--- a/app/controllers/documents_controller.rb
+++ b/app/controllers/documents_controller.rb
@@ -61,7 +61,7 @@ class DocumentsController < ApplicationController
           "items" => @issues.items,
         }
 
-        render :edit
+        render :edit, status: :unprocessable_entity
         return
       end
 

--- a/app/controllers/images_controller.rb
+++ b/app/controllers/images_controller.rb
@@ -23,7 +23,7 @@ class ImagesController < ApplicationController
           "items" => @issues.items,
         }
 
-        render :index, layout: rendering_context
+        render :index, layout: rendering_context, status: :unprocessable_entity
         return
       end
 
@@ -116,7 +116,7 @@ class ImagesController < ApplicationController
           "items" => @issues.items,
         }
 
-        render :edit, layout: rendering_context
+        render :edit, layout: rendering_context, status: :unprocessable_entity
         return
       end
 

--- a/app/controllers/withdraw_controller.rb
+++ b/app/controllers/withdraw_controller.rb
@@ -33,7 +33,7 @@ class WithdrawController < ApplicationController
           "items" => issues.items,
         }
 
-        render :new
+        render :new, status: :unprocessable_entity
         return
       end
 

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -24,7 +24,7 @@ Rails.application.load_tasks
 Capybara.server = :puma, { Silent: true }
 Capybara::Chromedriver::Logger.raise_js_errors = true
 Capybara::Chromedriver::Logger.filters = [
-  /the server responded with a status of 409/i,
+  /the server responded with a status of 422/i,
 ]
 
 RSpec.configure do |config|


### PR DESCRIPTION
We have an issue in IE11 (and any other browsers that need a fetch polyfill) where uploading and inserting an image does not work because we rely on a property (response.redirected) which is not supported by the fetch polyfill.

We also have a minor issue where we return a status code to users of a 200 when they need to fix issues they posted on a form. It's more semantic to the HTTP spec to return a [status of 422](https://httpstatusdogs.com/422-unprocessable-entity).

I've combined these two things to work around the problem. I've removed the flag we have in our JS of `done` for when we've redirected, and instead added a flag of `unprocessableEntity` for when there are issues. This can then be switched around in the conditionals.

Annoyingly I hit a problem with Capybara-Chromedriver-logger gem, and so have had to switch to a fork.