### PR TITLE
Delete attachments

### DIFF
--- a/app/controllers/file_attachments_controller.rb
+++ b/app/controllers/file_attachments_controller.rb
@@ -17,4 +17,13 @@ class FileAttachmentsController < ApplicationController
     edition, attachment_revision = result.to_h.values_at(:edition, :attachment_revision)
     redirect_to file_attachment_path(edition.document, attachment_revision.file_attachment)
   end
+
+  def destroy
+    result = FileAttachments::DestroyInteractor.call(params: params, user: current_user)
+    attachment_revision = result.attachment_revision
+
+    redirect_to file_attachments_path(params[:document]),
+                notice: t("file_attachments.index.flashes.deleted",
+                          file: attachment_revision.filename)
+  end
 end

--- a/app/interactors/file_attachments/destroy_interactor.rb
+++ b/app/interactors/file_attachments/destroy_interactor.rb
@@ -1,0 +1,43 @@
+# frozen_string_literal: true
+
+class FileAttachments::DestroyInteractor
+  include Interactor
+
+  delegate :params,
+           :user,
+           :edition,
+           :attachment_revision,
+           to: :context
+
+  def call
+    Edition.transaction do
+      find_and_lock_edition
+      find_and_remove_attachment
+      create_timeline_entry
+      update_preview
+    end
+  end
+
+private
+
+  def find_and_lock_edition
+    context.edition = Edition.lock.find_current(document: params[:document])
+  end
+
+  def find_and_remove_attachment
+    context.attachment_revision = edition.file_attachment_revisions
+      .find_by!(file_attachment_id: params[:file_attachment_id])
+
+    updater = Versioning::RevisionUpdater.new(edition.revision, user)
+    updater.remove_file_attachment(attachment_revision)
+    edition.assign_revision(updater.next_revision, user).save!
+  end
+
+  def create_timeline_entry
+    TimelineEntry.create_for_revision(entry_type: :file_attachment_deleted, edition: edition)
+  end
+
+  def update_preview
+    PreviewService.new(edition).try_create_preview
+  end
+end

--- a/app/interactors/images/destroy_interactor.rb
+++ b/app/interactors/images/destroy_interactor.rb
@@ -25,12 +25,10 @@ private
   end
 
   def find_and_remove_image
-    current_image_revision = edition.image_revisions.find_by!(image_id: params[:image_id])
+    context.image_revision = edition.image_revisions.find_by!(image_id: params[:image_id])
     updater = Versioning::RevisionUpdater.new(edition.revision, user)
-    updater.remove_image(current_image_revision)
+    updater.remove_image(image_revision)
     edition.assign_revision(updater.next_revision, user).save!
-
-    context.image_revision = current_image_revision
     context.removed_lead_image = updater.removed_lead_image?
   end
 

--- a/app/models/timeline_entry.rb
+++ b/app/models/timeline_entry.rb
@@ -46,7 +46,8 @@ class TimelineEntry < ApplicationRecord
                      scheduled: "scheduled",
                      unscheduled: "unscheduled",
                      scheduled_publishing_datetime_set: "scheduled_publishing_datetime_set",
