### PR TITLE
Render attachment

### DIFF
--- a/app/assets/stylesheets/components/_attachment-meta.scss
+++ b/app/assets/stylesheets/components/_attachment-meta.scss
@@ -1,54 +1,5 @@
-$thumbnail-width: 99px;
-$thumbnail-height: 140px;
-$thumbnail-border: 5px;
-$thumbnail-border-colour: rgba(11, 12, 12, .1);
-$thumbnail-shadow-colour: rgba(11, 12, 12, .4);
-
-.app-c-attachment-meta {
-  @include govuk-font(19);
-  @include govuk-clearfix;
-
-  margin-bottom: govuk-spacing(6);
-  padding-bottom: govuk-spacing(6);
-  border-bottom: 1px solid $govuk-border-colour;
-
-  .app-c-metadata {
-    margin-bottom: govuk-spacing(3);
-  }
-}
-
 .app-c-attachment-meta:last-child {
   border-bottom: 0;
-}
-
-.app-c-attachment-meta__thumbnail-container {
-  position: relative;
-  margin-right: govuk-spacing(5);
-  margin-bottom: govuk-spacing(3);
-  padding: $thumbnail-border;
-  float: left;
-}
-
-.app-c-attachment-meta__thumbnail-image {
-  display: block;
-  width: $thumbnail-width;
-  max-width: 100%;
-  height: $thumbnail-height;
-  outline: $thumbnail-border solid $thumbnail-border-colour;
-  background: govuk-colour("white");
-  box-shadow: 0 2px 2px $thumbnail-shadow-colour;
-}
-
-.app-c-attachment-meta__title {
-  @include govuk-font($size: 27);
-
-  margin: 0 0 govuk-spacing(3);
-}
-
-.app-c-attachment-meta__metadata {
-  @include govuk-font($size: 14);
-
-  margin: 0 0 govuk-spacing(3);
 }
 
 .app-c-attachment-meta__actions {

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -1,8 +1,6 @@
 # frozen_string_literal: true
 
 module ApplicationHelper
-  include TimeOptionsHelper
-
   def govspeak_to_html(govspeak)
     # We expect all the govspeak through this to be commited code where we
     # verify the safety

--- a/app/helpers/file_attachment_helper.rb
+++ b/app/helpers/file_attachment_helper.rb
@@ -7,6 +7,12 @@ module FileAttachmentHelper
     )
   end
 
+  def file_attachment_payload_attributes(file_attachment)
+    file_attachment_attributes(file_attachment).merge(
+      url: file_attachment.asset_url("file"),
+    )
+  end
+
 private
 
   def file_attachment_attributes(file_attachment)

--- a/app/helpers/file_attachment_helper.rb
+++ b/app/helpers/file_attachment_helper.rb
@@ -1,0 +1,22 @@
+# frozen_string_literal: true
+
+module FileAttachmentHelper
+  def file_attachment_in_app_attributes(file_attachment)
+    file_attachment_attributes(file_attachment).merge(
+      url: "#",
+    )
+  end
+
+private
+
+  def file_attachment_attributes(file_attachment)
+    {
+      id: file_attachment.filename,
+      title: file_attachment.title,
+      filename: file_attachment.filename,
+      content_type: file_attachment.content_type,
+      file_size: file_attachment.byte_size,
+      number_of_pages: file_attachment.number_of_pages,
+    }
+  end
+end

--- a/app/models/file_attachment/blob_revision.rb
+++ b/app/models/file_attachment/blob_revision.rb
@@ -18,6 +18,10 @@ class FileAttachment::BlobRevision < ApplicationRecord
     assets.find { |v| v.variant == variant }
   end
 
+  def asset_url(variant)
+    asset(variant)&.file_url
+  end
+
   def bytes_for_asset(variant)
     if variant == "file"
       blob.download

--- a/app/models/file_attachment/revision.rb
+++ b/app/models/file_attachment/revision.rb
@@ -17,6 +17,7 @@ class FileAttachment::Revision < ApplicationRecord
   delegate :title, to: :metadata_revision
   delegate :filename,
            :asset,
+           :asset_url,
            :assets,
            :ensure_assets,
            :content_type,

