### PR TITLE
Link Content Data page

### DIFF
--- a/app/services/content_data_url.rb
+++ b/app/services/content_data_url.rb
@@ -18,12 +18,35 @@ class ContentDataUrl
   end
 
   def displayable?(user)
-    has_content_data_access?(user)
+    has_content_data_access?(user) && expected_in_content_data?
   end
 
 private
 
   def has_content_data_access?(user)
     CONTENT_DATA_BETA_PARTNERS.include?(user.organisation_content_id)
+  end
+
+  def expected_in_content_data?
+    # Content Data ETL runs around 7am each day and pulls in data from the
+    # previous day. If content was first published yesterday we only want to
+    # show a link to the content data page after the ETL has run otherwise users
+    # will get a 404 page. Data Informed Content are looking at changing this so
+    # this check should only be temporary.
+    first_published_before_yesterday? ||
+      (first_published_yesterday? && content_data_etl_end_time_elapsed?)
+  end
+
+  def first_published_yesterday?
+    document.first_published_at.to_date == Date.yesterday
+  end
+
+  def first_published_before_yesterday?
+    document.first_published_at.to_date < Date.yesterday
+  end
+
+  def content_data_etl_end_time_elapsed?
+    # We assume that the Content Data ETL will have finished before 9am.
+    Time.current.hour >= 9
   end
 end

--- a/app/services/content_data_url.rb
+++ b/app/services/content_data_url.rb
@@ -1,0 +1,14 @@
+# frozen_string_literal: true
+
+class ContentDataUrl
+  attr_reader :document
+
+  def initialize(document)
+    @document = document
+  end
+
+  def url
+    content_data_root = Plek.new.external_url_for("content-data-admin")
+    content_data_root + "/metrics" + document.live_edition.base_path
+  end
+end

--- a/app/services/content_data_url.rb
+++ b/app/services/content_data_url.rb
@@ -1,6 +1,11 @@
 # frozen_string_literal: true
 
 class ContentDataUrl
+  # department-for-work-pensions, department-of-health-and-social-care, government-digital-service
+  CONTENT_DATA_BETA_PARTNERS = %w(b548a09f-8b35-4104-89f4-f1a40bf3136d
+                                  7cd6bf12-bbe9-4118-8523-f927b0442156
+                                  af07d5a5-df63-4ddc-9383-6a666845ebe9).freeze
+
   attr_reader :document
 
   def initialize(document)
@@ -10,5 +15,15 @@ class ContentDataUrl
   def url
     content_data_root = Plek.new.external_url_for("content-data-admin")
     content_data_root + "/metrics" + document.live_edition.base_path
+  end
+
+  def displayable?(user)
+    has_content_data_access?(user)
+  end
+
+private
+
+  def has_content_data_access?(user)
+    CONTENT_DATA_BETA_PARTNERS.include?(user.organisation_content_id)
   end
 end

--- a/app/views/documents/show/_actions.html.erb
+++ b/app/views/documents/show/_actions.html.erb
@@ -88,9 +88,12 @@
         <li>
           <%= link_to "View published edition on GOV.UK", EditionUrl.new(@edition.document.live_edition).public_url, class: "govuk-link govuk-link--no-visited-state" %>
         </li>
-        <li>
-          <%= link_to "View data about this page", ContentDataUrl.new(@edition.document).url, target: "_blank", class: "govuk-link govuk-link--no-visited-state" %>
-        </li>
+        <% content_data_url = ContentDataUrl.new(@edition.document) %>
+        <% if content_data_url.displayable?(current_user) %>
+          <li>
+            <%= link_to "View data about this page", content_data_url.url, target: "_blank", class: "govuk-link govuk-link--no-visited-state" %>
+          </li>
+        <% end %>
       </ul>
     <% end %>
   </div>

