### PR TITLE
Publish and delete assets

### DIFF
--- a/app/models/edition.rb
+++ b/app/models/edition.rb
@@ -67,6 +67,7 @@ class Edition < ApplicationRecord
            :image_revisions_without_lead,
            :scheduled_publishing_datetime,
            :file_attachment_revisions,
+           :assets,
            to: :revision
 
   MINIMUM_SCHEDULING_TIME = { minutes: 15 }.freeze

--- a/app/models/file_attachment/asset.rb
+++ b/app/models/file_attachment/asset.rb
@@ -22,6 +22,12 @@ class FileAttachment::Asset < ApplicationRecord
 
   delegate :filename, :content_type, to: :blob_revision
 
+  def asset_manager_id
+    url_array = file_url.to_s.split("/")
+    # https://github.com/alphagov/asset-manager#create-an-asset
+    url_array[url_array.length - 2]
+  end
+
   def bytes
     blob_revision.bytes_for_asset(variant)
   end

--- a/app/models/file_attachment/asset.rb
+++ b/app/models/file_attachment/asset.rb
@@ -9,9 +9,14 @@ class FileAttachment::Asset < ApplicationRecord
   belongs_to :blob_revision,
              class_name: "FileAttachment::BlobRevision"
 
+  belongs_to :superseded_by,
+             class_name: "FileAttachment::Asset",
+             optional: true
+
   enum state: { absent: "absent",
                 draft: "draft",
-                live: "live" }
+                live: "live",
+                superseded: "superseded" }
 
   enum variant: { file: "file", thumbnail: "thumbnail" }
 

--- a/app/models/revision.rb
+++ b/app/models/revision.rb
@@ -80,4 +80,8 @@ class Revision < ApplicationRecord
   def image_revisions_without_lead
     image_revisions.reject { |i| i.id == lead_image_revision_id }
   end
+
+  def assets
+    image_revisions.flat_map(&:assets) + file_attachment_revisions.flat_map(&:assets)
+  end
 end

--- a/app/services/delete_draft_service.rb
+++ b/app/services/delete_draft_service.rb
@@ -15,10 +15,7 @@ class DeleteDraftService
     raise "Trying to delete a live document" if edition.live?
 
     begin
-      assets = edition.image_revisions.flat_map(&:assets) +
-        edition.file_attachment_revisions.flat_map(&:assets)
-
-      delete_assets(assets)
+      delete_assets(edition.assets)
       discard_draft(edition)
     rescue GdsApi::BaseError
       document.current_edition.update!(revision_synced: false)

--- a/app/services/draft_asset_cleanup_service.rb
+++ b/app/services/draft_asset_cleanup_service.rb
@@ -7,10 +7,7 @@ class DraftAssetCleanupService
 
     return unless previous_revision
 
-    current_assets = current_revision.image_revisions.flat_map(&:assets)
-    previous_assets = previous_revision.image_revisions.flat_map(&:assets)
-
-    delete_assets(previous_assets - current_assets)
+    delete_assets(previous_assets(previous_revision) - current_assets(current_revision))
   end
 
 private
@@ -27,5 +24,17 @@ private
 
       asset.absent!
     end
+  end
+
+  def current_assets(current_revision)
+    current_image_assets = current_revision.image_revisions.flat_map(&:assets)
+    current_file_attachment_assets = current_revision.file_attachment_revisions.flat_map(&:assets)
+    current_image_assets + current_file_attachment_assets
+  end
+
+  def previous_assets(previous_revision)
+    previous_image_assets = previous_revision.image_revisions.flat_map(&:assets)
+    previous_file_attachment_assets = previous_revision.file_attachment_revisions.flat_map(&:assets)
+    previous_image_assets + previous_file_attachment_assets
   end
 end

