### PR TITLE
Add template_id to Notify settings

### DIFF
--- a/config/application.rb
+++ b/config/application.rb
@@ -40,7 +40,10 @@ module ContentPublisher
     end
 
     config.after_initialize do
-      config.action_mailer.notify_settings = { api_key: Rails.application.secrets.notify_api_key }
+      config.action_mailer.notify_settings = {
+        api_key: Rails.application.secrets.notify_api_key,
+        template_id: ENV["GOVUK_NOTIFY_TEMPLATE_ID"],
+      }
     end
   end
 end

--- a/lib/notify_delivery_method.rb
+++ b/lib/notify_delivery_method.rb
@@ -22,7 +22,7 @@ private
   def payload(mail)
     {
       email_address: mail.to.first,
-      template_id: mail[:template_id].to_s,
+      template_id: settings[:template_id],
       personalisation: {
         body: mail.body.raw_source,
         subject: mail.subject,

--- a/lib/tasks/notify.rake
+++ b/lib/tasks/notify.rake
@@ -7,7 +7,6 @@ namespace :notify do
 
     params = {
       to: args.email_address,
-      template_id: ENV["TEMPLATE_ID"] || "759acac6-da53-4a19-b591-b7538c7c39de",
       body: ENV["BODY"] || "This is a test email notification",
       subject: ENV["SUBJECT"] || "Test email notification",
     }

--- a/spec/lib/notify_delivery_method_spec.rb
+++ b/spec/lib/notify_delivery_method_spec.rb
@@ -3,19 +3,25 @@
 RSpec.describe NotifyDeliveryMethod do
   describe "#deliver!" do
     it "calls Notify's send_email endpoint" do
-      headers = { to: "x@y.com", template_id: SecureRandom.uuid }
-      personalisation = { body: "Body content", subject: "A subject line" }
-      message = Mail::Message.new(headers.merge(personalisation))
+      headers = { to: "x@y.com",
+                  body: "Body content",
+                  subject: "A subject line" }
+      template_id = SecureRandom.uuid
+      message = Mail::Message.new(headers)
 
       client = instance_double("Notifications::Client")
       allow(Notifications::Client).to receive(:new).and_return(client)
 
       expect(client).to receive(:send_email)
         .with(email_address: headers[:to],
-              template_id: headers[:template_id],
-              personalisation: personalisation)
+              template_id: template_id,
+              personalisation: {
+                body: headers[:body],
+                subject: headers[:subject],
+              })
 
-      NotifyDeliveryMethod.new(api_key: "api-key").deliver!(message)
+      NotifyDeliveryMethod.new(api_key: "api-key", template_id: template_id)
+                          .deliver!(message)
     end
   end
 end

--- a/spec/tasks/notify_rake_spec.rb
+++ b/spec/tasks/notify_rake_spec.rb
@@ -6,11 +6,10 @@ RSpec.describe "Notify rake tasks" do
     before { Rake::Task["notify:send_email"].reenable }
 
     it "sends an email notification via GOV.UK Notify" do
-      template_id = SecureRandom.uuid
       body = "Body content"
       subject = "A subject line"
 
-      ClimateControl.modify(TEMPLATE_ID: template_id, BODY: body, SUBJECT: subject) do
+      ClimateControl.modify(BODY: body, SUBJECT: subject) do
         expect { Rake::Task["notify:send_email"].invoke(email_address) }
           .to change { ActionMailer::Base.deliveries.count }.by(1)
       end
@@ -25,7 +24,6 @@ RSpec.describe "Notify rake tasks" do
       Rake::Task["notify:send_email"].invoke(email_address)
       message = ActionMailer::Base.deliveries.last
 
-      expect(message[:template_id].to_s).to eq("759acac6-da53-4a19-b591-b7538c7c39de")
       expect(message.body.raw_source).to eq("This is a test email notification")
       expect(message.subject).to eq("Test email notification")
     end


### PR DESCRIPTION
https://trello.com/c/NUdRomQV/714-set-up-content-publisher-to-use-notify

Following convention of accessing delivery method config via Action Mailer settings, we add Notify template id to Notify settings. This removes the need for us to include a template id in the Mail object and pass a template id env to the `notify:send_email` rake task.