--- a/app/views/documents/show/_actions.html.erb
+++ b/app/views/documents/show/_actions.html.erb
@@ -86,7 +86,7 @@
       <hr class="govuk-section-break govuk-section-break--m govuk-section-break--visible" />
       <ul class="govuk-list govuk-!-margin-0">
         <li>
-          <%= link_to "View published edition on GOV.UK", EditionUrl.new(@edition.document.live_edition).public_url, class: "govuk-link govuk-link--no-visited-state" %>
+          <%= link_to "View on GOV.UK", EditionUrl.new(@edition.document.live_edition).public_url, class: "govuk-link govuk-link--no-visited-state" %>
         </li>
         <% content_data_url = ContentDataUrl.new(@edition.document) %>
         <% if content_data_url.displayable?(current_user) %>

--- a/app/views/documents/show/_actions.html.erb
+++ b/app/views/documents/show/_actions.html.erb
@@ -84,7 +84,14 @@
 
     <% if @edition.document.live_edition %>
       <hr class="govuk-section-break govuk-section-break--m govuk-section-break--visible" />
-      <%= link_to "View published edition on GOV.UK", EditionUrl.new(@edition.document.live_edition).public_url, class: "govuk-link govuk-link--no-visited-state" %>
+      <ul class="govuk-list govuk-!-margin-0">
+        <li>
+          <%= link_to "View published edition on GOV.UK", EditionUrl.new(@edition.document.live_edition).public_url, class: "govuk-link govuk-link--no-visited-state" %>
+        </li>
+        <li>
+          <%= link_to "View data about this page", ContentDataUrl.new(@edition.document).url, target: "_blank", class: "govuk-link govuk-link--no-visited-state" %>
+        </li>
+      </ul>
     <% end %>
   </div>
 </div>

--- a/app/views/documents/show/_actions.html.erb
+++ b/app/views/documents/show/_actions.html.erb
@@ -91,7 +91,11 @@
         <% content_data_url = ContentDataUrl.new(@edition.document) %>
         <% if content_data_url.displayable?(current_user) %>
           <li>
-            <%= link_to "View data about this page", content_data_url.url, target: "_blank", class: "govuk-link govuk-link--no-visited-state" %>
+            <%= link_to "View data about this page",
+                        content_data_url.url,
+                        target: "_blank",
+                        class: "govuk-link govuk-link--no-visited-state",
+                        data: { gtm: "content-data-app-clickthrough" } %>
           </li>
         <% end %>
       </ul>

--- a/app/views/documents/show/_actions.html.erb
+++ b/app/views/documents/show/_actions.html.erb
@@ -89,7 +89,7 @@
           <%= link_to "View on GOV.UK", EditionUrl.new(@edition.document.live_edition).public_url, class: "govuk-link govuk-link--no-visited-state" %>
         </li>
         <% content_data_url = ContentDataUrl.new(@edition.document) %>
-        <% if content_data_url.displayable?(current_user) %>
+        <% if content_data_url.displayable?(current_user) && current_user.has_permission?(User::PRE_RELEASE_FEATURES_PERMISSION) %>
           <li>
             <%= link_to "View data about this page",
                         content_data_url.url,

--- a/spec/factories/edition_factory.rb
+++ b/spec/factories/edition_factory.rb
@@ -17,6 +17,7 @@ FactoryBot.define do
       state { "draft" }
       lead_image_revision { nil }
       image_revisions { [] }
+      first_published_at { nil }
     end
 
     after(:build) do |edition, evaluator|
@@ -27,6 +28,7 @@ FactoryBot.define do
           content_id: evaluator.content_id,
           locale: evaluator.locale,
           document_type_id: evaluator.document_type_id,
+          first_published_at: evaluator.first_published_at,
         )
       end
 
@@ -73,6 +75,7 @@ FactoryBot.define do
     trait :published do
       summary { SecureRandom.alphanumeric(10) }
       live { true }