--- a/app/services/govspeak_document/in_app_options.rb
+++ b/app/services/govspeak_document/in_app_options.rb
@@ -2,15 +2,23 @@
 
 class GovspeakDocument::InAppOptions < GovspeakDocument::Options
   include Rails.application.routes.url_helpers
+  include FileAttachmentHelper
 
   def to_h
-    super.merge(images: in_app_images)
+    super.merge(
+      images: in_app_images,
+      attachments: in_app_attachments,
+    )
   end
 
 private
 
   def in_app_images
     edition.revision.image_revisions.map { |image_revision| image_attributes(image_revision) }
+  end
+
+  def in_app_attachments
+    edition.file_attachment_revisions.map { |far| file_attachment_in_app_attributes(far) }
   end
 
   def image_attributes(image_revision)

--- a/app/services/govspeak_document/payload_options.rb
+++ b/app/services/govspeak_document/payload_options.rb
@@ -2,16 +2,25 @@
 
 
 class GovspeakDocument::PayloadOptions < GovspeakDocument::Options
+  include FileAttachmentHelper
+
   attr_reader :text, :edition
 
   def to_h
-    super.merge(images: payload_images)
+    super.merge(
+      images: payload_images,
+      attachments: payload_attachments,
+    )
   end
 
 private
 
   def payload_images
     edition.revision.image_revisions.map { |image_revision| image_attributes(image_revision) }
+  end
+
+  def payload_attachments
+    edition.file_attachment_revisions.map { |far| file_attachment_payload_attributes(far) }
   end
 
   def image_attributes(image_revision)

--- a/app/views/components/_attachment_meta.html.erb
+++ b/app/views/components/_attachment_meta.html.erb
@@ -1,35 +1,14 @@
 <%
   id ||= nil
-  title ||= nil
-  thumbnail_src ||= nil
   actions ||= []
-  metadata_items ||= []
 %>
 
 <%= tag.div class: "app-c-attachment-meta", id: id do %>
-  <%= tag.div class: "app-c-attachment-meta__thumbnail-container" do %>
-
-    <%= tag.img class: "app-c-attachment-meta__thumbnail-image",
-      src: thumbnail_src,
-      alt: title
-    %>
-
-  <% end %>
-
-  <%= tag.div class: "app-c-attachment-meta__metadata-container" do %>
-
-    <%= tag.p class: "app-c-attachment-meta__title" do %>
-      <%= link_to title, url, class: 'govuk-link' %>
-    <% end %>
-
-    <% if metadata_items.any? %>
-      <%= tag.p class: "app-c-attachment-meta__metadata" do %>
-        <%= metadata_items.join(", ") %>
-      <% end %>
-    <% end %>
-
-  <% end %>
-
+  <%= render "govuk_publishing_components/components/attachment", {
+    attachment: attachment,
+    hide_help_text: true,
+    target: "_blank",
+  } %>
   <% if actions.any? %>
     <%= tag.ul class: "app-c-attachment-meta__actions" do %>
       <% actions.each do |action| %>

--- a/app/views/components/_metadata.html.erb
+++ b/app/views/components/_metadata.html.erb
@@ -4,8 +4,11 @@
   list_classes = %w(app-c-metadata__list)
   list_classes << 'app-c-metadata__list--inline' if inline
   data_attributes ||= nil
+  margin_bottom ||= 0
+  component_classes = %w(app-c-metadata)
+  component_classes << "govuk-!-margin-bottom-#{margin_bottom}" unless margin_bottom.zero?
 %>
-<%= tag.div class: 'app-c-metadata', data: data_attributes do %>
+<%= tag.div class: component_classes, data: data_attributes do %>
   <% if items.any? %>
     <%= tag.dl class: list_classes do %>
       <% items.each do |item| %>

--- a/app/views/components/docs/attachment_meta.yml
+++ b/app/views/components/docs/attachment_meta.yml
@@ -1,31 +1,20 @@
 name: Attachment meta
-description: Displays an attachment with the associated metadata and possible actions
+description: Displays an attachment with actions
 body: |
