### PR TITLE
Show markdown component errors on edit document page

### DIFF
--- a/app/assets/javascripts/components/markdown-editor.js
+++ b/app/assets/javascripts/components/markdown-editor.js
@@ -94,6 +94,9 @@ window.GOVUK.Modules = window.GOVUK.Modules || {};
 
   MarkdownEditor.prototype.fetchGovspeakPreview = function (text) {
     var path = this.$module.getAttribute('data-govspeak-path')
+    if (!path) {
+      return window.Promise.reject('Govspeak path not set')
+    }
     var url = new URL(document.location.origin + path)
 
     var formData = new window.FormData()

--- a/app/views/components/_markdown_editor.html.erb
+++ b/app/views/components/_markdown_editor.html.erb
@@ -5,6 +5,10 @@
   contextual_guidance ||= nil
   govspeak_path ||= nil
   edition ||= nil
+  error_items ||= []
+
+  component_classes = %w[app-c-markdown-editor govuk-form-group]
+  component_classes << "govuk-form-group--error" if error_items.any?
 
   insert_items = []
 
@@ -29,7 +33,7 @@
     ]
   end
 %>
-<%= tag.div class: "app-c-markdown-editor",
+<%= tag.div class: component_classes,
   data: {
     "module": "markdown-editor",
     "govspeak-path": govspeak_path,
@@ -38,6 +42,13 @@
   <%= render "govuk_publishing_components/components/label", {
       html_for: textarea[:id]
   }.merge(label.symbolize_keys) %>
+
+  <% if error_items.any? %>
+    <%= render "govuk_publishing_components/components/error_message", {
+      text: error_items.map { |item| html_escape(item[:text]) }.join("<br/>").html_safe
+    } %>
+  <% end %>
+
   <div class="app-c-markdown-editor__container js-markdown-editor__container">
     <div class="app-c-markdown-editor__head js-markdown-editor__head">
       <div class="app-c-markdown-editor__preview-toggle">

--- a/app/views/components/_markdown_editor.html.erb
+++ b/app/views/components/_markdown_editor.html.erb
@@ -4,6 +4,30 @@
   preview_button_text ||= 'Preview markdown'
   contextual_guidance ||= nil
   govspeak_path ||= nil
+  edition ||= nil
+
+  insert_items = []
+
+  if edition
+    insert_items = [
+      {
+        text: "Contact",
+        button_options: {
+          value: "add_contact",
+          name: "submit",
+        },
+      },
+      {
+        text: "Image",
+        href: images_path(edition.document),
+        target: "_blank",
+        data_attributes: {
+          module: "inline-image-modal",
+          "modal-action": "open",
+        }
+      }
+    ]
+  end
 %>
 <%= tag.div class: "app-c-markdown-editor",
   data: {
@@ -40,28 +64,13 @@
           <md-unordered-list class="app-c-markdown-editor__toolbar-button" title="Bullets" aria-label="Bullets" data-gtm="markdown-toolbar-selection">
             <%= render "components/markdown_editor/bullets.svg" %>
           </md-unordered-list>
-          <%= render "components/toolbar_dropdown", {
-            title: "Insert...",
-            align: 'right',
-            items: [
-              {
-                text: "Contact",
-                button_options: {
-                  value: "add_contact",
-                  name: "submit",
-                },
-              },
-              {
-                text: "Image",
-                href: images_path(@edition.document),
-                target: "_blank",
-                data_attributes: {
-                  module: "inline-image-modal",
-                  "modal-action": "open",
-                }
-              }
-            ]
-          } %>
+          <% if insert_items.any? %>
+            <%= render "components/toolbar_dropdown", {
+              title: "Insert...",
+              align: 'right',
+              items: insert_items
+            } %>
+          <% end %>
         </markdown-toolbar>
       </div>
     </div>

--- a/app/views/components/docs/markdown_editor.yml
+++ b/app/views/components/docs/markdown_editor.yml
@@ -24,3 +24,12 @@ examples:
         name: markdown-editor
         id: markdown-editor
       contextual_guidance: "document-contents-guidance"
+  with_error:
+    data:
+      label:
+        text: Body with error
+      textarea:
+        name: markdown-editor-error
+        id: markdown-editor-error
+      error_items:
+        - text: There is a problem with this input

--- a/app/views/components/docs/markdown_editor.yml
+++ b/app/views/components/docs/markdown_editor.yml
@@ -23,5 +23,4 @@ examples:
       textarea:
         name: markdown-editor
         id: markdown-editor
-      govspeak_preview_path: "#"
       contextual_guidance: "document-contents-guidance"

--- a/app/views/documents/edit.html.erb
+++ b/app/views/documents/edit.html.erb
@@ -103,7 +103,12 @@
   <% end %>
 
   <% @edition.document_type.contents.each do |field| %>
-    <%= render "documents/fields/#{field.type}_input", field: field, edition: @edition, revision: @revision %>
+    <%= render "documents/fields/#{field.type}_input",
+      field: field,
+      edition: @edition,
+      revision: @revision,
+      issues: @issues
+    %>
   <% end %>
 
   <% if @edition.document.live_edition %>

--- a/app/views/documents/fields/_govspeak_input.html.erb
+++ b/app/views/documents/fields/_govspeak_input.html.erb
@@ -20,6 +20,7 @@
       contextual_guidance: "document-contents-guidance",
       govspeak_path: govspeak_preview_path(edition.document),
       edition: edition,
+      error_items: issues&.items_for(field.id.to_sym)
     } %>
   </div>
 

--- a/app/views/documents/fields/_govspeak_input.html.erb
+++ b/app/views/documents/fields/_govspeak_input.html.erb
@@ -19,6 +19,7 @@
       },
       contextual_guidance: "document-contents-guidance",
       govspeak_path: govspeak_preview_path(edition.document),
+      edition: edition,
     } %>
   </div>
 


### PR DESCRIPTION
Trello: https://trello.com/c/SdMUjUmj/722-resolve-xss-issues-raised-by-pen-testers

This PR does a few things:

- It fixes problems that was causing the markdown to not render in component guide, this whole component is a bit dubious though. See commit for more info.
- Adds error_items support to the markdown component
- Wires errors into markdown component on edit document page

Screenshot:

![screencapture-localhost-3221-documents-49ea88bd-1e07-4d65-bf08-00b361f1efe9-en-2019-04-04-16_56_30](https://user-images.githubusercontent.com/282717/55572035-a9163e80-56fe-11e9-867e-482ffa8b8c32.png)