+      first_published_at { Time.current }
 
       after(:build) do |edition, evaluator|
         edition.status = evaluator.association(
@@ -87,6 +90,7 @@ FactoryBot.define do
     trait :withdrawn do
       summary { SecureRandom.alphanumeric(10) }
       live { true }
+      first_published_at { Time.current }
 
       transient do
         withdrawal { nil }

--- a/spec/features/content_data/content_data_link_spec.rb
+++ b/spec/features/content_data/content_data_link_spec.rb
@@ -1,0 +1,25 @@
+# frozen_string_literal: true
+
+RSpec.feature "Link to content data admin app data page" do
+  scenario do
+    given_there_is_a_published_edition
+    when_i_visit_the_summary_page
+    then_i_see_a_link_to_the_content_data_page_for_the_document
+  end
+
+  def given_there_is_a_published_edition
+    @edition = create(:edition, :published)
+  end
+
+  def when_i_visit_the_summary_page
+    visit document_path(@edition.document)
+  end
+
+  def then_i_see_a_link_to_the_content_data_page_for_the_document
+    content_data_url_prefix = "https://content-data-admin.test.gov.uk/metrics"
+    expect(page).to have_link(
+      "View data about this page",
+      href: content_data_url_prefix + @edition.base_path,
+    )
+  end
+end

--- a/spec/features/content_data/content_data_link_spec.rb
+++ b/spec/features/content_data/content_data_link_spec.rb
@@ -2,13 +2,14 @@
 
 RSpec.feature "Link to content data admin app data page" do
   scenario do
-    given_there_is_a_published_edition
+    given_there_is_an_edition_published_before_yesterday
     when_i_visit_the_summary_page
     then_i_see_a_link_to_the_content_data_page_for_the_document
   end
 
-  def given_there_is_a_published_edition
-    @edition = create(:edition, :published)
+  def given_there_is_an_edition_published_before_yesterday
+    document = create(:document, first_published_at: 2.days.ago)
+    @edition = create(:edition, :published, document: document)
   end
 
   def when_i_visit_the_summary_page

--- a/spec/features/workflow/publish_spec.rb
+++ b/spec/features/workflow/publish_spec.rb
@@ -70,7 +70,7 @@ RSpec.feature "Publishing an edition" do
   def and_the_content_is_shown_as_published
     visit document_path(@edition.document)
     expect(page).to have_content(I18n.t!("user_facing_states.published.name"))
-    expect(page).to have_link("View published edition on GOV.UK", href: "https://www.test.gov.uk/news/banana-pricing-updates")
+    expect(page).to have_link("View on GOV.UK", href: "https://www.test.gov.uk/news/banana-pricing-updates")
   end
 
   def and_there_is_a_history_entry

--- a/spec/services/content_data_url_spec.rb
+++ b/spec/services/content_data_url_spec.rb
@@ -1,13 +1,26 @@
 # frozen_string_literal: true
 
 RSpec.describe ContentDataUrl do
+  let(:document) { build(:document, :with_live_edition) }
+
   describe "#url" do
     it "returns a Content Data Admin data page URL for the document" do
-      document = build(:document, :with_live_edition)
       base_path = document.current_edition.base_path
       data_page_url = ContentDataUrl.new(document).url
 
       expect(data_page_url).to eq("https://content-data-admin.test.gov.uk/metrics#{base_path}")
+    end
+  end
+
+  describe "#displayable" do
+    it "returns true if the user is part of a Content Data beta partner organisation" do
+      user = build(:user, organisation_content_id: "af07d5a5-df63-4ddc-9383-6a666845ebe9")
+      expect(ContentDataUrl.new(document).displayable?(user)).to be true
+    end
+
+    it "returns false if the user is not part of a Content Data beta partner organisation" do
+      user = build(:user, organisation_content_id: SecureRandom.uuid)
+      expect(ContentDataUrl.new(document).displayable?(user)).to be false
     end
   end
 end

--- a/spec/services/content_data_url_spec.rb
+++ b/spec/services/content_data_url_spec.rb
@@ -1,7 +1,10 @@
 # frozen_string_literal: true
 
 RSpec.describe ContentDataUrl do
-  let(:document) { build(:document, :with_live_edition) }
+  include ActiveSupport::Testing::TimeHelpers
+
+  let(:document) { build(:document, :with_live_edition, first_published_at: 2.days.ago) }
+  let(:beta_partner) { build(:user, organisation_content_id: "af07d5a5-df63-4ddc-9383-6a666845ebe9") }
 
   describe "#url" do
     it "returns a Content Data Admin data page URL for the document" do
@@ -13,14 +16,40 @@ RSpec.describe ContentDataUrl do
   end
 
   describe "#displayable" do
-    it "returns true if the user is part of a Content Data beta partner organisation" do
-      user = build(:user, organisation_content_id: "af07d5a5-df63-4ddc-9383-6a666845ebe9")
-      expect(ContentDataUrl.new(document).displayable?(user)).to be true
+    it "returns true if the user is part of a Content Data beta partner organisation and edition was published before yesterday" do
+      expect(ContentDataUrl.new(document).displayable?(beta_partner)).to be true
     end
 
     it "returns false if the user is not part of a Content Data beta partner organisation" do
       user = build(:user, organisation_content_id: SecureRandom.uuid)
       expect(ContentDataUrl.new(document).displayable?(user)).to be false
+    end
+
+    it "returns false if the document was first published today" do
+      document.first_published_at = Time.current
+      document.save!
+
+      expect(ContentDataUrl.new(document).displayable?(beta_partner)).to be false
+    end
+
+    it "returns false if the document was first published yesterday and it is currently before 9am" do
+      document.first_published_at = Time.current.yesterday
+      document.save!
+      before_nine_am_today = Time.current.change(hour: 8, min: 59)
+
+      travel_to(before_nine_am_today) do
+        expect(ContentDataUrl.new(document).displayable?(beta_partner)).to be false
+      end
+    end
+
+    it "returns true if the document was first published yesterday and it is currently 9am" do
+      document.first_published_at = Time.current.yesterday
+      document.save!
+      nine_am_today = Time.current.change(hour: 9)
+
+      travel_to(nine_am_today) do
+        expect(ContentDataUrl.new(document).displayable?(beta_partner)).to be true
+      end
     end
   end
 end

--- a/spec/services/content_data_url_spec.rb
+++ b/spec/services/content_data_url_spec.rb
@@ -1,0 +1,13 @@
+# frozen_string_literal: true
+
+RSpec.describe ContentDataUrl do
+  describe "#url" do
+    it "returns a Content Data Admin data page URL for the document" do
+      document = build(:document, :with_live_edition)
+      base_path = document.current_edition.base_path
+      data_page_url = ContentDataUrl.new(document).url
+
+      expect(data_page_url).to eq("https://content-data-admin.test.gov.uk/metrics#{base_path}")
+    end
+  end
+end


### PR DESCRIPTION
For https://trello.com/c/y1CtmFT9/763-link-from-our-app-to-content-data-page

This adds a link to the data page in the Content Data app for a particular piece of content.  The conditions under which we display a link are:
- The user must be part of an organisation that is a Content Data beta partner (otherwise they won't be able to access the page), AND
- Content was published before yesterday, OR
- Content was published yesterday AND it is after 9am (the Content Data ETL runs at 7am and finishes around 7.30am.  I've agreed with Sean in Data Informed Content that 9am gives enough buffer time in case the ETL is delayed).

As part of this PR we have also changed the 'View published content on GOV.UK' link text to 'View on GOV.UK'.  The link to Content Data appears below this, and in order to stop the 'View published content...' link from wrapping we've made it shorter.

<img width="323" alt="Screen Shot 2019-04-09 at 15 43 33" src="https://user-images.githubusercontent.com/13434452/55809697-44802880-5ade-11e9-8df4-79014bbdbcb6.png">
