### PR TITLE
Up the linkables timeout to 3 seconds.

### DIFF
--- a/app/services/linkables_service.rb
+++ b/app/services/linkables_service.rb
@@ -24,7 +24,7 @@ private
     # Maybe we'll need to go further with this a la:
     # https://github.com/alphagov/whitehall/blob/fc62edcd5a9b1ba8bfb22911f69f128083535127/app/models/policy.rb#L45-L58
     @linkables ||= Rails.cache.fetch("linkables.#{document_type}", CACHE_OPTIONS) do
-      GdsApi.publishing_api_v2(timeout: 1).get_linkables(document_type: document_type).to_hash
+      GdsApi.publishing_api_v2(timeout: 3).get_linkables(document_type: document_type).to_hash
     end
   end
 end


### PR DESCRIPTION
This is very much an attempt to quick fix the common support requests
we're receiving about timeout problems with the application.

This will give us up to 3 seconds before giving up on loading linkables
rather than 1. The most common linkable we see having this problem is
organisations which on April 10th seems to have hit up to 14 seconds 😬.
So doing this will only limit occurrences of this rather than removing
them all.

I chose 3 seconds as I believe this gives us enough time that in most
cases even with a timeout here we'll still return a response before
nginx gives up and returns a 504.