### PR TITLE
Download attachments

### DIFF
--- a/app/controllers/file_attachments_controller.rb
+++ b/app/controllers/file_attachments_controller.rb
@@ -12,6 +12,17 @@ class FileAttachmentsController < ApplicationController
       .find_by!(file_attachment_id: params[:file_attachment_id])
   end
 
+  def preview
+    result = FileAttachments::PreviewInteractor.call(params: params)
+    asset, can_preview, api_error = result.to_h.values_at(:asset, :can_preview, :api_error)
+
+    if api_error || !can_preview
+      render :preview_pending
+    else
+      redirect_to asset.file_url
+    end
+  end
+
   def create
     result = FileAttachments::CreateInteractor.call(params: params, user: current_user)
     edition, attachment_revision, issues = result.to_h.values_at(:edition, :attachment_revision, :issues)

--- a/app/helpers/file_attachment_helper.rb
+++ b/app/helpers/file_attachment_helper.rb
@@ -1,28 +1,28 @@
 # frozen_string_literal: true
 
 module FileAttachmentHelper
-  def file_attachment_in_app_attributes(file_attachment)
-    file_attachment_attributes(file_attachment).merge(
-      url: "#",
+  def file_attachment_in_app_attributes(attachment_revision, document)
+    file_attachment_attributes(attachment_revision).merge(
+      url: preview_file_attachment_path(document, attachment_revision.file_attachment),
     )
   end
 
-  def file_attachment_payload_attributes(file_attachment)
-    file_attachment_attributes(file_attachment).merge(
-      url: file_attachment.asset_url("file"),
+  def file_attachment_payload_attributes(attachment_revision)
+    file_attachment_attributes(attachment_revision).merge(
+      url: attachment_revision.asset_url("file"),
     )
   end
 
 private
 
-  def file_attachment_attributes(file_attachment)
+  def file_attachment_attributes(attachment_revision)
     {
-      id: file_attachment.filename,
-      title: file_attachment.title,
-      filename: file_attachment.filename,
-      content_type: file_attachment.content_type,
-      file_size: file_attachment.byte_size,
-      number_of_pages: file_attachment.number_of_pages,
+      id: attachment_revision.filename,
+      title: attachment_revision.title,
+      filename: attachment_revision.filename,
+      content_type: attachment_revision.content_type,
+      file_size: attachment_revision.byte_size,
+      number_of_pages: attachment_revision.number_of_pages,
     }
   end
 end

--- a/app/interactors/file_attachments/preview_interactor.rb
+++ b/app/interactors/file_attachments/preview_interactor.rb
@@ -1,0 +1,50 @@
+# frozen_string_literal: true
+
+class FileAttachments::PreviewInteractor
+  include Interactor
+
+  delegate :params,
+           :edition,
+           :attachment_revision,
+           :asset,
+           to: :context
+
+  def call
+    Edition.transaction do
+      find_and_lock_edition
+      find_attachment
+      check_uploaded
+      check_available
+    end
+  end
+
+private
+
+  def find_and_lock_edition
+    context.edition = Edition.lock.find_current(document: params[:document])
+  end
+
+  def find_attachment
+    context.attachment_revision = edition.file_attachment_revisions
+      .find_by!(file_attachment_id: params[:file_attachment_id])
+  end
+
+  def check_uploaded
+    attachment_revision.ensure_assets
+    context.asset = attachment_revision.asset("file")
+
+    if asset.absent?
+      PreviewAssetService.new(edition).upload_asset(asset)
+      context.fail!(can_preview: false)
+    end
+  rescue GdsApi::BaseError
+    context.fail!(api_error: true)
+  end
+
+  def check_available
+    service = PreviewAssetService.new(edition)
+    context.can_preview = service.can_preview_asset?(asset)
+  rescue GdsApi::BaseError
+    context.fail!(api_error: true)
+  end
+end

--- a/app/services/asset_manager_service.rb
+++ b/app/services/asset_manager_service.rb
@@ -19,6 +19,10 @@ class AssetManagerService
     )
   end
 
+  def get(asset)
+    GdsApi.asset_manager.asset(asset.asset_manager_id).to_h
+  end
+
   def redirect(asset, to:)
     GdsApi.asset_manager.update_asset(
       asset.asset_manager_id,

--- a/app/services/govspeak_document/in_app_options.rb
+++ b/app/services/govspeak_document/in_app_options.rb
@@ -18,7 +18,9 @@ private
   end
 
   def in_app_attachments
-    edition.file_attachment_revisions.map { |far| file_attachment_in_app_attributes(far) }
+    edition.file_attachment_revisions.map do |attachment_revision|
+      file_attachment_in_app_attributes(attachment_revision, edition.document)
+    end
   end
 
   def image_attributes(image_revision)

--- a/app/services/preview_asset_service.rb
+++ b/app/services/preview_asset_service.rb
@@ -1,0 +1,27 @@
+# frozen_string_literal: true
+
+class PreviewAssetService
+  attr_reader :edition
+
+  def initialize(edition)
+    @edition = edition
+  end
+
+  def upload_asset(asset)
+    return unless asset.absent?
+
+    auth_bypass_id = EditionUrl.new(edition).auth_bypass_id
+    file_url = AssetManagerService.new.upload(asset, auth_bypass_id)
+    asset.update!(file_url: file_url, state: :draft)
+  rescue GdsApi::BaseError => e
+    GovukError.notify(e)
+    raise
+  end
+
+  def can_preview_asset?(asset)
+    AssetManagerService.new.get(asset)["state"] == "uploaded"
+  rescue GdsApi::BaseError => e
+    GovukError.notify(e)
+    raise
+  end
+end

--- a/app/services/preview_asset_service.rb
+++ b/app/services/preview_asset_service.rb
@@ -7,6 +7,18 @@ class PreviewAssetService
     @edition = edition
   end
 
+  def upload_assets
+    edition.image_revisions.each do |image_revision|
+      image_revision.ensure_assets
+      image_revision.assets.each { |asset| upload_asset(asset) }
+    end
+
+    edition.file_attachment_revisions.each do |file_attachment_revision|
+      file_attachment_revision.ensure_assets
+      file_attachment_revision.assets.each { |asset| upload_asset(asset) }
+    end
+  end
+
   def upload_asset(asset)
     return unless asset.absent?
 

--- a/app/views/file_attachments/_file_attachment.html.erb
+++ b/app/views/file_attachments/_file_attachment.html.erb
@@ -3,7 +3,14 @@
 <% actions << link_to(
   "Insert attachment",
   file_attachment_path(document, attachment.file_attachment),
-  class: "govuk-link govuk-link--no-visited-state app-link--button",
+  class: "govuk-link govuk-link--no-visited-state",
+) %>
+
+<% actions << link_to(
+  "Preview",
+  preview_file_attachment_path(document, attachment.file_attachment),
+  target: :_blank,
+  class: "govuk-link govuk-link--no-visited-state"
 ) %>
 
 <% actions << capture do %>

--- a/app/views/file_attachments/_file_attachment.html.erb
+++ b/app/views/file_attachments/_file_attachment.html.erb
@@ -24,6 +24,6 @@
 <% end %>
 
 <%= render "components/attachment_meta", {
-  attachment: file_attachment_in_app_attributes(attachment),
+  attachment: file_attachment_in_app_attributes(attachment, document),
   actions: actions,
 } %>

--- a/app/views/file_attachments/preview_pending.html.erb
+++ b/app/views/file_attachments/preview_pending.html.erb
@@ -1,0 +1,3 @@
+<%= content_for :title, t("file_attachments.preview_pending.title") %>
+
+<%= render_govspeak(t("file_attachments.preview_pending.description_govspeak")) %>

--- a/app/views/file_attachments/show.html.erb
+++ b/app/views/file_attachments/show.html.erb
@@ -4,7 +4,7 @@
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
     <%= render "govuk_publishing_components/components/attachment", {
-      attachment: file_attachment_in_app_attributes(@attachment),
+      attachment: file_attachment_in_app_attributes(@attachment, @edition.document),
       target: "_blank",
     } %>
 
@@ -25,7 +25,7 @@
 
     <div class="govuk-body">
       <%= render "govuk_publishing_components/components/attachment_link", {
-        attachment: file_attachment_in_app_attributes(@attachment),
+        attachment: file_attachment_in_app_attributes(@attachment, @edition.document),
         target: "_blank"
       } %>
     </div>

--- a/config/locales/en/file_attachments/preview_pending.yml
+++ b/config/locales/en/file_attachments/preview_pending.yml
@@ -1,0 +1,4 @@
+en:
+  file_attachments:
+    preview_pending:
+      title: Sorry, this file isn't available for preview yet

--- a/config/locales/en/file_attachments/preview_pending.yml
+++ b/config/locales/en/file_attachments/preview_pending.yml
@@ -1,4 +1,8 @@
 en:
   file_attachments:
     preview_pending:
-      title: Sorry, this file isn't available for preview yet
+      title: Sorry, this file isn't available yet
+      description_govspeak: |
+        Your file is being scanned and will be ready to preview soon.
+
+        Please refresh or [raise a support request](https://support.publishing.service.gov.uk/technical_fault_report/new) if it's not available after 5 minutes.

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -77,6 +77,7 @@ Rails.application.routes.draw do
     get "/file-attachments" => "file_attachments#index", as: :file_attachments
     post "/file-attachments" => "file_attachments#create", as: :create_file_attachment
     get "/file-attachments/:file_attachment_id" => "file_attachments#show", as: :file_attachment
+    get "/file-attachments/:file_attachment_id/preview" => "file_attachments#preview", as: :preview_file_attachment
     delete "/file-attachments/:file_attachment_id" => "file_attachments#destroy", as: :destroy_file_attachment
   end
 

--- a/spec/features/editing_file_attachments/preview_file_attachment_asset_manager_down_spec.rb
+++ b/spec/features/editing_file_attachments/preview_file_attachment_asset_manager_down_spec.rb
@@ -1,0 +1,35 @@
+# frozen_string_literal: true
+
+RSpec.feature "Preview file attachment when Asset Manager is down" do
+  scenario do
+    given_there_is_an_edition_with_attachments
+    and_asset_manager_is_down
+    when_i_preview_the_attachment
+    then_i_should_see_a_pending_page
+  end
+
+  def given_there_is_an_edition_with_attachments
+    body_field = build(:field, id: "body", type: "govspeak")
+    document_type = build(:document_type, contents: [body_field])
+    @attachment_revision = create(:file_attachment_revision)
+
+    @edition = create(:edition,
+                      document_type_id: document_type.id,
+                      file_attachment_revisions: [@attachment_revision])
+  end
+
+  def and_asset_manager_is_down
+    stub_asset_manager_isnt_available
+  end
+
+  def when_i_preview_the_attachment
+    visit edit_document_path(@edition.document)
+    find("markdown-toolbar details").click
+    click_on "Attachment"
+    click_on "Preview"
+  end
+
+  def then_i_should_see_a_pending_page
+    expect(page).to have_content I18n.t!("file_attachments.preview_pending.title")
+  end
+end

--- a/spec/features/editing_file_attachments/preview_file_attachment_spec.rb
+++ b/spec/features/editing_file_attachments/preview_file_attachment_spec.rb
@@ -1,0 +1,41 @@
+# frozen_string_literal: true
+
+RSpec.feature "Preview file attachment", js: true do
+  scenario do
+    given_there_is_an_edition_with_attachments
+    and_the_attachment_is_available
+    when_i_preview_the_attachment
+    then_i_should_see_the_attachment
+  end
+
+  def given_there_is_an_edition_with_attachments
+    body_field = build(:field, id: "body", type: "govspeak")
+    document_type = build(:document_type, contents: [body_field])
+    @attachment_revision = create(:file_attachment_revision, :on_asset_manager)
+    @asset = @attachment_revision.asset("file")
+
+    @edition = create(:edition,
+                      document_type_id: document_type.id,
+                      file_attachment_revisions: [@attachment_revision])
+  end
+
+  def and_the_attachment_is_available
+    stub_asset_manager_has_an_asset(@asset.asset_manager_id, "state": "uploaded")
+  end
+
+  def when_i_preview_the_attachment
+    visit edit_document_path(@edition.document)
+    find("markdown-toolbar details").click
+    @new_window = window_opened_by { click_on "Attachment" }
+
+    within_window(@new_window) do
+      @preview_window = window_opened_by { click_on "Preview" }
+    end
+  end
+
+  def then_i_should_see_the_attachment
+    within_window @preview_window do
+      expect(current_url).to eq @asset.file_url
+    end
+  end
+end

--- a/spec/features/editing_file_attachments/preview_file_attachment_unavailable_spec.rb
+++ b/spec/features/editing_file_attachments/preview_file_attachment_unavailable_spec.rb
@@ -1,0 +1,37 @@
+# frozen_string_literal: true
+
+RSpec.feature "Preview file attachment when unavailable" do
+  scenario do
+    given_there_is_an_edition_with_attachments
+    when_i_preview_the_attachment
+    then_i_should_see_a_pending_page
+    and_the_preview_creation_was_successful
+  end
+
+  def given_there_is_an_edition_with_attachments
+    body_field = build(:field, id: "body", type: "govspeak")
+    document_type = build(:document_type, contents: [body_field])
+    @attachment_revision = create(:file_attachment_revision)
+    @asset = @attachment_revision.asset("file")
+
+    @edition = create(:edition,
+                      document_type_id: document_type.id,
+                      file_attachment_revisions: [@attachment_revision])
+  end
+
+  def when_i_preview_the_attachment
+    @request = stub_asset_manager_receives_an_asset(filename: @asset.filename)
+    visit edit_document_path(@edition.document)
+    find("markdown-toolbar details").click
+    click_on "Attachment"
+    click_on "Preview"
+  end
+
+  def then_i_should_see_a_pending_page
+    expect(page).to have_content I18n.t!("file_attachments.preview_pending.title")
+  end
+
+  def and_the_preview_creation_was_successful
+    expect(@request).to have_been_requested
+  end
+end

--- a/spec/interactors/file_attachments/preview_interactor_spec.rb
+++ b/spec/interactors/file_attachments/preview_interactor_spec.rb
@@ -1,0 +1,70 @@
+# frozen_string_literal: true
+
+RSpec.describe FileAttachments::PreviewInteractor do
+  describe ".call" do
+    let(:file_attachment) { create :file_attachment }
+    let(:edition) { create :edition }
+
+    let(:params) do
+      { document: edition.document.to_param, file_attachment_id: file_attachment.id }
+    end
+
+    let(:preview_asset_service) do
+      instance_double("PreviewAssetService", upload_asset: nil, can_preview_asset?: nil)
+    end
+
+    before do
+      allow(PreviewAssetService).to receive(:new) { preview_asset_service }
+    end
+
+    context "when the asset is present on Asset Manager" do
+      before do
+        attachment_revision = create :file_attachment_revision, :on_asset_manager, file_attachment: file_attachment
+        edition.file_attachment_revisions << attachment_revision
+      end
+
+      it "returns the asset when it's available to download" do
+        allow(preview_asset_service).to receive(:can_preview_asset?) { true }
+        result = FileAttachments::PreviewInteractor.call(params: params)
+        expect(result.asset).to be_a FileAttachment::Asset
+        expect(result.can_preview).to be_truthy
+        expect(result.api_error).to be_falsey
+      end
+
+      it "returns a can_preview flag when the asset is unavailable" do
+        allow(preview_asset_service).to receive(:can_preview_asset?) { false }
+        result = FileAttachments::PreviewInteractor.call(params: params)
+        expect(result.can_preview).to be_falsey
+      end
+
+      it "returns an api_error flag when Asset Manager is down" do
+        allow(preview_asset_service).to receive(:can_preview_asset?).and_raise(GdsApi::BaseError)
+        result = FileAttachments::PreviewInteractor.call(params: params)
+        expect(result.api_error).to be_truthy
+      end
+    end
+
+    context "when the asset is absent from Asset Manager" do
+      before do
+        attachment_revision = create :file_attachment_revision, file_attachment: file_attachment
+        edition.file_attachment_revisions << attachment_revision
+      end
+
+      it "uploads the asset" do
+        expect(preview_asset_service).to receive(:upload_asset)
+        FileAttachments::PreviewInteractor.call(params: params)
+      end
+
+      it "returns a can_preview flag" do
+        result = FileAttachments::PreviewInteractor.call(params: params)
+        expect(result.can_preview).to be_falsey
+      end
+
+      it "returns an api_error flag when Asset Manager is down" do
+        allow(preview_asset_service).to receive(:upload_asset).and_raise(GdsApi::BaseError)
+        result = FileAttachments::PreviewInteractor.call(params: params)
+        expect(result.api_error).to be_truthy
+      end
+    end
+  end
+end

--- a/spec/services/govspeak_document/in_app_options_spec.rb
+++ b/spec/services/govspeak_document/in_app_options_spec.rb
@@ -1,6 +1,8 @@
 # frozen_string_literal: true
 
 RSpec.describe GovspeakDocument::InAppOptions do
+  include Rails.application.routes.url_helpers
+
   describe "#to_h" do
     it "returns a hash of image attributes" do
       image_revision = build(:image_revision,
@@ -25,13 +27,13 @@ RSpec.describe GovspeakDocument::InAppOptions do
     end
 
     it "returns a hash of file attachment attributes" do
-      file_attachment_revision = build(:file_attachment_revision,
-                                       fixture: "13kb-1-page-attachment.pdf",
-                                       filename: "13kb-1-page-attachment.pdf",
-                                       title: "A title",
-                                       number_of_pages: 1)
+      attachment_revision = create(:file_attachment_revision,
+                                   fixture: "13kb-1-page-attachment.pdf",
+                                   filename: "13kb-1-page-attachment.pdf",
+                                   title: "A title",
+                                   number_of_pages: 1)
       edition = build(:edition,
-                      file_attachment_revisions: [file_attachment_revision])
+                      file_attachment_revisions: [attachment_revision])
 
       in_app_options = GovspeakDocument::InAppOptions.new("govspeak", edition)
       actual_attachment_options = in_app_options.to_h[:attachments].first
@@ -44,7 +46,7 @@ RSpec.describe GovspeakDocument::InAppOptions do
           content_type: "application/pdf",
           number_of_pages: 1,
           file_size: 13264,
-          # TODO add url expectation when we have an internal preview URL
+          url: preview_file_attachment_path(edition.document, attachment_revision.file_attachment),
         ),
       )
     end

--- a/spec/services/preview_asset_service_spec.rb
+++ b/spec/services/preview_asset_service_spec.rb
@@ -1,0 +1,76 @@
+# frozen_string_literal: true
+
+RSpec.describe PreviewAssetService do
+  describe "#upload_assets" do
+    it "uploads the image assets" do
+      image_revision = create(:image_revision)
+      edition = create(:edition, image_revisions: [image_revision])
+      expect_any_instance_of(PreviewAssetService).to receive(:upload_asset).at_least(:once)
+      PreviewAssetService.new(edition).upload_assets
+    end
+
+    it "uploads the file attachment assets" do
+      file_attachment_revision = create(:file_attachment_revision)
+      edition = create(:edition, file_attachment_revisions: [file_attachment_revision])
+      expect_any_instance_of(PreviewAssetService).to receive(:upload_asset).at_least(:once)
+      PreviewAssetService.new(edition).upload_assets
+    end
+  end
+
+  describe "#upload_asset" do
+    let(:edition) { create :edition }
+
+    let(:asset) do
+      double(absent?: true,
+             asset_manager_id: "id",
+             update!: false,
+             bytes: "0x123",
+             filename: "abc.png",
+             content_type: "image/png")
+    end
+
+    context "when the asset is not on Asset Manager" do
+      it "uploads the asset" do
+        request = stub_asset_manager_receives_an_asset
+        expect(asset).to receive(:update!).with a_hash_including(state: :draft)
+        PreviewAssetService.new(edition).upload_asset(asset)
+        expect(request).to have_been_requested.at_least_once
+      end
+    end
+
+    context "when the asset is on Asset Manager" do
+      it "doesn't upload the asset" do
+        allow(asset).to receive(:absent?) { false }
+        request = stub_asset_manager_receives_an_asset
+        PreviewAssetService.new(edition).upload_asset(asset)
+        expect(asset).to_not have_received(:update!)
+        expect(request).to_not have_been_requested
+      end
+    end
+  end
+
+  describe "#can_preview_asset?" do
+    let(:edition) { create :edition }
+
+    let(:asset) do
+      double(absent?: true,
+             asset_manager_id: "id",
+             update!: false,
+             bytes: "0x123",
+             filename: "abc.png",
+             content_type: "image/png")
+    end
+
+    it "returns true when the asset is uploaded" do
+      stub_asset_manager_has_an_asset("id", "state": "uploaded")
+      result = PreviewAssetService.new(edition).can_preview_asset?(asset)
+      expect(result).to be_truthy
+    end
+
+    it "returns false when the asset is being scanned" do
+      stub_asset_manager_has_an_asset("id", "state": "unscanned")
+      result = PreviewAssetService.new(edition).can_preview_asset?(asset)
+      expect(result).to be_falsey
+    end
+  end
+end

--- a/spec/services/preview_service_spec.rb
+++ b/spec/services/preview_service_spec.rb
@@ -5,10 +5,14 @@ RSpec.describe PreviewService do
     instance_double("DraftAssetCleanupService", call: nil)
   end
 
+  let(:preview_asset_service) do
+    instance_double("PreviewAssetService", upload_assets: nil)
+  end
+
   before do
     stub_any_publishing_api_put_content
-    stub_any_asset_manager_call
     allow(DraftAssetCleanupService).to receive(:new) { draft_asset_cleanup_service }
+    allow(PreviewAssetService).to receive(:new) { preview_asset_service }
   end
 
   describe "#create_preview" do
@@ -31,65 +35,10 @@ RSpec.describe PreviewService do
       PreviewService.new(edition).create_preview
     end
 
-    context "when there are assets that aren't on Asset Manager" do
-      it "uploads the assets to Asset Manager" do
-        image_revision = create(:image_revision)
-        file_attachment_revision = create(:file_attachment_revision)
-        edition = create(:edition,
-                         image_revisions: [image_revision],
-                         file_attachment_revisions: [file_attachment_revision])
-
-        request = stub_asset_manager_receives_an_asset
-        PreviewService.new(edition).create_preview
-
-        expect(request).to have_been_requested.at_least_once
-        asset_states = image_revision.assets.map(&:state) + file_attachment_revision.assets.map(&:state)
-        expect(asset_states.uniq).to match(%w[draft])
-      end
-    end
-
-    context "when there are assets that are on Asset Manager" do
-      let(:image_revision_draft) do
-        create(:image_revision, :on_asset_manager, state: :draft)
-      end
-
-      let(:image_revision_live) do
-        create(:image_revision, :on_asset_manager, state: :live)
-      end
-
-      let(:file_attachment_revision_draft) do
-        create(:file_attachment_revision, :on_asset_manager, state: :draft)
-      end
-
-      let(:file_attachment_revision_live) do
-        create(:file_attachment_revision, :on_asset_manager, state: :live)
-      end
-
-      let(:edition) do
-        create(:edition,
-               image_revisions: [image_revision_draft, image_revision_live],
-               file_attachment_revisions: [file_attachment_revision_draft, file_attachment_revision_live])
-      end
-
-      it "doesn't change the state of assets on asset manager" do
-        PreviewService.new(edition).create_preview
-
-        draft_asset_states = image_revision_draft.assets.map(&:state) +
-          file_attachment_revision_draft.assets.map(&:state)
-        expect(draft_asset_states.uniq).to match(%w[draft])
-
-        live_asset_states = image_revision_live.assets.map(&:state) +
-          file_attachment_revision_live.assets.map(&:state)
-        expect(live_asset_states.uniq).to match(%w[live])
-      end
-
-      it "doesn't upload assets to asset manager" do
-        request = stub_asset_manager_receives_an_asset
-
-        PreviewService.new(edition).create_preview
-
-        expect(request).not_to have_been_requested
-      end
+    it "delegates previewing assets" do
+      edition = create(:edition)
+      expect(preview_asset_service).to receive(:upload_assets)
+      PreviewService.new(edition).create_preview
     end
 
     context "when Publishing API is down" do
@@ -103,14 +52,11 @@ RSpec.describe PreviewService do
       end
     end
 
-    context "when there are images and Asset Manager is down" do
+    context "when the asset upload fails" do
       it "sets revision_synced to false on the edition" do
-        stub_asset_manager_isnt_available
-        image_revision = create(:image_revision)
-        edition = create(:edition, image_revisions: [image_revision], revision_synced: true)
-
-        expect { PreviewService.new(edition).create_preview }
-          .to raise_error(GdsApi::BaseError)
+        allow(preview_asset_service).to receive(:upload_assets).and_raise(GdsApi::BaseError)
+        edition = create(:edition, revision_synced: true)
+        expect { PreviewService.new(edition).create_preview }.to raise_error(GdsApi::BaseError)
         expect(edition.revision_synced).to be(false)
       end
     end


### PR DESCRIPTION
https://trello.com/c/xpS0zlU4/803-download-an-attachment-file-through-content-publisher

This is the initial attempt at doing 'intelligent preview' for an asset, so that we redirect to Asset Manager only when we know a file is available, and potentially try to upload it if it's not in Asset Manager at all e.g. if it was uploaded as part of the edit form for a document. Further work:

   - Use the auth bypass token in the asset URL
   - Use the new preview path elsewhere in the app
   - Consider if we want special behaviour for infected files

I've done a bit of refactoring on the PreviewService, which had similar code for managing assets, to keep the tests manageable. The commit explains a bit more about the pros/cons of doing that - it seems to be a compromise between duplication and stubbing our own code.