### PR TITLE
Add GTM tags when embedding a video

### DIFF
--- a/app/views/components/_markdown_editor.html.erb
+++ b/app/views/components/_markdown_editor.html.erb
@@ -36,6 +36,7 @@
         target: "_blank",
         data_attributes: {
           module: "video-embed-modal",
+          gtm: "open-video-embed-modal",
           "modal-action": "open",
           "modal-action-url": video_embed_path
         }

--- a/app/views/video_embed/new.html.erb
+++ b/app/views/video_embed/new.html.erb
@@ -31,6 +31,9 @@
 
   <%= render "govuk_publishing_components/components/button", {
     margin_bottom: true,
+    data_attributes: {
+      gtm: "insert-video-embed"
+    },
     text: "Embed video",
   } %>
 <% end %>


### PR DESCRIPTION
https://trello.com/c/4kQa7EZO/762-allow-users-embed-videos

It looks like we prefer to begin our GTM tags with a verb, so I've stuck
with that convention.