### PR TITLE
Use date-input component for scheduling date

### DIFF
--- a/app/assets/stylesheets/objects/_side.scss
+++ b/app/assets/stylesheets/objects/_side.scss
@@ -21,4 +21,8 @@
   .govuk-section-break {
     clear: both;
   }
+
+  .govuk-details__text {
+    padding: govuk-spacing(3);
+  }
 }

--- a/app/views/documents/show/_scheduling_form.html.erb
+++ b/app/views/documents/show/_scheduling_form.html.erb
@@ -19,24 +19,28 @@
 } do %>
   <%= form_tag(save_scheduled_publishing_datetime_path(@edition.document),
                id: "scheduled_publishing_datetime") do %>
-    <%= render "govuk_publishing_components/components/input", {
-      label: { text: "Day" },
-      name: "scheduled[day]",
-      maxlength: 2,
-      value: submitted_values&.fetch("day") || publish_date&.day,
-    } %>
-    <%= render "govuk_publishing_components/components/input", {
-      label: { text: "Month" },
-      name: "scheduled[month]",
-      maxlength: 2,
-      value: submitted_values&.fetch("month") || publish_date&.month,
-    } %>
-    <%= render "govuk_publishing_components/components/input", {
-      label: { text: "Year" },
-      name: "scheduled[year]",
-      maxlength: 4,
-      value: submitted_values&.fetch("year") || publish_date&.year,
-    } %>
+     <%= render "govuk_publishing_components/components/date_input", {
+       legend_text: "Date",
+       hint: "For example, 27 3 2027",
+       name: 'scheduled',
+       items: [
+         {
+           name: "day",
+           width: 2,
+           value: submitted_values&.fetch("day") || publish_date&.day
+         },
+         {
+           name: "month",
+           width: 2,
+           value: submitted_values&.fetch("month") || publish_date&.month,
+         },
+         {
+           name: "year",
+           width: 4,
+           value: submitted_values&.fetch("year") || publish_date&.year,
+         }
+       ]
+     } %>
     <%= render "govuk_publishing_components/components/select", {
       label: "Time",
       id: "scheduled[time]",


### PR DESCRIPTION
- Replace the multiple inputs for inserting date with the date-input component
- Adjust whitespacing in the details element within the side area to fit the default date-input fields in one line

[Trello card](https://trello.com/c/0ZphzvRd)