--- a/app/services/publish_asset_service.rb
+++ b/app/services/publish_asset_service.rb
@@ -1,0 +1,98 @@
+# frozen_string_literal: true
+
+class PublishAssetService
+  def publish_assets(edition, live_edition)
+    assets = edition.file_attachment_revisions.flat_map(&:assets) +
+      edition.image_revisions.flat_map(&:assets)
+
+    assets.each do |asset|
+      raise "Expected asset to be on asset manager" if asset.absent?
+      next unless asset.draft?
+
+      AssetManagerService.new.publish(asset)
+      asset.live!
+    end
+
+    retire_old_file_attachments(edition, live_edition)
+    retire_old_images(edition, live_edition)
+  end
+
+private
+
+  def retire_old_file_attachments(edition, live_edition)
+    return unless live_edition
+
+    live_edition.file_attachment_revisions.each do |live_revision|
+      current_revision = find_file_attachment_revision(edition, live_revision)
+
+      if current_revision
+        redirect_assets(live_revision, current_revision)
+      else
+        live_revision.assets.each { |a| delete_asset(a) }
+      end
+    end
+  end
+
+  def retire_old_images(edition, live_edition)
+    return unless live_edition
+
+    live_edition.image_revisions.each do |live_revision|
+      current_revision = find_image_revision(edition, live_revision)
+
+      if current_revision
+        redirect_assets(live_revision, current_revision)
+      else
+        live_revision.assets.each { |a| delete_asset(a) }
+      end
+    end
+  end
+
+  def redirect_assets(live_revision, current_revision)
+    live_revision.assets.each do |live_asset|
+      current_asset = current_revision.asset(live_asset.variant)
+
+      if current_asset
+        redirect_asset(live_asset, current_asset)
+      else
+        delete_asset(live_asset)
+      end
+    end
+  end
+
+  def redirect_asset(live_asset, current_asset)
+    return if live_asset.absent?
+    return if live_asset == current_asset
+
+    begin
+      AssetManagerService.new.redirect(live_asset, to: current_asset.file_url)
+      live_asset.update!(state: :superseded, superseded_by: current_asset)
+    rescue GdsApi::HTTPNotFound
+      Rails.logger.warn("No asset to supersede for id #{live_asset.asset_manager_id}")
+      live_asset.absent!
+    end
+  end
+
+  def delete_asset(live_asset)
+    return if live_asset.absent?
+
+    begin
+      AssetManagerService.new.delete(live_asset)
+    rescue GdsApi::HTTPNotFound
+      Rails.logger.warn("No asset to delete for id #{live_asset.asset_manager_id}")
+    end
+
+    live_asset.absent!
+  end
+
+  def find_image_revision(edition, live_revision)
+    edition.image_revisions.find do |r|
+      r.image_id == live_revision.image_id
+    end
+  end
+
+  def find_file_attachment_revision(edition, live_revision)
+    edition.file_attachment_revisions.find do |r|
+      r.file_attachment_id == live_revision.file_attachment_id
+    end
+  end
+end

--- a/app/services/publish_asset_service.rb
+++ b/app/services/publish_asset_service.rb
@@ -2,10 +2,7 @@
 
 class PublishAssetService
   def publish_assets(edition, live_edition)
-    assets = edition.file_attachment_revisions.flat_map(&:assets) +
-      edition.image_revisions.flat_map(&:assets)
-
-    assets.each do |asset|
+    edition.assets.each do |asset|
       raise "Expected asset to be on asset manager" if asset.absent?
       next unless asset.draft?
 

--- a/app/services/publish_service.rb
+++ b/app/services/publish_service.rb
@@ -11,8 +11,7 @@ class PublishService
   def publish(user:, with_review:)
     live_edition = document.live_edition
 
-    publish_new_images
-    retire_old_images(live_edition)
+    PublishAssetService.new.publish_assets(edition, live_edition)
 
     GdsApi.publishing_api_v2.publish(
       document.content_id,
@@ -51,72 +50,5 @@ private
     return if document.first_published_at
 
     document.update!(first_published_at: Time.current)
-  end
-
-  def publish_new_images
-    assets = edition.image_revisions.flat_map(&:assets)
-
-    assets.each do |asset|
-      raise "Expected asset to be on asset manager" if asset.absent?
-      next unless asset.draft?
-
-      AssetManagerService.new.publish(asset)
-      asset.live!
-    end
-  end
-
-  def retire_old_images(live_edition)
-    return unless live_edition
-
-    live_edition.image_revisions.each do |old_revision|
-      new_revision = find_image_revision(edition, old_revision)
-
-      if new_revision
-        redirect_image_assets(old_revision, new_revision)
-      else
-        old_revision.assets.each { |a| remove_image_asset(a) }
-      end
-    end
-  end
-
-  def redirect_image_assets(old_revision, new_revision)
-    old_revision.assets.each do |old_asset|
-      new_asset = new_revision.asset(old_asset.variant)
-
-      if new_asset
-        redirect_image_asset(old_asset, new_asset)
-      else
-        remove_image_asset(old_asset)
-      end
-    end
-  end
-
-  def remove_image_asset(asset)
-    return if asset.absent?
-
-    begin
-      AssetManagerService.new.delete(asset)
-    rescue GdsApi::HTTPNotFound
-      Rails.logger.warn("No asset to delete for id #{asset.asset_manager_id}")
-    end
-
-    asset.absent!
-  end
-
-  def redirect_image_asset(from_asset, to_asset)
-    return if from_asset.absent?
-    return if from_asset == to_asset
-
-    begin
-      AssetManagerService.new.redirect(from_asset, to: to_asset.file_url)
-      from_asset.update!(state: :superseded, superseded_by: to_asset)
-    rescue GdsApi::HTTPNotFound
-      Rails.logger.warn("No asset to supersede for id #{from_asset.asset_manager_id}")
-      from_asset.absent!
-    end
-  end
-
-  def find_image_revision(edition, old_revision)
-    edition.image_revisions.find { |r| r.image_id == old_revision.image_id }
   end
 end

--- a/app/services/remove_service.rb
+++ b/app/services/remove_service.rb
@@ -24,10 +24,7 @@ class RemoveService
       )
     end
 
