### PR TITLE
Publish notification 2

### DIFF
--- a/app/controllers/publish_controller.rb
+++ b/app/controllers/publish_controller.rb
@@ -75,7 +75,7 @@ private
 
   def send_notifications(edition)
     edition.editors.each do |user|
-      PublishMailer.publish_email(edition.status, user).deliver_later
+      PublishMailer.publish_email(edition, user).deliver_later
     end
   end
 end

--- a/app/jobs/email_delivery_job.rb
+++ b/app/jobs/email_delivery_job.rb
@@ -1,0 +1,8 @@
+# frozen_string_literal: true
+
+class EmailDeliveryJob < ActionMailer::DeliveryJob
+  # retry at 3s, 18s, 83s, 258s, 627s
+  retry_on(Notifications::Client::RequestError,
+           wait: :exponentially_longer,
+           attempts: 5)
+end

--- a/app/jobs/scheduled_publishing_job.rb
+++ b/app/jobs/scheduled_publishing_job.rb
@@ -15,7 +15,7 @@ class ScheduledPublishingJob < ApplicationJob
       user = edition.status.created_by
       reviewed = edition.status.details.reviewed
 
-      PublishService.new(edition.document)
+      PublishService.new(edition)
                     .publish(user: user, with_review: reviewed)
     end
   end

--- a/app/mailers/application_mailer.rb
+++ b/app/mailers/application_mailer.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+class ApplicationMailer < ActionMailer::Base
+  def default_url_options
+    { host: Plek.new.external_url_for("content-publisher") }
+  end
+end

--- a/app/mailers/publish_mailer.rb
+++ b/app/mailers/publish_mailer.rb
@@ -1,0 +1,24 @@
+# frozen_string_literal: true
+
+class PublishMailer < ApplicationMailer
+  self.delivery_job = EmailDeliveryJob
+
+  def publish_email(status, user)
+    @user = user
+    @status = status
+    @edition = status.edition
+    mail(to: user.email, subject: subject)
+  end
+
+private
+
+  def subject
+    if @edition.number > 1
+      I18n.t("publish_mailer.publish_email.subject.update",
+             title: @edition.title)
+    else
+      I18n.t("publish_mailer.publish_email.subject.#{@status.state}",
+             title: @edition.title)
+    end
+  end
+end

--- a/app/mailers/publish_mailer.rb
+++ b/app/mailers/publish_mailer.rb
@@ -3,10 +3,15 @@
 class PublishMailer < ApplicationMailer
   self.delivery_job = EmailDeliveryJob
 
-  def publish_email(status, user)
+  def publish_email(edition, user)
     @user = user
-    @status = status
-    @edition = status.edition
+    @edition = edition
+    @status = edition.status
+
+    unless @status.published? || @status.published_but_needs_2i?
+      raise "Cannot send publish email with a non-published state"
+    end
+
     mail(to: user.email, subject: subject)
   end
 

--- a/app/models/edition.rb
+++ b/app/models/edition.rb
@@ -42,6 +42,8 @@ class Edition < ApplicationRecord
 
   has_and_belongs_to_many :revisions
 
+  has_many :statuses
+
   has_many :internal_notes
 
   delegate :content_id, :locale, :document_type, :topics, :document_topics, to: :document
@@ -178,5 +180,10 @@ class Edition < ApplicationRecord
                       last_edited_at: Time.current)
 
     self
+  end
+
+  def editors
+    user_ids = statuses.pluck(:created_by_id) + revisions.pluck(:created_by_id)
+    User.where(id: user_ids.uniq)
   end
 end

--- a/app/views/documents/show/_contents.html.erb
+++ b/app/views/documents/show/_contents.html.erb
@@ -14,7 +14,7 @@
   } %>
 <% end %>
 
