### PR TITLE
Use autocomplete as dropdown for time input

### DIFF
--- a/app/assets/javascripts/components/autocomplete.js
+++ b/app/assets/javascripts/components/autocomplete.js
@@ -11,6 +11,8 @@ window.GOVUK.Modules = window.GOVUK.Modules || {};
 
     if (type === 'with-hint-on-options') {
       this.initAutoCompleteWithHintOnOptions()
+    } else if (type === 'without-narrowing-results') {
+      this.initAutoCompleteWithoutNarrowingResults()
     } else {
       this.initAutoComplete()
     }
@@ -67,6 +69,54 @@ window.GOVUK.Modules = window.GOVUK.Modules || {};
         suggestion: function (result) {
           return result && result.text + '<span class="autocomplete__option-hint">' + result.hint + '</span>'
         }
+      },
+      onConfirm: function (result) {
+        var value = result && result.value
+        var options = [].filter.call($select.options, function (option) {
+          return option.value === value
+        })
+
+        if (options.length) {
+          options[0].selected = true
+        }
+      }
+    })
+
+    $select.style.display = 'none'
+    $select.id = $select.id + '-select'
+  }
+
+  Autocomplete.prototype.initAutoCompleteWithoutNarrowingResults = function () {
+    // Read options and associated data attributes and feed that as results for inputValueTemplate
+    var $select = this.$module.querySelector('select')
+
+    if (!$select) {
+      return
+    }
+
+    var $options = $select.querySelectorAll('option')
+    var $selectedOption = $select.querySelector('option[selected]')
+    if (!$selectedOption) {
+      $selectedOption = $options[0]
+    }
+    var defaultValue = $selectedOption.textContent
+
+    new window.accessibleAutocomplete({ // eslint-disable-line no-new, new-cap
+      id: $select.id,
+      name: $select.name,
+      element: this.$module,
+      showAllValues: true,
+      defaultValue: defaultValue,
+      autoselect: false,
+      dropdownArrow: function (config) {
+        return '<svg class="' + config.className + '" style="top: 8px;" viewBox="0 0 512 512" ><path d="M256,298.3L256,298.3L256,298.3l174.2-167.2c4.3-4.2,11.4-4.1,15.8,0.2l30.6,29.9c4.4,4.3,4.5,11.3,0.2,15.5L264.1,380.9  c-2.2,2.2-5.2,3.2-8.1,3c-3,0.1-5.9-0.9-8.1-3L35.2,176.7c-4.3-4.2-4.2-11.2,0.2-15.5L66,131.3c4.4-4.3,11.5-4.4,15.8-0.2L256,298.3  z"/></svg>'
+      },
+      source: function (query, syncResults) {
+        var results = []
+        $options.forEach(function ($el) {
+          results.push($el.textContent)
+        })
+        syncResults(results)
       },
       onConfirm: function (result) {
         var value = result && result.value

--- a/app/assets/javascripts/components/autocomplete.js
+++ b/app/assets/javascripts/components/autocomplete.js
@@ -120,7 +120,7 @@ window.GOVUK.Modules = window.GOVUK.Modules || {};
       },
       onConfirm: function (result) {
         var value = result && result.value
-        var options = [].filter.call($select.options, function (option) {
+        var options = [].filter.call($options, function (option) {
           return option.value === value
         })
 
@@ -130,8 +130,7 @@ window.GOVUK.Modules = window.GOVUK.Modules || {};
       }
     })
 
-    $select.style.display = 'none'
-    $select.id = $select.id + '-select'
+    $select.parentNode.removeChild($select)
   }
 
   Modules.Autocomplete = Autocomplete

--- a/app/assets/stylesheets/components/_autocomplete.scss
+++ b/app/assets/stylesheets/components/_autocomplete.scss
@@ -1,5 +1,19 @@
 @import "vendor/accessible-autocomplete/dist/accessible-autocomplete.min";
 
+.autocomplete__wrapper {
+  background: govuk-colour('white');
+}
+
+.autocomplete__input {
+  @include govuk-font(19);
+  color: $govuk-text-colour;
+  z-index: 1;
+}
+
+.autocomplete__dropdown-arrow-down {
+  z-index: 0;
+}
+
 .autocomplete__option {
   @include govuk-font(19);
   color: $govuk-text-colour;

--- a/app/helpers/time_options_helper.rb
+++ b/app/helpers/time_options_helper.rb
@@ -4,8 +4,9 @@ module TimeOptionsHelper
   DEFAULT_PUBLISHING_TIME = "9:00am"
 
   def time_options(selected = nil)
-    options = times.map { |time| [time, time] }
-    selected_options = times.map { |time| [time, time] if time == (selected || DEFAULT_PUBLISHING_TIME) }.compact
+    extended_times = extend_times_with_selection(times, selected)
+    options = extended_times.map { |time| [time, time] }
+    selected_options = extended_times.select { |time| time == (selected || DEFAULT_PUBLISHING_TIME) }.compact
     options_for_select = { options: options, selected_options: selected_options }
     options_for_select
   end
@@ -22,5 +23,18 @@ private
     incremented_hours.each { |hour| meridiem_hours << hour + "pm" }
     meridiem_hours[0] = "12:01am"
     meridiem_hours
+  end
+
+  def extend_times_with_selection(times, selected)
+    if times && selected
+      position = 0
+      selected_meridiem = selected.chars.last(2).join
+      times.each_with_index do |time, index|
+        time_meridiem = time.chars.last(2).join
+        position = index if selected < time && time_meridiem == selected_meridiem && !position
+      end
+      times.insert(position, selected)
+    end
+    times
   end
 end

--- a/app/helpers/time_options_helper.rb
+++ b/app/helpers/time_options_helper.rb
@@ -4,14 +4,10 @@ module TimeOptionsHelper
   DEFAULT_PUBLISHING_TIME = "9:00am"
 
   def time_options(selected = nil)
-    options = times.map { |time| { text: time, value: time } }
-    options.each do |option|
-      if option[:text] == (selected || DEFAULT_PUBLISHING_TIME)
-        option[:selected] = true
-        break
-      end
-    end
-    options
+    options = times.map { |time| [time, time] }
+    selected_options = times.map { |time| [time, time] if time == (selected || DEFAULT_PUBLISHING_TIME) }.compact
+    options_for_select = { options: options, selected_options: selected_options }
+    options_for_select
   end
 
 private

--- a/app/views/components/docs/autocomplete.yml
+++ b/app/views/components/docs/autocomplete.yml
@@ -105,3 +105,21 @@ examples:
           - United Kingdom
           - uk
           - data-hint: London
+  autocomplete_without_narrowing_results:
+    data:
+      id: autocomplete-without-narrowing-results
+      name: autocomplete-without-narrowing-results
+      type: without-narrowing-results
+      label:
+        text: Select your country
+      data_module: autocomplete
+      options:
+        -
+          - France
+          - fr
+        -
+          - United Arab Emirates
+          - uae
+        -
+          - United Kingdom
+          - uk

--- a/app/views/documents/show/_scheduling_form.html.erb
+++ b/app/views/documents/show/_scheduling_form.html.erb
@@ -41,11 +41,17 @@
          }
        ]
      } %>
