### PR TITLE
Split adding/updating images/attachments

### DIFF
--- a/app/controllers/file_attachments_controller.rb
+++ b/app/controllers/file_attachments_controller.rb
@@ -14,7 +14,7 @@ class FileAttachmentsController < ApplicationController
       ).call(current_user)
 
       updater = Versioning::RevisionUpdater.new(edition.revision, current_user)
-      updater.update_file_attachment(attachment_revision)
+      updater.add_file_attachment(attachment_revision)
 
       edition.assign_revision(updater.next_revision, current_user).save!
 

--- a/app/controllers/images_controller.rb
+++ b/app/controllers/images_controller.rb
@@ -25,7 +25,7 @@ class ImagesController < ApplicationController
 
       image_revision = ImageUploadService.new(params[:image], edition.revision).call(current_user)
       updater = Versioning::RevisionUpdater.new(edition.revision, current_user)
-      updater.update_image(image_revision)
+      updater.add_image(image_revision)
       edition.assign_revision(updater.next_revision, current_user).save!
       PreviewService.new(edition).try_create_preview
       redirect_to crop_image_path(params[:document], image_revision.image_id, wizard: "upload")

--- a/app/services/versioning/revision_updater/file_attachment.rb
+++ b/app/services/versioning/revision_updater/file_attachment.rb
@@ -3,15 +3,19 @@
 module Versioning
   class RevisionUpdater
     module FileAttachment
-      def update_file_attachment(attachment_revision)
-        revisions = other_file_attachments(attachment_revision) + [attachment_revision]
+      def add_file_attachment(attachment_revision)
+        if attachment_exists?(attachment_revision)
+          raise "Cannot add another revision for the same file attachment"
+        end
+
+        revisions = revision.file_attachment_revisions + [attachment_revision]
         assign(file_attachment_revisions: revisions)
       end
 
     private
 
-      def other_file_attachments(attachment_revision)
-        revision.file_attachment_revisions.reject do |far|
+      def attachment_exists?(attachment_revision)
+        revision.file_attachment_revisions.find do |far|
           far.file_attachment_id == attachment_revision.file_attachment_id
         end
       end

--- a/app/services/versioning/revision_updater/image.rb
+++ b/app/services/versioning/revision_updater/image.rb
@@ -3,7 +3,19 @@
 module Versioning
   class RevisionUpdater
     module Image
+      def add_image(image_revision)
+        if image_exists?(image_revision)
+          raise "Cannot add another revision for the same image"
+        end
+
+        assign(image_revisions: revision.image_revisions + [image_revision])
+      end
+
       def update_image(image_revision, selected = false)