-    assets = edition.image_revisions.flat_map(&:assets) +
-      edition.file_attachment_revisions.flat_map(&:assets)
-
-    delete_assets(assets)
+    delete_assets(edition.assets)
   end
 
 private

--- a/app/services/remove_service.rb
+++ b/app/services/remove_service.rb
@@ -24,7 +24,10 @@ class RemoveService
       )
     end
 
-    delete_assets(edition)
+    assets = edition.image_revisions.flat_map(&:assets) +
+      edition.file_attachment_revisions.flat_map(&:assets)
+
+    delete_assets(assets)
   end
 
 private
@@ -41,12 +44,8 @@ private
     end
   end
 
-  def delete_assets(edition)
-    edition.image_revisions.each { |ir| remove_image_revision(ir) }
-  end
-
-  def remove_image_revision(image_revision)
-    image_revision.assets.each do |asset|
+  def delete_assets(assets)
+    assets.each do |asset|
       next if asset.absent?
 
       begin

--- a/db/migrate/20190426090323_add_superseded_by_to_file_attachment_assets.rb
+++ b/db/migrate/20190426090323_add_superseded_by_to_file_attachment_assets.rb
@@ -1,0 +1,12 @@
+# frozen_string_literal: true
+
+class AddSupersededByToFileAttachmentAssets < ActiveRecord::Migration[5.2]
+  def change
+    add_reference :file_attachment_assets,
+      :superseded_by,
+      foreign_key: { to_table: :file_attachment_assets,
+                     on_delete: :restrict },
+                     index: false,
+                     null: true
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -96,6 +96,7 @@ ActiveRecord::Schema.define(version: 2019_04_30_091427) do
     t.string "state", default: "absent", null: false
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
+    t.bigint "superseded_by_id"
     t.index ["blob_revision_id", "variant"], name: "index_file_attachment_assets_on_blob_revision_id_and_variant", unique: true
     t.index ["blob_revision_id"], name: "index_file_attachment_assets_on_blob_revision_id"
     t.index ["file_url"], name: "index_file_attachment_assets_on_file_url", unique: true
@@ -312,8 +313,8 @@ ActiveRecord::Schema.define(version: 2019_04_30_091427) do
   create_table "withdrawals", force: :cascade do |t|
     t.string "public_explanation", null: false
     t.datetime "created_at", null: false
-    t.datetime "withdrawn_at", null: false
     t.bigint "published_status_id", null: false
+    t.datetime "withdrawn_at", null: false
   end
 
   add_foreign_key "content_revisions", "users", column: "created_by_id", on_delete: :restrict
@@ -325,6 +326,7 @@ ActiveRecord::Schema.define(version: 2019_04_30_091427) do
   add_foreign_key "editions", "users", column: "last_edited_by_id", on_delete: :restrict
   add_foreign_key "editions_revisions", "editions", on_delete: :restrict
   add_foreign_key "editions_revisions", "revisions", on_delete: :restrict
+  add_foreign_key "file_attachment_assets", "file_attachment_assets", column: "superseded_by_id", on_delete: :restrict
   add_foreign_key "file_attachment_assets", "file_attachment_blob_revisions", column: "blob_revision_id", on_delete: :restrict
   add_foreign_key "file_attachment_blob_revisions", "active_storage_blobs", column: "blob_id", on_delete: :restrict
   add_foreign_key "file_attachment_blob_revisions", "users", column: "created_by_id", on_delete: :restrict

