### PR TITLE
Create a TimelineEntry when uploading a file attachment

### DIFF
--- a/app/interactors/file_attachments/create_interactor.rb
+++ b/app/interactors/file_attachments/create_interactor.rb
@@ -13,7 +13,9 @@ class FileAttachments::CreateInteractor
     Edition.transaction do
       find_and_lock_edition
       upload_attachment
+
       update_edition
+      create_timeline_entry
       update_preview
     end
   end
@@ -30,6 +32,10 @@ private
       edition.revision,
       params[:title],
     ).call(user)
+  end
+
+  def create_timeline_entry
+    TimelineEntry.create_for_revision(entry_type: :file_attachment_uploaded, edition: edition)
   end
 
   def update_edition

--- a/app/models/timeline_entry.rb
+++ b/app/models/timeline_entry.rb
@@ -47,6 +47,7 @@ class TimelineEntry < ApplicationRecord
                      unscheduled: "unscheduled",
                      scheduled_publishing_datetime_set: "scheduled_publishing_datetime_set",
                      scheduled_publishing_datetime_cleared: "scheduled_publishing_datetime_cleared",
+                     file_attachment_uploaded: "file_attachment_uploaded",
                      file_attachment_deleted: "file_attachment_deleted" }
 
   def self.create_for_status_change(entry_type:,

--- a/config/locales/en/documents/history.yml
+++ b/config/locales/en/documents/history.yml
@@ -29,3 +29,4 @@ en:
         scheduled_publishing_datetime_set: "Scheduled publishing date and time set"
         scheduled_publishing_datetime_cleared: "Scheduled publishing date and time cleared"
         file_attachment_deleted: "Deleted attachment"
+        file_attachment_uploaded: "Uploaded attachment"

--- a/spec/features/editing_file_attachments/upload_file_attachment_spec.rb
+++ b/spec/features/editing_file_attachments/upload_file_attachment_spec.rb
@@ -7,7 +7,7 @@ RSpec.feature "Upload file attachment" do
     and_i_go_to_insert_an_attachment
     and_i_upload_a_file_attachment
     then_i_can_see_the_attachment_markdown
-    and_the_preview_creation_succeeded
+    and_the_attachment_has_been_uploaded_successfully
   end
 
   def given_there_is_an_edition
@@ -41,8 +41,13 @@ RSpec.feature "Upload file attachment" do
     expect(page).to have_content("[AttachmentLink: attachment.csv]")
   end
 
-  def and_the_preview_creation_succeeded
+  def and_the_attachment_has_been_uploaded_successfully
     expect(@publishing_api_request).to have_been_requested
     expect(@asset_manager_request).to have_been_requested.at_least_once
+
+    visit document_path(@edition.document)
+    within first(".app-timeline-entry") do
+      expect(page).to have_content I18n.t!("documents.history.entry_types.file_attachment_uploaded")
+    end
   end
 end


### PR DESCRIPTION
This adds a TimelineEntry to the documents history everytime a file
attachment is uploaded.

Trello:
https://trello.com/c/604eHfVR/833-create-timelineentry-when-uploading-a-file-attachment