+        unless image_exists?(image_revision)
+          raise "Cannot update an image that doesn't exist"
+        end
+
         assign(
           image_revisions: other_images(image_revision) + [image_revision],
           lead_image_revision: next_lead_image(image_revision, selected),
@@ -30,6 +42,10 @@ module Versioning
 
       def other_images(image_revision)
         revision.image_revisions.reject { |ir| ir.image_id == image_revision.image_id }
+      end
+
+      def image_exists?(image_revision)
+        revision.image_revisions.find { |ir| ir.image_id == image_revision.image_id }
       end
 
       def next_lead_image(image_revision, selected = false)

--- a/spec/services/versioning/revision_updater/file_attachment_spec.rb
+++ b/spec/services/versioning/revision_updater/file_attachment_spec.rb
@@ -7,28 +7,23 @@ RSpec.describe Versioning::RevisionUpdater::FileAttachment do
     create :revision, file_attachment_revisions: [file_attachment_revision]
   end
 
-  describe "#update_file_attachment" do
+  describe "#add_file_attachment" do
     it "extends file attachment revisions with a new file attachment" do
       new_file_attachment = create :file_attachment_revision
 
       updater = Versioning::RevisionUpdater.new(revision, user)
-      updater.update_file_attachment(new_file_attachment)
+      updater.add_file_attachment(new_file_attachment)
 
       next_revision = updater.next_revision
       expect(next_revision.file_attachment_revisions)
         .to match_array [file_attachment_revision, new_file_attachment]
     end
 
-    it "updates an existing file attachment with a new revision" do
-      updated_file_attachment = create :file_attachment_revision,
-                                file_attachment_id: file_attachment_revision.file_attachment_id
-
+    it "raises an error if a revision exists for the same attachment" do
       updater = Versioning::RevisionUpdater.new(revision, user)
-      updater.update_file_attachment(updated_file_attachment)
 
-      next_revision = updater.next_revision
-      expect(next_revision.file_attachment_revisions)
-        .to match_array [updated_file_attachment]
+      expect { updater.add_file_attachment(file_attachment_revision) }
+        .to raise_error(RuntimeError, "Cannot add another revision for the same file attachment")
     end
   end
 end

--- a/spec/services/versioning/revision_updater/image_spec.rb
+++ b/spec/services/versioning/revision_updater/image_spec.rb
@@ -4,18 +4,28 @@ RSpec.describe Versioning::RevisionUpdater::Image do
   let(:user) { create :user }
   let(:image_revision) { create :image_revision }
 
-  describe "#update_image" do
+  describe "#add_image" do
     it "extends image revisions with a new image" do
       revision = create :revision, image_revisions: [image_revision]
       new_image = create :image_revision
 
       updater = Versioning::RevisionUpdater.new(revision, user)
-      updater.update_image(new_image)
+      updater.add_image(new_image)
 
       next_revision = updater.next_revision
       expect(next_revision.image_revisions).to match_array [image_revision, new_image]
     end
 
+    it "raises an error if the image already exists" do
+      revision = create :revision, image_revisions: [image_revision]
+      updater = Versioning::RevisionUpdater.new(revision, user)
+
+      expect { updater.add_image(image_revision) }
+        .to raise_error(RuntimeError, "Cannot add another revision for the same image")
+    end
+  end
+
+  describe "#update_image" do
     it "updates an existing image with a new revision" do
       revision = create :revision, image_revisions: [image_revision]
       updated_image = create :image_revision, image_id: image_revision.image_id
@@ -27,11 +37,23 @@ RSpec.describe Versioning::RevisionUpdater::Image do
       expect(next_revision.image_revisions).to match_array [updated_image]
     end
 
+    it "raises an error if there is no image to update" do
+      revision = create :revision
+      updater = Versioning::RevisionUpdater.new(revision, user)
+
+      expect { updater.update_image(image_revision) }
+        .to raise_error(RuntimeError, "Cannot update an image that doesn't exist")
+    end
+
     it "preserves another existing image as the lead" do
-      revision = create :revision, lead_image_revision: image_revision
+      other_image_revision = create :image_revision
+      updated_image = create :image_revision, image_id: other_image_revision.image_id
+
+      revision = create :revision, image_revisions: [image_revision, other_image_revision],
+                                   lead_image_revision: image_revision
 
       updater = Versioning::RevisionUpdater.new(revision, user)
-      updater.update_image(create(:image_revision))
+      updater.update_image(updated_image)
 
       next_revision = updater.next_revision
       expect(next_revision.lead_image_revision).to eq image_revision
@@ -40,9 +62,10 @@ RSpec.describe Versioning::RevisionUpdater::Image do
     end
 
     it "preserves the given image as the lead if selected" do
-      revision = create :revision, lead_image_revision: image_revision
-      updated_image = create :image_revision, image_id: image_revision.image_id
+      revision = create :revision, image_revisions: [image_revision],
+                                   lead_image_revision: image_revision
 
+      updated_image = create :image_revision, image_id: image_revision.image_id
       updater = Versioning::RevisionUpdater.new(revision, user)
       updater.update_image(updated_image, true)
 
@@ -53,8 +76,8 @@ RSpec.describe Versioning::RevisionUpdater::Image do
     end
 
     it "sets the given image as the lead if selected" do
-      revision = create :revision
-      updated_image = create :image_revision
+      revision = create :revision, image_revisions: [image_revision]
+      updated_image = create :image_revision, image_id: image_revision.image_id
 
       updater = Versioning::RevisionUpdater.new(revision, user)
       updater.update_image(updated_image, true)
@@ -66,9 +89,10 @@ RSpec.describe Versioning::RevisionUpdater::Image do
     end
 
     it "unsets the given image as the lead if not selected" do
-      revision = create :revision, lead_image_revision: image_revision
-      updated_image = create :image_revision, image_id: image_revision.image_id
+      revision = create :revision, image_revisions: [image_revision],
+                                   lead_image_revision: image_revision
 
+      updated_image = create :image_revision, image_id: image_revision.image_id
       updater = Versioning::RevisionUpdater.new(revision, user)
       updater.update_image(updated_image)
 


### PR DESCRIPTION
https://trello.com/c/pd6fOgwf/800-follow-up-steps-on-minimal-workflow-for-inline-attachments

Previously we used a single 'update' method to handle the addition of
new images and attachments, as well as the substitution of an existing
image or attachment with a new revision. While adding a new image or
attachment happens to be a special case of 'updating', the call to the
'update' method in the context of addition is confusing. This splits the
'add' aspect out of the 'update' method and adds a few pre-checks.