### PR TITLE
Video embed

### DIFF
--- a/app/assets/javascripts/application.js
+++ b/app/assets/javascripts/application.js
@@ -31,6 +31,7 @@
 //= require modules/gtm-copy-paste-listener.js
 //= require modules/gtm-selected-topics-listener.js
 //= require modules/inline-image-modal.js
+//= require modules/video-embed-modal.js
 //= require modules/warn-before-unload.js
 
 // load after other components (esp. autocomplete)

--- a/app/assets/javascripts/modal/modal-fetch.js
+++ b/app/assets/javascripts/modal/modal-fetch.js
@@ -4,9 +4,10 @@ window.ModalFetch.getLink = function (item) {
   var controller = new window.AbortController()
   var headers = { 'Content-Publisher-Rendering-Context': 'modal' }
   var options = { credentials: 'include', signal: controller.signal, headers: headers }
+  var href = item.dataset.modalActionUrl || item.href
   setTimeout(function () { controller.abort() }, 5000)
 
-  return window.fetch(item.href, options)
+  return window.fetch(href, options)
     .then(function (response) {
       if (!response.ok) {
         window.ModalFetch.debug(response)

--- a/app/assets/javascripts/modules/video-embed-modal.js
+++ b/app/assets/javascripts/modules/video-embed-modal.js
@@ -1,0 +1,70 @@
+function VideoEmbedModal ($module) {
+  this.$module = $module
+  this.$modal = document.getElementById('modal')
+  this.workflow = new window.ModalWorkflow(this.$modal)
+}
+
+VideoEmbedModal.prototype.init = function () {
+  if (!this.$module || !this.$modal) {
+    return
+  }
+
+  this.$multiSectionViewer = this.$modal
+    .querySelector('[data-module="multi-section-viewer"]')
+
+  this.$module.addEventListener('click', function (event) {
+    event.preventDefault()
+    this.performAction(this.$module)
+  }.bind(this))
+}
+
+VideoEmbedModal.prototype.render = function (response) {
+  response
+    .then(this.renderSuccess.bind(this))
+    .catch(this.renderError.bind(this))
+}
+
+VideoEmbedModal.prototype.renderError = function (result) {
+  window.Raven.captureException(result)
+  console.error(result)
+  this.$multiSectionViewer.showStaticSection('error')
+}
+
+VideoEmbedModal.prototype.renderSuccess = function (result) {
+  this.$multiSectionViewer.showDynamicSection(result.body)
+  this.workflow.overrideActions(this.performAction.bind(this))
+  this.workflow.initComponents()
+}
+
+VideoEmbedModal.prototype.insertSnippet = function (text) {
+  var editor = this.$module.closest('[data-module="markdown-editor"]')
+  editor.selectionReplace(text, { surroundWithNewLines: true })
+}
+
+VideoEmbedModal.prototype.performAction = function (item) {
+  var handlers = {
+    'open': function () {
+      this.$modal.open()
+      this.render(window.ModalFetch.getLink(item))
+    },
+    'insert': function () {
+      window.ModalFetch.postForm(item)
+        .then(function (result) {
+          if (result.unprocessableEntity) {
+            this.renderSuccess(result)
+          } else {
+            this.$modal.close()
+            this.insertSnippet(result.body)
+          }
+        }.bind(this))
+        .catch(this.renderError.bind(this))
+    }
+  }
+
+  this.$modal.focusDialog()
+  this.$multiSectionViewer.showStaticSection('loading')
+  handlers[item.dataset.modalAction].bind(this)()
+}
+
+var element = document.querySelector('[data-module="video-embed-modal"]')
+new VideoEmbedModal(element).init()

--- a/app/controllers/video_embed_controller.rb
+++ b/app/controllers/video_embed_controller.rb
@@ -1,0 +1,21 @@
+# frozen_string_literal: true
+
+class VideoEmbedController < ApplicationController
+  def new
+    if rendering_context != "modal"
+      head :bad_request
+      return
+    end
+
+    render :new, layout: rendering_context
+  end
+
+  def create
+    if rendering_context != "modal"
+      head :bad_request
+      return
+    end
+
+    render inline: "[#{params[:title]}](#{params[:url]})"
+  end
+end

--- a/app/services/requirements/video_embed_checker.rb
+++ b/app/services/requirements/video_embed_checker.rb
@@ -1,0 +1,34 @@
+# frozen_string_literal: true
+
+module Requirements
+  class VideoEmbedChecker
+    YOUTUBE_HOST = "youtube.com"
+    YOUTU_HOST = "youtu.be"
+
+    def pre_embed_issues(title: nil, url: nil)
+      issues = []
+
+      if title.blank?
+        issues << Issue.new(:video_embed_title, :blank)
+      end
+
+      if url.blank?
+        issues << Issue.new(:video_embed_url, :blank)
+      elsif !youtube_url?(url)
+        issues << Issue.new(:video_embed_url, :non_youtube)
+      end
+
+      CheckerIssues.new(issues)
+    end
+
+  private
+
+    def youtube_url?(url)
+      uri = URI.parse(url)
+      return true if uri.host.to_s.end_with?(YOUTU_HOST)
+
+      uri.host.to_s.end_with?(YOUTUBE_HOST) &&
+        uri.path == "/watch" && uri.query.match(/v=/)
+    end
+  end
+end

--- a/app/views/components/_markdown_editor.html.erb
+++ b/app/views/components/_markdown_editor.html.erb
@@ -29,6 +29,16 @@
           module: "inline-image-modal",
           "modal-action": "open",
         }
+      },
+      {
+        text: "Video",
+        href: "https://www.gov.uk/guidance/how-to-publish-on-gov-uk/markdown#video",
+        target: "_blank",
+        data_attributes: {
+          module: "video-embed-modal",
+          "modal-action": "open",
+          "modal-action-url": video_embed_path
+        }
       }
     ]
   end

--- a/app/views/images/edit.html.erb
+++ b/app/views/images/edit.html.erb
@@ -1,6 +1,6 @@
 <%
 title_key = rendering_context == "modal" ? "images.edit.title_modal" : "images.edit.title"
-content_for :title,t(title_key, title: @edition.title_or_fallback)
+content_for :title, t(title_key, title: @edition.title_or_fallback)
 %>
 
 <% content_for :back_link, render_back_link(

--- a/app/views/images/index.html.erb
+++ b/app/views/images/index.html.erb
@@ -1,6 +1,6 @@
 <%
 title_key = rendering_context == "modal" ? "images.index.title_modal" : "images.index.title"
-content_for :title,t(title_key, title: @edition.title_or_fallback)
+content_for :title, t(title_key, title: @edition.title_or_fallback)
 %>
 
 <% unless rendering_context == "modal" %>

--- a/app/views/video_embed/new.html.erb
+++ b/app/views/video_embed/new.html.erb
@@ -1,0 +1,32 @@
+<% content_for :title, t("video_embed.new.title") %>
+
+<%= render_govspeak(t("video_embed.new.guidance_markdown")) %>
+
+<%= form_tag(
+  video_embed_path,
+  data: {
+    modal_action: "insert"
+  }
+) do %>
+  <%= render "govuk_publishing_components/components/input", {
+    label: {
+      text: t("video_embed.new.form_labels.title"),
+      bold: true
+    },
+    name: "title"
+  } %>
+
+  <%= render "govuk_publishing_components/components/input", {
+    label: {
+      text: t("video_embed.new.form_labels.url"),
+      bold: true
+    },
+    hint: t("video_embed.new.form_labels.url_hint"),
+    name: "url"
+  } %>
+
+  <%= render "govuk_publishing_components/components/button", {
+    margin_bottom: true,
+    text: "Embed video",
+  } %>
+<% end %>

--- a/app/views/video_embed/new.html.erb
+++ b/app/views/video_embed/new.html.erb
@@ -13,6 +13,8 @@
       text: t("video_embed.new.form_labels.title"),
       bold: true
     },
+    error_items: @issues&.items_for(:video_embed_title),
+    value: params[:title],
     name: "title"
   } %>
 
