### PR TITLE
Frontend cleanup

### DIFF
--- a/app/views/components/_contextual_guidance.html.erb
+++ b/app/views/components/_contextual_guidance.html.erb
@@ -1,10 +1,13 @@
 <%
-  id ||= "input-#{SecureRandom.hex(4)}"
+  id ||= nil
   title ||= nil
+  data_attributes ||= {}
+  data_attributes[:module] = "contextual-guidance"
 %>
-<div id="<%= id %>" class="app-c-contextual-guidance__wrapper" data-module="contextual-guidance">
-  <div class="app-c-contextual-guidance">
-    <h2 class="govuk-heading-s"><%= title %></h2>
+
+<%= tag.div class: "app-c-contextual-guidance__wrapper", id: id, data: data_attributes do %>
+  <%= tag.div class: "app-c-contextual-guidance" do %>
+    <%= tag.h2 title, class: "govuk-heading-s" %>
     <%= yield %>
-  </div>
-</div>
+  <% end %>
+<% end %>

--- a/app/views/components/_formatted_text.html.erb
+++ b/app/views/components/_formatted_text.html.erb
@@ -1,3 +1,4 @@
-<pre class="app-c-formatted-text">
+<%# Don't indent elements inside the pre tag %>
+<%= tag.pre class: "app-c-formatted-text" do %>
 <%= text[0..chars] %> <% if text.length > chars %>…<% end %>
-</pre>
+<% end %>

--- a/app/views/components/_image_cropper.html.erb
+++ b/app/views/components/_image_cropper.html.erb
@@ -1,10 +1,12 @@
 <%
-  id ||= "image-meta-#{SecureRandom.hex(4)}"
+  id ||= nil
   alt_text ||= nil
   exact_dimensions ||= false
+  data_attributes ||= {}
+  data_attributes[:module] = "image-cropper" unless exact_dimensions
 %>
 
-<div class="app-c-image-cropper" id="<%= id %>" <%= "data-module=image-cropper" unless exact_dimensions %>>
+<%= tag.div class: "app-c-image-cropper", id: id, data: data_attributes do %>
 
   <%= tag.p class: "app-c-image-cropper__no-js-description" do %>
     The image you selected has been automatically resized to fit on GOV.UK. If you have JavaScript enabled in your browser you will be able to manually crop and resize the image.
@@ -25,15 +27,15 @@
     <% end %>
   <% end %>
 
-  <div class="app-c-image-cropper__container">
+  <%= tag.div class: "app-c-image-cropper__container" do %>
     <%= tag.img class: "app-c-image-cropper__image",
       src: src,
       alt: alt_text
     %>
-  </div>
+  <% end%>
 
   <%= hidden_field_tag 'image_revision[crop_x]', crop_x, class: "js-image-cropper-x" %>
   <%= hidden_field_tag 'image_revision[crop_y]', crop_y, class: "js-image-cropper-y" %>
   <%= hidden_field_tag 'image_revision[crop_width]', crop_width, class: "js-image-cropper-width" %>
   <%= hidden_field_tag 'image_revision[crop_height]', crop_height, class: "js-image-cropper-height" %>
-</div>
+<% end %>

--- a/app/views/components/_multi_section_viewer.html.erb
+++ b/app/views/components/_multi_section_viewer.html.erb
@@ -1,14 +1,19 @@
 <%
   id ||= "multi-section-viewer-#{SecureRandom.hex(4)}"
   sections ||= []
+  data_attributes ||= {}
+  data_attributes[:module] = "multi-section-viewer"
+  aria_attributes ||= {}
+  aria_attributes[:live] = "assertive"
 %>
 
-<div id="<%= id %>" class="app-c-multi-section-viewer" data-module="multi-section-viewer" aria-live="assertive">
+<%= tag.div class: "app-c-multi-section-viewer",
+  id: id,
+  data: data_attributes,
+  aria: aria_attributes do %>
   <% sections.each do |section| %>
-    <section class="app-c-multi-section-viewer__section" id="<%= section[:id] %>">
-      <%= section[:content] %>
-    </section>
+    <%= tag.section section[:content], class: "app-c-multi-section-viewer__section", id: section[:id] %>
   <% end %>
 
-  <div class="app-c-multi-section-viewer__section js-dynamic-section"></div>
-</div>
+  <%= tag.div class: "app-c-multi-section-viewer__section js-dynamic-section" %>
+<% end %>

--- a/app/views/components/_side_navigation.html.erb
+++ b/app/views/components/_side_navigation.html.erb
@@ -1,5 +1,5 @@
 <%
-  id ||= "side-navigation-#{SecureRandom.hex(4)}"
+  id ||= nil
   items ||= []
 %>
 

--- a/app/views/components/_summary.html.erb
+++ b/app/views/components/_summary.html.erb
@@ -5,48 +5,38 @@
   items ||= []
 %>
 
