### PR TITLE
Stop scheduling feature

### DIFF
--- a/app/controllers/unschedule_controller.rb
+++ b/app/controllers/unschedule_controller.rb
@@ -1,0 +1,35 @@
+# frozen_string_literal: true
+
+class UnscheduleController < ApplicationController
+  def unschedule
+    Document.transaction do
+      document = Document.with_current_edition.lock!.find_by_param(params[:id])
+      edition = document.current_edition
+      schedule = edition.status.details
+
+      remove_scheduled_publishing_datetime(edition)
+
+      state = schedule.reviewed? ? "submitted_for_review" : "draft"
+      edition.assign_status(state, current_user)
+      edition.save!
+
+      TimelineEntry.create_for_status_change(
+        entry_type: :unscheduled,
+        status: edition.status,
+      )
+
+      redirect_to document_path(document)
+    end
+  end
+
+private
+
+  def remove_scheduled_publishing_datetime(edition)
+    current_revision = edition.revision
+    new_revision = current_revision.build_revision_update(
+      { scheduled_publishing_datetime: nil }, current_user
+    )
+
+    edition.assign_revision(new_revision, current_user).save!
+  end
+end

--- a/app/models/timeline_entry.rb
+++ b/app/models/timeline_entry.rb
@@ -44,6 +44,7 @@ class TimelineEntry < ApplicationRecord
                      draft_discarded: "draft_discarded",
                      draft_reset: "draft_reset",
                      scheduled: "scheduled",
+                     unscheduled: "unscheduled",
                      scheduled_publishing_datetime_set: "scheduled_publishing_datetime_set",
                      scheduled_publishing_datetime_cleared: "scheduled_publishing_datetime_cleared" }
 

--- a/app/views/documents/show/_actions.html.erb
+++ b/app/views/documents/show/_actions.html.erb
@@ -57,6 +57,10 @@
       <%= form_tag create_preview_path(@edition.document) do %>
         <%= render "govuk_publishing_components/components/button", text: "Preview" %>
       <% end %>
+      <%= form_tag unschedule_path(@edition.document) do %>
+        <%= render "govuk_publishing_components/components/button", text: "Stop scheduled publishing", secondary: true
+      %>
+      <% end %>
       <%= delete_draft_link %>
     <% else %>
       <%= form_tag submit_document_for_2i_path(@edition.document) do %>

--- a/config/locales/en/documents/history.yml
+++ b/config/locales/en/documents/history.yml
@@ -25,5 +25,6 @@ en:
         draft_reset: "Draft reset to last published edition"
         unwithdrawn: "Unwithdrawn"
         scheduled: "Scheduled to publish"
+        unscheduled: "Unscheduled"
         scheduled_publishing_datetime_set: "Scheduled publishing date and time set"
         scheduled_publishing_datetime_cleared: "Scheduled publishing date and time cleared"

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -19,6 +19,8 @@ Rails.application.routes.draw do
   post "/documents/:id/schedule" => "schedule#schedule"
   get "/documents/:id/scheduled" => "schedule#scheduled", as: :scheduled
 
+  post "/documents/:id/unschedule" => "unschedule#unschedule", as: :unschedule
+
   get "/documents" => "documents#index"
   get "/documents/:id/edit" => "documents#edit", as: :edit_document
   patch "/documents/:id" => "documents#update", as: :document

--- a/spec/features/workflow/unschedule_spec.rb
+++ b/spec/features/workflow/unschedule_spec.rb
@@ -1,0 +1,31 @@
+# frozen_string_literal: true
+
+RSpec.feature "Unschedule an edition" do
+  scenario do
+    given_there_is_a_scheduled_document
+    when_i_visit_the_summary_page
+    and_i_click_stop_scheduled_publishing
+    then_the_document_is_no_longer_scheduled
+  end
+
+  def given_there_is_a_scheduled_document
+    schedule = create(:scheduling, reviewed: true)
+    @edition = create(:edition, :scheduled, scheduling: schedule)
+  end
+
+  def when_i_visit_the_summary_page
+    visit document_path(@edition.document)
+  end
+
+  def and_i_click_stop_scheduled_publishing
+    click_on "Stop scheduled publishing"
+  end
+
+  def then_the_document_is_no_longer_scheduled
+    expect(page).to have_content(I18n.t!("user_facing_states.submitted_for_review.name"))
+
+    within first(".app-timeline-entry") do
+      expect(page).to have_content I18n.t!("documents.history.entry_types.unscheduled")
+    end
+  end
+end


### PR DESCRIPTION
Users can cancel their scheduled content so Content Publisher no longer sets its state to `scheduled`.  Content reverts back to its pre-scheduling status, factoring in whether it was flagged has having been reviewed or not when it was scheduled.

https://trello.com/c/iwxNCu9n/692-allow-users-to-revert-scheduled-status