-<% if @edition.number > 1 && @edition.update_type == "major" %>
+<% if @edition.number > 1 && @edition.major? %>
   <% edition_metadata << {
     field: t("documents.show.contents.items.change_note"),
     value: @edition.change_note,

--- a/app/views/publish_mailer/publish_email.text.erb
+++ b/app/views/publish_mailer/publish_email.text.erb
@@ -1,36 +1,36 @@
 <%= @edition.document_type.label %> ‘<%= @edition.title %>’
 
-<% if @edition.number > 1 %>
+<% if @edition.number > 1 -%>
   <%= t("publish_mailer.publish_email.details.update",
     time: @status.created_at.strftime("%l:%M%P").strip,
     date: @status.created_at.strftime("%d %B %Y"),
     user: @status.created_by.name,
   ) %>
-<% else %>
+<% else -%>
   <%= t("publish_mailer.publish_email.details.publish",
     time: @status.created_at.strftime("%l:%M%P").strip,
     date: @status.created_at.strftime("%d %B %Y"),
     user: @status.created_by.name,
   ) %>
-<% end %>
+<% end -%>
 
 <%= t("publish_mailer.publish_email.delay_warning") %>
 
 <%= t("publish_mailer.publish_email.page_address") %>
 <%= EditionUrl.new(@edition).public_url %>
 
-<% if @edition.number > 1 %>
-  <% if @edition.major? %>
+<% if @edition.number > 1 -%>
+  <% if @edition.major? -%>
     <%= t("publish_mailer.publish_email.change_note") %>
-    <%= @edition.change_note %>
-  <% else %>
-    <%= t("publish_mailer.publish_email.minor_update") %>
-  <% end %>
-<% end %>
+    <%= @edition.change_note -%>
+  <% else -%>
+    <%= t("publish_mailer.publish_email.minor_update") -%>
+  <% end -%>
+<% end -%>
 
-<% if @edition.published_but_needs_2i? %>
+<% if @edition.published_but_needs_2i? -%>
   <%= t("publish_mailer.publish_email.2i_warning") %>
-<% end %>
+<% end -%>
 
 <%= t("publish_mailer.publish_email.edit_in_app") %>
 <%= document_url(@edition.document) %>

--- a/app/views/publish_mailer/publish_email.text.erb
+++ b/app/views/publish_mailer/publish_email.text.erb
@@ -1,0 +1,36 @@
+<%= @edition.document_type.label %> ‘<%= @edition.title %>’
+
+<% if @edition.number > 1 %>
+  <%= t("publish_mailer.publish_email.details.update",
+    time: @status.created_at.strftime("%l:%M%P").strip,
+    date: @status.created_at.strftime("%d %B %Y"),
+    user: @status.created_by.name,
+  ) %>
+<% else %>
+  <%= t("publish_mailer.publish_email.details.publish",
+    time: @status.created_at.strftime("%l:%M%P").strip,
+    date: @status.created_at.strftime("%d %B %Y"),
+    user: @status.created_by.name,
+  ) %>
+<% end %>
+
+<%= t("publish_mailer.publish_email.delay_warning") %>
+
+<%= t("publish_mailer.publish_email.page_address") %>
+<%= EditionUrl.new(@edition).public_url %>
+
+<% if @edition.number > 1 %>
+  <% if @edition.major? %>
+    <%= t("publish_mailer.publish_email.change_note") %>
+    <%= @edition.change_note %>
+  <% else %>
+    <%= t("publish_mailer.publish_email.minor_update") %>
+  <% end %>
+<% end %>
+
+<% if @edition.published_but_needs_2i? %>
+  <%= t("publish_mailer.publish_email.2i_warning") %>
+<% end %>
+
+<%= t("publish_mailer.publish_email.edit_in_app") %>
+<%= document_url(@edition.document) %>

--- a/config/locales/en/publish_mailer/publish_email.yml
+++ b/config/locales/en/publish_mailer/publish_email.yml
@@ -1,0 +1,16 @@
+en:
+  publish_mailer:
+    publish_email:
+      subject:
+        published: "Published: ‘%{title}’"
+        published_but_needs_2i: "Published but needs 2i review: ‘%{title}’"
+        update: "Update published: ‘%{title}’"
+      details:
+        publish: "Published at %{time} on %{date} by %{user}"
+        update: "Update published at %{time} on %{date} by %{user}"
+      delay_warning: It may take 5 minutes to appear live.
+      page_address: Page address
+      change_note: Public change note
+      edit_in_app: Edit in Content Publisher
+      2i_warning: This content still needs 2i review. It can then be approved or updated.
+      minor_update: A minor style update

--- a/config/sidekiq.yml
+++ b/config/sidekiq.yml
@@ -5,3 +5,6 @@
 :logfile: ./log/sidekiq.json.log
 development:
   :logfile: null
+:queues:
+  - default
+  - mailers

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -5,4 +5,5 @@ user = User.find_or_create_by!(name: "publisher")
 gds_organisation_content_id = "af07d5a5-df63-4ddc-9383-6a666845ebe9"
 
 user.update!(permissions: [User::PRE_RELEASE_FEATURES_PERMISSION],
-            organisation_content_id: gds_organisation_content_id)
+             organisation_content_id: gds_organisation_content_id,
+             email: "someone-else@example.com")

--- a/spec/factories/user_factory.rb
+++ b/spec/factories/user_factory.rb
@@ -4,6 +4,7 @@ FactoryBot.define do
   factory :user do
     name { "John Smith" }
     uid { SecureRandom.uuid }