-<div class="app-c-summary" id="<%= id %>">
-
-<% if title %>
-  <h2 class="govuk-heading-m">
-    <%= title[:text] %>
-  </h2>
-  <% if title[:change_url] %>
-  <a class="app-c-summary__change-section-link"
-     href="<%= title[:change_url] %>"
-     title="Change <%= title[:text] %>"
-     data-gtm="content-change">
-    Change<span class="govuk-visually-hidden"> <%= title[:text] %></span>
-  </a>
-  <% end %>
-<% end %>
-
-<% if items.any? %>
-  <dl class="app-c-summary__list app-c-summary__list--short">
-    <% items.each do |item| %>
-    <div class="app-c-summary__contents">
-      <dt class="app-c-summary__question">
-        <%= item[:field] %>
-      </dt>
-      <dd class="app-c-summary__answer">
-        <%= item[:value] %>
-      </dd>
-      <% if item[:change_url] %>
-      <dd class="app-c-summary__change">
-        <a class="app-c-summary__change-link" href="<%= item[:change_url] %>">
-          Change<span class="govuk-visually-hidden"> <%= item[:field] %></span>
-        </a>
-      </dd>
+<%= tag.div class: "app-c-summary", id: id do %>
+  <% if title %>
+    <%= tag.h2 title[:text], class:"govuk-heading-m" %>
+    <% if title[:change_url] %>
+      <%= link_to title[:change_url], class: "app-c-summary__change-section-link",
+        title: "Change #{title[:text]}",
+        data: { gtm: "content-change" } do %>
+        Change<span class="govuk-visually-hidden"> <%= title[:text] %></span>
       <% end %>
-    </div>
     <% end %>
-  </dl>
-<% end %>
+  <% end %>
 
-<% if block %>
-  <div class="app-c-summary__block">
-    <%= block %>
-  </div>
-<% end %>
+  <% if items.any? %>
+    <%= tag.dl class: "app-c-summary__list app-c-summary__list--short" do %>
+      <% items.each do |item| %>
+        <%= tag.div class: "app-c-summary__contents" do %>
 
-</div>
+          <%= tag.dt item[:field], class:"app-c-summary__question" %>
+          <%= tag.dd item[:value], class:"app-c-summary__answer" %>
+
+          <% if item[:change_url] %>
+            <%= tag.dd link_to, class:"app-c-summary__change" do %>
+              <%= link_to item[:change_url], class:"app-c-summary__change-link" do %>
+                Change<span class="govuk-visually-hidden"> <%= item[:field] %></span>
+              <% end %>
+            <% end %>
+          <% end %>
+
+        <% end %>
+      <% end %>
+    <% end %>
+  <% end %>
+
+  <%= tag.div block, class: "app-c-summary__block" if block %>
+<% end %>

--- a/app/views/components/_toolbar_dropdown.html.erb
+++ b/app/views/components/_toolbar_dropdown.html.erb
@@ -1,5 +1,5 @@
 <%
-  id ||= "toolbar-dropdown-#{SecureRandom.hex(4)}"
+  id ||= nil
   align ||= false
   items ||= []
   data_attributes ||= {}

--- a/app/views/components/_warning_summary.html.erb
+++ b/app/views/components/_warning_summary.html.erb
@@ -2,30 +2,27 @@
   title ||= false
   description ||= false
   items ||= []
-  id ||= "app-c-warning-summary-#{SecureRandom.hex(4)}"
+  id ||= nil
 %>
 
-<div class="app-c-warning-summary" id="<%= id %>">
-  <h2 class="app-c-warning-summary__title">
-    <%= title %>
-  </h2>
+<%= tag.div class: "app-c-warning-summary", id: id do %>
+  <%= tag.h2 title, class: "app-c-warning-summary__title" %>
 
-  <div class="app-c-warning-summary__body">
+  <%= tag.div class: "app-c-warning-summary__body" do %>
     <% if description %>
       <%= description %>
     <% end %>
 
     <% if items.any? %>
-    <ul class="govuk-list app-c-warning-summary__list">
-      <% items.each_with_index do |item, index| %>
+      <%= tag.ul class:"govuk-list app-c-warning-summary__list" do %>
+        <% items.each_with_index do |item, index| %>
           <% if item[:href] %>
-            <li><%= link_to item[:text], item[:href], class: "govuk-link govuk-link--no-visited-state" %></li>
+            <%= tag.li link_to(item[:text], item[:href], class: "govuk-link govuk-link--no-visited-state") %>
           <% else %>
-            <li><%= item[:text] %></li>
+            <%= tag.li item[:text] %>
           <% end %>
-        </li>
+        <% end %>
       <% end %>
-    </ul>
     <% end %>
-  </div>
-</div>
+  <% end %>
+<% end %>

--- a/app/views/components/docs/url_preview.yml
+++ b/app/views/components/docs/url_preview.yml
@@ -3,7 +3,7 @@ description: Generates URL from an input value and validates it with a server en
 body: |
   This component uses an text input field to get the input value, sends the value to
   a server endpoint and returns the appropriate response
-shared_accessibility_criteria:
+shared_accessibility_criteria: |
   The component must:
 
   * update its content to reflect changes in the referenced input field

--- a/spec/javascripts/components/contextual-guidance-spec.js
+++ b/spec/javascripts/components/contextual-guidance-spec.js
@@ -1,5 +1,5 @@
-/* global describe beforeEach afterEach it expect */
-/* global $, GOVUK */
+/* eslint-env jasmine, jquery */
+/* global GOVUK */
 
 describe('Contextual guidance component', function () {
   'use strict'

--- a/spec/javascripts/components/toolbar-dropdown-spec.js
+++ b/spec/javascripts/components/toolbar-dropdown-spec.js
@@ -1,5 +1,5 @@
-/* global describe beforeEach afterEach it expect */
-/* global GOVUK, $ */
+/* eslint-env jasmine, jquery */
+/* global GOVUK */
 
 describe('Toolbar dropdown component', function () {
   'use strict'


### PR DESCRIPTION
This PR does the following in an attempt to code consistency:
- Update templates to only generate unique `id`s when mandatory and make use of rails view helpers to simplify the logic and preserve markup formatting
- Rename `dropdown-spec` to `toolbar-dropdown-spec` as it was missed when renaming the component
- Declare `eslint-env` consistently in spec files
- Fixed a wrongly formatted YAML line which is currently breaking the component-guide