### PR TITLE
Change the many assets association on FileAttachment::FileRevision

### DIFF
--- a/app/models/file_attachment/file_revision.rb
+++ b/app/models/file_attachment/file_revision.rb
@@ -6,11 +6,21 @@ class FileAttachment::FileRevision < ApplicationRecord
 
   belongs_to :created_by, class_name: "User", optional: true
 
-  has_many :assets, class_name: "FileAttachment::Asset"
+  # There is an expectation there will also be a thumbnail asset
+  has_one :file_asset,
+          -> { where(variant: :file) },
+          class_name: "FileAttachment::Asset",
+          inverse_of: :file_revision
 
   delegate :content_type, to: :blob
 
   def readonly?
     !new_record?
+  end
+
+  def ensure_assets
+    unless file_asset
+      self.file_asset = FileAttachment::Asset.new(file_revision: self, variant: :file)
+    end
   end
 end

--- a/spec/factories/file_attachment_file_revision_factory.rb
+++ b/spec/factories/file_attachment_file_revision_factory.rb
@@ -18,6 +18,22 @@ FactoryBot.define do
         filename: file_revision.filename,
       )
       file_revision.size = File.size(fixture_path) unless file_revision.size
+
+      file_revision.ensure_assets
+    end
+
+    trait :on_asset_manager do
+      transient do
+        state { :draft }
+      end
+
+      after(:build) do |file_revision, evaluator|
+        file_revision.file_asset.assign_attributes(
+          state: evaluator.state,
+          file_url: "https://asset-manager.test.gov.uk/media/" +
+            "asset-id#{SecureRandom.hex(8)}/#{file_revision.filename}",
+        )
+      end
     end
   end
 end

--- a/spec/models/file_attachment/file_revision_spec.rb
+++ b/spec/models/file_attachment/file_revision_spec.rb
@@ -1,0 +1,24 @@
+# frozen_string_literal: true
+
+RSpec.describe FileAttachment::FileRevision do
+  describe "#ensure_assets" do
+    it "doesn't change an asset that already exists" do
+      file_revision = build(:file_attachment_file_revision)
+      file_asset = file_revision.file_asset
+
+      file_revision.ensure_assets
+
+      expect(file_revision.file_asset).to be(file_asset)
+    end
+
+    it "creates a file asset if it doesn't exist" do
+      file_revision = build(:file_attachment_file_revision)
+      file_revision.file_asset = nil
+
+      file_revision.ensure_assets
+
+      expect(file_revision.file_asset).not_to be_nil
+      expect(file_revision.file_asset.variant).to eq("file")
+    end
+  end
+end


### PR DESCRIPTION
Trello: https://trello.com/c/3c6nomPo/782-mvp-of-inline-attachment-flow-add-and-insert

This changes the approach to managing the assets associated with with a
FileAttachment::FileRevision. The collection approach makes sense for
images where we have a group of different sizes but less so for files
where we will mostly have a single file and occasionally a thumbnail.
Thus rather than having a group this has specific associations.

I was initially tempted to swap the association to be held by the
file_revision model with a link to the Asset, however this wouldn't have
worked because the Asset needs access to the FileRevision and it can't
determine this if it can be associated on different join points.

It's a bit unclear what the future of the ensure_assets method is as I
don't know how that will determine whether a thumnbnail asset should
exist or not for a PDF, but we'll cross that bridge when we come to it.