### PR TITLE
This fixes a missing newline after the update type

### DIFF
--- a/app/views/publish_mailer/publish_email.text.erb
+++ b/app/views/publish_mailer/publish_email.text.erb
@@ -1,17 +1,17 @@
 <%= @edition.document_type.label %> ‘<%= @edition.title %>’
 
 <% if @edition.number > 1 -%>
-  <%= t("publish_mailer.publish_email.details.update",
-    time: @status.created_at.strftime("%l:%M%P").strip,
-    date: @status.created_at.strftime("%d %B %Y"),
-    user: @status.created_by.name,
-  ) %>
+<%= t("publish_mailer.publish_email.details.update",
+  time: @status.created_at.strftime("%l:%M%P").strip,
+  date: @status.created_at.strftime("%d %B %Y"),
+  user: @status.created_by.name,
+) %>
 <% else -%>
-  <%= t("publish_mailer.publish_email.details.publish",
-    time: @status.created_at.strftime("%l:%M%P").strip,
-    date: @status.created_at.strftime("%d %B %Y"),
-    user: @status.created_by.name,
-  ) %>
+<%= t("publish_mailer.publish_email.details.publish",
+  time: @status.created_at.strftime("%l:%M%P").strip,
+  date: @status.created_at.strftime("%d %B %Y"),
+  user: @status.created_by.name,
+) %>
 <% end -%>
 
 <%= t("publish_mailer.publish_email.delay_warning") %>
@@ -20,16 +20,16 @@
 <%= EditionUrl.new(@edition).public_url %>
 
 <% if @edition.number > 1 -%>
-  <% if @edition.major? -%>
-    <%= t("publish_mailer.publish_email.change_note") %>
-    <%= @edition.change_note -%>
-  <% else -%>
-    <%= t("publish_mailer.publish_email.minor_update") -%>
-  <% end -%>
+<% if @edition.major? -%>
+<%= t("publish_mailer.publish_email.change_note") %>
+<%= @edition.change_note %>
+<% else -%>
+<%= t("publish_mailer.publish_email.minor_update") %>
+<% end -%>
 <% end -%>
 
 <% if @edition.published_but_needs_2i? -%>
-  <%= t("publish_mailer.publish_email.2i_warning") %>
+<%= t("publish_mailer.publish_email.2i_warning") %>
 <% end -%>
 
 <%= t("publish_mailer.publish_email.edit_in_app") %>

--- a/lib/mail_recipient_interceptor.rb
+++ b/lib/mail_recipient_interceptor.rb
@@ -2,7 +2,7 @@
 
 class MailRecipientInterceptor
   def self.delivering_email(message)
-    body_prefix = "Intended recipient(s): #{message.to.join(', ')}\n"
+    body_prefix = "Intended recipient(s): #{message.to.join(', ')}\n\n"
 
     message.body = body_prefix + message.body.raw_source
     message.to = ENV["EMAIL_ADDRESS_OVERRIDE"]


### PR DESCRIPTION
https://trello.com/c/CJSGxDmN/717-notify-editors-when-content-has-been-published

GOV.UK Notify was also styling one of the lines strangely, which seems
to be related to the indentation from ERB. This removes all node
indentationt to make the output more predictable.