### PR TITLE
Update the domain for the Content Data app

### DIFF
--- a/app/services/content_data_url.rb
+++ b/app/services/content_data_url.rb
@@ -13,7 +13,7 @@ class ContentDataUrl
   end
 
   def url
-    content_data_root = Plek.new.external_url_for("content-data-admin")
+    content_data_root = Plek.new.external_url_for("content-data")
     content_data_root + "/metrics" + document.live_edition.base_path
   end
 

--- a/spec/features/content_data/content_data_link_spec.rb
+++ b/spec/features/content_data/content_data_link_spec.rb
@@ -17,7 +17,7 @@ RSpec.feature "Link to content data admin app data page" do
   end
 
   def then_i_see_a_link_to_the_content_data_page_for_the_document
-    content_data_url_prefix = "https://content-data-admin.test.gov.uk/metrics"
+    content_data_url_prefix = "https://content-data.test.gov.uk/metrics"
     expect(page).to have_link(
       "View data about this page",
       href: content_data_url_prefix + @edition.base_path,

--- a/spec/services/content_data_url_spec.rb
+++ b/spec/services/content_data_url_spec.rb
@@ -11,7 +11,7 @@ RSpec.describe ContentDataUrl do
       base_path = document.current_edition.base_path
       data_page_url = ContentDataUrl.new(document).url
 
-      expect(data_page_url).to eq("https://content-data-admin.test.gov.uk/metrics#{base_path}")
+      expect(data_page_url).to eq("https://content-data.test.gov.uk/metrics#{base_path}")
     end
   end
 


### PR DESCRIPTION
The domain for the Content Data App, described in some places as
content-data-admin has changed. It's now
`content-data.publishing.service.gov.uk` rather than
`content-data-admin.publishing.service.gov.uk`.

Requests using the old domain name will be redirected to the new
domain, but to avoid that redirect, this commit updates the domain
that Content Publisher links to.