### PR TITLE
Show attachment snippet on separate page

### DIFF
--- a/app/controllers/file_attachments_controller.rb
+++ b/app/controllers/file_attachments_controller.rb
@@ -5,9 +5,16 @@ class FileAttachmentsController < ApplicationController
     @edition = Edition.find_current(document: params[:document])
   end
 
+  def show
+    @edition = Edition.find_current(document: params[:document])
+
+    @attachment = @edition.file_attachment_revisions
+      .find_by!(file_attachment_id: params[:file_attachment_id])
+  end
+
   def create
     result = FileAttachments::CreateInteractor.call(params: params, user: current_user)
-    edition = result.edition
-    redirect_to file_attachments_path(edition.document)
+    edition, attachment_revision = result.to_h.values_at(:edition, :attachment_revision)
+    redirect_to file_attachment_path(edition.document, attachment_revision.file_attachment)
   end
 end

--- a/app/models/file_attachment/blob_revision.rb
+++ b/app/models/file_attachment/blob_revision.rb
@@ -8,7 +8,7 @@ class FileAttachment::BlobRevision < ApplicationRecord
 
   has_many :assets, class_name: "FileAttachment::Asset"
 
-  delegate :content_type, to: :blob
+  delegate :content_type, :byte_size, to: :blob
 
   def readonly?
     !new_record?

--- a/app/models/file_attachment/revision.rb
+++ b/app/models/file_attachment/revision.rb
@@ -19,7 +19,8 @@ class FileAttachment::Revision < ApplicationRecord
            :asset,
            :assets,
            :ensure_assets,
-           :blob,
+           :content_type,
+           :byte_size,
            to: :blob_revision
 
   def readonly?

--- a/app/models/file_attachment/revision.rb
+++ b/app/models/file_attachment/revision.rb
@@ -19,6 +19,7 @@ class FileAttachment::Revision < ApplicationRecord
            :asset,
            :assets,
            :ensure_assets,
+           :blob,
            to: :blob_revision
 
   def readonly?

