### PR TITLE
Edition loading controllers

### DIFF
--- a/app/controllers/debug_controller.rb
+++ b/app/controllers/debug_controller.rb
@@ -5,7 +5,7 @@ class DebugController < ApplicationController
   helper_method :revision_diff
 
   def index
-    @document = Document.find_by_param(params[:id])
+    @document = Document.find_by_param(params[:document])
 
     image_preload = {
       lead_image_revision: %i[file_revision metadata_revision],

--- a/app/controllers/editions_controller.rb
+++ b/app/controllers/editions_controller.rb
@@ -2,31 +2,27 @@
 
 class EditionsController < ApplicationController
   def create
-    Document.transaction do
-      document = Document.with_current_edition.lock.find_by_param(params[:document_id])
-
-      current_edition = document.current_edition
-
-      unless current_edition.live?
+    Edition.find_and_lock_current(document: params[:document]) do |edition|
+      unless edition.live?
         # FIXME: this shouldn't be an exception but we've not worked out the
         # right response - maybe bad request or a redirect with flash?
         raise "Can't create a new edition when the current edition is a draft"
       end
 
-      current_edition.update!(current: false)
+      edition.update!(current: false)
 
       next_edition = Edition.find_by(
-        document: document,
-        number: current_edition.number + 1,
+        document: edition.document,
+        number: edition.number + 1,
       )
 
       if next_edition
-        next_edition.resume_discarded(current_edition, current_user)
+        next_edition.resume_discarded(edition, current_user)
 
         TimelineEntry.create_for_status_change(entry_type: :draft_reset,
                                                status: next_edition.status)
       else
-        next_edition = Edition.create_next_edition(current_edition, current_user)
+        next_edition = Edition.create_next_edition(edition, current_user)
 
         TimelineEntry.create_for_status_change(entry_type: :new_edition,
                                                status: next_edition.status)
@@ -34,7 +30,7 @@ class EditionsController < ApplicationController
 
       PreviewService.new(next_edition).try_create_preview
 
-      redirect_to edit_document_path(document)
+      redirect_to edit_document_path(next_edition.document)
     end
   end
 end

--- a/app/controllers/govspeak_preview_controller.rb
+++ b/app/controllers/govspeak_preview_controller.rb
@@ -4,9 +4,8 @@ class GovspeakPreviewController < ApplicationController
   skip_before_action :verify_authenticity_token
 
   def to_html
-    @document = Document.with_current_edition.find_by_param(params[:id])
-    current_edition = @document.current_edition
-    govspeak_html = GovspeakDocument.new(params[:govspeak], current_edition).in_app_html
+    edition = Edition.find_current(document: params[:document])
+    govspeak_html = GovspeakDocument.new(params[:govspeak], edition).in_app_html
     render partial: "govuk_publishing_components/components/govspeak",
            locals: { content: govspeak_html.html_safe } # rubocop:disable Rails/OutputSafety
   end

--- a/app/controllers/review_controller.rb
+++ b/app/controllers/review_controller.rb
@@ -2,51 +2,45 @@
 
 class ReviewController < ApplicationController
   def submit_for_2i
-    Document.transaction do
-      document = Document.with_current_edition.lock.find_by_param(params[:id])
-      current_edition = document.current_edition
-
+    Edition.find_and_lock_current(document: params[:document]) do |edition|
       begin
-        issues = Requirements::EditionChecker.new(current_edition)
+        issues = Requirements::EditionChecker.new(edition)
                                              .pre_publish_issues(rescue_api_errors: false)
-
-        if issues.any?
-          redirect_to document_path(document), tried_to_publish: true
-          return
-        end
-
-        current_edition.assign_status(:submitted_for_review, current_user).save!
-
-        TimelineEntry.create_for_status_change(entry_type: :submitted,
-                                               status: current_edition.status)
-
-        flash[:submitted_for_review] = true
-        redirect_to document
       rescue GdsApi::BaseError => e
         GovukError.notify(e)
-        redirect_to document, alert_with_description: t("documents.show.flashes.2i_error")
+        redirect_to edition.document, alert_with_description: t("documents.show.flashes.2i_error")
+        next
       end
+
+      if issues.any?
+        redirect_to document_path(edition.document), tried_to_publish: true
+        next
+      end
+
+      edition.assign_status(:submitted_for_review, current_user).save!
+
+      TimelineEntry.create_for_status_change(entry_type: :submitted,
+                                             status: edition.status)
+
+      flash[:submitted_for_review] = true
+      redirect_to edition.document
     end
   end
 
   def approve
-    Document.transaction do
-      document = Document.with_current_edition.lock.find_by_param(params[:id])
-
-      current_edition = document.current_edition
-
-      if !current_edition.status.published_but_needs_2i?
+    Edition.find_and_lock_current(document: params[:document]) do |edition|
+      if !edition.status.published_but_needs_2i?
         # FIXME: this shouldn't be an exception but we've not worked out the
         # right response - maybe bad request or a redirect with flash?
         raise "Can't approve a document that doesn't need 2i"
       end
 
-      current_edition.assign_status(:published, current_user).save!
+      edition.assign_status(:published, current_user).save!
 
       TimelineEntry.create_for_status_change(entry_type: :approved,
-                                             status: current_edition.status)
+                                             status: edition.status)
 