-  Metadata contains title, file format, file size, number of pages. Actions can be insert, preview, edit and delete.
-  The component is dependent on the govuk-frontend grid system.
-accessibility_criteria: |
-  The image must:
-
-  * have alt text
+  This component embeds the govuk_publishing_components attachment component
+  with reduced data. Links to open the file use `target="_blank"` to open in a
+  new tab.
+shared_accessibility_criteria:
+  - link
 examples:
   default:
     data:
-      url: https://www.gov.uk/government/publications/minimum-wage-jobs-in-ashfield-local-authority-since-2009
-      thumbnail_src: https://assets.digital.cabinet-office.gov.uk/government/assets/pub-cover-doc-afe3b0a8a9511beeca890340170aee8b5649413f948e512c9b8ce432d8513d32.png
-      title: Document attachment
-      metadata_items:
-       - file_format: MS Word Document
-       - file_size: 24.2KB
-       - page_length: 2 pages
-  with_actions:
-    data:
-      url: https://www.gov.uk/government/world-location-news/294043.es-419
-      thumbnail_src: https://assets.digital.cabinet-office.gov.uk/government/uploads/system/uploads/attachment_data/file/496127/thumbnail_LPC_FoI_09.12.15_NMW_jobs_Ashfield_LA.pdf.png
-      title: PDF attachment
-      metadata_items:
-       - file_format: PDF
-       - file_size: 153KB
-       - page_length: 12 pages
+      attachment:
+        url: https://assets.publishing.service.gov.uk/government/uploads/system/uploads/attachment_data/file/289058/11-1276-the-future-of-computer-trading-in-financial-markets.pdf
+        title: "Future of computer trading in financial markets: working paper"
+        file_size: 895078
+        content_type: application/pdf
+        number_of_pages: 56
       actions:
         - <a class="govuk-link" href="#">Insert attachment</a>
         - <a class="govuk-link" href="#">Preview</a>

--- a/app/views/components/docs/metadata.yml
+++ b/app/views/components/docs/metadata.yml
@@ -17,3 +17,13 @@ examples:
         value: "11:02pm on 10 August 2018"
       - field: "First published on GOV.UK"
         value: "12:00pm on 10 August 2018"
+  inline:
+    description: |
+      Metadata can be displayed in a single line per entry
+    data:
+      items:
+      - field: Alt text
+        value: A nice tree
+      - field: "Markdown code"
+        value: "[Image: file.jpg]"
+      inline: true

--- a/app/views/components/docs/metadata.yml
+++ b/app/views/components/docs/metadata.yml
@@ -27,3 +27,15 @@ examples:
       - field: "Markdown code"
         value: "[Image: file.jpg]"
       inline: true
+  with_margin_bottom:
+    description: |
+      The component accepts a number for margin bottom from 0 to 9
+      (0px to 60px) using the GOV.UK Frontend spacing scale. It defaults to a
+      margin bottom of 0.
+    data:
+      items:
+      - field: "Last updated"
+        value: "12:58pm on 17 August 2018"
+      - field: "Created"
+        value: "11:02pm on 10 August 2018"
+      margin_bottom: 3

--- a/app/views/file_attachments/_file_attachment.html.erb
+++ b/app/views/file_attachments/_file_attachment.html.erb
@@ -2,14 +2,15 @@
 
 <% actions << link_to(
   "Insert attachment",
-  file_attachment_path(document, attachment.file_attachment)
+  file_attachment_path(document, attachment.file_attachment),
+  class: "govuk-link govuk-link--no-visited-state app-link--button",
 ) %>
 
 <% actions << capture do %>
   <%= form_tag(
     destroy_file_attachment_path(document, attachment.file_attachment_id),
     method: :delete,
-    class: "app-inline-block"
+    class: "app-inline-block",
   ) do %>
     <button class="govuk-link app-link--button app-link--destructive">Delete attachment</button>
   <% end %>

--- a/app/views/file_attachments/_file_attachment.html.erb
+++ b/app/views/file_attachments/_file_attachment.html.erb
@@ -16,12 +16,6 @@
 <% end %>
 
 <%= render "components/attachment_meta", {
-  attachment: {
-    title: attachment.title,
-    url: "#",
-    content_type: attachment.content_type,
-    file_size: attachment.byte_size,
-    number_of_pages: attachment.number_of_pages,
-  },
-  actions: actions
+  attachment: file_attachment_in_app_attributes(attachment),
+  actions: actions,
 } %>

