### PR TITLE
Add Mail Recipient Interceptor

### DIFF
--- a/config/initializers/mail_recipient_interceptor.rb
+++ b/config/initializers/mail_recipient_interceptor.rb
@@ -1,3 +1,3 @@
-if ENV.fetch("GOVUK_NOTIFY_ALLOW_LIST", nil)
+if ENV.fetch("EMAIL_ADDRESS_OVERRRIDE", nil)
   ActionMailer::Base.register_interceptor(MailRecipientInterceptor)
 end

--- a/config/initializers/mail_recipient_interceptor.rb
+++ b/config/initializers/mail_recipient_interceptor.rb
@@ -1,0 +1,3 @@
+if ENV.fetch("GOVUK_NOTIFY_ALLOW_LIST", nil)
+  ActionMailer::Base.register_interceptor(MailRecipientInterceptor)
+end

--- a/config/secrets.yml
+++ b/config/secrets.yml
@@ -5,10 +5,8 @@ development:
 test:
   secret_key_base: secret
   jwt_auth_secret: secret
-  notify_non_production_allow_list: ["allowed@example.com"]
 
 production:
   secret_key_base: <%= ENV['SECRET_KEY_BASE'] %>
   jwt_auth_secret: <%= ENV['JWT_AUTH_SECRET'] %>
   notify_api_key: <%= ENV['GOVUK_NOTIFY_API_KEY'] %>
-  notify_non_production_allow_list: <%= ENV['GOVUK_NOTIFY_ALLOW_LIST'] %>

--- a/config/secrets.yml
+++ b/config/secrets.yml
@@ -5,8 +5,10 @@ development:
 test:
   secret_key_base: secret
   jwt_auth_secret: secret
+  notify_non_production_allow_list: ["allowed@example.com"]
 
 production:
   secret_key_base: <%= ENV['SECRET_KEY_BASE'] %>
   jwt_auth_secret: <%= ENV['JWT_AUTH_SECRET'] %>
   notify_api_key: <%= ENV['GOVUK_NOTIFY_API_KEY'] %>
+  notify_non_production_allow_list: <%= ENV['GOVUK_NOTIFY_ALLOW_LIST'] %>

--- a/lib/mail_recipient_interceptor.rb
+++ b/lib/mail_recipient_interceptor.rb
@@ -2,6 +2,9 @@
 
 class MailRecipientInterceptor
   def self.delivering_email(message)
+    body_prefix = "Intended recipient(s): #{message.to.join(', ')}\n"
+
+    message.body = body_prefix + message.body.raw_source
     message.to = ENV["GOVUK_NOTIFY_ALLOW_LIST"]
   end
 end

--- a/lib/mail_recipient_interceptor.rb
+++ b/lib/mail_recipient_interceptor.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+class MailRecipientInterceptor
+  def self.delivering_email(message)
+    message.to = ENV["GOVUK_NOTIFY_ALLOW_LIST"]
+  end
+end

--- a/lib/mail_recipient_interceptor.rb
+++ b/lib/mail_recipient_interceptor.rb
@@ -5,6 +5,6 @@ class MailRecipientInterceptor
     body_prefix = "Intended recipient(s): #{message.to.join(', ')}\n"
 
     message.body = body_prefix + message.body.raw_source
-    message.to = ENV["GOVUK_NOTIFY_ALLOW_LIST"]
+    message.to = ENV["EMAIL_ADDRESS_OVERRIDE"]
   end
 end

--- a/lib/notify_delivery_method.rb
+++ b/lib/notify_delivery_method.rb
@@ -20,6 +20,10 @@ private
   end
 
   def payload(mail)
+    if mail.to.length > 1
+      raise "Sending emails with multiple recipients is not supported"
+    end
+
     {
       email_address: mail.to.first,
       template_id: settings[:template_id],

--- a/spec/lib/mail_recipient_interceptor_spec.rb
+++ b/spec/lib/mail_recipient_interceptor_spec.rb
@@ -8,7 +8,7 @@ RSpec.describe MailRecipientInterceptor do
     let(:mail) { Mail.new(to: original_recipient) }
 
     before do
-      ClimateControl.modify(GOVUK_NOTIFY_ALLOW_LIST: "allowed@example.com") do
+      ClimateControl.modify(EMAIL_ADDRESS_OVERRIDE: "allowed@example.com") do
         MailRecipientInterceptor.delivering_email(mail)
       end
     end

--- a/spec/lib/mail_recipient_interceptor_spec.rb
+++ b/spec/lib/mail_recipient_interceptor_spec.rb
@@ -4,14 +4,21 @@ require "mail_recipient_interceptor"
 
 RSpec.describe MailRecipientInterceptor do
   describe "#delivering_email" do
-    it "intercepts emails and sends to an allow-listed email address" do
-      mail = Mail.new(to: "not-allowed@example.com")
+    let(:original_recipient) { "not-allowed@example.com" }
+    let(:mail) { Mail.new(to: original_recipient) }
 
+    before do
       ClimateControl.modify(GOVUK_NOTIFY_ALLOW_LIST: "allowed@example.com") do
         MailRecipientInterceptor.delivering_email(mail)
       end
+    end
 
+    it "intercepts emails and sends to an allow-listed email address" do
       expect(mail.to).to include("allowed@example.com")
+    end
+
+    it "intercepts emails and prefixes the original recipient to the body" do
+      expect(mail.body.raw_source).to include(original_recipient)
     end
   end
 end

--- a/spec/lib/mail_recipient_interceptor_spec.rb
+++ b/spec/lib/mail_recipient_interceptor_spec.rb
@@ -1,0 +1,17 @@
+# frozen_string_literal: true
+
+require "mail_recipient_interceptor"
+
+RSpec.describe MailRecipientInterceptor do
+  describe "#delivering_email" do
+    it "intercepts emails and sends to an allow-listed email address" do
+      mail = Mail.new(to: "not-allowed@example.com")
+
+      ClimateControl.modify(GOVUK_NOTIFY_ALLOW_LIST: "allowed@example.com") do
+        MailRecipientInterceptor.delivering_email(mail)
+      end
+
+      expect(mail.to).to include("allowed@example.com")
+    end
+  end
+end


### PR DESCRIPTION
For https://trello.com/c/eNpUY7Ek/744-add-email-intercept

We don't want users to receive notifications in integration and staging
environments as they could get confused with production notifications. While
Notify allows us to specify certain email addresses to only receive
notifications in integration and staging, if a notification is sent to a
non-allowed email address (for example in future when publishers receive
notifications that their content has been published) then Notify will return a
`BadRequestError` which is not ideal.

To avoid this, we create a Mail Recipient Interceptor to intercept emails that
are sent in integration and staging and route them to a team email address
instead of the original intended recipient.  We prefix the intended recipient to the
body of the email so that we can easily know who was intended to receive the 
intercepted emails.