### PR TITLE
Prevent double clicking for create/destroy actions

### DIFF
--- a/app/views/documents/index.html.erb
+++ b/app/views/documents/index.html.erb
@@ -1,7 +1,12 @@
 <% content_for :title, t("documents.index.title") %>
 
 <% content_for :title_side, render("govuk_publishing_components/components/button", {
-  text: "Create new document", href: new_document_path, margin_bottom: true
+  text: "Create new document",
+  href: new_document_path,
+  margin_bottom: true,
+  data_attributes: {
+    "prevent-double-click": true
+  }
 }) %>
 
 <div class="govuk-grid-row">

--- a/app/views/documents/show/_delete_draft.html.erb
+++ b/app/views/documents/show/_delete_draft.html.erb
@@ -6,7 +6,10 @@
   ) do %>
     <%= render "govuk_publishing_components/components/button", {
       text: "Yes, delete draft",
-      destructive: true
+      destructive: true,
+      data_attributes: {
+        "prevent-double-click": true
+      }
     } %>
 
   <%= link_to "Cancel",

--- a/app/views/file_attachments/index.html.erb
+++ b/app/views/file_attachments/index.html.erb
@@ -24,6 +24,9 @@
           } %>
         <%= render "govuk_publishing_components/components/button", {
           text: "Upload",
+          data_attributes: {
+            "prevent-double-click": true
+          }
         } %>
       <% end %>
     </div>

--- a/app/views/images/index.html.erb
+++ b/app/views/images/index.html.erb
@@ -35,6 +35,9 @@ content_for :title, t(title_key, title: @edition.title_or_fallback)
 
         <%= render "govuk_publishing_components/components/button", {
           text: "Upload",
+          data_attributes: {
+            "prevent-double-click": true
+          }
         } %>
       <% end %>
     </div>


### PR DESCRIPTION
This prevents create/destroy buttons from performing an action twice which may result in a system error (double creations) or erroring not being able to remove a non-existent item.

[Trello card](https://trello.com/c/JLkfkNxQ)