--- a/app/views/file_attachments/_file_attachment.html.erb
+++ b/app/views/file_attachments/_file_attachment.html.erb
@@ -16,12 +16,12 @@
 <% end %>
 
 <%= render "components/attachment_meta", {
-  id: "file-attachment-#{attachment.file_attachment_id}",
-  title: attachment.title,
-  url: "#",
-  metadata_items: [
-    attachment.content_type,
-    number_to_human_size(attachment.byte_size),
-  ],
+  attachment: {
+    title: attachment.title,
+    url: "#",
+    content_type: attachment.content_type,
+    file_size: attachment.byte_size,
+    number_of_pages: attachment.number_of_pages,
+  },
   actions: actions
 } %>

--- a/app/views/file_attachments/show.html.erb
+++ b/app/views/file_attachments/show.html.erb
@@ -16,6 +16,7 @@
         },
       ],
       inline: true,
+      margin_bottom: 3,
     } %>
     <p class="govuk-body"><%= t("file_attachments.show.attachment_instructions") %></p>
     </p>
@@ -36,6 +37,7 @@
         },
       ],
       inline: true,
+      margin_bottom: 3,
     } %>
     <p class="govuk-body"><%= t("file_attachments.show.attachment_link_instructions") %></p>
   </div>

--- a/app/views/file_attachments/show.html.erb
+++ b/app/views/file_attachments/show.html.erb
@@ -3,9 +3,18 @@
 
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
+    <%= render "govuk_publishing_components/components/attachment", {
+      attachment: {
+        title: @attachment.title,
+        url: "#",
+        content_type: @attachment.content_type,
+        file_size: @attachment.byte_size,
+        number_of_pages: @attachment.number_of_pages,
+      },
+      target: "_blank"
+    } %>
+
     <dl>
-      <dt class="govuk-body">Title</dt>
-      <dd class="govuk-body"><%= @attachment.title %></dd>
       <dt class="govuk-body">Attachment markdown:</dt>
       <dd class="govuk-body"><%= t("file_attachments.index.attachment_markdown", filename: @attachment.filename) %></dd>
     </dl>

--- a/app/views/file_attachments/show.html.erb
+++ b/app/views/file_attachments/show.html.erb
@@ -4,14 +4,8 @@
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
     <%= render "govuk_publishing_components/components/attachment", {
-      attachment: {
-        title: @attachment.title,
-        url: "#",
-        content_type: @attachment.content_type,
-        file_size: @attachment.byte_size,
-        number_of_pages: @attachment.number_of_pages,
-      },
-      target: "_blank"
+      attachment: file_attachment_in_app_attributes(@attachment),
+      target: "_blank",
     } %>
 
     <dl>
@@ -30,13 +24,7 @@
 
     <div class="govuk-body">
       <%= render "govuk_publishing_components/components/attachment_link", {
-        attachment: {
-          title: @attachment.title,
-          url: "#",
-          content_type: @attachment.content_type,
-          file_size: @attachment.byte_size,
-          number_of_pages: @attachment.number_of_pages,
-        },
+        attachment: file_attachment_in_app_attributes(@attachment),
         target: "_blank"
       } %>
     </div>

--- a/app/views/file_attachments/show.html.erb
+++ b/app/views/file_attachments/show.html.erb
@@ -8,19 +8,19 @@
       target: "_blank",
     } %>
 
-    <dl>
-      <dt class="govuk-body">Attachment markdown:</dt>
-      <dd class="govuk-body"><%= t("file_attachments.index.attachment_markdown", filename: @attachment.filename) %></dd>
-    </dl>
+    <%= render "components/metadata", {
+      items: [
+        {
+          field: t("file_attachments.show.markdown_code"),
+          value: t("file_attachments.show.attachment_markdown", filename: @attachment.filename)
+        },
+      ],
+      inline: true,
+    } %>
+    <p class="govuk-body"><%= t("file_attachments.show.attachment_instructions") %></p>
+    </p>
 
     <hr class="govuk-!-margin-bottom-6 govuk-!-margin-top-6"/>
