### PR TITLE
Add nta font

### DIFF
--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -1,5 +1,6 @@
 @import "govuk_publishing_components/all_components";
 
+@import "core/typography";
 @import "core/link";
 
 @import "objects/grid";

--- a/app/assets/stylesheets/core/_typography.scss
+++ b/app/assets/stylesheets/core/_typography.scss
@@ -1,0 +1,3 @@
+// TODO: remove the font-face include when govuk_publishing_components doesn't
+// rely on govuk_template and has $govuk-compatibility-govuktemplate set to false
+@include _govuk-font-face-nta;


### PR DESCRIPTION
Font loading is by default disabled since govuk-frontend v.2.9.0 https://github.com/alphagov/govuk-frontend/releases/tag/v2.9.0 for projects that are [set to be compatible with govuk-template](https://github.com/alphagov/govuk_publishing_components/blob/master/app/assets/stylesheets/govuk_publishing_components/components/helpers/_govuk-frontend-settings.scss#L3) as it's the case with govuk_publishing_component. The reason behind this change is to [ensure the font file is not required twice](https://github.com/alphagov/govuk_publishing_components/issues/597) for projects that rely on govuk_template. So, the font comes disabled from govuk_publishing_component and needs to be enabled in repos that don't rely govuk_template.

### Before
![screenshot-content-publisher integration publishing service gov uk-2019 03 27-14-34-19](https://user-images.githubusercontent.com/788096/55084967-bfd4e980-509d-11e9-8a49-5721a7c17952.png)

### After
![screenshot-localhost-3221-2019 03 27-14-36-36](https://user-images.githubusercontent.com/788096/55084980-c4010700-509d-11e9-9a87-dbc4a8228b3c.png)
