### PR TITLE
Include errors with relevant field on withdraw form

### DIFF
--- a/app/controllers/withdraw_controller.rb
+++ b/app/controllers/withdraw_controller.rb
@@ -33,7 +33,7 @@ class WithdrawController < ApplicationController
         }
 
         render :new,
-               assigns: { edition: edition, public_explanation: public_explanation },
+               assigns: { edition: edition, public_explanation: public_explanation, issues: issues },
                status: :unprocessable_entity
         next
       end

--- a/app/views/withdraw/new.html.erb
+++ b/app/views/withdraw/new.html.erb
@@ -17,6 +17,7 @@
         },
         id: "withdrawal_public_explanation",
         value: @public_explanation,
+        error_items: @issues&.items_for(:public_explanation),
         name: "public_explanation",
         rows: 6,
         data: {


### PR DESCRIPTION
Trello: https://trello.com/c/SdMUjUmj/722-resolve-xss-issues-raised-by-pen-testers

This form previously only showed issues as a flash message, this now includes them with the fields.

Screenshot:

![screencapture-localhost-3221-documents-f34f85f1-bd03-4df1-971c-e62b9add8f08-en-withdraw-2019-04-04-15_28_47](https://user-images.githubusercontent.com/282717/55571819-34db9b00-56fe-11e9-8dd5-77bc87cc389a.png)
