### PR TITLE
Fix Notify delivery method and interceptor

### DIFF
--- a/config/application.rb
+++ b/config/application.rb
@@ -29,21 +29,12 @@ module ContentPublisher
     # the framework and any gems in your application.
 
     config.action_view.raise_on_missing_translations = true
-
     config.i18n.load_path += Dir[Rails.root.join("config", "locales", "**", "*.yml")]
     config.action_view.raise_on_missing_translations = true
-
     config.time_zone = "London"
 
     unless Rails.application.secrets.jwt_auth_secret
       raise "JWT auth secret is not configured. See config/secrets.yml"
-    end
-
-    config.after_initialize do
-      config.action_mailer.notify_settings = {
-        api_key: Rails.application.secrets.notify_api_key,
-        template_id: ENV["GOVUK_NOTIFY_TEMPLATE_ID"],
-      }
     end
   end
 end

--- a/config/initializers/mail_recipient_interceptor.rb
+++ b/config/initializers/mail_recipient_interceptor.rb
@@ -1,3 +1,5 @@
-if ENV.fetch("EMAIL_ADDRESS_OVERRRIDE", nil)
+require "mail_recipient_interceptor"
+
+if ENV.fetch("EMAIL_ADDRESS_OVERRIDE", nil)
   ActionMailer::Base.register_interceptor(MailRecipientInterceptor)
 end

--- a/config/initializers/mailer.rb
+++ b/config/initializers/mailer.rb
@@ -1,2 +1,5 @@
 require "notify_delivery_method"
-ActionMailer::Base.add_delivery_method :notify, NotifyDeliveryMethod
+
+ActionMailer::Base.add_delivery_method :notify, NotifyDeliveryMethod,
+  notify_api_key: Rails.application.secrets.notify_api_key,
+  template_id: ENV["GOVUK_NOTIFY_TEMPLATE_ID"]

--- a/config/secrets.yml
+++ b/config/secrets.yml
@@ -1,6 +1,7 @@
 development:
   secret_key_base: secret
   jwt_auth_secret: secret
+  notify_api_key: <%= ENV['GOVUK_NOTIFY_API_KEY'] %>
 
 test:
   secret_key_base: secret


### PR DESCRIPTION
https://trello.com/c/CJSGxDmN/717-notify-editors-when-content-has-been-published

This fixes the NotifyDeliveryMethod to pass the settings to the
constructor, as well as adding a missing 'require' statement on the
MailRecipientInterceptor when it's added by the initializer.