### PR TITLE
 Create abort middleware for Sidekiq

### DIFF
--- a/config/initializers/sidekiq.rb
+++ b/config/initializers/sidekiq.rb
@@ -1,0 +1,9 @@
+# frozen_string_literal: true
+
+require "sidekiq_abort_middleware"
+
+Sidekiq.configure_server do |config|
+  config.server_middleware do |chain|
+    chain.add SidekiqAbortMiddleware
+  end
+end

--- a/lib/sidekiq_abort_middleware.rb
+++ b/lib/sidekiq_abort_middleware.rb
@@ -1,0 +1,11 @@
+# frozen_string_literal: true
+
+class AbortWorkerError < RuntimeError; end
+
+class SidekiqAbortMiddleware
+  def call(_worker, _job, _queue)
+    yield
+  rescue AbortWorkerError => e
+    Sidekiq.logger.warn(e.message)
+  end
+end

--- a/spec/lib/sidekiq_abort_middleware_spec.rb
+++ b/spec/lib/sidekiq_abort_middleware_spec.rb
@@ -1,0 +1,24 @@
+# frozen_string_literal: true
+
+require "sidekiq_abort_middleware"
+
+RSpec.describe SidekiqAbortMiddleware do
+  context "when a job raises an AbortWorkerError" do
+    it "catches the exception and sidekiq logs a warning of the exception message" do
+      block = -> { raise AbortWorkerError, "worker was aborted" }
+
+      expect(Sidekiq.logger).to receive(:warn).with("worker was aborted")
+
+      expect { SidekiqAbortMiddleware.new.call(nil, nil, nil, &block) }
+        .not_to raise_error
+    end
+  end
+
+  context "when a job doesn't raise an AbortWorkerError" do
+    it "runs the block" do
+      ran = false
+      SidekiqAbortMiddleware.new.call(nil, nil, nil) { ran = true }
+      expect(ran).to be(true)
+    end
+  end
+end

--- a/spec/workers/scheduled_publishing_worker_spec.rb
+++ b/spec/workers/scheduled_publishing_worker_spec.rb
@@ -17,14 +17,16 @@ RSpec.describe ScheduledPublishingWorker, type: :worker do
 
     it "aborts the worker and does not call Publish Service if edition id cannot be found" do
       expect_any_instance_of(PublishService).not_to receive(:publish)
-      ScheduledPublishingWorker.new.perform(100)
+      expect { ScheduledPublishingWorker.new.perform(100) }
+        .to raise_error(AbortWorkerError)
     end
 
     it "aborts the worker and does not call Publish Service if the edition is not scheduled" do
       edition = create(:edition)
       expect_any_instance_of(PublishService).not_to receive(:publish)
 
-      ScheduledPublishingWorker.new.perform(edition.id)
+      expect { ScheduledPublishingWorker.new.perform(edition.id) }
+        .to raise_error(AbortWorkerError)
     end
 
     it "aborts the worker and does not call Publish Service if the edition's scheduled publishing datetime is in the future" do
@@ -33,7 +35,8 @@ RSpec.describe ScheduledPublishingWorker, type: :worker do
                        scheduled_publishing_datetime: Time.current.tomorrow)
       expect_any_instance_of(PublishService).not_to receive(:publish)
 
-      ScheduledPublishingWorker.new.perform(edition.id)
+      expect { ScheduledPublishingWorker.new.perform(edition.id) }
+        .to raise_error(AbortWorkerError)
     end
   end
 end


### PR DESCRIPTION
Trello: https://trello.com/c/rXTLvzSu/685-scheduling-is-sent-to-the-publishing-api

Paired with @emmabeynon on this

This sets up a middleware for sidekiq to provide the means to abort from
a worker and have this not cause any automatic retries.

The reasons for adding this are:

- To allow means to explicitly abort a worker from any point in a
worker, as opposed to only a return call in the perform method;
- To be able to provide direct feedback on worker aborting in test and
console scenarios.

Adding this is pretty simple but does mean some annoying decisions about
where to place code. The middleware itself seemed to belong in a lib
directory I went for /lib rather than creating /app/lib since that does
not exist in this app.

The exception also needs a place to live too, I decided against following the
[errors dir][1] as used in Publishing API and felt that putting it with
the middleware was the most logical place. It felt a bit wrong that it
wasn't under a module namespace, but that felt like it'd add unnecessary
verbosity to the code.

[1]: https://github.com/alphagov/publishing-api/tree/979479f908a06fe592cd6818c42e2cd6ca064eef/app/errors