--- a/app/services/file_attachment_upload_service.rb
+++ b/app/services/file_attachment_upload_service.rb
@@ -17,7 +17,7 @@ class FileAttachmentUploadService
     )
 
     blob_revision = FileAttachment::BlobRevision.new(
-      blob: blob, created_by: user, filename: filename, size: file.size,
+      blob: blob, created_by: user, filename: filename,
     )
 
     metadata_revision = FileAttachment::MetadataRevision.new(

--- a/app/views/components/_attachment_meta.html.erb
+++ b/app/views/components/_attachment_meta.html.erb
@@ -24,7 +24,7 @@
 
     <% if metadata_items.any? %>
       <%= tag.p class: "app-c-attachment-meta__metadata" do %>
-        <%= metadata_items.map {|metadata| metadata.values.map {|value| "#{value}"} }.join(', ') %>
+        <%= metadata_items.join(", ") %>
       <% end %>
     <% end %>
 

--- a/app/views/file_attachments/_file_attachment.html.erb
+++ b/app/views/file_attachments/_file_attachment.html.erb
@@ -1,7 +1,0 @@
-<h3 class="govuk-heading-s"><%= attachment.title %></h3>
-<dl>
-  <dt class="govuk-body">Attachment markdown:</dt>
-  <dd class="govuk-body"><%= t("file_attachments.index.attachment_markdown", filename: attachment.filename) %></dd>
-  <dt class="govuk-body">Attachment link markdown:</dt>
-  <dd class="govuk-body"><%= t("file_attachments.index.attachment_link_markdown", filename: attachment.filename) %></dd>
-</dl>

--- a/app/views/file_attachments/index.html.erb
+++ b/app/views/file_attachments/index.html.erb
@@ -39,7 +39,17 @@
       </h2>
 
       <% attachments.each do |attachment| %>
-        <%= render "file_attachment", attachment: attachment, document: @edition.document %>
+        <%= render "components/attachment_meta", {
+          title: attachment.title,
+          url: "#",
+          metadata_items: [
+            attachment.content_type,
+            number_to_human_size(attachment.byte_size),
+          ],
+          actions: [
+            link_to("Insert attachment", file_attachment_path(@edition.document, attachment.file_attachment))
+          ]
+        } %>
       <% end %>
     <% end %>
   </div>

--- a/app/views/file_attachments/show.html.erb
+++ b/app/views/file_attachments/show.html.erb
@@ -1,0 +1,22 @@
+<% content_for :title, t("file_attachments.show.title") %>
+<% content_for :back_link, render_back_link(href: file_attachments_path(@edition.document)) %>
+
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-two-thirds">
+    <dl>
+      <dt class="govuk-body">Title</dt>
+      <dd class="govuk-body"><%= @attachment.title %></dd>
+      <dt class="govuk-body">Attachment markdown:</dt>
+      <dd class="govuk-body"><%= t("file_attachments.index.attachment_markdown", filename: @attachment.filename) %></dd>
+    </dl>
+
+    <hr class="govuk-!-margin-bottom-6 govuk-!-margin-top-6"/>
+
+    <dl>
+      <dt class="govuk-body">Title</dt>
+      <dd class="govuk-body"><%= @attachment.title %></dd>
+      <dt class="govuk-body">Attachment link markdown:</dt>
+      <dd class="govuk-body"><%= t("file_attachments.index.attachment_link_markdown", filename: @attachment.filename) %></dd>
+    </dl>
+  </div>
+</div>

--- a/config/locales/en/file_attachments/show.yml
+++ b/config/locales/en/file_attachments/show.yml
@@ -1,0 +1,4 @@
+en:
+  file_attachments:
+    show:
+      title: Insert attachment

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -76,6 +76,7 @@ Rails.application.routes.draw do
 
     get "/file-attachments" => "file_attachments#index", as: :file_attachments
     post "/file-attachments" => "file_attachments#create", as: :create_file_attachment
+    get "/file-attachments/:file_attachment_id" => "file_attachments#show", as: :file_attachment
   end
 
   get "/healthcheck", to: proc { [200, {}, %w[OK]] }

--- a/db/migrate/20190430091427_remove_redundant_file_attachment_size.rb
+++ b/db/migrate/20190430091427_remove_redundant_file_attachment_size.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+class RemoveRedundantFileAttachmentSize < ActiveRecord::Migration[5.2]
+  def change
+    remove_column :file_attachment_blob_revisions, :size # rubocop:disable Rails/ReversibleMigration
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2019_04_24_145213) do
+ActiveRecord::Schema.define(version: 2019_04_30_091427) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -106,7 +106,6 @@ ActiveRecord::Schema.define(version: 2019_04_24_145213) do
     t.bigint "created_by_id"
     t.string "filename", null: false
     t.datetime "created_at", null: false
-    t.bigint "size", null: false
     t.index ["blob_id"], name: "index_file_attachment_blob_revisions_on_blob_id"
   end
 

--- a/spec/factories/file_attachment_blob_revision_factory.rb
+++ b/spec/factories/file_attachment_blob_revision_factory.rb
@@ -18,7 +18,6 @@ FactoryBot.define do
         io: File.new(fixture_path),
         filename: blob_revision.filename,
       )
-      blob_revision.size = File.size(fixture_path) unless blob_revision.size
 
       if evaluator.assets
         blob_revision.assets = evaluator.assets


### PR DESCRIPTION
https://trello.com/c/gf8wSm9P/825-build-page-for-inserting-inline-attachments-to-match-design

Previously we showed the markdown snippet for an attachment as part of
the list of attachments for an edition. This moves the snippet to a
separate page and makes use of the attachment_meta component to work
towards matching the design for both of these pages.

## The New

### Show page
<img width="1013" alt="Screen Shot 2019-04-30 at 09 27 09" src="https://user-images.githubusercontent.com/9029009/56949222-309e7400-6b2a-11e9-85a2-ba12b2680b07.png">

### Index page
<img width="717" alt="Screen Shot 2019-04-30 at 09 27 19" src="https://user-images.githubusercontent.com/9029009/56949224-3300ce00-6b2a-11e9-8cc5-7d01763dc69e.png">

## The Old

### Index page
<img width="736" alt="Screen Shot 2019-04-30 at 09 28 27" src="https://user-images.githubusercontent.com/9029009/56949261-56c41400-6b2a-11e9-906d-250b0732f3a3.png">

