### PR TITLE
Avoid DateTime and multiple parsing of Date/Time

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -48,3 +48,6 @@ Rails/DynamicFindBy:
 
 Rails/SaveBang:
   Enabled: true
+
+Style/DateTime:
+  Enabled: true

--- a/spec/services/requirements/scheduled_datetime_checker_spec.rb
+++ b/spec/services/requirements/scheduled_datetime_checker_spec.rb
@@ -11,51 +11,9 @@ RSpec.describe Requirements::ScheduledDatetimeChecker do
     }
   end
 
-  describe "#date_issues" do
+  describe "#pre_submit_issues" do
     it "returns no issues if there are none" do
-      issues = Requirements::ScheduledDatetimeChecker.new(datetime_params).date_issues
-      expect(issues.items).to be_empty
-    end
-
-    it "returns an issue if the date is invalid" do
-      datetime_params[:day] = ""
-      datetime_params[:month] = ""
-      datetime_params[:year] = ""
-
-      invalid_date = I18n.t!(
-        "requirements.scheduled_datetime.invalid.form_message",
-        field: "Date",
-      )
-
-      issues = Requirements::ScheduledDatetimeChecker.new(datetime_params).date_issues
-      expect(issues.items_for(:scheduled_datetime))
-        .to include(a_hash_including(text: invalid_date))
-    end
-  end
-
-  describe "#time_issues" do
-    it "returns no issues if there are none" do
-      issues = Requirements::ScheduledDatetimeChecker.new(datetime_params).time_issues
-      expect(issues.items).to be_empty
-    end
-
-    it "returns an issue if the time values are invalid" do
-      datetime_params[:time] = ""
-
-      issues = Requirements::ScheduledDatetimeChecker.new(datetime_params).time_issues
-      time_issue = I18n.t!(
-        "requirements.scheduled_datetime.invalid.form_message",
-        field: "Time",
-      )
-
-      expect(issues.items_for(:scheduled_datetime))
-        .to include(a_hash_including(text: time_issue))
-    end
-  end
-
-  describe "#datetime_issues" do
-    it "returns no issues if the datetime is in the future within the limit" do
-      issues = Requirements::ScheduledDatetimeChecker.new(datetime_params).datetime_issues
+      issues = Requirements::ScheduledDatetimeChecker.new(datetime_params).pre_submit_issues
       expect(issues.items).to be_empty
     end
 
@@ -65,7 +23,7 @@ RSpec.describe Requirements::ScheduledDatetimeChecker do
       datetime_params[:month] = past_datetime.month
       datetime_params[:year] = past_datetime.year
 
-      issues = Requirements::ScheduledDatetimeChecker.new(datetime_params).datetime_issues
+      issues = Requirements::ScheduledDatetimeChecker.new(datetime_params).pre_submit_issues
       datetime_issue = I18n.t!("requirements.scheduled_datetime.in_the_past.form_message")
 
       expect(issues.items_for(:scheduled_datetime))
@@ -80,7 +38,7 @@ RSpec.describe Requirements::ScheduledDatetimeChecker do
       datetime_params[:month] = future_date_time.month.to_i
       datetime_params[:year] = future_date_time.year.to_i
 
-      issues = Requirements::ScheduledDatetimeChecker.new(datetime_params).datetime_issues
+      issues = Requirements::ScheduledDatetimeChecker.new(datetime_params).pre_submit_issues
       datetime_issue = I18n.t!("requirements.scheduled_datetime.too_far_in_future.form_message",
                                time_period: "14 months")
 
@@ -97,36 +55,15 @@ RSpec.describe Requirements::ScheduledDatetimeChecker do
       datetime_params[:year] = future_datetime.year
       datetime_params[:time] = future_datetime.strftime("%l:%M%P").strip
 
-      issues = Requirements::ScheduledDatetimeChecker.new(datetime_params).datetime_issues
+      issues = Requirements::ScheduledDatetimeChecker.new(datetime_params).pre_submit_issues
       datetime_issue = I18n.t!("requirements.scheduled_datetime.too_close_to_now.form_message",
                                time_period: "15 minutes")
 
       expect(issues.items_for(:scheduled_datetime))
         .to include(a_hash_including(text: datetime_issue))
     end
-  end
 
-  describe "#pre_submit_issues" do
-    it "returns no issues if there are none" do
-      issues = Requirements::ScheduledDatetimeChecker.new(datetime_params).pre_submit_issues
-      expect(issues.items).to be_empty
-    end
-
-    it "returns datetime issues if any are present" do
-      past_datetime = valid_datetime - 2.days
-      datetime_params[:day] = past_datetime.day
-      datetime_params[:month] = past_datetime.month
-      datetime_params[:year] = past_datetime.year
-
-      datetime_issue = I18n.t!("requirements.scheduled_datetime.in_the_past.form_message")
-
-      issues = Requirements::ScheduledDatetimeChecker.new(datetime_params).pre_submit_issues
-
-      expect(issues.items_for(:scheduled_datetime))
-        .to include(a_hash_including(text: datetime_issue))
-    end
-
-    it "returns date and time issues if any are present" do
+    it "returns an issue if the date or time fields are blank" do
       datetime_params[:day] = ""
       datetime_params[:time] = ""
 
@@ -144,6 +81,7 @@ RSpec.describe Requirements::ScheduledDatetimeChecker do
 
       expect(issues.items_for(:scheduled_datetime))
       .to include(a_hash_including(text: date_issue))
+
       expect(issues.items_for(:scheduled_datetime))
         .to include(a_hash_including(text: time_issue))
     end


### PR DESCRIPTION
https://ci.integration.publishing.service.gov.uk/job/content-publisher/job/use-active-job/5/console

    Previously we did two rounds of parsing of the date and time when
    setting the schedule for publishing a document, as follows:
    
      parsed_date = Date.parse('2019-04-01')
      => '2019-04-01'
    
      parsed_time = Time.parse('09:00am')
      => '2019-03-29 09:00:00 +0000'
    
      DateTime.parse("#{parsed_date} #{parsed_time}").in_time_zone
      DateTime.parse('2019-04-01 2019-03-29 09:00:00 +0000').in_time_zone
      => '2019-04-01 10:00:00 +01:00'
    
    Double-parsing the time separately from the date caused us to inject a
    UTC override '+0000' into what would otherwise have been a BST date.
    This fixes the requirements checker to avoid double-parsing of the time.
    
    In order to help avoid future timezone issues, this also adds a cop to
    encourage the use of Time, instead of DateTime. The existance of both
    classes is apparently historical - Time functions equivalently with the
    added benefit that we have a RuboCop to ensure we use it with 'zone'.