### PR TITLE
Fix clear all filters link

### DIFF
--- a/app/views/documents/index/_filters.html.erb
+++ b/app/views/documents/index/_filters.html.erb
@@ -80,10 +80,11 @@
   <%= hidden_field_tag "sort", @sort %>
 
   <%= render "govuk_publishing_components/components/button", {
-    text: "Filter"
+    text: "Filter",
+    margin_bottom: true
   } %>
 
-  <p>
+  <p class="govuk-body">
     <%= link_to "Clear all filters",
                 documents_path(organisation: ""),
                 class: "govuk-link govuk-link--no-visited-state" %>


### PR DESCRIPTION
The "Clear all filters" is not being styled properly, hence it's displayed in a different size.

### Before
<img width="230" alt="Screen Shot 2019-04-01 at 14 50 22" src="https://user-images.githubusercontent.com/788096/55332540-87fae700-548d-11e9-8659-12889a8e5b44.png">

### After
<img width="230" alt="Screen Shot 2019-04-01 at 14 50 05" src="https://user-images.githubusercontent.com/788096/55332555-8c270480-548d-11e9-91e4-fa04cdd678c0.png">