-
-    <dl>
-      <dt class="govuk-body">Title</dt>
-      <dd class="govuk-body"><%= @attachment.title %></dd>
-      <dt class="govuk-body">Attachment link markdown:</dt>
-      <dd class="govuk-body"><%= t("file_attachments.index.attachment_link_markdown", filename: @attachment.filename) %></dd>
-    </dl>
 
     <div class="govuk-body">
       <%= render "govuk_publishing_components/components/attachment_link", {
@@ -28,5 +28,15 @@
         target: "_blank"
       } %>
     </div>
+    <%= render "components/metadata", {
+      items: [
+        {
+          field: t("file_attachments.show.markdown_code"),
+          value: t("file_attachments.show.attachment_link_markdown", filename: @attachment.filename)
+        },
+      ],
+      inline: true,
+    } %>
+    <p class="govuk-body"><%= t("file_attachments.show.attachment_link_instructions") %></p>
   </div>
 </div>

--- a/config/locales/en/file_attachments/index.yml
+++ b/config/locales/en/file_attachments/index.yml
@@ -13,8 +13,6 @@ en:
         heading: Attachment title
         hint_text: Use the official title of the document
       other_attachments: Other attachments
-      attachment_markdown: "[Attachment: %{filename}]"
-      attachment_link_markdown: "[AttachmentLink: %{filename}]"
       flashes:
         deleted: "Attachment ‘%{file}’ has been deleted"
         upload_requirements: You need to

--- a/config/locales/en/file_attachments/show.yml
+++ b/config/locales/en/file_attachments/show.yml
@@ -2,3 +2,12 @@ en:
   file_attachments:
     show:
       title: Insert attachment
+      markdown_code: "Markdown code"
+      attachment_markdown: "[Attachment: %{filename}]"
+      attachment_link_markdown: "[AttachmentLink: %{filename}]"
+      attachment_instructions: |
+        Copy the markdown code and paste it into the text in a new paragraph
+        where you want the file to appear.
+      attachment_link_instructions: |
+        Copy the markdown code and paste it into the text where you want the
+        file link to appear.

--- a/spec/factories/file_attachment_revision_factory.rb
+++ b/spec/factories/file_attachment_revision_factory.rb
@@ -7,6 +7,7 @@ FactoryBot.define do
 
     transient do
       filename { SecureRandom.hex(8) }
+      number_of_pages { nil }
       fixture { "text-file.txt" }
       title { SecureRandom.hex(8) }
       assets { nil }
@@ -17,6 +18,7 @@ FactoryBot.define do
         revision.blob_revision = evaluator.association(
           :file_attachment_blob_revision,
           filename: evaluator.filename,
+          number_of_pages: evaluator.number_of_pages,
           fixture: evaluator.fixture,
           assets: evaluator.assets,
         )
@@ -40,6 +42,7 @@ FactoryBot.define do
           :file_attachment_blob_revision,
           :on_asset_manager,
           filename: evaluator.filename,
+          number_of_pages: evaluator.number_of_pages,
           fixture: evaluator.fixture,
           state: evaluator.state,
           assets: evaluator.assets,

--- a/spec/features/editing_file_attachments/upload_file_attachment_spec.rb
+++ b/spec/features/editing_file_attachments/upload_file_attachment_spec.rb
@@ -7,7 +7,7 @@ RSpec.feature "Upload file attachment" do
     and_i_go_to_insert_an_attachment
     and_i_upload_a_file_attachment
     then_i_can_see_the_attachment_markdown
-    and_i_can_see_a_preview_of_the_attachment_link
+    and_i_can_see_previews_of_the_attachment
     and_the_attachment_has_been_uploaded_successfully
   end
 
@@ -32,21 +32,29 @@ RSpec.feature "Upload file attachment" do
     @publishing_api_request = stub_publishing_api_put_content(@edition.content_id, {})
 
     @attachment_filename = "13kb-1-page-attachment.pdf"
