### PR TITLE
Sanitise govspeak and debug output

### DIFF
--- a/app/services/govspeak_document.rb
+++ b/app/services/govspeak_document.rb
@@ -10,11 +10,11 @@ class GovspeakDocument
 
   def in_app_html
     in_app_options = InAppOptions.new(text, edition).to_h
-    Govspeak::Document.new(text, in_app_options).to_html
+    Govspeak::Document.new(text, in_app_options).to_sanitized_html
   end
 
   def payload_html
     payload_options = PayloadOptions.new(text, edition).to_h
-    Govspeak::Document.new(text, payload_options).to_html
+    Govspeak::Document.new(text, payload_options).to_sanitized_html
   end
 end

--- a/app/views/debug/index.html.erb
+++ b/app/views/debug/index.html.erb
@@ -30,7 +30,7 @@
         field = "#{diff[0]} #{diff[1]}"
         {
           field: field,
-          value: ("<code>" + diff.last.inspect + "</code>").html_safe,
+          value: ("<code>" + html_escape(diff.last.inspect) + "</code>").html_safe,
         }
       end
 


### PR DESCRIPTION
It turns out that govspeak doesn't do any sanitising of user input. This resolves this by using the `to_sanitize_html` method when rendering govspeak of user input. We can't actually use this same method for all of our govspeak rendering of markdown files, as these uses `<a target />` which isn't allowed by the Govspeak::HtmlSanitizer.

It turns out there is a [`valid?`](https://github.com/alphagov/govspeak/blob/34b2cd789b51ab9ce11cee5a0e8bfe3fac274da4/lib/govspeak.rb#L89) method in Govspeak which other publishing apps use ([1](https://github.com/alphagov/whitehall/blob/a94e27e0869ee086dae8278abaa0a5e96a7b306a/app/validators/safe_html_validator.rb), [2](https://github.com/alphagov/specialist-publisher/blob/e2782bcfb518ac497e978e48320e556675c4940a/app/validators/safe_html_validator.rb)) to prevent undesirable HTML. I plan to do this validation in a separate PR as they're not going to be the best form of validation since they don't tell you what's wrong specifically just a blanket failure, and thus they may be contentious.

There is also a lack of escaping on our debug view which has now been addressed.

