### PR TITLE
More File Attachment modelling

### DIFF
--- a/app/models/edition.rb
+++ b/app/models/edition.rb
@@ -66,6 +66,7 @@ class Edition < ApplicationRecord
            :image_revisions,
            :image_revisions_without_lead,
            :scheduled_publishing_datetime,
+           :file_attachment_revisions,
            to: :revision
 
   MINIMUM_SCHEDULING_TIME = { minutes: 15 }.freeze

--- a/app/models/file_attachment/file_revision.rb
+++ b/app/models/file_attachment/file_revision.rb
@@ -2,7 +2,13 @@
 
 # This is an immutable model
 class FileAttachment::FileRevision < ApplicationRecord
+  belongs_to :blob, class_name: "ActiveStorage::Blob"
+
   belongs_to :created_by, class_name: "User", optional: true
+
+  has_many :assets, class_name: "FileAttachment::Asset"
+
+  delegate :content_type, to: :blob
 
   def readonly?
     !new_record?

--- a/app/models/file_attachment/revision.rb
+++ b/app/models/file_attachment/revision.rb
@@ -9,6 +9,9 @@ class FileAttachment::Revision < ApplicationRecord
   belongs_to :metadata_revision, class_name: "FileAttachment::MetadataRevision"
   belongs_to :file_revision, class_name: "FileAttachment::FileRevision"
 
+  # TODO this picks the wrong table (Image::Revision also broken)
+  has_and_belongs_to_many :revisions
+
   delegate :title, to: :metadata_revision
   delegate :filename, to: :file_revision
 

--- a/app/models/file_attachment/revision.rb
+++ b/app/models/file_attachment/revision.rb
@@ -9,8 +9,10 @@ class FileAttachment::Revision < ApplicationRecord
   belongs_to :metadata_revision, class_name: "FileAttachment::MetadataRevision"
   belongs_to :file_revision, class_name: "FileAttachment::FileRevision"
 
-  # TODO this picks the wrong table (Image::Revision also broken)
-  has_and_belongs_to_many :revisions
+  has_and_belongs_to_many :revisions,
+                          class_name: "::Revision",
+                          foreign_key: "file_attachment_revision_id",
+                          join_table: "revisions_file_attachment_revisions"
 
   delegate :title, to: :metadata_revision
   delegate :filename, to: :file_revision

--- a/app/models/image/revision.rb
+++ b/app/models/image/revision.rb
@@ -10,7 +10,10 @@ class Image::Revision < ApplicationRecord
 
   belongs_to :created_by, class_name: "User", optional: true
 
-  has_and_belongs_to_many :revisions
+  has_and_belongs_to_many :revisions,
+                          class_name: "::Revision",
+                          foreign_key: "image_revision_id",
+                          join_table: "revisions_image_revisions"
 
   belongs_to :image, class_name: "Image"
 

--- a/spec/factories/file_attachment_factory.rb
+++ b/spec/factories/file_attachment_factory.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+FactoryBot.define do
+  factory :file_attachment do
+    association :created_by, factory: :user
+  end
+end

--- a/spec/factories/file_attachment_file_revision_factory.rb
+++ b/spec/factories/file_attachment_file_revision_factory.rb
@@ -1,0 +1,23 @@
+# frozen_string_literal: true
+
+FactoryBot.define do
+  factory :file_attachment_file_revision, class: FileAttachment::FileRevision do
+    association :created_by, factory: :user
+
+    filename { SecureRandom.hex(8) }
+
+    transient do
+      fixture { "text-file.txt" }
+    end
+
+    after(:build) do |file_revision, evaluator|
+      fixture_path = Rails.root.join("spec/fixtures/files/#{evaluator.fixture}")
+
+      file_revision.blob = ActiveStorage::Blob.build_after_upload(
+        io: File.new(fixture_path),
+        filename: file_revision.filename,
+      )
+      file_revision.size = File.size(fixture_path) unless file_revision.size
+    end
+  end
+end

--- a/spec/factories/file_attachment_metadata_revision_factory.rb
+++ b/spec/factories/file_attachment_metadata_revision_factory.rb
@@ -1,0 +1,8 @@
+# frozen_string_literal: true
+
+FactoryBot.define do
+  factory :file_attachment_metadata_revision, class: FileAttachment::MetadataRevision do
+    association :created_by, factory: :user
+    title { SecureRandom.hex(8) }
+  end
+end

--- a/spec/factories/file_attachment_revision_factory.rb
+++ b/spec/factories/file_attachment_revision_factory.rb
@@ -1,0 +1,31 @@
+# frozen_string_literal: true
+
+FactoryBot.define do
+  factory :file_attachment_revision, class: FileAttachment::Revision do
+    association :file_attachment, factory: :file_attachment
+    association :created_by, factory: :user
+
+    transient do
+      filename { SecureRandom.hex(8) }
+      fixture { "text-file.txt" }
+      title { SecureRandom.hex(8) }
+    end
+
+    after(:build) do |revision, evaluator|
+      unless revision.file_revision
+        revision.file_revision = evaluator.association(
+          :file_attachment_file_revision,
+          filename: evaluator.filename,
+          fixture: evaluator.fixture,
+        )
+      end
+
+      unless revision.metadata_revision
+        revision.metadata_revision = evaluator.association(
+          :file_attachment_metadata_revision,
+          title: evaluator.title,
+        )
+      end
+    end
+  end
+end


### PR DESCRIPTION
Trello: https://trello.com/c/3c6nomPo/782-mvp-of-inline-attachment-flow-add-and-insert

This fixes a few things Emma and I caught today while working on the MVP and adds in some factories. 
A few of the things here are cherry picked from the [create-form-to-upload-attachments](https://github.com/alphagov/content-publisher/tree/create-form-to-upload-attachment) branch