@@ -22,6 +24,8 @@
       bold: true
     },
     hint: t("video_embed.new.form_labels.url_hint"),
+    error_items: @issues&.items_for(:video_embed_url),
+    value: params[:url],
     name: "url"
   } %>
 

--- a/config/locales/en/requirements.yml
+++ b/config/locales/en/requirements.yml
@@ -88,3 +88,11 @@ en:
     review_status:
       not_selected:
         form_message: Select an option
+    video_embed_title:
+      blank:
+        form_message: Enter a title
+    video_embed_url:
+      blank:
+        form_message: Enter a web address
+      non_youtube:
+        form_message: Enter a valid YouTube web address

--- a/config/locales/en/video_embed/new.yml
+++ b/config/locales/en/video_embed/new.yml
@@ -3,6 +3,8 @@ en:
     new:
       title: Embed YouTube video
       guidance_markdown: Only YouTube videos can be embedded on GOV.UK. [Full guidance on videos on GOV.UK](https://www.gov.uk/guidance/how-to-publish-on-gov-uk/markdown#video){:target="_blank"}.
+      flashes:
+        requirements: You must
       form_labels:
         title: Video title
         url: YouTube video web address

--- a/config/locales/en/video_embed/new.yml
+++ b/config/locales/en/video_embed/new.yml
@@ -1,0 +1,9 @@
+en:
+  video_embed:
+    new:
+      title: Embed YouTube video
+      guidance_markdown: Only YouTube videos can be embedded on GOV.UK. [Full guidance on videos on GOV.UK](https://www.gov.uk/guidance/how-to-publish-on-gov-uk/markdown#video){:target="_blank"}.
+      form_labels:
+        title: Video title
+        url: YouTube video web address
+        url_hint: "Links should start: https://www.youtube.com/watch"

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -81,6 +81,9 @@ Rails.application.routes.draw do
   get "/beta-capabilities" => "publisher_information#beta_capabilities", as: :beta_capabilities
   get "/publisher-updates" => "publisher_information#publisher_updates", as: :publisher_updates
 
+  get "/video-embed" => "video_embed#new", as: :video_embed
+  post "/video-embed" => "video_embed#create", as: :create_video_embed
+
   mount GovukPublishingComponents::Engine, at: "/component-guide"
 
   if Rails.env.test?

--- a/spec/features/editing_content/insert_video_embed_requirements_spec.rb
+++ b/spec/features/editing_content/insert_video_embed_requirements_spec.rb
@@ -1,0 +1,38 @@
+# frozen_string_literal: true
+
+RSpec.describe "Insert video embed", js: true do
+  scenario do
+    given_there_is_an_edition
+    when_i_go_to_edit_the_edition
+    and_i_click_to_insert_a_video
+    and_i_embed_an_invalid_video
+    then_i_see_an_error_to_fix_the_issues
+  end
+
+  def given_there_is_an_edition
+    body_field = build(:field, id: "body", type: "govspeak")
+    document_type = build(:document_type, contents: [body_field])
+    @edition = create(:edition, document_type_id: document_type.id)
+  end
+
+  def when_i_go_to_edit_the_edition
+    visit edit_document_path(@edition.document)
+  end
+
+  def and_i_click_to_insert_a_video
+    within(".app-c-markdown-editor") do
+      find("markdown-toolbar details").click
+      click_on "Video"
+    end
+  end
+
+  def and_i_embed_an_invalid_video
+    click_on "Embed video"
+  end
+
+  def then_i_see_an_error_to_fix_the_issues
+    within(".gem-c-error-summary") do
+      expect(page).to have_content(I18n.t!("requirements.video_embed_title.blank.form_message"))
+    end
+  end
+end

--- a/spec/features/editing_content/insert_video_embed_spec.rb
+++ b/spec/features/editing_content/insert_video_embed_spec.rb
@@ -1,0 +1,39 @@
+# frozen_string_literal: true
+
+RSpec.describe "Insert video embed", js: true do
+  scenario do
+    given_there_is_an_edition
+    when_i_go_to_edit_the_edition
+    and_i_click_to_insert_a_video
+    and_i_enter_and_embed_a_video
+    then_i_see_the_snippet_is_inserted
+  end
+
+  def given_there_is_an_edition
+    body_field = build(:field, id: "body", type: "govspeak")
+    document_type = build(:document_type, contents: [body_field])
+    @edition = create(:edition, document_type_id: document_type.id)
+  end
+
+  def when_i_go_to_edit_the_edition
+    visit edit_document_path(@edition.document)
+  end
+
+  def and_i_click_to_insert_a_video
+    within(".app-c-markdown-editor") do
+      find("markdown-toolbar details").click
+      click_on "Video"
+    end
+  end
+
+  def and_i_enter_and_embed_a_video
+    fill_in "title", with: "A title"
+    fill_in "url", with: "https://www.youtube.com/watch?v=G8KpPw303PY"
+    click_on "Embed video"
+  end
+
+  def then_i_see_the_snippet_is_inserted
+    snippet = "[A title](https://www.youtube.com/watch?v=G8KpPw303PY)"
+    expect(find("#body").value).to match snippet
+  end
+end

--- a/spec/services/requirements/video_embed_checker_spec.rb
+++ b/spec/services/requirements/video_embed_checker_spec.rb
@@ -1,0 +1,43 @@
+# frozen_string_literal: true
+
+RSpec.describe Requirements::VideoEmbedChecker do
+  describe "#pre_embed_issues" do
+    it "returns no issues when there are none" do
+      issues = Requirements::VideoEmbedChecker.new.pre_embed_issues(
+        title: "A title", url: "https://www.youtube.com/watch?v=hY7m5jjJ9mM",
+      )
+
+      expect(issues.items).to be_empty
+
+      issues = Requirements::VideoEmbedChecker.new.pre_embed_issues(
+        title: "A title", url: "https://youtu.be/FdeioVndUhs",
+      )
+
+      expect(issues.items).to be_empty
+    end
+
+    it "returns an issue when the title is blank" do
+      issues = Requirements::VideoEmbedChecker.new.pre_embed_issues
+      form_message = issues.items_for(:video_embed_title).first[:text]
+      expect(form_message).to eq(I18n.t!("requirements.video_embed_title.blank.form_message"))
+    end
+
+    it "returns an issue for invalid URL hosts" do
+      issues = Requirements::VideoEmbedChecker.new.pre_embed_issues(url: "/on-localhost")
+      form_message = issues.items_for(:video_embed_url).first[:text]
+      expect(form_message).to eq(I18n.t!("requirements.video_embed_url.non_youtube.form_message"))
+    end
+
+    it "returns an issue when the URL is blank" do
+      issues = Requirements::VideoEmbedChecker.new.pre_embed_issues
+      form_message = issues.items_for(:video_embed_url).first[:text]
+      expect(form_message).to eq(I18n.t!("requirements.video_embed_url.blank.form_message"))
+    end
+
+    it "returns an issue for non-YouTube URLs" do
+      issues = Requirements::VideoEmbedChecker.new.pre_embed_issues(url: "http://vimeo.com")
+      form_message = issues.items_for(:video_embed_url).first[:text]
+      expect(form_message).to eq(I18n.t!("requirements.video_embed_url.non_youtube.form_message"))
+    end
+  end
+end


### PR DESCRIPTION
https://trello.com/c/4kQa7EZO/762-allow-users-embed-videos

This adds an embed video workflow, which is only accessible in the context of a modal. Please see the commits for further info. Future things to look into:

   - Reduce duplication of the render logic between the two modal modules
   - Make the modal appear at two thirds with for this workflow