--- a/spec/services/draft_asset_cleanup_service_spec.rb
+++ b/spec/services/draft_asset_cleanup_service_spec.rb
@@ -5,7 +5,12 @@ RSpec.describe DraftAssetCleanupService do
     context "when the previous revision has draft assets that aren't used" do
       it "deletes the assets that aren't used" do
         image_revision = create(:image_revision, :on_asset_manager, state: :draft)
-        preceding_revision = create(:revision, image_revisions: [image_revision])
+        file_attachment_revision = create(:file_attachment_revision, :on_asset_manager)
+
+        preceding_revision = create(:revision,
+                                    image_revisions: [image_revision],
+                                    file_attachment_revisions: [file_attachment_revision])
+
         current_revision = create(:revision, preceded_by: preceding_revision)
         edition = create(:edition, revision: current_revision)
 
@@ -15,16 +20,24 @@ RSpec.describe DraftAssetCleanupService do
 
         expect(request).to have_been_requested.at_least_once
         expect(image_revision.assets.map(&:state).uniq).to match(%w[absent])
+        expect(file_attachment_revision.assets.map(&:state).uniq).to match(%w[absent])
       end
     end
 
     context "when the previous revision has assets that are used on the current revision" do
       it "doesn't change the assets" do
         image_revision = create(:image_revision, :on_asset_manager, state: :draft)
-        preceding_revision = create(:revision, image_revisions: [image_revision])
+        file_attachment_revision = create(:file_attachment_revision, :on_asset_manager)
+
+        preceding_revision = create(:revision,
+                                    image_revisions: [image_revision],
+                                    file_attachment_revisions: [file_attachment_revision])
+
         current_revision = create(:revision,
                                   image_revisions: [image_revision],
+                                  file_attachment_revisions: [file_attachment_revision],
                                   preceded_by: preceding_revision)
+
         edition = create(:edition, revision: current_revision)
 
         request = stub_asset_manager_deletes_any_asset
@@ -33,13 +46,19 @@ RSpec.describe DraftAssetCleanupService do
 
         expect(request).not_to have_been_requested
         expect(image_revision.assets.map(&:state).uniq).to match(%w[draft])
+        expect(file_attachment_revision.assets.map(&:state).uniq).to match(%w[draft])
       end
     end
 
     context "when the previous revision has assets that are live" do
       it "doesn't change the assets" do
         image_revision = create(:image_revision, :on_asset_manager, state: :live)
-        preceding_revision = create(:revision, image_revisions: [image_revision])
+        file_attachment_revision = create(:file_attachment_revision, :on_asset_manager, state: :live)
+
+        preceding_revision = create(:revision,
+                                    image_revisions: [image_revision],
+                                    file_attachment_revisions: [file_attachment_revision])
+
         current_revision = create(:revision, preceded_by: preceding_revision)
         edition = create(:edition, revision: current_revision)
 
@@ -49,6 +68,7 @@ RSpec.describe DraftAssetCleanupService do
 
         expect(request).not_to have_been_requested
         expect(image_revision.assets.map(&:state).uniq).to match(%w[live])
+        expect(file_attachment_revision.assets.map(&:state).uniq).to match(%w[live])
       end
     end
 
@@ -65,7 +85,12 @@ RSpec.describe DraftAssetCleanupService do
     context "when assets to remove are not on asset manager" do
       it "marks the assets as absent" do
         image_revision = create(:image_revision, :on_asset_manager, state: :draft)
-        preceding_revision = create(:revision, image_revisions: [image_revision])
+        file_attachment_revision = create(:file_attachment_revision, :on_asset_manager, state: :draft)
+
+        preceding_revision = create(:revision,
+                                    image_revisions: [image_revision],
+                                    file_attachment_revisions: [file_attachment_revision])
+
         current_revision = create(:revision, preceded_by: preceding_revision)
         edition = create(:edition, revision: current_revision)
 
@@ -74,6 +99,7 @@ RSpec.describe DraftAssetCleanupService do
         DraftAssetCleanupService.new.call(edition)
 
         expect(image_revision.assets.map(&:state).uniq).to match(%w[absent])
+        expect(file_attachment_revision.assets.map(&:state).uniq).to match(%w[absent])
       end
     end
   end

