### PR TITLE
Fix and improve radio buttons on confirmation

### DIFF
--- a/app/controllers/publish_controller.rb
+++ b/app/controllers/publish_controller.rb
@@ -19,19 +19,27 @@ class PublishController < ApplicationController
 
   def publish
     Edition.find_and_lock_current(document: params[:document]) do |edition|
+      if params[:review_status].nil?
+        flash["alert_with_items"] = {
+          "title" => t("publish.confirmation.radio_not_selected.title"),
+          "items" => [{ 'text': t("publish.confirmation.radio_not_selected.description_govspeak") }],
+        }
+        redirect_to publish_confirmation_path(edition.document)
+        next
+      end
+
       if edition.live?
         redirect_to published_path(edition.document)
         next
       end
 
-      with_review = params[:review_state] == "reviewed"
+      with_review = params[:review_status] == "reviewed"
 
       begin
         live_edition = PublishService.new(edition.document)
                                      .publish(user: current_user, with_review: with_review)
       rescue GdsApi::BaseError
-        redirect_to edition.document,
-                    alert_with_description: t("documents.show.flashes.publish_error")
+        redirect_to edition.document, alert_with_description: t("documents.show.flashes.publish_error")
         next
       end
 

--- a/app/views/publish/confirmation.html.erb
+++ b/app/views/publish/confirmation.html.erb
@@ -5,7 +5,7 @@
   <div class="govuk-grid-column-two-thirds">
     <%= form_tag publish_confirmation_path(@edition.document), data: { "gtm-checked-inputs": "publish-document" } do %>
       <%= render "govuk_publishing_components/components/radio", {
-        name: "review_state",
+        name: "review_status",
         items: [
           {
             value: "reviewed",

--- a/config/locales/en/publish/confirmation.yml
+++ b/config/locales/en/publish/confirmation.yml
@@ -4,3 +4,6 @@ en:
       title: Publish
       has_been_reviewed: "This content has been reviewed and approved for publication"
       should_be_reviewed: "This content needs to be published urgently but should be reviewed as soon as possible"
+      radio_not_selected:
+        title: You must
+        description_govspeak: Select a publishing option

--- a/config/locales/en/schedule/confirmation.yml
+++ b/config/locales/en/schedule/confirmation.yml
@@ -6,3 +6,6 @@ en:
       review_status:
         reviewed: This content has been reviewed and approved for publication.
         not_reviewed: This content needs to be published urgently but should be reviewed as soon as possible.
+      radio_not_selected:
+        title: You must
+        description_govspeak: Select a publishing option

--- a/spec/features/workflow/publish_asset_manager_down_spec.rb
+++ b/spec/features/workflow/publish_asset_manager_down_spec.rb
@@ -26,6 +26,7 @@ RSpec.feature "Publishing an edition when Asset Manager is down" do
   def when_i_try_to_publish_the_edition
     visit document_path(@edition.document)
     click_on "Publish"
+    choose I18n.t!("publish.confirmation.has_been_reviewed")
     click_on "Confirm publish"
   end
 
@@ -37,6 +38,7 @@ RSpec.feature "Publishing an edition when Asset Manager is down" do
     @request = stub_asset_manager_updates_any_asset
     visit document_path(@edition.document)
     click_on "Publish"
+    choose I18n.t!("publish.confirmation.has_been_reviewed")
     click_on "Confirm publish"
   end
 

--- a/spec/features/workflow/publish_publishing_api_down_spec.rb
+++ b/spec/features/workflow/publish_publishing_api_down_spec.rb
@@ -23,6 +23,7 @@ RSpec.feature "Publishing an edition when the Publishing API is down" do
   def when_i_try_to_publish_the_edition
     visit document_path(@edition.document)
     click_on "Publish"
+    choose I18n.t!("publish.confirmation.has_been_reviewed")
     click_on "Confirm publish"
   end
 
@@ -35,6 +36,7 @@ RSpec.feature "Publishing an edition when the Publishing API is down" do
     @request = stub_publishing_api_publish(@edition.content_id, {})
     visit document_path(@edition.document)
     click_on "Publish"
+    choose I18n.t!("publish.confirmation.has_been_reviewed")
     click_on "Confirm publish"
   end
 

--- a/spec/features/workflow/publish_review_status_not_selected_spec.rb
+++ b/spec/features/workflow/publish_review_status_not_selected_spec.rb
@@ -1,0 +1,30 @@
+# frozen_string_literal: true
+
+RSpec.feature "Publish without confirming a review status" do
+  scenario do
+    given_there_is_an_edition_in_draft
+    when_i_visit_the_summary_page
+    and_try_and_publish_without_selecting_a_review_status
+    then_an_error_is_displayed
+  end
+
+  def given_there_is_an_edition_in_draft
+    @edition = create(:edition, :publishable)
+  end
+
+  def when_i_visit_the_summary_page
+    visit document_path(@edition.document)
+  end
+
+  def and_try_and_publish_without_selecting_a_review_status
+    click_on "Publish"
+    click_on "Confirm publish"
+  end
+
+  def then_an_error_is_displayed
+    within(".gem-c-error-summary") do
+      expect(page).to have_content(I18n.t!("publish.confirmation.radio_not_selected.title"))
+      expect(page).to have_content(I18n.t!("publish.confirmation.radio_not_selected.description_govspeak"))
+    end
+  end
+end

--- a/spec/features/workflow/schedule_review_status_not_selected_spec.rb
+++ b/spec/features/workflow/schedule_review_status_not_selected_spec.rb
@@ -1,0 +1,30 @@
+# frozen_string_literal: true
+
+RSpec.feature "Schedule without confirming a review status" do
+  scenario do
+    given_there_is_an_edition_ready_to_schedule
+    when_i_visit_the_summary_page
+    and_try_and_schedule_without_selecting_a_review_status
+    then_an_error_is_displayed
+  end
+
+  def given_there_is_an_edition_ready_to_schedule
+    @edition = create(:edition, scheduled_publishing_datetime: Time.current.tomorrow)
+  end
+
+  def when_i_visit_the_summary_page
+    visit document_path(@edition.document)
+  end
+
+  def and_try_and_schedule_without_selecting_a_review_status
+    click_on "Schedule"
+    click_on "Publish"
+  end
+
+  def then_an_error_is_displayed
+    within(".gem-c-error-summary") do
+      expect(page).to have_content(I18n.t!("schedule.confirmation.radio_not_selected.title"))
+      expect(page).to have_content(I18n.t!("schedule.confirmation.radio_not_selected.description_govspeak"))
+    end
+  end
+end

--- a/spec/features/workflow/schedule_spec.rb
+++ b/spec/features/workflow/schedule_spec.rb
@@ -4,9 +4,7 @@ RSpec.feature "Schedule an edition" do
   scenario do
     given_there_is_an_edition_ready_to_schedule
     when_i_visit_the_summary_page
-    and_i_click_on_schedule
-    and_i_select_the_content_has_been_reviewed_option
-    and_i_click_on_publish
+    and_i_schedule_a_document
     then_i_see_the_edition_has_been_scheduled
     and_i_can_no_longer_edit_the_content
   end
@@ -21,15 +19,9 @@ RSpec.feature "Schedule an edition" do
     visit document_path(@edition.document)
   end
 
-  def and_i_click_on_schedule
+  def and_i_schedule_a_document
     click_on "Schedule"
-  end
-
-  def and_i_select_the_content_has_been_reviewed_option
     choose I18n.t!("schedule.confirmation.review_status.reviewed")
-  end
-
-  def and_i_click_on_publish
     click_on "Publish"
   end
 


### PR DESCRIPTION
Currently when a user clicks 'Publish' on the confirmation screen without selecting whether the document has been approved or not we default the document to 'published without review', this is a bad user experience. 

We should ensure that a user confirms a review status when publishing / scheduling a document.