+    email { "someone@example.com" }
 
     trait :managing_editor do
       permissions { [User::MANAGING_EDITOR_PERMISSION] }

--- a/spec/features/workflow/publish_spec.rb
+++ b/spec/features/workflow/publish_spec.rb
@@ -1,18 +1,51 @@
 # frozen_string_literal: true
 
 RSpec.feature "Publishing an edition" do
-  scenario do
+  include ActiveSupport::Testing::TimeHelpers
+
+  scenario "first edition" do
     given_there_is_an_edition_in_draft
     when_i_visit_the_summary_page
     and_i_publish_the_edition
     then_i_see_the_publish_succeeded
     and_the_content_is_shown_as_published
     and_there_is_a_history_entry
+    and_i_receive_a_confirmation_email
+  end
+
+  scenario "major change" do
+    given_there_is_a_major_change_to_a_live_edition
+    when_i_visit_the_summary_page
+    and_i_publish_the_edition
+    then_i_receive_an_email_about_the_major_change
+  end
+
+  scenario "minor change" do
+    given_there_is_a_minor_change_to_a_live_edition
+    when_i_visit_the_summary_page
+    and_i_publish_the_edition
+    then_i_receive_an_email_about_the_minor_change
+  end
+
+  def given_there_is_a_major_change_to_a_live_edition
+    @edition = create(:edition, :publishable,
+                      number: 2,
+                      update_type: "major",
+                      created_at: 1.day.ago,
+                      change_note: "The best major change ever")
+  end
+
+  def given_there_is_a_minor_change_to_a_live_edition
+    @edition = create(:edition, :publishable,
+                      number: 2,
+                      update_type: "minor")
   end
 
   def given_there_is_an_edition_in_draft
