### PR TITLE
No js insert image new tab

### DIFF
--- a/app/assets/javascripts/components/toolbar-dropdown.js
+++ b/app/assets/javascripts/components/toolbar-dropdown.js
@@ -8,11 +8,17 @@ window.GOVUK.Modules = window.GOVUK.Modules || {};
     this.$module = $module[0]
     this.$title = this.$module.querySelector('.app-c-toolbar-dropdown__title')
     this.$container = this.$module.querySelector('.app-c-toolbar-dropdown__container')
-    this.$buttons = this.$module.querySelectorAll('.app-c-toolbar-dropdown__button')
-
     this.$module.addEventListener('blur', ToolbarDropdown.prototype.handleBlur.bind(this), true)
-    this.$buttons.forEach(function ($button) {
-      $button.addEventListener('click', ToolbarDropdown.prototype.handleButtonClick.bind(this), true)
+
+    var $buttons = this.$module.querySelectorAll('.app-c-toolbar-dropdown__button')
+    var $links = this.$module.querySelectorAll('.app-c-toolbar-dropdown__link')
+
+    $buttons.forEach(function ($button) {
+      $button.addEventListener('click', ToolbarDropdown.prototype.handleClick.bind(this), true)
+    }, this)
+
+    $links.forEach(function ($link) {
+      $link.addEventListener('click', ToolbarDropdown.prototype.handleClick.bind(this), true)
     }, this)
   }
 
@@ -27,7 +33,7 @@ window.GOVUK.Modules = window.GOVUK.Modules || {};
     }
   }
 
-  ToolbarDropdown.prototype.handleButtonClick = function (event) {
+  ToolbarDropdown.prototype.handleClick = function (event) {
     this.closeToolbarDropdown()
   }
 

--- a/app/assets/javascripts/modal/modal-fetch.js
+++ b/app/assets/javascripts/modal/modal-fetch.js
@@ -4,10 +4,9 @@ window.ModalFetch.getLink = function (item) {
   var controller = new window.AbortController()
   var headers = { 'Content-Publisher-Rendering-Context': 'modal' }
   var options = { credentials: 'include', signal: controller.signal, headers: headers }
-  var url = item.href || item.dataset.modalActionUrl
   setTimeout(function () { controller.abort() }, 5000)
 
-  return window.fetch(url, options)
+  return window.fetch(item.href, options)
     .then(function (response) {
       if (!response.ok) {
         window.ModalFetch.debug(response)

--- a/app/assets/stylesheets/components/_toolbar-dropdown.scss
+++ b/app/assets/stylesheets/components/_toolbar-dropdown.scss
@@ -62,6 +62,33 @@ $dropdown-arrow-spacing: $dropdown-arrow-size / 2;
   padding: 0;
 }
 
+.app-c-toolbar-dropdown__link {
+  @include govuk-font($size: 16);
+  @include govuk-focusable;
+
+  appearance: none;
+  -webkit-appearance: none;
+
+  background: govuk-colour("grey-4");
+  color: $govuk-text-colour;
+  padding: govuk-spacing(3);
+  text-decoration: none;
+  display: block;
+
+  &:hover {
+    background-color: govuk-colour("grey-3");
+  }
+
+  &:focus {
+    outline-offset: -$govuk-focus-width;
+  }
+
+  &::-moz-focus-inner {
+    border: 0;
+    padding: 0;
+  }
+}
+
 .app-c-toolbar-dropdown__button {
   @include govuk-font($size: 16);
   @include govuk-focusable;

--- a/app/views/components/_markdown_editor.html.erb
+++ b/app/views/components/_markdown_editor.html.erb
@@ -46,16 +46,18 @@
             items: [
               {
                 text: "Contact",
-                value: "add_contact",
-                name: "submit"
+                button_options: {
+                  value: "add_contact",
+                  name: "submit",
+                },
               },
               {
                 text: "Image",
-                value: "add_image",
+                href: images_path(@edition.document),
+                target: "_blank",
                 data_attributes: {
                   module: "inline-image-modal",
                   "modal-action": "open",
-                  "modal-action-url": images_path(@edition.document)
                 }
               }
             ]

--- a/app/views/components/_toolbar_dropdown.html.erb
+++ b/app/views/components/_toolbar_dropdown.html.erb
@@ -15,13 +15,20 @@
       <%= tag.ul class: "app-c-toolbar-dropdown__list" do %>
         <% items.each do |item| %>
           <%= tag.li class: "app-c-toolbar-dropdown__list-item" do %>
-            <%= tag.button item[:text],
-              class:"app-c-toolbar-dropdown__button",
-              type: "submit",
-              name: item[:name],
-              value: item[:value],
-              data: item[:data_attributes]
-            %>
+            <% if item[:button_options] %>
+              <%= tag.button item[:text],
+                class: "app-c-toolbar-dropdown__button",
+                type: "submit",
+                name: item[:button_options][:name],
+                value: item[:button_options][:value]
+              %>
+            <% else %>
+              <%= link_to item[:text], item[:href],
+                class: "app-c-toolbar-dropdown__link",
+                data: item[:data_attributes],
+                target: item[:target]
+              %>
+            <% end %>
           <% end %>
         <% end %>
       <% end %>

--- a/app/views/components/docs/toolbar_dropdown.yml
+++ b/app/views/components/docs/toolbar_dropdown.yml
@@ -16,13 +16,15 @@ examples:
       title: Insert...
       items:
         - text: Image
+          href: '#'
+          target: _blank
           data_attributes:
             module: inline-image-modal
             modal-action: open
         - text: Contact
-          data_attributes:
-            module: inline-contact-modal
-            modal-action: open
+          button_options:
+            value: add_contact
+            name: submit
 
   within_markdown_editor_toolbar:
     embed: |
@@ -36,10 +38,12 @@ examples:
       align: right
       items:
         - text: Image
+          href: '#'
+          target: _blank
           data_attributes:
             module: inline-image-modal
             modal-action: open
         - text: Contact
-          data_attributes:
-            module: inline-contact-modal
-            modal-action: open
+          button_options:
+            value: add_contact
+            name: submit


### PR DESCRIPTION
https://trello.com/c/RxrZShDD/694-open-a-new-tab-when-inserting-inline-images-without-javascript

    This changes the toolbar-dropdown component to work with links by
    default, so that we can use a target attribute to open a new tab for
    inserting images for users without JS. Moving the button-specific
    options into a namespace should make them easy to remove, as the need
    for them is coupled to the current way we insert contacts.

Note that the toolbar-dropdown component doesn't work in Safari, in case you end up testing this in that browser :-).