### PR TITLE
Image crop params

### DIFF
--- a/app/controllers/images_controller.rb
+++ b/app/controllers/images_controller.rb
@@ -160,8 +160,10 @@ private
 
   def update_crop_params
     image_aspect_ratio = Image::HEIGHT.to_f / Image::WIDTH
-    crop_height = params[:crop_width].to_i * image_aspect_ratio
-    # FIXME: this will raise a warning because of unpermitted paramaters
-    params.permit(:crop_x, :crop_y, :crop_width).merge(crop_height: crop_height.to_i)
+
+    params
+      .require(:image_revision)
+      .permit(:crop_x, :crop_y, :crop_width, :crop_width)
+      .tap { |p| p[:crop_height] = (p[:crop_width].to_i * image_aspect_ratio).to_i }
   end
 end

--- a/app/controllers/images_controller.rb
+++ b/app/controllers/images_controller.rb
@@ -164,6 +164,6 @@ private
     params
       .require(:image_revision)
       .permit(:crop_x, :crop_y, :crop_width, :crop_width)
-      .tap { |p| p[:crop_height] = (p[:crop_width].to_i * image_aspect_ratio).to_i }
+      .tap { |p| p[:crop_height] = (p[:crop_width].to_i * image_aspect_ratio).round }
   end
 end

--- a/app/views/components/_image_cropper.html.erb
+++ b/app/views/components/_image_cropper.html.erb
@@ -32,8 +32,8 @@
     %>
   </div>
 
-  <%= hidden_field_tag 'crop_x', crop_x, class: "js-image-cropper-x" %>
-  <%= hidden_field_tag 'crop_y', crop_y, class: "js-image-cropper-y" %>
-  <%= hidden_field_tag 'crop_width', crop_width, class: "js-image-cropper-width" %>
-  <%= hidden_field_tag 'crop_height', crop_height, class: "js-image-cropper-height" %>
+  <%= hidden_field_tag 'image_revision[crop_x]', crop_x, class: "js-image-cropper-x" %>
+  <%= hidden_field_tag 'image_revision[crop_y]', crop_y, class: "js-image-cropper-y" %>
+  <%= hidden_field_tag 'image_revision[crop_width]', crop_width, class: "js-image-cropper-width" %>
+  <%= hidden_field_tag 'image_revision[crop_height]', crop_height, class: "js-image-cropper-height" %>
 </div>


### PR DESCRIPTION
This fixes the warning about unpermitted params, and the longstanding fixme.

It also switches to round a crop number rather than floor it. See commits for further details.