-      redirect_to document, notice: t("documents.show.flashes.approved")
+      redirect_to edition.document, notice: t("documents.show.flashes.approved")
     end
   end
 end

--- a/app/controllers/unpublish_controller.rb
+++ b/app/controllers/unpublish_controller.rb
@@ -2,6 +2,6 @@
 
 class UnpublishController < ApplicationController
   def remove
-    @document = Document.with_current_edition.find_by_param(params[:id])
+    @edition = Edition.find_current(document: params[:document])
   end
 end

--- a/app/controllers/unschedule_controller.rb
+++ b/app/controllers/unschedule_controller.rb
@@ -2,9 +2,7 @@
 
 class UnscheduleController < ApplicationController
   def unschedule
-    Document.transaction do
-      document = Document.with_current_edition.lock!.find_by_param(params[:id])
-      edition = document.current_edition
+    Edition.find_and_lock_current(document: params[:document]) do |edition|
       schedule = edition.status.details
 
       remove_scheduled_publishing_datetime(edition)
@@ -18,7 +16,7 @@ class UnscheduleController < ApplicationController
         status: edition.status,
       )
 
-      redirect_to document_path(document)
+      redirect_to document_path(edition.document)
     end
   end
 

--- a/app/models/edition.rb
+++ b/app/models/edition.rb
@@ -42,7 +42,7 @@ class Edition < ApplicationRecord
 
   has_many :internal_notes
 
-  delegate :content_id, :locale, :document_type, :topics, to: :document
+  delegate :content_id, :locale, :document_type, :topics, :document_topics, to: :document
 
   # delegate each state enum method
   state_methods = Status.states.keys.map { |s| (s + "?").to_sym }

--- a/app/views/contacts/search.html.erb
+++ b/app/views/contacts/search.html.erb
@@ -1,4 +1,4 @@
-<% content_for :back_link, render_back_link(href: edit_document_path(@document)) %>
+<% content_for :back_link, render_back_link(href: edit_document_path(@edition.document)) %>
 <% content_for :browser_title, t("contacts.search.title") %>
 
 <%
