### PR TITLE
Refactor and fix transactions

### DIFF
--- a/app/controllers/unwithdraw_controller.rb
+++ b/app/controllers/unwithdraw_controller.rb
@@ -13,14 +13,12 @@ class UnwithdrawController < ApplicationController
 
   def unwithdraw
     Edition.find_and_lock_current(document: params[:document]) do |edition|
-      begin
-        UnwithdrawService.new.call(edition, current_user)
-        redirect_to edition.document
-      rescue GdsApi::BaseError => e
-        GovukError.notify(e)
-        redirect_to edition.document,
-                    alert_with_description: t("documents.show.flashes.unwithdraw_error")
-      end
+      UnwithdrawService.new.call(edition, current_user)
+      redirect_to edition.document
     end
+  rescue GdsApi::BaseError => e
+    GovukError.notify(e)
+    redirect_to document_path(params[:document]),
+      alert_with_description: t("documents.show.flashes.unwithdraw_error")
   end
 end

--- a/app/services/remove_service.rb
+++ b/app/services/remove_service.rb
@@ -2,7 +2,7 @@
 
 class RemoveService
   def call(edition, removal)
-    Document.transaction(requires_new: true) do
+    Document.transaction do
       edition.document.lock!
       check_removeable(edition)
 

--- a/app/services/unwithdraw_service.rb
+++ b/app/services/unwithdraw_service.rb
@@ -2,24 +2,22 @@
 
 class UnwithdrawService
   def call(edition, user = nil)
-    Document.transaction(requires_new: true) do
-      raise "edition must be withdrawn to be unwithdrawn" unless edition.withdrawn?
+    raise "edition must be withdrawn to be unwithdrawn" unless edition.withdrawn?
 
-      withdrawal = edition.status.details
-      published_status = withdrawal.published_status
+    withdrawal = edition.status.details
+    published_status = withdrawal.published_status
 
-      edition.assign_status(published_status.state, user)
-      edition.save!
+    edition.assign_status(published_status.state, user)
+    edition.save!
 
-      TimelineEntry.create_for_status_change(
-        entry_type: :unwithdrawn,
-        status: edition.status,
-      )
+    TimelineEntry.create_for_status_change(
+      entry_type: :unwithdrawn,
+      status: edition.status,
+    )
 
-      GdsApi.publishing_api_v2.republish(
-        edition.content_id,
-        locale: "en",
-      )
-    end
+    GdsApi.publishing_api_v2.republish(
+      edition.content_id,
+      locale: "en",
+    )
   end
 end


### PR DESCRIPTION
In a few places within the app we seem to use nested transactions which aren't actually necessary as long as the rescue block is put in the correct place.

## Before
Previously there was a nested transaction where the parent transaction didn't perform any database operations and had a confusing rollback procedure.

If we just removed the nested transaction and did nothing else then
this would not work as expected. The reason for this is that when a
GdsApi exception is thrown the exception would be rescued before the
transaction had a chance to roll back, meaning records could be
updated / created even if a GdsApi error is thrown.

## Now 
The rescue is outside the only transaction, this means when a GdsApi exception
is thrown the transaction handles all the roll backs it needs to do,
uninterrupted. Then when this is complete the exception is bubbled up to
the containing method which is then rescued successfully.

Having a single transaction is better due to it being easier to understand.