### PR TITLE
Remove (now) unnecessary overwrites

### DIFF
--- a/app/assets/stylesheets/utilities/_overwrites.scss
+++ b/app/assets/stylesheets/utilities/_overwrites.scss
@@ -69,10 +69,3 @@
     @include govuk-font(19);
   }
 }
-
-// Remove this after the modal-dialogue component handles this overwrite
-.govuk-template {
-  @include govuk-media-query($media-type: screen) {
-    overflow-y: inherit;
-  }
-}

--- a/app/assets/stylesheets/utilities/_overwrites.scss
+++ b/app/assets/stylesheets/utilities/_overwrites.scss
@@ -1,7 +1,3 @@
-.gem-c-success-alert__message {
-  margin: 0;
-}
-
 .gem-c-textarea {
   max-width: 100%;
 }


### PR DESCRIPTION
Remove margin overwrite on success-alert as [the component was updated to have a margin: 0 by default](https://github.com/alphagov/govuk_publishing_components/blob/master/app/assets/stylesheets/govuk_publishing_components/components/_success-alert.scss#L15)
Remove govuk-template overwrite as [the modal dialogue component was updated to deal with this](alphagov/govuk_publishing_components#805).