### PR TITLE
Bump govuk_test to 0.4.2

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -42,7 +42,7 @@ group :development, :test do
   gem "factory_bot_rails", "~> 5"
   gem "govuk-lint", "~> 3"
   gem "govuk_schemas", "~> 3.2"
-  gem "govuk_test", "~> 0.3"
+  gem "govuk_test", "~> 0.4"
   gem "jasmine", "~> 3.4"
   gem "jasmine_selenium_runner", "~> 3", require: false
   gem "rspec-rails", "~> 3"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -53,7 +53,7 @@ GEM
       tzinfo (~> 1.1)
     addressable (2.6.0)
       public_suffix (>= 2.0.2, < 4.0)
-    archive-zip (0.11.0)
+    archive-zip (0.12.0)
       io-like (~> 0.3.0)
     arel (9.0.0)
     ast (2.4.0)
@@ -90,7 +90,7 @@ GEM
       xpath (~> 3.2)
     childprocess (0.9.0)
       ffi (~> 1.0, >= 1.0.11)
-    chromedriver-helper (2.1.0)
+    chromedriver-helper (2.1.1)
       archive-zip (~> 0.10)
       nokogiri (~> 1.8)
     climate_control (0.2.0)
@@ -173,9 +173,10 @@ GEM
       sidekiq (>= 5, < 6)
       sidekiq-logging-json (~> 0.0)
       sidekiq-statsd (~> 0.1)
-    govuk_test (0.3.1)
+    govuk_test (0.4.2)
       capybara
       chromedriver-helper
+      ptools
       puma
       selenium-webdriver
     hashdiff (0.3.9)
@@ -282,8 +283,9 @@ GEM
     phantomjs (2.1.1.0)
     plek (2.1.1)
     powerpack (0.1.2)
+    ptools (1.3.5)
     public_suffix (3.0.3)
-    puma (3.12.0)
+    puma (3.12.1)
     rack (2.0.7)
     rack-cache (1.9.0)
       rack (>= 0.4)
@@ -461,7 +463,7 @@ DEPENDENCIES
   govuk_publishing_components (~> 16.11)
   govuk_schemas (~> 3.2)
   govuk_sidekiq (~> 3)
-  govuk_test (~> 0.3)
+  govuk_test (~> 0.4)
   hashdiff (~> 0.3)
   image_processing (~> 1)
   jasmine (~> 3.4)


### PR DESCRIPTION
This updates to the latest version of govuk_test in order to take
advantage of the new env var to disable the now-deprecated
chromedriver-helper.