+    @title = "A title"
+
     find('form input[type="file"]').set(Rails.root.join(file_fixture(@attachment_filename)))
-    fill_in "title", with: "A title"
+    fill_in "title", with: @title
     click_on "Upload"
   end
 
   def then_i_can_see_the_attachment_markdown
-    expect(page).to have_content("[Attachment: 13kb-1-page-attachment.pdf]")
+    expect(page).to have_content("[Attachment: #{@attachment_filename}]")
+    expect(page).to have_content("[AttachmentLink: #{@attachment_filename}]")
   end
 
-  def and_i_can_see_a_preview_of_the_attachment_link
-    attachment = FileAttachment::Revision.last
+  def and_i_can_see_previews_of_the_attachment
+    metadata = "PDF, 13 KB, 1 page"
+
+    within(".gem-c-attachment") do
+      expect(page).to have_content(@title)
+      expect(page).to have_content(metadata)
+    end
 
     within(".gem-c-attachment-link") do
-      expect(page).to have_link(attachment.title, href: "#")
-      expect(page).to have_content("PDF, 13 KB, 1 page")
+      expect(page).to have_content(@title)
+      expect(page).to have_content(metadata)
     end
   end
 

--- a/spec/services/govspeak_document/in_app_options_spec.rb
+++ b/spec/services/govspeak_document/in_app_options_spec.rb
@@ -13,12 +13,16 @@ RSpec.describe GovspeakDocument::InAppOptions do
 
       in_app_options = GovspeakDocument::InAppOptions.new("govspeak", edition)
       actual_image_options = in_app_options.to_h[:images].first
-      expect(actual_image_options[:alt_text]).to eq("Some alt text")
-      expect(actual_image_options[:caption]).to eq("An optional caption")
-      expect(actual_image_options[:credit]).to eq("An optional credit")
-      expect(actual_image_options[:url]).to match("/representations")
-      expect(actual_image_options[:url]).to match("filename.png")
-      expect(actual_image_options[:id]).to eq("filename.png")
+
+      expect(actual_image_options).to match(
+        a_hash_including(
+          id: "filename.png",
+          alt_text: "Some alt text",
+          caption: "An optional caption",
+          credit: "An optional credit",
+          url: a_string_matching(%r{/representations/.*/filename.png}),
+        ),
+      )
     end
 
     it "returns the local representation of a file attachment" do
@@ -33,13 +37,17 @@ RSpec.describe GovspeakDocument::InAppOptions do
       in_app_options = GovspeakDocument::InAppOptions.new("govspeak", edition)
       actual_attachment_options = in_app_options.to_h[:attachments].first
 
-      expect(actual_attachment_options[:filename]).to eq("13kb-1-page-attachment.pdf")
-      expect(actual_attachment_options[:title]).to eq("A title")
-      expect(actual_attachment_options[:content_type]).to eq("application/pdf")
-      expect(actual_attachment_options[:number_of_pages]).to eq(1)
-      expect(actual_attachment_options[:file_size]).to eq(13264)
-      # TODO add url expectation when we have an internal preview URL
-      expect(actual_attachment_options[:id]).to eq("13kb-1-page-attachment.pdf")
+      expect(actual_attachment_options).to match(
+        a_hash_including(
+          id: "13kb-1-page-attachment.pdf",
+          filename: "13kb-1-page-attachment.pdf",
+          title: "A title",
+          content_type: "application/pdf",
+          number_of_pages: 1,
+          file_size: 13264,
+          # TODO add url expectation when we have an internal preview URL
+        ),
+      )
     end
   end
 end

--- a/spec/services/govspeak_document/in_app_options_spec.rb
+++ b/spec/services/govspeak_document/in_app_options_spec.rb
@@ -20,5 +20,26 @@ RSpec.describe GovspeakDocument::InAppOptions do
       expect(actual_image_options[:url]).to match("filename.png")
       expect(actual_image_options[:id]).to eq("filename.png")
     end
