### PR TITLE
Remove redundant rescue_from in ImagesController

### DIFF
--- a/app/controllers/images_controller.rb
+++ b/app/controllers/images_controller.rb
@@ -1,11 +1,6 @@
 # frozen_string_literal: true
 
 class ImagesController < ApplicationController
-  rescue_from GdsApi::BaseError do |e|
-    GovukError.notify(e)
-    redirect_to images_path, alert_with_description: t("images.index.flashes.api_error")
-  end
-
   def index
     @edition = Edition.find_current(document: params[:document])
     render layout: rendering_context


### PR DESCRIPTION
https://trello.com/c/wrIdevce/738-audit-the-way-we-rescue-gdsapi-errors-and-identify-pain-points

This is no longer required because the PreviewService doesn't throw any
errors when using #try_create_preview.