### PR TITLE
Fix previous input lost on document edit

### DIFF
--- a/app/controllers/documents_controller.rb
+++ b/app/controllers/documents_controller.rb
@@ -58,7 +58,9 @@ class DocumentsController < ApplicationController
           "items" => @issues.items,
         }
 
-        render :edit, assigns: { edition: edition, revision: edition.revision }, status: :unprocessable_entity
+        render :edit,
+               assigns: { edition: edition, revision: updater.next_revision },
+               status: :unprocessable_entity
         next
       end
 

--- a/spec/features/editing_content/edit_edition_requirements_spec.rb
+++ b/spec/features/editing_content/edit_edition_requirements_spec.rb
@@ -2,21 +2,31 @@
 
 RSpec.feature "Edit an edition with requirements issues" do
   scenario do
-    given_there_is_an_edition_with_issues
-    when_i_visit_the_edit_document_page_and_save
+    given_there_is_an_edition
+    when_i_visit_the_edit_document_page
+    and_submit_a_request_with_requirement_issues
     then_i_should_see_an_error_to_fix_the_issues
+    and_see_my_previous_submission
   end
 
-  def given_there_is_an_edition_with_issues
-    @edition = create(:edition, title: "")
+  def given_there_is_an_edition
+    @edition = create(:edition, title: "Valid title")
   end
 
-  def when_i_visit_the_edit_document_page_and_save
+  def when_i_visit_the_edit_document_page
     visit edit_document_path(@edition.document)
+  end
+
+  def and_submit_a_request_with_requirement_issues
+    fill_in "revision[title]", with: ""
     click_on "Save"
   end
 
   def then_i_should_see_an_error_to_fix_the_issues
     expect(page).to have_content(I18n.t!("requirements.title.blank.form_message"))
+  end
+
+  def and_see_my_previous_submission
+    expect(page).to have_field("revision[title]", with: "")
   end
 end


### PR DESCRIPTION
We can't refer to edition.revision at this point as it isn't yet
persisted to edition.

I've updated the test to catch this scenario if it re-occurs.