-                     scheduled_publishing_datetime_cleared: "scheduled_publishing_datetime_cleared" }
+                     scheduled_publishing_datetime_cleared: "scheduled_publishing_datetime_cleared",
+                     file_attachment_deleted: "file_attachment_deleted" }
 
   def self.create_for_status_change(entry_type:,
                                     status:,

--- a/app/services/versioning/revision_updater/file_attachment.rb
+++ b/app/services/versioning/revision_updater/file_attachment.rb
@@ -12,12 +12,21 @@ module Versioning
         assign(file_attachment_revisions: revisions)
       end
 
+      def remove_file_attachment(attachment_revision)
+        assign(file_attachment_revisions: other_file_attachments(attachment_revision))
+      end
+
     private
 
       def attachment_exists?(attachment_revision)
         revision.file_attachment_revisions.find do |far|
           far.file_attachment_id == attachment_revision.file_attachment_id
         end
+      end
+
+      def other_file_attachments(attachment_revision)
+        revision.file_attachment_revisions
+          .reject { |ar| ar.file_attachment_id == attachment_revision.file_attachment_id }
       end
     end
   end

--- a/app/views/file_attachments/_file_attachment.html.erb
+++ b/app/views/file_attachments/_file_attachment.html.erb
@@ -1,0 +1,27 @@
+<% actions = [] %>
+
+<% actions << link_to(
+  "Insert attachment",
+  file_attachment_path(document, attachment.file_attachment)
+) %>
+
+<% actions << capture do %>
+  <%= form_tag(
+    destroy_file_attachment_path(document, attachment.file_attachment_id),
+    method: :delete,
+    class: "app-inline-block"
+  ) do %>
+    <button class="govuk-link app-link--button app-link--destructive">Delete attachment</button>
+  <% end %>
+<% end %>
+
+<%= render "components/attachment_meta", {
+  id: "file-attachment-#{attachment.file_attachment_id}",
+  title: attachment.title,
+  url: "#",
+  metadata_items: [
+    attachment.content_type,
+    number_to_human_size(attachment.byte_size),
+  ],
+  actions: actions
+} %>

--- a/app/views/file_attachments/index.html.erb
+++ b/app/views/file_attachments/index.html.erb
@@ -29,6 +29,7 @@
     </div>
   </div>
 </div>
+
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
     <% attachments = @edition.file_attachment_revisions %>
@@ -39,17 +40,7 @@
       </h2>
 
       <% attachments.each do |attachment| %>
-        <%= render "components/attachment_meta", {
-          title: attachment.title,
-          url: "#",
-          metadata_items: [
-            attachment.content_type,
-            number_to_human_size(attachment.byte_size),
-          ],
-          actions: [
-            link_to("Insert attachment", file_attachment_path(@edition.document, attachment.file_attachment))
-          ]
-        } %>
+        <%= render "file_attachment", document: @edition.document, attachment: attachment %>
       <% end %>
     <% end %>
   </div>

--- a/config/locales/en/documents/history.yml
+++ b/config/locales/en/documents/history.yml
@@ -28,3 +28,4 @@ en:
         unscheduled: "Unscheduled"
         scheduled_publishing_datetime_set: "Scheduled publishing date and time set"
         scheduled_publishing_datetime_cleared: "Scheduled publishing date and time cleared"
+        file_attachment_deleted: "Deleted attachment"

--- a/config/locales/en/file_attachments/index.yml
+++ b/config/locales/en/file_attachments/index.yml
@@ -15,3 +15,5 @@ en:
       other_attachments: Other attachments
       attachment_markdown: "[Attachment: %{filename}]"
       attachment_link_markdown: "[AttachmentLink: %{filename}]"
+      flashes:
+        deleted: "Attachment ‘%{file}’ has been deleted"

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -77,6 +77,7 @@ Rails.application.routes.draw do
     get "/file-attachments" => "file_attachments#index", as: :file_attachments
     post "/file-attachments" => "file_attachments#create", as: :create_file_attachment
     get "/file-attachments/:file_attachment_id" => "file_attachments#show", as: :file_attachment
+    delete "/file-attachments/:file_attachment_id" => "file_attachments#destroy", as: :destroy_file_attachment
   end
 
   get "/healthcheck", to: proc { [200, {}, %w[OK]] }

--- a/spec/features/editing_file_attachments/delete_file_attachment_spec.rb
+++ b/spec/features/editing_file_attachments/delete_file_attachment_spec.rb
@@ -1,0 +1,49 @@
+# frozen_string_literal: true
+
+RSpec.feature "Delete a file attachment" do
+  scenario do
+    given_there_is_an_edition_with_attachments
+    when_i_insert_an_attachment
+    and_i_delete_the_attachment
+    then_i_see_the_attachment_is_gone
+    and_the_preview_creation_succeeded
+  end
+
+  def given_there_is_an_edition_with_attachments
+    body_field = build(:field, id: "body", type: "govspeak")
+    document_type = build(:document_type, contents: [body_field])
+    @attachment_revision = create(:file_attachment_revision, :on_asset_manager)
+
+    @edition = create(:edition,
+                      document_type_id: document_type.id,
+                      file_attachment_revisions: [@attachment_revision])
+  end
+
+  def when_i_insert_an_attachment
+    visit edit_document_path(@edition.document)
+    find("markdown-toolbar details").click
+    click_on "Attachment"
+  end
+
+  def and_i_delete_the_attachment
+    @put_content_request = stub_publishing_api_put_content(@edition.content_id, {})
+    @delete_asset_request = stub_asset_manager_deletes_any_asset
+    click_on "Delete attachment"
+  end
+
+  def then_i_see_the_attachment_is_gone
+    expect(all("#file-attachment-#{@attachment_revision.file_attachment_id}").count).to be_zero
+    expect(page).to have_content(I18n.t!("file_attachments.index.flashes.deleted", file: @attachment_revision.filename))
+  end
+
+  def and_the_preview_creation_succeeded
+    expect(@put_content_request).to have_been_requested
+    expect(@delete_asset_request).to have_been_requested.at_least_once
+
+    visit document_path(@edition.document)
+    expect(page).to have_content(I18n.t!("user_facing_states.draft.name"))
+
+    click_on "Document history"
+    expect(page).to have_content(I18n.t!("documents.history.entry_types.file_attachment_deleted"))
+  end
+end

--- a/spec/services/versioning/revision_updater/file_attachment_spec.rb
+++ b/spec/services/versioning/revision_updater/file_attachment_spec.rb
@@ -2,28 +2,43 @@
 
 RSpec.describe Versioning::RevisionUpdater::FileAttachment do
   let(:user) { create :user }
-  let(:file_attachment_revision) { create :file_attachment_revision }
+  let(:attachment_revision) { create :file_attachment_revision }
+
   let(:revision) do
-    create :revision, file_attachment_revisions: [file_attachment_revision]
+    create :revision, file_attachment_revisions: [attachment_revision]
   end
 
   describe "#add_file_attachment" do
     it "extends file attachment revisions with a new file attachment" do
-      new_file_attachment = create :file_attachment_revision
+      new_attachment = create :file_attachment_revision
 
       updater = Versioning::RevisionUpdater.new(revision, user)
-      updater.add_file_attachment(new_file_attachment)
+      updater.add_file_attachment(new_attachment)
 
       next_revision = updater.next_revision
       expect(next_revision.file_attachment_revisions)
-        .to match_array [file_attachment_revision, new_file_attachment]
+        .to match_array [attachment_revision, new_attachment]
     end
 
     it "raises an error if a revision exists for the same attachment" do
       updater = Versioning::RevisionUpdater.new(revision, user)
 
-      expect { updater.add_file_attachment(file_attachment_revision) }
+      expect { updater.add_file_attachment(attachment_revision) }
         .to raise_error(RuntimeError, "Cannot add another revision for the same file attachment")
+    end
+  end
+
+  describe "#remove_file_attachment" do
+    it "removes the attachment from the attachment revisions" do
+      other_attachment_revision = create :file_attachment_revision
+      revision = create :revision, file_attachment_revisions: [other_attachment_revision,
+                                                               attachment_revision]
+
+      updater = Versioning::RevisionUpdater.new(revision, user)
+      updater.remove_file_attachment(attachment_revision)
+
+      next_revision = updater.next_revision
+      expect(next_revision.file_attachment_revisions).to match_array [other_attachment_revision]
     end
   end
 end


### PR DESCRIPTION
https://trello.com/c/H1bevu6s/818-provide-means-to-delete-an-attachment

This adds a 'Delete attachment' action, which mostly works the same as for images.