### PR TITLE
Unreserve paths when discarding a first edition

### DIFF
--- a/app/models/edition.rb
+++ b/app/models/edition.rb
@@ -40,6 +40,8 @@ class Edition < ApplicationRecord
 
   has_many :timeline_entries
 
+  has_and_belongs_to_many :revisions
+
   has_many :internal_notes
 
   delegate :content_id, :locale, :document_type, :topics, :document_topics, to: :document

--- a/app/services/delete_draft_service.rb
+++ b/app/services/delete_draft_service.rb
@@ -9,18 +9,16 @@ class DeleteDraftService
   end
 
   def delete
-    raise "Trying to delete a document without a current edition" unless document.current_edition
-    raise "Trying to delete a live document" if document.current_edition.live?
+    edition = document.current_edition
 
-    current_edition = document.current_edition
-    current_edition.image_revisions.each { |ir| delete_image_revision(ir) }
-    discard_draft
+    raise "Trying to delete a document without a current edition" unless edition
+    raise "Trying to delete a live document" if edition.live?
 
-    current_edition.assign_status(:discarded, user)
-                   .update!(current: false)
+    edition.image_revisions.each { |ir| delete_image_revision(ir) }
+    discard_draft(edition)
 
-    live_edition = document.live_edition
-    live_edition&.update!(current: true)
+    reset_live_edition if document.live_edition
+    discard_path_reservations(edition) if edition.number == 1
   rescue GdsApi::BaseError
     document.current_edition.update!(revision_synced: false)
     raise
@@ -28,10 +26,29 @@ class DeleteDraftService
 
 private
 
-  def discard_draft
-    GdsApi.publishing_api_v2.discard_draft(document.content_id)
-  rescue GdsApi::HTTPNotFound
-    Rails.logger.warn("No draft to discard for content id #{document.content_id}")
+  def discard_path_reservations(edition)
+    paths = edition.revisions.map(&:base_path).uniq.compact
+    publishing_app = PublishingApiPayload::PUBLISHING_APP
+
+    paths.each do |path|
+      GdsApi.publishing_api.unreserve_path(path, publishing_app)
+    rescue GdsApi::HTTPNotFound
+      Rails.logger.warn("Tried to discard unreserved path #{path}")
+    end
+  end
+
+  def reset_live_edition
+    document.live_edition.update!(current: true)
+  end
+
+  def discard_draft(edition)
+    begin
+      GdsApi.publishing_api_v2.discard_draft(document.content_id)
+    rescue GdsApi::HTTPNotFound
+      Rails.logger.warn("No draft to discard for content id #{document.content_id}")
+    end
+
+    edition.assign_status(:discarded, user).update!(current: false)
   end
 
   def delete_image_revision(image_revision)

--- a/spec/features/workflow/delete_draft_asset_manager_down_spec.rb
+++ b/spec/features/workflow/delete_draft_asset_manager_down_spec.rb
@@ -33,6 +33,7 @@ RSpec.feature "Delete draft with Asset Manager down" do
   end
 
   def and_i_delete_the_draft
+    stub_publishing_api_unreserve_path(@edition.base_path)
     stub_any_publishing_api_discard_draft
     click_on "Delete draft"
     click_on "Yes, delete draft"

--- a/spec/features/workflow/delete_draft_publishing_api_down_spec.rb
+++ b/spec/features/workflow/delete_draft_publishing_api_down_spec.rb
@@ -20,7 +20,8 @@ RSpec.feature "Delete draft when the Publishing API is down" do
   end
 
   def when_the_api_is_up_and_i_try_again
-    @request = stub_publishing_api_discard_draft(@edition.content_id)
+    stub_publishing_api_discard_draft(@edition.content_id)
+    stub_publishing_api_unreserve_path(@edition.base_path)
     click_on "Delete draft"
     click_on "Yes, delete draft"
   end

--- a/spec/features/workflow/delete_draft_spec.rb
+++ b/spec/features/workflow/delete_draft_spec.rb
@@ -22,6 +22,7 @@ RSpec.feature "Delete draft" do
 
   def and_i_delete_the_draft
     @content_request = stub_publishing_api_discard_draft(@edition.content_id)
+    @unreserve_request = stub_publishing_api_unreserve_path(@edition.base_path)
     @image_request = stub_asset_manager_deletes_any_asset
 
     click_on "Delete draft"
@@ -36,5 +37,6 @@ RSpec.feature "Delete draft" do
   def and_the_draft_is_discarded
     expect(@content_request).to have_been_requested
     expect(@image_request).to have_been_requested.at_least_once
+    expect(@unreserve_request).to have_been_requested
   end
 end

--- a/spec/services/delete_draft_service_spec.rb
+++ b/spec/services/delete_draft_service_spec.rb
@@ -20,6 +20,7 @@ RSpec.describe DeleteDraftService do
 
     it "attempts to delete the document preview" do
       document = create :document, :with_current_edition
+      stub_publishing_api_unreserve_path(document.current_edition.base_path)
       request = stub_publishing_api_discard_draft(document.content_id)
       DeleteDraftService.new(document, user).delete
       expect(request).to have_been_requested
@@ -30,6 +31,7 @@ RSpec.describe DeleteDraftService do
       edition = create :edition, lead_image_revision: image_revision
 
       stub_publishing_api_discard_draft(edition.content_id)
