### PR TITLE
Bump paste-html-to-govspeak to 0.2.2

### DIFF
--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
     "core-js-bundle": "^3.0.0-alpha.1",
     "cropperjs": "^1.4.3",
     "es5-polyfill": "^0.0.6",
-    "paste-html-to-govspeak": "^0.2.1",
+    "paste-html-to-govspeak": "^0.2.2",
     "raven-js": "^3.27.0",
     "url-polyfill": "^1.1.3",
     "whatwg-fetch": "^3.0.0"

--- a/yarn.lock
+++ b/yarn.lock
@@ -832,10 +832,10 @@ parse-json@^4.0.0:
     error-ex "^1.3.1"
     json-parse-better-errors "^1.0.1"
 
-paste-html-to-govspeak@^0.2.1:
-  version "0.2.1"
-  resolved "https://registry.yarnpkg.com/paste-html-to-govspeak/-/paste-html-to-govspeak-0.2.1.tgz#42ee088d39f8f1ada42e7d17aac96c8daab33566"
-  integrity sha512-JdoRiXr3BNNTm0nOCkNfCEs+pHMVFvU5wQo63WI9lUHKQRurdU73cbl6Km48CotOm2XZt7/KOd+ww7poPySUVQ==
+paste-html-to-govspeak@^0.2.2:
+  version "0.2.2"
+  resolved "https://registry.yarnpkg.com/paste-html-to-govspeak/-/paste-html-to-govspeak-0.2.2.tgz#7966cf10dca3cae82770f35c79f66b6aaf07ecb2"
+  integrity sha512-Pwog/JBO98ch5PjpFr7zashgW2uS0QcS3AKK1WO+o8APIqh8ERMzqmFgMzHOC8eYidYUAEBy0gwbw1y6MR9Bkg==
 
 path-exists@^2.0.0:
   version "2.1.0"


### PR DESCRIPTION
Trello: https://trello.com/c/7pL98HiY/780-investigate-chrome-address-bar-copy-and-paste-issue

This resolves an issue pasting from chrome address bar.