### PR TITLE
Improve re-init for frontend components in modal

### DIFF
--- a/app/assets/javascripts/modal/modal-workflow.js
+++ b/app/assets/javascripts/modal/modal-workflow.js
@@ -6,15 +6,7 @@ function ModalWorkflow ($modal) {
 
 ModalWorkflow.prototype.initComponents = function () {
   window.GOVUK.modules.start($(this.$modal))
-
-  // TODO: change ErrorSummary so it just focusses when it's initialised
-  var $errorSummary = document.querySelector('[data-module="error-summary"]')
-
-  if (!$errorSummary) {
-    return
-  }
-
-  $errorSummary.focus()
+  window.GOVUKFrontend.initAll(this.$modal)
 }
 
 ModalWorkflow.prototype.overrideActions = function (actions) {


### PR DESCRIPTION
https://trello.com/c/S9BlkYgz/794-support-govuk-frontend-components-in-the-context-of-a-modal

Previously we had to manually interact with the error-summary component,
which is part of govuk-frontend, in order to ensure it was focussed when
the modal displays an error. This replaces the manual code with a call
to re-init all govuk-frontend components on the modal element and its
children - previously this was only possible for the entire page, which
had a real risk of initialising components twice on other elements.

We should still use components with caution in the context of the modal,
as some are still coupled to the outer window e.g. the tabs component
modifies the page URL, which doesn't make sense within a modal.