@@ -10,7 +10,7 @@
 %>
 
 <%= form_tag(
-  insert_contact_path(@document),
+  insert_contact_path(@edition.document),
   data: { gtm: "insert-contact-submit" },
 ) do %>
   <%= render "components/autocomplete", {

--- a/app/views/contacts/search_api_down.html.erb
+++ b/app/views/contacts/search_api_down.html.erb
@@ -1,4 +1,4 @@
-<% content_for :back_link, render_back_link(href: document_path(@document)) %>
+<% content_for :back_link, render_back_link(href: edit_document_path(@edition.document)) %>
 <% content_for :title, t("contacts.search.title") %>
 
 <p class="govuk-body">

--- a/app/views/images/crop.html.erb
+++ b/app/views/images/crop.html.erb
@@ -1,17 +1,17 @@
 <%
 title_key = rendering_context == "modal" ? "images.crop.title_modal" : "images.crop.title"
-content_for :title,t(title_key, title: @document.current_edition.title_or_fallback)
+content_for :title,t(title_key, title: @edition.title_or_fallback)
 %>
 
 <% content_for :back_link, render_back_link(
-  href: images_path(@document),
+  href: images_path(@edition.document),
   data_attributes: {
     "modal-action": "cropBack",
   }
 ) %>
 
 <%= form_tag(
-  crop_image_path(@document, @image_revision.image_id),
+  crop_image_path(@edition.document, @image_revision.image_id),
   method: :patch,
   data: {
     "modal-action": "crop",

--- a/app/views/images/edit.html.erb
+++ b/app/views/images/edit.html.erb
@@ -1,10 +1,10 @@
 <%
 title_key = rendering_context == "modal" ? "images.edit.title_modal" : "images.edit.title"
-content_for :title,t(title_key, title: @document.current_edition.title_or_fallback)
+content_for :title,t(title_key, title: @edition.title_or_fallback)
 %>
 
 <% content_for :back_link, render_back_link(
-  href: crop_image_path(@document, @image_revision.image_id, wizard: params[:wizard]),
+  href: crop_image_path(@edition.document, @image_revision.image_id, wizard: params[:wizard]),
   data_attributes: {
     "modal-action": "metaBack"
   }
@@ -18,7 +18,7 @@ content_for :title,t(title_key, title: @document.current_edition.title_or_fallba
 } %>
 
 <%= form_tag(
-  update_image_path(@document, @image_revision.image_id, wizard: params[:wizard]),
+  update_image_path(@edition.document, @image_revision.image_id, wizard: params[:wizard]),
   method: :patch,
   class: "app-c-contextual-guidance__form",
   data: {
@@ -111,7 +111,7 @@ content_for :title,t(title_key, title: @document.current_edition.title_or_fallba
           items: [
             {
               label: t("images.edit.form_labels.lead_image"),
-              checked: @document.current_edition.lead_image_revision == @image_revision,
+              checked: @edition.lead_image_revision == @image_revision,
               name: "lead_image",
             }
           ]

--- a/app/views/images/index.html.erb
+++ b/app/views/images/index.html.erb
@@ -1,10 +1,10 @@
 <%
 title_key = rendering_context == "modal" ? "images.index.title_modal" : "images.index.title"
-content_for :title,t(title_key, title: @document.current_edition.title_or_fallback)
+content_for :title,t(title_key, title: @edition.title_or_fallback)
 %>
 
 <% unless rendering_context == "modal" %>
-  <% content_for :back_link, render_back_link(href: document_path(@document)) %>
+  <% content_for :back_link, render_back_link(href: document_path(@edition.document)) %>
 <% end %>
 
 <div class="govuk-grid-row">
@@ -17,7 +17,7 @@ content_for :title,t(title_key, title: @document.current_edition.title_or_fallba
       <% end %>
 
       <%= form_tag(
-        create_image_path(@document),
+        create_image_path(@edition.document),
         multipart: true,
         data: {
           gtm: "image-upload-submit",
@@ -39,11 +39,11 @@ content_for :title,t(title_key, title: @document.current_edition.title_or_fallba
       <% end %>
     </div>
 
-    <% if lead_image = @document.current_edition.lead_image_revision %>
-      <%= render "lead_image", lead_image: lead_image, document: @document %>
+    <% if lead_image = @edition.lead_image_revision %>
+      <%= render "lead_image", lead_image: lead_image, document: @edition.document %>
     <% end %>
 
-    <% images = @document.current_edition.image_revisions_without_lead %>
+    <% images = @edition.image_revisions_without_lead %>
 
     <% if images.any? %>
       <h2 class="govuk-heading-m">
@@ -51,7 +51,7 @@ content_for :title,t(title_key, title: @document.current_edition.title_or_fallba
       </h2>
 
       <% images.each do |image| %>
-        <%= render "image", image: image, document: @document %>
+        <%= render "image", image: image, document: @edition.document %>
       <% end %>
     <% end %>
   </div>

--- a/app/views/preview/show.html.erb
+++ b/app/views/preview/show.html.erb
@@ -1,11 +1,10 @@
-<% content_for :back_link, render_back_link(href: document_path(@document)) %>
-<% current_edition = @document.current_edition %>
-<% content_for :title, t("preview.show.title", title: current_edition.title_or_fallback) %>
+<% content_for :back_link, render_back_link(href: document_path(@edition.document)) %>
+<% content_for :title, t("preview.show.title", title: @edition.title_or_fallback) %>
 
 
 <%= render "components/page_preview",
-  title: current_edition.title,
-  base_path: current_edition.base_path,
-  description: current_edition.summary,
-  url: EditionUrl.new(current_edition).secret_preview_url
+  title: @edition.title,
+  base_path: @edition.base_path,
+  description: @edition.summary,
+  url: EditionUrl.new(@edition).secret_preview_url
 %>

--- a/app/views/publish/confirmation.html.erb
+++ b/app/views/publish/confirmation.html.erb
@@ -1,9 +1,9 @@
-<% content_for :back_link, render_back_link(href: document_path(@document)) %>
+<% content_for :back_link, render_back_link(href: document_path(@edition.document)) %>
 <% content_for :title, t("publish.confirmation.title") %>
 
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
-    <%= form_tag publish_confirmation_path(@document), data: { "gtm-checked-inputs": "publish-document" } do %>
+    <%= form_tag publish_confirmation_path(@edition.document), data: { "gtm-checked-inputs": "publish-document" } do %>
       <%= render "govuk_publishing_components/components/radio", {
         name: "review_state",
         items: [

--- a/app/views/tags/edit.html.erb
+++ b/app/views/tags/edit.html.erb
@@ -1,5 +1,5 @@
-<% content_for :back_link, render_back_link(href: document_path(@document)) %>
-<% content_for :title, t("tags.edit.title", title: @revision.title_or_fallback) %>
+<% content_for :back_link, render_back_link(href: document_path(@edition.document)) %>
+<% content_for :title, t("tags.edit.title", title: @edition.title_or_fallback) %>
 
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
@@ -7,13 +7,13 @@
   </div>
 </div>
 
-<%= form_tag(tags_path(@document), data: { "warn-before-unload": "true" }, class: "app-c-contextual-guidance__form") do %>
-  <% @document.document_type.tags.each do |tag_field| %>
+<%= form_tag(tags_path(@edition.document), data: { "warn-before-unload": "true" }, class: "app-c-contextual-guidance__form") do %>
+  <% @edition.document_type.tags.each do |tag_field| %>
     <div class="govuk-grid-row">
       <div class="govuk-grid-column-two-thirds">
         <%= render "tags/tags/#{tag_field.type}_input",
           tag_field: tag_field,
-          tags: @revision.tags %>
+          tags: @edition.tags %>
       </div>
     </div>
   <% end %>

--- a/app/views/tags/edit_api_down.html.erb
+++ b/app/views/tags/edit_api_down.html.erb
@@ -1,5 +1,5 @@
-<% content_for :back_link, render_back_link(href: document_path(@document)) %>
-<% content_for :title, t("tags.edit.title", title: @revision.title_or_fallback) %>
+<% content_for :back_link, render_back_link(href: document_path(@edition.document)) %>
+<% content_for :title, t("tags.edit.title", title: @edition.title_or_fallback) %>
 
 <p class="govuk-body">
   <%= t("tags.edit.api_down") %>

--- a/app/views/topics/edit.html.erb
+++ b/app/views/topics/edit.html.erb
@@ -1,5 +1,5 @@
-<% content_for :back_link, render_back_link(href: document_path(@document)) %>
-<% content_for :title, t("topics.edit.title", title: @document.current_edition.title_or_fallback) %>
+<% content_for :back_link, render_back_link(href: document_path(@edition.document)) %>
+<% content_for :title, t("topics.edit.title", title: @edition.title_or_fallback) %>
 
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
@@ -57,13 +57,13 @@
   </li>
 <% end %>
 
-<%= form_tag update_topics_path(@document), data: { "gtm-selected-topics": "" }, method: :patch do %>
+<%= form_tag update_topics_path(@edition.document), data: { "gtm-selected-topics": "" }, method: :patch do %>
   <h2 class="govuk-heading-m"><%= t("topics.edit.selected_title") %></h2>
   <miller-columns-selected class="miller-columns-selected" id="selected-items" for="miller-columns"></miller-columns-selected>
 
   <miller-columns id="miller-columns" class="miller-columns" for="taxonomy" selected="selected-items">
   <ul id="taxonomy">
-    <% Topic.govuk_homepage(@document.document_topics.index).children.each do |topic| %>
+    <% Topic.govuk_homepage(@edition.document_topics.index).children.each do |topic| %>
       <% unroll(topic) %>
     <% end %>
   </ul>

--- a/app/views/topics/edit_api_down.html.erb
+++ b/app/views/topics/edit_api_down.html.erb
@@ -1,5 +1,5 @@
-<% content_for :back_link, render_back_link(href: document_path(@document)) %>
-<% content_for :title, t("topics.edit.title", title: @document.current_edition.title_or_fallback) %>
+<% content_for :back_link, render_back_link(href: document_path(@edition.document)) %>
+<% content_for :title, t("topics.edit.title", title: @edition.title_or_fallback) %>
 
 <p class="govuk-body">
   <%= t("topics.edit.api_down") %>

--- a/app/views/unpublish/remove.html.erb
+++ b/app/views/unpublish/remove.html.erb
@@ -1,4 +1,4 @@
-<% content_for :back_link, render_back_link(href: document_path(@document)) %>
+<% content_for :back_link, render_back_link(href: document_path(@edition.document)) %>
 <% content_for :title, t("unpublish.remove.title") %>
 
 <div class="govuk-grid-row">

--- a/app/views/unwithdraw/non_managing_editor.html.erb
+++ b/app/views/unwithdraw/non_managing_editor.html.erb
@@ -1,4 +1,4 @@
-<% content_for :back_link, render_back_link(href: document_path(@document)) %>
+<% content_for :back_link, render_back_link(href: document_path(@edition.document)) %>
 <% content_for :title, t("unwithdraw.no_managing_editor_permission.title") %>
 
 <div class="govuk-grid-row">

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -45,8 +45,8 @@ Rails.application.routes.draw do
   get "/documents/:document/preview" => "preview#show", as: :preview_document
   post "/documents/:document/create-preview" => "preview#create", as: :create_preview
 
-  get "/documents/:id/withdraw" => "withdraw#new", as: :withdraw
-  post "/documents/:id/withdraw" => "withdraw#create"
+  get "/documents/:document/withdraw" => "withdraw#new", as: :withdraw
+  post "/documents/:document/withdraw" => "withdraw#create"
 
   get "/documents/:id/unwithdraw" => "unwithdraw#confirm", as: :confirm_unwithdraw
   post "/documents/:id/unwithdraw" => "unwithdraw#unwithdraw", as: :unwithdraw

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -36,8 +36,8 @@ Rails.application.routes.draw do
   get "/documents/:document/search-contacts" => "contacts#search", as: :search_contacts
   post "/documents/:document/search-contacts" => "contacts#insert", as: :insert_contact
 
-  post "/documents/:id/submit-for-2i" => "review#submit_for_2i", as: :submit_document_for_2i
-  post "/documents/:id/approve" => "review#approve", as: :approve_document
+  post "/documents/:document/submit-for-2i" => "review#submit_for_2i", as: :submit_document_for_2i
+  post "/documents/:document/approve" => "review#approve", as: :approve_document
 
   get "/documents/:id/tags" => "tags#edit", as: :tags
   post "/documents/:id/tags" => "tags#update"

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -48,8 +48,8 @@ Rails.application.routes.draw do
   get "/documents/:document/withdraw" => "withdraw#new", as: :withdraw
   post "/documents/:document/withdraw" => "withdraw#create"
 
-  get "/documents/:id/unwithdraw" => "unwithdraw#confirm", as: :confirm_unwithdraw
-  post "/documents/:id/unwithdraw" => "unwithdraw#unwithdraw", as: :unwithdraw
+  get "/documents/:document/unwithdraw" => "unwithdraw#confirm", as: :confirm_unwithdraw
+  post "/documents/:document/unwithdraw" => "unwithdraw#unwithdraw", as: :unwithdraw
 
   get "/documents/:id/remove" => "unpublish#remove", as: :remove
 

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -8,67 +8,72 @@ Rails.application.routes.draw do
   get "/documents/choose-document-type" => "new_document#choose_document_type", as: :choose_document_type
   post "/documents/create" => "new_document#create", as: :create_document
 
-  get "/documents/:document/publish" => "publish#confirmation", as: :publish_confirmation
-  post "/documents/:document/publish" => "publish#publish"
-  get "/documents/:document/published" => "publish#published", as: :published
-
-  post "/documents/:document/save-scheduled-publishing-datetime" => "schedule#save_scheduled_publishing_datetime", as: :save_scheduled_publishing_datetime
-  post "/documents/:document/clear-scheduled-publishing-datetime" => "schedule#clear_scheduled_publishing_datetime", as: :clear_scheduled_publishing_datetime
-
-  get "/documents/:document/schedule" => "schedule#confirmation", as: :scheduling_confirmation
-  post "/documents/:document/schedule" => "schedule#schedule"
-  get "/documents/:document/scheduled" => "schedule#scheduled", as: :scheduled
-
-  post "/documents/:id/unschedule" => "unschedule#unschedule", as: :unschedule
-
   get "/documents" => "documents#index"
-  get "/documents/:document/edit" => "documents#edit", as: :edit_document
-  patch "/documents/:document" => "documents#update", as: :document
-  get "/documents/:document" => "documents#show"
-  get "/documents/:document/generate-path" => "documents#generate_path", as: :generate_path
-  get "/documents/:document/delete-draft" => "documents#confirm_delete_draft", as: :delete_draft
-  delete "/documents/:document" => "documents#destroy"
 
-  post "/documents/:document/internal_notes" => "internal_notes#create", as: :create_internal_note
+  scope "/documents/:document" do
+    get "" => "documents#show", as: :document
+    patch "" => "documents#update"
+    delete "" => "documents#destroy"
+    get "/edit" => "documents#edit", as: :edit_document
+    get "/generate-path" => "documents#generate_path", as: :generate_path
+    get "/delete-draft" => "documents#confirm_delete_draft", as: :delete_draft
 
-  get "/documents/:document/debug" => "debug#index", as: :debug_document
+    get "/publish" => "publish#confirmation", as: :publish_confirmation
+    post "/publish" => "publish#publish"
+    get "/published" => "publish#published", as: :published
 
-  get "/documents/:document/search-contacts" => "contacts#search", as: :search_contacts
-  post "/documents/:document/search-contacts" => "contacts#insert", as: :insert_contact
+    post "/save-scheduled-publishing-datetime" => "schedule#save_scheduled_publishing_datetime", as: :save_scheduled_publishing_datetime
+    post "/clear-scheduled-publishing-datetime" => "schedule#clear_scheduled_publishing_datetime", as: :clear_scheduled_publishing_datetime
 
-  post "/documents/:document/submit-for-2i" => "review#submit_for_2i", as: :submit_document_for_2i
-  post "/documents/:document/approve" => "review#approve", as: :approve_document
+    get "/schedule" => "schedule#confirmation", as: :scheduling_confirmation
+    post "/schedule" => "schedule#schedule"
+    get "/scheduled" => "schedule#scheduled", as: :scheduled
 
-  get "/documents/:document/tags" => "tags#edit", as: :tags
-  post "/documents/:document/tags" => "tags#update"
+    post "/unschedule" => "unschedule#unschedule", as: :unschedule
 
-  get "/documents/:document/preview" => "preview#show", as: :preview_document
-  post "/documents/:document/create-preview" => "preview#create", as: :create_preview
+    post "/internal_notes" => "internal_notes#create", as: :create_internal_note
 
-  get "/documents/:document/withdraw" => "withdraw#new", as: :withdraw
-  post "/documents/:document/withdraw" => "withdraw#create"
+    get "/debug" => "debug#index", as: :debug_document
 
-  get "/documents/:document/unwithdraw" => "unwithdraw#confirm", as: :confirm_unwithdraw
-  post "/documents/:document/unwithdraw" => "unwithdraw#unwithdraw", as: :unwithdraw
+    get "/search-contacts" => "contacts#search", as: :search_contacts
+    post "/search-contacts" => "contacts#insert", as: :insert_contact
 
-  get "/documents/:document/remove" => "unpublish#remove", as: :remove
+    post "/submit-for-2i" => "review#submit_for_2i", as: :submit_document_for_2i
+    post "/approve" => "review#approve", as: :approve_document
 
-  get "/documents/:document/images" => "images#index", as: :images
-  post "/documents/:document/images" => "images#create", as: :create_image
-  get "/documents/:document/images/:image_id/download" => "images#download", as: :download_image
-  get "/documents/:document/images/:image_id/crop" => "images#crop", as: :crop_image
-  patch "/documents/:document/images/:image_id/crop" => "images#update_crop"
-  get "/documents/:document/images/:image_id/edit" => "images#edit", as: :edit_image
-  patch "/documents/:document/images/:image_id/edit" => "images#update", as: :update_image
-  delete "/documents/:document/images/:image_id" => "images#destroy", as: :destroy_image
+    get "/tags" => "tags#edit", as: :tags
+    post "/tags" => "tags#update"
 
-  post "/documents/:document/lead-image/:image_id" => "lead_image#choose", as: :choose_lead_image
-  delete "/documents/:document/lead-image" => "lead_image#remove", as: :remove_lead_image
+    get "/preview" => "preview#show", as: :preview_document
+    post "/create-preview" => "preview#create", as: :create_preview
 
-  get "/documents/:document/topics" => "topics#edit", as: :topics
-  patch "/documents/:document/topics" => "topics#update", as: :update_topics
+    get "/withdraw" => "withdraw#new", as: :withdraw
+    post "/withdraw" => "withdraw#create"
 
-  post "/documents/:document/editions" => "editions#create", as: :create_edition
+    get "/unwithdraw" => "unwithdraw#confirm", as: :confirm_unwithdraw
+    post "/unwithdraw" => "unwithdraw#unwithdraw", as: :unwithdraw
+
+    get "/remove" => "unpublish#remove", as: :remove
+
+    get "/images" => "images#index", as: :images
+    post "/images" => "images#create", as: :create_image
+    get "/images/:image_id/download" => "images#download", as: :download_image
+    get "/images/:image_id/crop" => "images#crop", as: :crop_image
+    patch "/images/:image_id/crop" => "images#update_crop"
+    get "/images/:image_id/edit" => "images#edit", as: :edit_image
+    patch "/images/:image_id/edit" => "images#update", as: :update_image
+    delete "/images/:image_id" => "images#destroy", as: :destroy_image
+
+    post "/lead-image/:image_id" => "lead_image#choose", as: :choose_lead_image
+    delete "/lead-image" => "lead_image#remove", as: :remove_lead_image
+
+    get "/topics" => "topics#edit", as: :topics
+    patch "/topics" => "topics#update", as: :update_topics
+
+    post "/editions" => "editions#create", as: :create_edition
+
+    post "/govspeak-preview" => "govspeak_preview#to_html", as: :govspeak_preview
+  end
 
   get "/healthcheck", to: proc { [200, {}, %w[OK]] }
 
@@ -77,8 +82,6 @@ Rails.application.routes.draw do
   get "/how-to-use-publisher" => "publisher_information#how_to_use_publisher", as: :how_to_use_publisher
   get "/beta-capabilities" => "publisher_information#beta_capabilities", as: :beta_capabilities
   get "/publisher-updates" => "publisher_information#publisher_updates", as: :publisher_updates
-
-  post "/documents/:document/govspeak-preview" => "govspeak_preview#to_html", as: :govspeak_preview
 
   mount GovukPublishingComponents::Engine, at: "/component-guide"
 

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -51,7 +51,7 @@ Rails.application.routes.draw do
   get "/documents/:document/unwithdraw" => "unwithdraw#confirm", as: :confirm_unwithdraw
   post "/documents/:document/unwithdraw" => "unwithdraw#unwithdraw", as: :unwithdraw
 
-  get "/documents/:id/remove" => "unpublish#remove", as: :remove
+  get "/documents/:document/remove" => "unpublish#remove", as: :remove
 
   get "/documents/:document_id/images" => "images#index", as: :images
   post "/documents/:document_id/images" => "images#create", as: :create_image

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -29,7 +29,7 @@ Rails.application.routes.draw do
   get "/documents/:document/delete-draft" => "documents#confirm_delete_draft", as: :delete_draft
   delete "/documents/:document" => "documents#destroy"
 
-  post "/documents/:id/internal_notes" => "internal_notes#create", as: :create_internal_note
+  post "/documents/:document/internal_notes" => "internal_notes#create", as: :create_internal_note
 
   get "/documents/:id/debug" => "debug#index", as: :debug_document
 

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -31,7 +31,7 @@ Rails.application.routes.draw do
 
   post "/documents/:document/internal_notes" => "internal_notes#create", as: :create_internal_note
 
-  get "/documents/:id/debug" => "debug#index", as: :debug_document
+  get "/documents/:document/debug" => "debug#index", as: :debug_document
 
   get "/documents/:id/search-contacts" => "contacts#search", as: :search_contacts
   post "/documents/:id/search-contacts" => "contacts#insert", as: :insert_contact

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -8,9 +8,9 @@ Rails.application.routes.draw do
   get "/documents/choose-document-type" => "new_document#choose_document_type", as: :choose_document_type
   post "/documents/create" => "new_document#create", as: :create_document
 
-  get "/documents/:id/publish" => "publish#confirmation", as: :publish_confirmation
-  post "/documents/:id/publish" => "publish#publish"
-  get "/documents/:id/published" => "publish#published", as: :published
+  get "/documents/:document/publish" => "publish#confirmation", as: :publish_confirmation
+  post "/documents/:document/publish" => "publish#publish"
+  get "/documents/:document/published" => "publish#published", as: :published
 
   post "/documents/:id/save-scheduled-publishing-datetime" => "schedule#save_scheduled_publishing_datetime", as: :save_scheduled_publishing_datetime
   post "/documents/:id/clear-scheduled-publishing-datetime" => "schedule#clear_scheduled_publishing_datetime", as: :clear_scheduled_publishing_datetime

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -39,8 +39,8 @@ Rails.application.routes.draw do
   post "/documents/:document/submit-for-2i" => "review#submit_for_2i", as: :submit_document_for_2i
   post "/documents/:document/approve" => "review#approve", as: :approve_document
 
-  get "/documents/:id/tags" => "tags#edit", as: :tags
-  post "/documents/:id/tags" => "tags#update"
+  get "/documents/:document/tags" => "tags#edit", as: :tags
+  post "/documents/:document/tags" => "tags#update"
 
   get "/documents/:id/preview" => "preview#show", as: :preview_document
   post "/documents/:id/create-preview" => "preview#create", as: :create_preview

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -65,8 +65,8 @@ Rails.application.routes.draw do
   post "/documents/:document/lead-image/:image_id" => "lead_image#choose", as: :choose_lead_image
   delete "/documents/:document/lead-image" => "lead_image#remove", as: :remove_lead_image
 
-  get "/documents/:document_id/topics" => "topics#edit", as: :topics
-  patch "/documents/:document_id/topics" => "topics#update", as: :update_topics
+  get "/documents/:document/topics" => "topics#edit", as: :topics
+  patch "/documents/:document/topics" => "topics#update", as: :update_topics
 
   post "/documents/:document_id/editions" => "editions#create", as: :create_edition
 

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -33,8 +33,8 @@ Rails.application.routes.draw do
 
   get "/documents/:document/debug" => "debug#index", as: :debug_document
 
-  get "/documents/:id/search-contacts" => "contacts#search", as: :search_contacts
-  post "/documents/:id/search-contacts" => "contacts#insert", as: :insert_contact
+  get "/documents/:document/search-contacts" => "contacts#search", as: :search_contacts
+  post "/documents/:document/search-contacts" => "contacts#insert", as: :insert_contact
 
   post "/documents/:id/submit-for-2i" => "review#submit_for_2i", as: :submit_document_for_2i
   post "/documents/:id/approve" => "review#approve", as: :approve_document

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -53,17 +53,17 @@ Rails.application.routes.draw do
 
   get "/documents/:document/remove" => "unpublish#remove", as: :remove
 
-  get "/documents/:document_id/images" => "images#index", as: :images
-  post "/documents/:document_id/images" => "images#create", as: :create_image
-  get "/documents/:document_id/images/:image_id/download" => "images#download", as: :download_image
-  get "/documents/:document_id/images/:image_id/crop" => "images#crop", as: :crop_image
-  patch "/documents/:document_id/images/:image_id/crop" => "images#update_crop"
-  get "/documents/:document_id/images/:image_id/edit" => "images#edit", as: :edit_image
-  patch "/documents/:document_id/images/:image_id/edit" => "images#update", as: :update_image
-  delete "/documents/:document_id/images/:image_id" => "images#destroy", as: :destroy_image
+  get "/documents/:document/images" => "images#index", as: :images
+  post "/documents/:document/images" => "images#create", as: :create_image
+  get "/documents/:document/images/:image_id/download" => "images#download", as: :download_image
+  get "/documents/:document/images/:image_id/crop" => "images#crop", as: :crop_image
+  patch "/documents/:document/images/:image_id/crop" => "images#update_crop"
+  get "/documents/:document/images/:image_id/edit" => "images#edit", as: :edit_image
+  patch "/documents/:document/images/:image_id/edit" => "images#update", as: :update_image
+  delete "/documents/:document/images/:image_id" => "images#destroy", as: :destroy_image
 
-  post "/documents/:document_id/lead-image/:image_id" => "lead_image#choose", as: :choose_lead_image
-  delete "/documents/:document_id/lead-image" => "lead_image#remove", as: :remove_lead_image
+  post "/documents/:document/lead-image/:image_id" => "lead_image#choose", as: :choose_lead_image
+  delete "/documents/:document/lead-image" => "lead_image#remove", as: :remove_lead_image
 
   get "/documents/:document_id/topics" => "topics#edit", as: :topics
   patch "/documents/:document_id/topics" => "topics#update", as: :update_topics

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -12,12 +12,12 @@ Rails.application.routes.draw do
   post "/documents/:document/publish" => "publish#publish"
   get "/documents/:document/published" => "publish#published", as: :published
 
-  post "/documents/:id/save-scheduled-publishing-datetime" => "schedule#save_scheduled_publishing_datetime", as: :save_scheduled_publishing_datetime
-  post "/documents/:id/clear-scheduled-publishing-datetime" => "schedule#clear_scheduled_publishing_datetime", as: :clear_scheduled_publishing_datetime
+  post "/documents/:document/save-scheduled-publishing-datetime" => "schedule#save_scheduled_publishing_datetime", as: :save_scheduled_publishing_datetime
+  post "/documents/:document/clear-scheduled-publishing-datetime" => "schedule#clear_scheduled_publishing_datetime", as: :clear_scheduled_publishing_datetime
 
-  get "/documents/:id/schedule" => "schedule#confirmation", as: :scheduling_confirmation
-  post "/documents/:id/schedule" => "schedule#schedule"
-  get "/documents/:id/scheduled" => "schedule#scheduled", as: :scheduled
+  get "/documents/:document/schedule" => "schedule#confirmation", as: :scheduling_confirmation
+  post "/documents/:document/schedule" => "schedule#schedule"
+  get "/documents/:document/scheduled" => "schedule#scheduled", as: :scheduled
 
   post "/documents/:id/unschedule" => "unschedule#unschedule", as: :unschedule
 

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -68,7 +68,7 @@ Rails.application.routes.draw do
   get "/documents/:document/topics" => "topics#edit", as: :topics
   patch "/documents/:document/topics" => "topics#update", as: :update_topics
 
-  post "/documents/:document_id/editions" => "editions#create", as: :create_edition
+  post "/documents/:document/editions" => "editions#create", as: :create_edition
 
   get "/healthcheck", to: proc { [200, {}, %w[OK]] }
 

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -42,8 +42,8 @@ Rails.application.routes.draw do
   get "/documents/:document/tags" => "tags#edit", as: :tags
   post "/documents/:document/tags" => "tags#update"
 
-  get "/documents/:id/preview" => "preview#show", as: :preview_document
-  post "/documents/:id/create-preview" => "preview#create", as: :create_preview
+  get "/documents/:document/preview" => "preview#show", as: :preview_document
+  post "/documents/:document/create-preview" => "preview#create", as: :create_preview
 
   get "/documents/:id/withdraw" => "withdraw#new", as: :withdraw
   post "/documents/:id/withdraw" => "withdraw#create"

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -78,7 +78,7 @@ Rails.application.routes.draw do
   get "/beta-capabilities" => "publisher_information#beta_capabilities", as: :beta_capabilities
   get "/publisher-updates" => "publisher_information#publisher_updates", as: :publisher_updates
 
-  post "/documents/:id/govspeak-preview" => "govspeak_preview#to_html", as: :govspeak_preview
+  post "/documents/:document/govspeak-preview" => "govspeak_preview#to_html", as: :govspeak_preview
 
   mount GovukPublishingComponents::Engine, at: "/component-guide"
 


### PR DESCRIPTION
This builds on top of the work of https://github.com/alphagov/content-publisher/pull/868 to add these methods into all of our controllers.

There aren't intended to be any functionality changes here. Small changes are: use of assigns in some places where instance variables are confusing, and using `edition.revision` in some places where we don't need to set it to a variable.

The biggest change is putting all the routes in a scope in: https://github.com/alphagov/content-publisher/blob/edition-loading-controllers/config/routes.rb