+
+    it "returns the local representation of a file attachment" do
+      file_attachment_revision = build(:file_attachment_revision,
+                                       fixture: "13kb-1-page-attachment.pdf",
+                                       filename: "13kb-1-page-attachment.pdf",
+                                       title: "A title",
+                                       number_of_pages: 1)
+      edition = build(:edition,
+                      file_attachment_revisions: [file_attachment_revision])
+
+      in_app_options = GovspeakDocument::InAppOptions.new("govspeak", edition)
+      actual_attachment_options = in_app_options.to_h[:attachments].first
+
+      expect(actual_attachment_options[:filename]).to eq("13kb-1-page-attachment.pdf")
+      expect(actual_attachment_options[:title]).to eq("A title")
+      expect(actual_attachment_options[:content_type]).to eq("application/pdf")
+      expect(actual_attachment_options[:number_of_pages]).to eq(1)
+      expect(actual_attachment_options[:file_size]).to eq(13264)
+      # TODO add url expectation when we have an internal preview URL
+      expect(actual_attachment_options[:id]).to eq("13kb-1-page-attachment.pdf")
+    end
   end
 end

--- a/spec/services/govspeak_document/in_app_options_spec.rb
+++ b/spec/services/govspeak_document/in_app_options_spec.rb
@@ -2,14 +2,13 @@
 
 RSpec.describe GovspeakDocument::InAppOptions do
   describe "#to_h" do
-    it "returns the local representation of the image" do
+    it "returns a hash of image attributes" do
       image_revision = build(:image_revision,
                              alt_text: "Some alt text",
                              caption: "An optional caption",
                              credit: "An optional credit",
                              filename: "filename.png")
-      edition = build(:edition,
-                      image_revisions: [image_revision])
+      edition = build(:edition, image_revisions: [image_revision])
 
       in_app_options = GovspeakDocument::InAppOptions.new("govspeak", edition)
       actual_image_options = in_app_options.to_h[:images].first
@@ -25,7 +24,7 @@ RSpec.describe GovspeakDocument::InAppOptions do
       )
     end
 
-    it "returns the local representation of a file attachment" do
+    it "returns a hash of file attachment attributes" do
       file_attachment_revision = build(:file_attachment_revision,
                                        fixture: "13kb-1-page-attachment.pdf",
                                        filename: "13kb-1-page-attachment.pdf",

--- a/spec/services/govspeak_document/payload_options_spec.rb
+++ b/spec/services/govspeak_document/payload_options_spec.rb
@@ -14,12 +14,16 @@ RSpec.describe GovspeakDocument::PayloadOptions do
 
       payload_options = GovspeakDocument::PayloadOptions.new("govspeak", edition)
       actual_image_options = payload_options.to_h[:images].first
-      expect(actual_image_options[:alt_text]).to eq("Some alt text")
-      expect(actual_image_options[:caption]).to eq("An optional caption")
-      expect(actual_image_options[:credit]).to eq("An optional credit")
-      expect(actual_image_options[:url]).to match("filename.png")
-      expect(actual_image_options[:url]).to match("/media")
-      expect(actual_image_options[:id]).to eq("filename.png")
+
+      expect(actual_image_options).to match(
+        a_hash_including(
+          id: "filename.png",
+          alt_text: "Some alt text",
+          caption: "An optional caption",
+          credit: "An optional credit",
+          url: a_string_matching(%r{/media/.*/filename.png}),
+        ),
+      )
     end
 
     it "returns the remote asset options for a file attachment" do
@@ -35,14 +39,17 @@ RSpec.describe GovspeakDocument::PayloadOptions do
       payload_options = GovspeakDocument::PayloadOptions.new("govspeak", edition)
       actual_attachment_options = payload_options.to_h[:attachments].first
 
-      expect(actual_attachment_options[:filename]).to eq("13kb-1-page-attachment.pdf")
-      expect(actual_attachment_options[:title]).to eq("A title")
-      expect(actual_attachment_options[:content_type]).to eq("application/pdf")
-      expect(actual_attachment_options[:number_of_pages]).to eq(1)
-      expect(actual_attachment_options[:file_size]).to eq(13264)
-      expect(actual_attachment_options[:url]).to match("13kb-1-page-attachment.pdf")
-      expect(actual_attachment_options[:url]).to match("/media")
-      expect(actual_attachment_options[:id]).to eq("13kb-1-page-attachment.pdf")
+      expect(actual_attachment_options).to match(
+        a_hash_including(
+          id: "13kb-1-page-attachment.pdf",
+          filename: "13kb-1-page-attachment.pdf",
+          title: "A title",
+          content_type: "application/pdf",
+          number_of_pages: 1,
+          file_size: 13264,
+          url: a_string_matching(%r{/media/.*/13kb-1-page-attachment.pdf}),
+        ),
+      )
     end
   end
 end

--- a/spec/services/govspeak_document/payload_options_spec.rb
+++ b/spec/services/govspeak_document/payload_options_spec.rb
@@ -2,15 +2,14 @@
 
 RSpec.describe GovspeakDocument::PayloadOptions do
   describe "#to_h" do
-    it "returns the remote asset options for the image" do
+    it "returns a hash of image attributes" do
       image_revision = build(:image_revision,
                              :on_asset_manager,
                              alt_text: "Some alt text",
                              caption: "An optional caption",
                              credit: "An optional credit",
                              filename: "filename.png")
-      edition = build(:edition,
-                      image_revisions: [image_revision])
+      edition = build(:edition, image_revisions: [image_revision])
 
       payload_options = GovspeakDocument::PayloadOptions.new("govspeak", edition)
       actual_image_options = payload_options.to_h[:images].first
@@ -26,7 +25,7 @@ RSpec.describe GovspeakDocument::PayloadOptions do
       )
     end
 