--- a/spec/services/publish_asset_service_spec.rb
+++ b/spec/services/publish_asset_service_spec.rb
@@ -1,0 +1,115 @@
+# frozen_string_literal: true
+
+RSpec.describe PublishAssetService do
+  describe "#publish_assets" do
+    it "publishes the draft assets and marks them as live" do
+      image_revision = create(:image_revision, :on_asset_manager, state: :draft)
+      file_attachment_revision = create(:file_attachment_revision, :on_asset_manager, state: :draft)
+      edition = create(:edition,
+                       :publishable,
+                       file_attachment_revisions: [file_attachment_revision],
+                       image_revisions: [image_revision])
+
+      stub_asset_manager_updates_any_asset
+      PublishAssetService.new.publish_assets(edition, nil)
+      expect(file_attachment_revision.assets.map(&:state).uniq).to eq(%w[live])
+      expect(image_revision.assets.map(&:state).uniq).to eq(%w[live])
+    end
+
+    it "doesn't republish the assets that are already live" do
+      image_revision = create(:image_revision, :on_asset_manager, state: :live)
+      file_attachment_revision = create(:file_attachment_revision, :on_asset_manager, state: :live)
+      live_edition = create(:edition,
+                            :published,
+                            file_attachment_revisions: [file_attachment_revision],
+                            image_revisions: [image_revision],
+                            current: false)
+      edition = create(:edition,
+                       :publishable,
+                       file_attachment_revisions: [file_attachment_revision],
+                       image_revisions: [image_revision],
+                       document: live_edition.document)
+
+      request = stub_any_asset_manager_call
+      PublishAssetService.new.publish_assets(edition, live_edition)
+      expect(request).to_not have_been_requested
+    end
+
+    it "raises an error if an asset is marked as absent" do
+      image_revision = create(:image_revision, :on_asset_manager, state: :absent)
+      edition = create(:edition,
+                       :publishable,
+                       image_revisions: [image_revision])
+
+      expect { PublishAssetService.new.publish_assets(edition, nil) }.to raise_error("Expected asset to be on asset manager")
+    end
+
+    it "removes an asset not used by the current edition" do
+      image_revision_to_remove = create(:image_revision, :on_asset_manager, state: :live)
+      file_attachment_revision_to_remove = create(:file_attachment_revision, :on_asset_manager, state: :live)
+      live_edition = create(:edition,
+                            :published,
+                            image_revisions: [image_revision_to_remove],
+                            file_attachment_revisions: [file_attachment_revision_to_remove],
+                            current: false)
+      edition = create(:edition,
+                       :publishable,
+                       image_revisions: [],
+                       file_attachment_revisions: [],
+                       document: live_edition.document)
+
+      delete_request = stub_asset_manager_deletes_any_asset
+
+      PublishAssetService.new.publish_assets(edition, live_edition)
+      expect(file_attachment_revision_to_remove.assets.map(&:state).uniq).to eq(%w[absent])
+      expect(image_revision_to_remove.assets.map(&:state).uniq).to eq(%w[absent])
+      expect(delete_request).to have_been_requested.at_least_once
+    end
+  end
+
+  it "retains assets used by the current and live edition" do
+    image_revision_to_keep = create(:image_revision, :on_asset_manager, state: :live)
+    file_attachment_revision_to_keep = create(:file_attachment_revision, :on_asset_manager, state: :live)
+    live_edition = create(:edition,
+                          :published,
+                          image_revisions: [image_revision_to_keep],
+                          file_attachment_revisions: [file_attachment_revision_to_keep],
+                          current: false)
+    edition = create(:edition,
+                     :publishable,
+                     image_revisions: [image_revision_to_keep],
+                     file_attachment_revisions: [file_attachment_revision_to_keep],
+                     document: live_edition.document)
+
+    PublishAssetService.new.publish_assets(edition, live_edition)
+
+    expect(image_revision_to_keep.assets.map(&:state).uniq).to eq(%w[live])
+    expect(file_attachment_revision_to_keep.assets.map(&:state).uniq).to eq(%w[live])
+  end
+
+  it "redirects and supersedes the old asset to the new asset" do
+    old_image_revision = create(:image_revision, :on_asset_manager, state: :live)
+    old_file_attachment_revision = create(:file_attachment_revision, :on_asset_manager, state: :live)
+    new_file_attachment_revision = create(:file_attachment_revision, :on_asset_manager, file_attachment: old_file_attachment_revision.file_attachment)
+    new_image_revision = create(:image_revision, :on_asset_manager, image: old_image_revision.image)
+
+    live_edition = create(:edition,
+                          :published,
+                          image_revisions: [old_image_revision],
+                          file_attachment_revisions: [old_file_attachment_revision],
+                          current: false)
+    edition = create(:edition,
+                     :publishable,
+                     image_revisions: [new_image_revision],
+                     file_attachment_revisions: [new_file_attachment_revision],
+                     document: live_edition.document)
+
+    request = stub_asset_manager_updates_any_asset
+
+    PublishAssetService.new.publish_assets(edition, live_edition)
+
+    expect(old_file_attachment_revision.assets.map(&:state).uniq).to eq(%w[superseded])
+    expect(old_image_revision.assets.map(&:state).uniq).to eq(%w[superseded])
+    expect(request).to have_been_requested.at_least_once
+  end
+end