-    <%= render "govuk_publishing_components/components/select", {
-      label: "Time",
-      id: "scheduled[time]",
-      options: time_options(selected_time),
-    } %>
+     <% time_options = time_options(selected_time) %>
+     <%= render "components/autocomplete", {
+       id: "scheduled[time]",
+       name: "scheduled[time]",
+       label: {
+         text: "Time"
+       },
+       options: time_options[:options],
+       selected_options: time_options[:selected_options],
+       type: "without-narrowing-results"
+     } %>
     <% if current_scheduled_publish_datetime %>
       <%= render "govuk_publishing_components/components/button", {
         text: "Update"

--- a/spec/features/workflow/clear_scheduled_publishing_datetime_spec.rb
+++ b/spec/features/workflow/clear_scheduled_publishing_datetime_spec.rb
@@ -34,7 +34,7 @@ RSpec.feature "Clear scheduled publishing datetime" do
     expect(page).to have_selector(
       "[@name='scheduled[year]'][@value='#{@datetime.year}']",
     )
-    expect(page).to have_select("scheduled[time]", selected: "12:00pm")
+    expect(page).to have_field("scheduled[time]", text: "12:00pm")
   end
 
   def when_i_click_clear_date
@@ -54,7 +54,7 @@ RSpec.feature "Clear scheduled publishing datetime" do
     expect(page).to have_selector(
       "[@name='scheduled[year]'][@value='#{default_date.year}']",
     )
-    expect(page).to have_select("scheduled[time]", selected: "9:00am")
+    expect(page).to have_field("scheduled[time]", text: "9:00am")
 
     within first(".app-timeline-entry") do
       expect(page).to have_content I18n.t!("documents.history.entry_types.scheduled_publishing_datetime_cleared")

--- a/spec/features/workflow/set_scheduled_publishing_datetime_spec.rb
+++ b/spec/features/workflow/set_scheduled_publishing_datetime_spec.rb
@@ -35,8 +35,8 @@ RSpec.feature "Set scheduled publishing datetime" do
     expect(page).to have_selector(
       "[@name='scheduled[year]'][@value='#{default_date.year}']",
     )
-    expect(page).to have_select(
-      "scheduled[time]", selected: "9:00am"
+    expect(page).to have_field(
+      "scheduled[time]", text: "9:00am"
     )
   end
 
@@ -64,7 +64,7 @@ RSpec.feature "Set scheduled publishing datetime" do
     expect(page).to have_selector(
       "[@name='scheduled[year]'][@value='#{@date.year}']",
     )
-    expect(find_field("scheduled[time]").value).to eq("11:00pm")
+    expect(page).to have_field("scheduled[time]", text: "11:00am")
 
     within first(".app-timeline-entry") do
       expect(page).to have_content I18n.t!("documents.history.entry_types.scheduled_publishing_datetime_set")


### PR DESCRIPTION
This PR updates the autocomplete to support a custom configuration ([without-narrowing-results](https://content-publisher-revie-pr-957.herokuapp.com/component-guide/autocomplete/autocomplete_without_narrowing_results/preview)) in which essentially acts as a dropdown list which also allows custom input from users.

This custom configuration is used in [time select in the scheduling form](https://content-publisher-revie-pr-957.herokuapp.com/documents/d7e73a7d-17b2-4488-b41c-c6b3b5758dd3:en) as shown below.

### Before
<img width="299" alt="Screen Shot 2019-04-11 at 17 39 26" src="https://user-images.githubusercontent.com/788096/55974944-b7c1a000-5c80-11e9-9cbf-08f7842a12a5.png">

### After
<img width="299" alt="Screen Shot 2019-04-11 at 17 38 37" src="https://user-images.githubusercontent.com/788096/55974951-bd1eea80-5c80-11e9-83d4-ae35cce77391.png">


[Trello card](https://trello.com/c/QrEdhtTO)