+      stub_publishing_api_unreserve_path(edition.base_path)
       delete_request = stub_asset_manager_deletes_any_asset
 
       DeleteDraftService.new(edition.document, user).delete
@@ -38,8 +40,39 @@ RSpec.describe DeleteDraftService do
       expect(image_revision.reload.assets.map(&:state).uniq).to eq(%w[absent])
     end
 
+    it "attempts to delete path reservations for a first draft" do
+      edition = create :edition
+      previous_revision = create :revision
+      edition.revisions << previous_revision
+
+      stub_publishing_api_discard_draft(edition.content_id)
+
+      unreserve_request1 = stub_publishing_api_unreserve_path(
+        edition.base_path,
+        PublishingApiPayload::PUBLISHING_APP,
+      )
+
+      unreserve_request2 = stub_publishing_api_unreserve_path(
+        previous_revision.base_path,
+        PublishingApiPayload::PUBLISHING_APP,
+      )
+
+      DeleteDraftService.new(edition.document, user).delete
+
+      expect(unreserve_request1).to have_been_requested
+      expect(unreserve_request2).to have_been_requested
+    end
+
+    it "does not delete path reservations for published documents" do
+      document = create :document, :with_current_and_live_editions
+      stub_publishing_api_discard_draft(document.content_id)
+      DeleteDraftService.new(document, user).delete
+      expect(document.reload.current_edition).to eq document.live_edition
+    end
+
     it "sets the current edition of the document to nil if there is no live edition" do
       document = create :document, :with_current_edition
+      stub_publishing_api_unreserve_path(document.current_edition.base_path)
       stub_publishing_api_discard_draft(document.content_id)
       DeleteDraftService.new(document, user).delete
       expect(document.reload.current_edition).to be_nil
@@ -48,6 +81,7 @@ RSpec.describe DeleteDraftService do
     it "sets the current edition of the document to current_edition if there is a live edition" do
       document = create :document, :with_current_and_live_editions
       live_edition = document.live_edition
+      stub_publishing_api_unreserve_path(document.current_edition.base_path)
       stub_publishing_api_discard_draft(document.content_id)
       DeleteDraftService.new(document, user).delete
       expect(document.reload.current_edition).to eq(live_edition)
@@ -56,6 +90,7 @@ RSpec.describe DeleteDraftService do
     it "sets the status of the edition of the document to be discarded" do
       document = create :document, :with_current_edition
       edition = document.current_edition
+      stub_publishing_api_unreserve_path(document.current_edition.base_path)
       stub_publishing_api_discard_draft(document.content_id)
       DeleteDraftService.new(document, user).delete
       expect(edition.status).to be_discarded
@@ -63,6 +98,7 @@ RSpec.describe DeleteDraftService do
 
     it "copes if the document preview does not exist" do
       document = create :document, :with_current_edition
+      stub_publishing_api_unreserve_path(document.current_edition.base_path)
       stub_any_publishing_api_call_to_return_not_found
       DeleteDraftService.new(document, user).delete
       expect(document.reload.current_edition).to be_nil
@@ -72,12 +108,31 @@ RSpec.describe DeleteDraftService do
       image_revision = create :image_revision
       edition = create :edition, lead_image_revision: image_revision
 
+      stub_publishing_api_unreserve_path(edition.base_path)
       stub_publishing_api_discard_draft(edition.content_id)
       DeleteDraftService.new(edition.document, user).delete
 
       expect(edition.reload.status).to be_discarded
-
       expect(image_revision.reload.assets.map(&:state).uniq).to eq(%w[absent])
+    end
+
+    it "copes if the base path is not reserved" do
+      edition = create :edition
+
+      stub_publishing_api_unreserve_path_not_found(edition.base_path)
+      stub_publishing_api_discard_draft(edition.content_id)
+      DeleteDraftService.new(edition.document, user).delete
+
+      expect(edition.reload.status).to be_discarded
+    end
+
+    it "copes if the base path is not valid" do
+      edition = create :edition, base_path: nil
+
+      stub_publishing_api_discard_draft(edition.content_id)
+      DeleteDraftService.new(edition.document, user).delete
+
+      expect(edition.reload.status).to be_discarded
     end
 
     it "removes assets if the asset is on Asset Manager" do
@@ -88,6 +143,7 @@ RSpec.describe DeleteDraftService do
         stub_asset_manager_does_not_have_an_asset(asset.asset_manager_id)
       end
 
+      stub_publishing_api_unreserve_path(edition.base_path)
       stub_publishing_api_discard_draft(edition.content_id)
       DeleteDraftService.new(edition.document, user).delete
 


### PR DESCRIPTION
https://trello.com/c/6s9Bhzyj/632-delete-publishing-api-path-reservations-when-we-discard-drafts

Previously we only discarded the content when deleting a draft, which
leaves the original path reservations in the Publishing API. This
creates a problem if users begin creating their document in Content
Publisher, but need to start again in Whitehall.

This adds an association to the Edition model to retrieve all its
Revisions, which enables the DeleteDraftService to find and unreserve
all the associated base paths, so they can be used in other apps.

I've also refactored the DeleteDraftService to keep the top-level method
short and at a single level of abstraction.