-    it "returns the remote asset options for a file attachment" do
+    it "returns a hash of file attachment attributes" do
       file_attachment_revision = build(:file_attachment_revision,
                                        :on_asset_manager,
                                        fixture: "13kb-1-page-attachment.pdf",

--- a/spec/services/govspeak_document/payload_options_spec.rb
+++ b/spec/services/govspeak_document/payload_options_spec.rb
@@ -21,5 +21,28 @@ RSpec.describe GovspeakDocument::PayloadOptions do
       expect(actual_image_options[:url]).to match("/media")
       expect(actual_image_options[:id]).to eq("filename.png")
     end
+
+    it "returns the remote asset options for a file attachment" do
+      file_attachment_revision = build(:file_attachment_revision,
+                                       :on_asset_manager,
+                                       fixture: "13kb-1-page-attachment.pdf",
+                                       filename: "13kb-1-page-attachment.pdf",
+                                       title: "A title",
+                                       number_of_pages: 1)
+      edition = build(:edition,
+                      file_attachment_revisions: [file_attachment_revision])
+
+      payload_options = GovspeakDocument::PayloadOptions.new("govspeak", edition)
+      actual_attachment_options = payload_options.to_h[:attachments].first
+
+      expect(actual_attachment_options[:filename]).to eq("13kb-1-page-attachment.pdf")
+      expect(actual_attachment_options[:title]).to eq("A title")
+      expect(actual_attachment_options[:content_type]).to eq("application/pdf")
+      expect(actual_attachment_options[:number_of_pages]).to eq(1)
+      expect(actual_attachment_options[:file_size]).to eq(13264)
+      expect(actual_attachment_options[:url]).to match("13kb-1-page-attachment.pdf")
+      expect(actual_attachment_options[:url]).to match("/media")
+      expect(actual_attachment_options[:id]).to eq("13kb-1-page-attachment.pdf")
+    end
   end
 end


### PR DESCRIPTION
Trello: https://trello.com/c/zMYmFTPx/801-show-metadata-for-attachments

This is a draft as it waits for https://github.com/alphagov/govuk_publishing_components/pull/842 to be released.

This provides the rendering for attachments within the application and for govspeak.

A tricky part is that we have the same hash of attachment data that is used to render a component and is sent to govspeak. I tried to find a single place that could store that serialising logic. After initially going with a method on the model I tried out a Helper after a chat with Ben. I'm not quite sure where'd be best, there are disadvantages to all options.

See commits for more details

<img width="672" alt="Screen Shot 2019-05-08 at 16 51 15" src="https://user-images.githubusercontent.com/13434452/57389280-ba48e400-71b1-11e9-851b-547b589b7db3.png">
