### PR TITLE
Create publish intent request

### DIFF
--- a/app/controllers/schedule_controller.rb
+++ b/app/controllers/schedule_controller.rb
@@ -57,6 +57,9 @@ class ScheduleController < ApplicationController
 
       redirect_to scheduled_path(edition.document)
     end
+  rescue GdsApi::BaseError => e
+    GovukError.notify(e)
+    redirect_to document_path(params[:document]), alert_with_description: t("documents.show.flashes.schedule_error")
   end
 
   def scheduled

--- a/app/services/publishing_api_payload.rb
+++ b/app/services/publishing_api_payload.rb
@@ -35,6 +35,17 @@ class PublishingApiPayload
     payload
   end
 
+  def intent_payload
+    rendering_app = publishing_metadata.rendering_app
+    publish_time = edition.scheduled_publishing_datetime
+
+    {
+      publish_time: publish_time,
+      publishing_app: PUBLISHING_APP,
+      rendering_app: rendering_app,
+    }
+  end
+
 private
 
   def links

--- a/app/services/schedule_service.rb
+++ b/app/services/schedule_service.rb
@@ -11,6 +11,8 @@ class ScheduleService
     scheduling = Scheduling.new(pre_scheduled_status: edition.status, reviewed: reviewed)
     set_edition_status(scheduling, user)
     create_timeline_entry(scheduling)
+
+    create_publish_intent(edition)
   end
 
 private
@@ -26,5 +28,10 @@ private
       status: edition.status,
       details: scheduling,
     )
+  end
+
+  def create_publish_intent(edition)
+    payload = PublishingApiPayload.new(edition).intent_payload
+    GdsApi.publishing_api.put_intent(edition.base_path, payload)
   end
 end

--- a/config/locales/en/documents/show.yml
+++ b/config/locales/en/documents/show.yml
@@ -74,6 +74,9 @@ en:
         submitted_for_review:
           title: Content has been marked as ready for 2i review
           label: Send this document to another publisher for them to review. When content is ready you or they can publish it.
+        schedule_error:
+          title: Something has gone wrong
+          description_govspeak: Something went wrong when scheduling your document. Please try again or [raise a support request](https://support.publishing.service.gov.uk/technical_fault_report/new).
         delete_draft: Are you sure you want to delete this draft?
         delete_draft_error:
           title: Something has gone wrong

--- a/spec/features/workflow/schedule_publishing_api_down_spec.rb
+++ b/spec/features/workflow/schedule_publishing_api_down_spec.rb
@@ -1,0 +1,40 @@
+# frozen_string_literal: true
+
+RSpec.feature "Schedule a document when Publishing API is down" do
+  scenario do
+    given_there_is_an_edition_with_set_scheduled_publishing_datetime
+    and_the_publishing_api_is_down
+    when_i_visit_the_summary_page
+    and_i_try_to_schedule_the_edition
+    then_i_see_an_error_message
+    and_the_document_has_not_been_scheduled
+  end
+
+  def given_there_is_an_edition_with_set_scheduled_publishing_datetime
+    @datetime = Time.current.tomorrow
+    @edition = create(:edition, scheduled_publishing_datetime: @datetime)
+  end
+
+  def and_the_publishing_api_is_down
+    publishing_api_isnt_available
+  end
+
+  def when_i_visit_the_summary_page
+    visit document_path(@edition.document)
+  end
+
+  def and_i_try_to_schedule_the_edition
+    click_on "Schedule"
+    choose I18n.t!("schedule.confirmation.review_status.reviewed")
+    click_on "Publish"
+  end
+
+  def then_i_see_an_error_message
+    expect(page).to have_content(I18n.t!("documents.show.flashes.schedule_error.title"))
+  end
+
+  def and_the_document_has_not_been_scheduled
+    @edition.reload
+    expect(@edition.state).to_not eq("scheduled")
+  end
+end

--- a/spec/features/workflow/schedule_spec.rb
+++ b/spec/features/workflow/schedule_spec.rb
@@ -18,6 +18,7 @@ RSpec.feature "Schedule an edition" do
   def given_there_is_an_edition_with_set_scheduled_publishing_datetime
     @datetime = Time.current.tomorrow
     @edition = create(:edition, scheduled_publishing_datetime: @datetime)
+    @request = stub_default_publishing_api_put_intent
   end
 
   def when_i_visit_the_summary_page
@@ -43,6 +44,8 @@ RSpec.feature "Schedule an edition" do
     expect(ScheduledPublishingWorker)
       .to have_enqueued_sidekiq_job(@edition.id, govuk_header_args)
       .at(@datetime)
+
+    assert_requested @request
   end
 
   def then_i_see_the_edition_has_been_scheduled

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -10,6 +10,7 @@ require "byebug"
 require "govuk_schemas/rspec_matchers"
 require "simplecov"
 require "webmock/rspec"
+require "gds_api/test_helpers/publishing_api"
 require "gds_api/test_helpers/publishing_api_v2"
 require "gds_api/test_helpers/asset_manager"
 
@@ -38,6 +39,7 @@ RSpec.configure do |config|
   config.infer_spec_type_from_file_location!
   config.use_transactional_fixtures = true
   config.include FactoryBot::Syntax::Methods
+  config.include GdsApi::TestHelpers::PublishingApi
   config.include GdsApi::TestHelpers::PublishingApiV2
   config.include GdsApi::TestHelpers::AssetManager
   config.include GovukSchemas::RSpecMatchers


### PR DESCRIPTION
When a user schedules content to be published, we need to create a
publish intent in the Publishing API so that Content Store will run down
the TTL and the document's cache will expire as the new content is
published.

Trello:
https://trello.com/c/fXtvPpIO/696-create-publish-intent
