### PR TITLE
Add paste html to govspeak functionality

### DIFF
--- a/app/assets/javascripts/components/markdown-editor.js
+++ b/app/assets/javascripts/components/markdown-editor.js
@@ -34,8 +34,10 @@ window.GOVUK.Modules = window.GOVUK.Modules || {};
     this.bubbleFocusEventToComponent(this.$editButton)
     this.bubbleFocusEventToComponent(this.$previewButton)
 
-    // Convert pasted HTML to govspeak
-    this.$input.addEventListener('paste', window.pasteHtmlToGovspeak.pasteListener)
+    // Convert pasted HTML to govspeak. Behind a pre-release feature flag.
+    if (this.$input.dataset.pasteHtmlToGovspeak === 'true') {
+      this.$input.addEventListener('paste', window.pasteHtmlToGovspeak.pasteListener)
+    }
   }
 
   MarkdownEditor.prototype.handleSelectionReplace = function (text, options) {

--- a/app/assets/javascripts/components/markdown-editor.js
+++ b/app/assets/javascripts/components/markdown-editor.js
@@ -1,4 +1,6 @@
 //= require vendor/@alphagov/markdown-toolbar-element/dist/index.umd.js
+//= require paste-html-to-govspeak/dist/paste-html-to-markdown.js
+
 window.GOVUK = window.GOVUK || {}
 window.GOVUK.Modules = window.GOVUK.Modules || {};
 
@@ -31,6 +33,9 @@ window.GOVUK.Modules = window.GOVUK.Modules || {};
     this.bubbleFocusEventToComponent(this.$input)
     this.bubbleFocusEventToComponent(this.$editButton)
     this.bubbleFocusEventToComponent(this.$previewButton)
+
+    // Convert pasted HTML to govspeak
+    this.$input.addEventListener('paste', window.pasteHtmlToGovspeak.pasteListener)
   }
 
   MarkdownEditor.prototype.handleSelectionReplace = function (text, options) {

--- a/app/views/components/_markdown_editor.html.erb
+++ b/app/views/components/_markdown_editor.html.erb
@@ -6,11 +6,15 @@
   govspeak_path ||= nil
   edition ||= nil
   error_items ||= []
+  paste_html_to_govspeak ||= false
 
   component_classes = %w[app-c-markdown-editor govuk-form-group]
   component_classes << "govuk-form-group--error" if error_items.any?
 
   insert_items = []
+
+  textarea[:data] = textarea.fetch(:data, {})
+                            .merge({ "paste-html-to-govspeak": paste_html_to_govspeak })
 
   if edition
     insert_items = [

--- a/app/views/components/docs/markdown_editor.yml
+++ b/app/views/components/docs/markdown_editor.yml
@@ -33,3 +33,11 @@ examples:
         id: markdown-editor-error
       error_items:
         - text: There is a problem with this input
+  with_paste_html_to_govspeak:
+    data:
+      label:
+        text: Body
+      textarea:
+        name: markdown-editor-with-paste-html-to-govspeak
+        id: markdown-editor-with-paste-html-to-govspeak
+      paste_html_to_govspeak: true

--- a/app/views/documents/fields/_govspeak_input.html.erb
+++ b/app/views/documents/fields/_govspeak_input.html.erb
@@ -20,7 +20,8 @@
       contextual_guidance: "document-contents-guidance",
       govspeak_path: govspeak_preview_path(edition.document),
       edition: edition,
-      error_items: issues&.items_for(field.id.to_sym)
+      error_items: issues&.items_for(field.id.to_sym),
+      paste_html_to_govspeak: current_user.has_permission?(User::PRE_RELEASE_FEATURES_PERMISSION)
     } %>
   </div>
 

--- a/package.json
+++ b/package.json
@@ -24,6 +24,7 @@
     "core-js-bundle": "^3.0.0-alpha.1",
     "cropperjs": "^1.4.3",
     "es5-polyfill": "^0.0.6",
+    "paste-html-to-govspeak": "^0.2.0",
     "raven-js": "^3.27.0",
     "url-polyfill": "^1.1.3",
     "whatwg-fetch": "^3.0.0"

--- a/yarn.lock
+++ b/yarn.lock
@@ -832,6 +832,10 @@ parse-json@^4.0.0:
     error-ex "^1.3.1"
     json-parse-better-errors "^1.0.1"
 
+paste-html-to-govspeak@^0.2.0:
+  version "0.2.0"
+  resolved "https://registry.yarnpkg.com/paste-html-to-govspeak/-/paste-html-to-govspeak-0.2.0.tgz#5ed55fc6418c623c646032d2b740e3e86768d6b1"
+
 path-exists@^2.0.0:
   version "2.1.0"
   resolved "https://registry.yarnpkg.com/path-exists/-/path-exists-2.1.0.tgz#0feb6c64f0fc518d9a754dd5efb62c7022761f4b"


### PR DESCRIPTION
For https://trello.com/c/3JX1Pc9f/770-embed-paste-html-to-govspeak-functionality

This embeds the [paste-html-to-govspeak](https://www.npmjs.com/package/paste-html-to-govspeak) npm package in the body field on the edit document page.  We put this behind a pre-release feature flag for now; note that when we set this as a data attribute on the text area component the boolean value comes through as a string, which is why we check if this is equal to 'true' before adding a paste event listener.