### PR TITLE
Check govspeak is valid

### DIFF
--- a/app/controllers/withdraw_controller.rb
+++ b/app/controllers/withdraw_controller.rb
@@ -32,7 +32,9 @@ class WithdrawController < ApplicationController
           "items" => issues.items,
         }
 
-        render :new, assigns: { edition: edition }, status: :unprocessable_entity
+        render :new,
+               assigns: { edition: edition, public_explanation: public_explanation },
+               status: :unprocessable_entity
         next
       end
 
@@ -45,6 +47,6 @@ class WithdrawController < ApplicationController
     GovukError.notify(e)
     redirect_to withdraw_path(params[:document]),
       alert_with_description: t("withdraw.new.flashes.publishing_api_error"),
-      public_explanation: public_explanation
+      public_explanation: params[:public_explanation]
   end
 end

--- a/app/controllers/withdraw_controller.rb
+++ b/app/controllers/withdraw_controller.rb
@@ -23,7 +23,8 @@ class WithdrawController < ApplicationController
     public_explanation = params[:public_explanation]
 
     Edition.find_and_lock_current(document: params[:document]) do |edition|
-      issues = Requirements::WithdrawalChecker.new(public_explanation).pre_withdrawal_issues
+      issues = Requirements::WithdrawalChecker.new(public_explanation, edition)
+                                              .pre_withdrawal_issues
 
       if issues.any?
         flash["alert_with_items"] = {

--- a/app/services/govspeak_document.rb
+++ b/app/services/govspeak_document.rb
@@ -8,6 +8,11 @@ class GovspeakDocument
     @edition = edition
   end
 
+  def valid?
+    in_app_options = InAppOptions.new(text, edition).to_h
+    Govspeak::Document.new(text, in_app_options).valid?
+  end
+
   def in_app_html
     in_app_options = InAppOptions.new(text, edition).to_h
     Govspeak::Document.new(text, in_app_options).to_html

--- a/app/services/requirements/content_checker.rb
+++ b/app/services/requirements/content_checker.rb
@@ -35,6 +35,14 @@ module Requirements
         issues << Issue.new(:summary, :multiline)
       end
 
+      edition.document_type.contents.each do |field|
+        next unless field.type == "govspeak"
+
+        unless GovspeakDocument.new(revision.contents[field.id], edition).valid?
+          issues << Issue.new(field.id, :invalid_govspeak)
+        end
+      end
+
       CheckerIssues.new(issues)
     end
 

--- a/app/services/requirements/withdrawal_checker.rb
+++ b/app/services/requirements/withdrawal_checker.rb
@@ -2,10 +2,11 @@
 
 module Requirements
   class WithdrawalChecker
-    attr_reader :public_explanation
+    attr_reader :public_explanation, :edition
 
-    def initialize(public_explanation)
+    def initialize(public_explanation, edition)
       @public_explanation = public_explanation
+      @edition = edition
     end
 
     def pre_withdrawal_issues
@@ -13,6 +14,10 @@ module Requirements
 
       if public_explanation.blank?
         issues << Issue.new(:public_explanation, :blank)
+      end
+
+      unless GovspeakDocument.new(public_explanation, edition).valid?
+        issues << Issue.new(:public_explanation, :invalid_govspeak)
       end
 
       CheckerIssues.new(issues)

--- a/config/locales/en/requirements.yml
+++ b/config/locales/en/requirements.yml
@@ -27,6 +27,9 @@ en:
       blank:
         form_message: Enter a body
         summary_message: Enter a body
+      invalid_govspeak:
+        form_message: Remove HTML from the body
+        summary_message: Remove HTML from the body
     change_note:
       blank:
         form_message: Enter a change note

--- a/config/locales/en/requirements.yml
+++ b/config/locales/en/requirements.yml
@@ -67,6 +67,8 @@ en:
     public_explanation:
       blank:
         form_message: Enter a public explanation
+      invalid_govspeak:
+        form_message: Remove HTML from the public explanation
     scheduled_datetime:
       title: The scheduled publishing date and time needs to be changed
       in_the_past:

--- a/config/locales/en/requirements.yml
+++ b/config/locales/en/requirements.yml
@@ -28,8 +28,8 @@ en:
         form_message: Enter a body
         summary_message: Enter a body
       invalid_govspeak:
-        form_message: Remove HTML from the body
-        summary_message: Remove HTML from the body
+        form_message: Remove invalid HTML or any JavaScript from the body
+        summary_message: Remove invalid HTML or any JavaScript from the body
     change_note:
       blank:
         form_message: Enter a change note
@@ -68,7 +68,7 @@ en:
       blank:
         form_message: Enter a public explanation
       invalid_govspeak:
-        form_message: Remove HTML from the public explanation
+        form_message: Remove invalid HTML or any JavaScript from the public explanation
     scheduled_datetime:
       title: The scheduled publishing date and time needs to be changed
       in_the_past:

--- a/spec/services/requirements/content_checker_spec.rb
+++ b/spec/services/requirements/content_checker_spec.rb
@@ -74,6 +74,22 @@ RSpec.describe Requirements::ContentChecker do
       summary_message = issues.items_for(:summary, style: "summary").first[:text]
       expect(summary_message).to eq(I18n.t!("requirements.summary.multiline.summary_message"))
     end
+
+    it "returns an issue if the a govspeak field contains forbidden HTML" do
+      body_field = build :field, id: "body", type: "govspeak"
+      document_type = build :document_type, contents: [body_field]
+      edition = build :edition, document_type_id: document_type.id
+      revision = build :revision, contents: { body: "<script>alert('hi')</script>" }
+
+      issues = Requirements::ContentChecker.new(edition, revision)
+                                           .pre_preview_issues
+
+      form_message = issues.items_for(:body).first[:text]
+      expect(form_message).to eq(I18n.t!("requirements.body.invalid_govspeak.form_message"))
+
+      summary_message = issues.items_for(:body, style: "summary").first[:text]
+      expect(summary_message).to eq(I18n.t!("requirements.body.invalid_govspeak.summary_message"))
+    end
   end
 
   describe "#pre_publish_issues" do

--- a/spec/services/requirements/withdrawal_checker_spec.rb
+++ b/spec/services/requirements/withdrawal_checker_spec.rb
@@ -4,15 +4,25 @@ RSpec.describe Requirements::WithdrawalChecker do
   describe "#pre_withdrawal_issues" do
     it "returns no issues if there are none" do
       public_explanation = SecureRandom.alphanumeric
-      issues = Requirements::WithdrawalChecker.new(public_explanation).pre_withdrawal_issues
+      issues = Requirements::WithdrawalChecker.new(public_explanation, build(:edition))
+                                              .pre_withdrawal_issues
       expect(issues.items).to be_empty
     end
 
     it "returns an issue if there is no public explanation" do
-      issues = Requirements::WithdrawalChecker.new(nil).pre_withdrawal_issues
+      issues = Requirements::WithdrawalChecker.new(nil, build(:edition))
+                                              .pre_withdrawal_issues
 
       message = issues.items_for(:public_explanation).first[:text]
       expect(message).to eq(I18n.t!("requirements.public_explanation.blank.form_message"))
+    end
+
+    it "returns an issue if there is invalid govspeak in the public explanation" do
+      issues = Requirements::WithdrawalChecker.new("<script>alert('123')</script>", build(:edition))
+                                              .pre_withdrawal_issues
+
+      message = issues.items_for(:public_explanation).first[:text]
+      expect(message).to eq(I18n.t!("requirements.public_explanation.invalid_govspeak.form_message"))
     end
   end
 end


### PR DESCRIPTION
Trello: https://trello.com/c/SdMUjUmj/722-resolve-xss-issues-raised-by-pen-testers

Marked as DNM until final content decisions.

This adds validation for the places where we accept govspeak input. It is used as a means to tell them that the content they have entered can't be accepted. Writing the validation message is rather grim as there are quite a few reasons the `Govspeak#valid?` method can fail. I felt the simplest way
to resolve this was just to tell users to "Remove HTML" - this hasn't been content designed though and may need revising if there are situations where users are actively advised to enter HTML.