--- a/spec/services/remove_service_spec.rb
+++ b/spec/services/remove_service_spec.rb
@@ -92,29 +92,46 @@ RSpec.describe RemoveService do
     context "when an edition has assets" do
       it "removes assets that aren't absent" do
         image_revision = create(:image_revision, :on_asset_manager, state: :live)
-        edition = create(:edition, :published, lead_image_revision: image_revision)
+        file_attachment_revision = create(:file_attachment_revision, :on_asset_manager, state: :live)
+        edition = create(:edition,
+                         :published,
+                         lead_image_revision: image_revision,
+                         file_attachment_revisions: [file_attachment_revision])
+
         delete_request = stub_asset_manager_deletes_any_asset
 
         RemoveService.new.call(edition, build(:removal))
 
         expect(delete_request).to have_been_requested.at_least_once
         expect(image_revision.assets.map(&:state).uniq).to eq(%w[absent])
+        expect(file_attachment_revision.assets.map(&:state).uniq).to eq(%w[absent])
       end
 
       it "copes with assets that 404" do
         image_revision = create(:image_revision, :on_asset_manager, state: :live)
-        edition = create(:edition, :published, lead_image_revision: image_revision)
+        file_attachment_revision = create(:file_attachment_revision, :on_asset_manager, state: :live)
+        edition = create(:edition,
+                         :published,
+                         lead_image_revision: image_revision,
+                         file_attachment_revisions: [file_attachment_revision])
+
         delete_request = stub_asset_manager_deletes_any_asset.to_return(status: 404)
 
         RemoveService.new.call(edition, build(:removal))
 
         expect(delete_request).to have_been_requested.at_least_once
         expect(image_revision.assets.map(&:state).uniq).to eq(%w[absent])
+        expect(file_attachment_revision.assets.map(&:state).uniq).to eq(%w[absent])
       end
 
       it "ignores assets that are absent" do
         image_revision = create(:image_revision, :on_asset_manager, state: :absent)
-        edition = create(:edition, :published, lead_image_revision: image_revision)
+        file_attachment_revision = create(:file_attachment_revision, :on_asset_manager, state: :absent)
+        edition = create(:edition,
+                         :published,
+                         lead_image_revision: image_revision,
+                         file_attachment_revisions: [file_attachment_revision])
+
         delete_request = stub_asset_manager_deletes_any_asset
 
         RemoveService.new.call(edition, build(:removal))
@@ -128,7 +145,11 @@ RSpec.describe RemoveService do
 
       it "removes the edition" do
         image_revision = create(:image_revision, :on_asset_manager)
-        edition = create(:edition, :published, lead_image_revision: image_revision)
+        file_attachment_revision = create(:file_attachment_revision, :on_asset_manager)
+        edition = create(:edition,
+                         :published,
+                         lead_image_revision: image_revision,
+                         file_attachment_revisions: [file_attachment_revision])
 
         expect { RemoveService.new.call(edition, build(:removal)) }
           .to raise_error(GdsApi::BaseError)


### PR DESCRIPTION
Changes made in this PR:

* FileAttachmentAssets are published to asset manager when a document is published
* Deleted FileAttachmentAssets are only removed from asset manager when a document is published
* FileAttachmentAssets are removed from asset manager when a document is removed
* FileAttachmentAssets are removed from asset manager when a draft document is discarded
* Draft FileAttachmentAssets are cleaned up when they are removed from a draft document

The work for removing FileAttachmentAssets follows the same pattern that removing images already uses.

I've also created a new service to handle the publishing of assets as it made sense to separate the logic around the publishing of assets from the general publishing service. 

Trello:
https://trello.com/c/pd6fOgwf/800-follow-up-steps-on-minimal-workflow-for-inline-attachments
