### PR TITLE
Show error state on radio buttons if not selected

### DIFF
--- a/app/controllers/schedule_controller.rb
+++ b/app/controllers/schedule_controller.rb
@@ -43,9 +43,15 @@ class ScheduleController < ApplicationController
 
   def schedule
     Edition.find_and_lock_current(document: params[:document]) do |edition|
-      if params[:review_status].nil?
-        redirect_to scheduling_confirmation_path(edition.document),
-                    alert_with_items: t("schedule.confirmation.flashes.not_selected")
+      if params[:review_status].blank?
+        flash.now["alert_with_items"] = {
+          "title" => I18n.t!("schedule.confirmation.flashes.requirements"),
+          "items" => review_status_issues.items,
+        }
+
+        render :confirmation,
+               assigns: { issues: review_status_issues, edition: edition },
+               status: :unprocessable_entity
         next
       end
 
@@ -76,6 +82,12 @@ private
 
   def permitted_params
     params.require(:scheduled).permit(:year, :month, :day, :time)
+  end
+
+  def review_status_issues
+    @review_status_issues ||= Requirements::CheckerIssues.new([
+      Requirements::Issue.new(:review_status, :not_selected),
+    ])
   end
 
   def set_scheduled_publishing_datetime(edition, datetime = nil)

--- a/app/views/new_document/choose_document_type.html.erb
+++ b/app/views/new_document/choose_document_type.html.erb
@@ -6,7 +6,8 @@
     <%= form_tag create_document_path, data: { "gtm-checked-inputs": "new-document" } do %>
       <%= render "govuk_publishing_components/components/radio", {
         name: "document_type",
-        items: @document_types.map { |document_type|
+        error_items: @issues&.items_for(:document_type),
+        items: @supertype.document_types.map { |document_type|
           {
             value: document_type.id,
             text: document_type.label,

--- a/app/views/new_document/choose_supertype.html.erb
+++ b/app/views/new_document/choose_supertype.html.erb
@@ -6,6 +6,7 @@
     <%= form_tag(choose_document_type_path, method: :get, enforce_utf8: false, data: { "gtm-checked-inputs": "new-document" } ) do %>
       <%= render "govuk_publishing_components/components/radio", {
         name: "supertype",
+        error_items: @issues&.items_for(:supertype),
         items: @supertypes.map do |supertype|
           {
             value: supertype.id,

--- a/app/views/publish/confirmation.html.erb
+++ b/app/views/publish/confirmation.html.erb
@@ -6,6 +6,7 @@
     <%= form_tag publish_confirmation_path(@edition.document), data: { "gtm-checked-inputs": "publish-document" } do %>
       <%= render "govuk_publishing_components/components/radio", {
         name: "review_status",
+        error_items: @issues&.items_for(:review_status),
         items: [
           {
             value: "reviewed",

--- a/app/views/schedule/confirmation.html.erb
+++ b/app/views/schedule/confirmation.html.erb
@@ -10,6 +10,7 @@
       <%= render "govuk_publishing_components/components/radio", {
         name: "review_status",
         is_page_heading: true,
+        error_items: @issues&.items_for(:review_status),
         hint: t("schedule.confirmation.hint_text", time: scheduled_time, date: scheduled_date),
         items: [
           {

--- a/config/locales/en/new_document/choose_document_type.yml
+++ b/config/locales/en/new_document/choose_document_type.yml
@@ -2,6 +2,4 @@ en:
   new_document:
     choose_document_type:
       flashes:
-        not_selected:
-          title: You must
-          message: Select an option
+        requirements: You must

--- a/config/locales/en/new_document/choose_supertype.yml
+++ b/config/locales/en/new_document/choose_supertype.yml
@@ -3,6 +3,4 @@ en:
     choose_supertype:
       title: "What is the content for?"
       flashes:
-        not_selected:
-          title: You must
-          message: Select an option
+        requirements: You must

--- a/config/locales/en/publish/confirmation.yml
+++ b/config/locales/en/publish/confirmation.yml
@@ -5,6 +5,4 @@ en:
       has_been_reviewed: "This content has been reviewed and approved for publication"
       should_be_reviewed: "This content needs to be published urgently but should be reviewed as soon as possible"
       flashes:
-        not_selected:
-          title: You must
-          message: Select a publishing option
+        requirements: You must

--- a/config/locales/en/requirements.yml
+++ b/config/locales/en/requirements.yml
@@ -74,3 +74,12 @@ en:
         form_message: "Please select a date within the next %{time_period}"
       too_close_to_now:
         form_message: "Please select a time more than %{time_period} from now"
+    document_type:
+      not_selected:
+        form_message: Select an option
+    supertype:
+      not_selected:
+        form_message: Select an option
+    review_status:
+      not_selected:
+        form_message: Select an option

--- a/config/locales/en/schedule/confirmation.yml
+++ b/config/locales/en/schedule/confirmation.yml
@@ -7,6 +7,4 @@ en:
         reviewed: This content has been reviewed and approved for publication.
         not_reviewed: This content needs to be published urgently but should be reviewed as soon as possible.
       flashes:
-        not_selected:
-          title: You must
-          message: Select a publishing option
+        requirements: You must

--- a/spec/features/workflow/create_document_format_not_selected_spec.rb
+++ b/spec/features/workflow/create_document_format_not_selected_spec.rb
@@ -17,8 +17,7 @@ RSpec.feature "Creating a document without selecting a format" do
 
   def then_i_see_an_error_to_choose_a_supertype
     within(".gem-c-error-summary") do
-      expect(page).to have_content(I18n.t!("new_document.choose_supertype.flashes.not_selected.title"))
-      expect(page).to have_content(I18n.t!("new_document.choose_supertype.flashes.not_selected.message"))
+      expect(page).to have_content(I18n.t!("requirements.supertype.not_selected.form_message"))
     end
   end
 
@@ -33,8 +32,7 @@ RSpec.feature "Creating a document without selecting a format" do
 
   def then_i_see_an_error_to_choose_a_document_type
     within(".gem-c-error-summary") do
-      expect(page).to have_content(I18n.t!("new_document.choose_document_type.flashes.not_selected.title"))
-      expect(page).to have_content(I18n.t!("new_document.choose_document_type.flashes.not_selected.message"))
+      expect(page).to have_content(I18n.t!("requirements.document_type.not_selected.form_message"))
     end
   end
 end

--- a/spec/features/workflow/publish_review_status_not_selected_spec.rb
+++ b/spec/features/workflow/publish_review_status_not_selected_spec.rb
@@ -23,8 +23,7 @@ RSpec.feature "Publish without confirming a review status" do
 
   def then_an_error_is_displayed
     within(".gem-c-error-summary") do
-      expect(page).to have_content(I18n.t!("publish.confirmation.flashes.not_selected.title"))
-      expect(page).to have_content(I18n.t!("publish.confirmation.flashes.not_selected.message"))
+      expect(page).to have_content(I18n.t!("requirements.review_status.not_selected.form_message"))
     end
   end
 end

--- a/spec/features/workflow/schedule_review_status_not_selected_spec.rb
+++ b/spec/features/workflow/schedule_review_status_not_selected_spec.rb
@@ -23,8 +23,7 @@ RSpec.feature "Schedule without confirming a review status" do
 
   def then_an_error_is_displayed
     within(".gem-c-error-summary") do
-      expect(page).to have_content(I18n.t!("schedule.confirmation.flashes.not_selected.title"))
-      expect(page).to have_content(I18n.t!("schedule.confirmation.flashes.not_selected.message"))
+      expect(page).to have_content(I18n.t!("requirements.review_status.not_selected.form_message"))
     end
   end
 end


### PR DESCRIPTION
https://trello.com/c/LhoqJDhC/733-revisit-the-radio-buttons-for-the-publish-confirmation-screen

Previously we only displayed an error summary when a radio selection was
not made for publishing, scheduling, or choosing a format, which is
inconsistent with the design system pattern for forms. This modifies the
argument we pass to the radio component to include any error items, for
which it made sense to use the normal requirements data structures, but
without the boilerplate of having an actual checker class.