-    @edition = create(:edition,
-                      :publishable,
+    @creator = create(:user, email: "someone@example.com")
+
+    @edition = create(:edition, :publishable,
+                      created_by: @creator,
                       base_path: "/news/banana-pricing-updates")
   end
 
@@ -21,10 +54,12 @@ RSpec.feature "Publishing an edition" do
   end
 
   def and_i_publish_the_edition
-    click_on "Publish"
-    choose I18n.t!("publish.confirmation.has_been_reviewed")
-    @content_request = stub_publishing_api_publish(@edition.content_id, update_type: nil, locale: @edition.locale)
-    click_on "Confirm publish"
+    travel_to(@publish_date = Time.current) do
+      click_on "Publish"
+      choose I18n.t!("publish.confirmation.has_been_reviewed")
+      @content_request = stub_publishing_api_publish(@edition.content_id, update_type: nil, locale: @edition.locale)
+      click_on "Confirm publish"
+    end
   end
 
   def then_i_see_the_publish_succeeded
@@ -40,5 +75,48 @@ RSpec.feature "Publishing an edition" do
 
   def and_there_is_a_history_entry
     expect(page).to have_content(I18n.t!("documents.history.entry_types.published"))
+  end
+
+  def and_i_receive_a_confirmation_email
+    tos = ActionMailer::Base.deliveries.map(&:to)
+    message = ActionMailer::Base.deliveries.first
+
+    publish_time = @publish_date.strftime("%l:%M%P").strip
+    publish_date = @publish_date.strftime("%d %B %Y")
+    publish_user = current_user.name
+
+    expect(tos).to match_array [[@creator.email], [current_user.email]]
+    expect(message.body).to include("https://www.test.gov.uk/news/banana-pricing-updates")
+    expect(message.body).to include(document_path(@edition.document))
+
+    expect(message.subject).to eq(I18n.t("publish_mailer.publish_email.subject.published",
+                                         title: @edition.title))
+
+    expect(message.body).to include(I18n.t("publish_mailer.publish_email.details.publish",
+                                           time: publish_time,
+                                           date: publish_date,
+                                           user: publish_user))
+  end
+
+  def then_i_receive_an_email_about_the_major_change
+    message = ActionMailer::Base.deliveries.first
+
+    publish_time = @publish_date.strftime("%l:%M%P").strip
+    publish_date = @publish_date.strftime("%d %B %Y")
+    publish_user = current_user.name
+    expect(message.body).to include(@edition.change_note)
+
+    expect(message.subject).to eq(I18n.t("publish_mailer.publish_email.subject.update",
+                                         title: @edition.title))
+
+    expect(message.body).to include(I18n.t("publish_mailer.publish_email.details.update",
+                                           time: publish_time,
+                                           date: publish_date,
+                                           user: publish_user))
+  end
+
+  def then_i_receive_an_email_about_the_minor_change
+    message = ActionMailer::Base.deliveries.first
+    expect(message.body).to include(I18n.t!("publish_mailer.publish_email.minor_update"))
   end
 end

--- a/spec/features/workflow/publish_without_review_spec.rb
+++ b/spec/features/workflow/publish_without_review_spec.rb
@@ -1,11 +1,14 @@
 # frozen_string_literal: true
 
 RSpec.feature "Publish without review" do
+  include ActiveSupport::Testing::TimeHelpers
+
   scenario do
     given_there_is_an_edition
     when_i_visit_the_summary_page
     and_i_publish_without_review
     then_i_see_the_publish_succeeded
+    and_the_editors_receive_an_email
 
     when_i_visit_the_summary_page
     then_i_see_it_has_not_been_reviewed
@@ -15,18 +18,31 @@ RSpec.feature "Publish without review" do
   end
 
   def given_there_is_an_edition
-    @edition = create(:edition, :publishable)
+    @creator = create(:user, email: "someone@example.com")
+
+    @edition = create(:edition, :publishable,
+                      created_by: @creator,
+                      created_at: 1.day.ago,
+                      base_path: "/news/banana-pricing-updates")
   end
 
   def when_i_visit_the_summary_page
     visit document_path(@edition.document)
   end
 
+  def when_i_click_the_approve_button
+    travel_to(@publish_date + 1.hour) do
+      click_on "Approve"
+    end
+  end
+
   def and_i_publish_without_review
-    click_on "Publish"
-    choose I18n.t!("publish.confirmation.should_be_reviewed")
-    stub_any_publishing_api_publish
-    click_on "Confirm publish"
+    travel_to(@publish_date = Time.current) do
+      click_on "Publish"
+      choose I18n.t!("publish.confirmation.should_be_reviewed")
+      stub_any_publishing_api_publish
+      click_on "Confirm publish"
+    end
   end
 
   def then_i_see_the_publish_succeeded
@@ -41,10 +57,6 @@ RSpec.feature "Publish without review" do
     end
   end
 
-  def when_i_click_the_approve_button
-    click_on "Approve"
-  end
-
   def then_i_see_that_its_reviewed
     expect(page).to have_content I18n.t!("documents.show.flashes.approved")
     expect(page).to have_content I18n.t!("user_facing_states.published.name")
@@ -52,5 +64,26 @@ RSpec.feature "Publish without review" do
     within first(".app-timeline-entry") do
       expect(page).to have_content I18n.t!("documents.history.entry_types.approved")
     end
+  end
+
+  def and_the_editors_receive_an_email
+    tos = ActionMailer::Base.deliveries.map(&:to)
+    message = ActionMailer::Base.deliveries.first
+
+    publish_time = @publish_date.strftime("%l:%M%P").strip
+    publish_date = @publish_date.strftime("%d %B %Y")
+    publish_user = current_user.name
+
+    expect(tos).to match_array [[@creator.email], [current_user.email]]
+    expect(message.body).to include("https://www.test.gov.uk/news/banana-pricing-updates")
+    expect(message.body).to include(document_path(@edition.document))
+
+    expect(message.subject).to eq(I18n.t("publish_mailer.publish_email.subject.published_but_needs_2i",
+                                         title: @edition.title))
+
+    expect(message.body).to include(I18n.t("publish_mailer.publish_email.details.publish",
+                                           time: publish_time,
+                                           date: publish_date,
+                                           user: publish_user))
   end
 end

--- a/spec/features/workflow/schedule_spec.rb
+++ b/spec/features/workflow/schedule_spec.rb
@@ -3,6 +3,10 @@
 RSpec.feature "Schedule an edition" do
   include ActiveJob::TestHelper
 
+  background do
+    Sidekiq::Testing.fake!
+  end
+
   scenario do
     given_there_is_an_edition_ready_to_schedule
     when_i_visit_the_summary_page

--- a/spec/jobs/scheduled_publishing_job_spec.rb
+++ b/spec/jobs/scheduled_publishing_job_spec.rb
@@ -7,8 +7,11 @@ RSpec.describe ScheduledPublishingJob, inline: true do
                        :scheduled,
                        scheduled_publishing_datetime: Time.current)
       user = edition.status.created_by
+      publish_service = double(:publish_service, publish: nil)
 
-      expect_any_instance_of(PublishService)
+      expect(PublishService).to receive(:new).with(edition) { publish_service }
+
+      expect(publish_service)
         .to receive(:publish)
         .with(user: user, with_review: edition.status.details.reviewed)
 


### PR DESCRIPTION
https://trello.com/c/CJSGxDmN/717-notify-editors-when-content-has-been-published

This adds the ability to notify the editors of an edition by email when their document is published, with or without review. Editors are defined to be any user who has modified or change the state of an edition. Please see the commit for further details :-).