### PR TITLE
Add coverage checker for I18n locales

### DIFF
--- a/config/locales/en/documents/history.yml
+++ b/config/locales/en/documents/history.yml
@@ -16,7 +16,6 @@ en:
         image_updated: "Updated image"
         image_deleted: "Deleted image"
         new_edition: "New edition"
-        create_preview: "Create preview"
         withdrawn: "Withdrawn"
         withdrawn_updated: "Updated withdrawal explanation"
         removed: "Removed"

--- a/config/locales/en/images/index.yml
+++ b/config/locales/en/images/index.yml
@@ -20,6 +20,3 @@ en:
         lead_image:
           removed: "Image ‘%{file}’ has been deselected. Document will now use the default lead image"
           deleted: "Image ‘%{file}’ has been deleted. Document will now use the default lead image"
-        api_error:
-          title: Something has gone wrong
-          description_govspeak: Something went wrong when uploading your file. Please try again or [raise a support request](https://support.publishing.service.gov.uk/technical_fault_report/new).

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -18,6 +18,7 @@ require "govuk_sidekiq/testing"
 Dir[Rails.root.join("spec", "support", "**", "*.rb")].each { |f| require f }
 SimpleCov.start
 GovukTest.configure
+I18nCov.start
 WebMock.disable_net_connect!(allow_localhost: true)
 Capybara.automatic_label_click = true
 ActiveRecord::Migration.maintain_test_schema!

--- a/spec/support/i18n_cov.rb
+++ b/spec/support/i18n_cov.rb
@@ -1,0 +1,80 @@
+# frozen_string_literal: true
+
+require "singleton"
+
+class I18nCov
+  REPORT_PATH = Rails.root.join("coverage", "i18n")
+  IN_APP_LOCALE_FILES = Dir.glob(Rails.root.join("config", "locales", "**", "*.yml"))
+
+  include Singleton
+
+  attr_reader :locales, :used_keys
+
+  module I18nOverrides
+    def lookup(locale, key, scope = [], options = {})
+      I18nCov.log(key, scope)
+      super
+    end
+  end
+
+  class << self
+    delegate :start, :report, :log, to: :instance
+  end
+
+  def start(locales = nil)
+    @used_keys = []
+    @locales = locales || in_app_locales
+    I18n::Backend::Simple.include I18nOverrides
+  end
+
+  def log(key, scope)
+    key = (Array(scope || []) + [key]).compact.join(".")
+    used_keys << key unless used_keys.include?(key)
+  end
+
+  def report
+    return if used_keys.blank?
+
+    all = all_locale_keys
+    scoped_used = all.select { |as| used_keys.any? { |us| as.start_with?(us) } }
+
+    write_report(all - scoped_used)
+    print_message(all, scoped_used)
+  end
+
+private
+
+  def in_app_locales
+    IN_APP_LOCALE_FILES.map(&YAML.method(:load_file)).reduce({}, :deep_merge)
+  end
+
+  def all_locale_keys
+    locales.flat_map { |locale, ts| key_chains_for(locale, ts, is_root: true) }
+      .map { |key_chain| key_chain.join(".") }.uniq
+  end
+
+  def key_chains_for(key, value, is_root: false)
+    return [[key]] unless value.is_a? Hash
+
+    value.flat_map { |sub_key, sub_value| key_chains_for(sub_key, sub_value) }
+      .map { |sub_key| (is_root ? [] : [key]) + sub_key }
+  end
+
+  def write_report(unused)
+    FileUtils.mkdir_p(File.dirname(REPORT_PATH))
+
+    File.open(REPORT_PATH, "w") do |f|
+      f.puts("Keys not covered (potentially unused)\n\n")
+      unused.each { |key| f.puts key }
+    end
+  end
+
+  def print_message(all, used)
+    percent = ((used.count.to_f / all.count) * 100).round(2)
+
+    puts "Coverage report generated for I18n to #{Dir.pwd}/coverage/i18n. " +
+      "#{used.count} / #{all.count} keys (#{percent}%) covered."
+  end
+end
+
+END { I18nCov.report }


### PR DESCRIPTION
https://trello.com/c/s122Fg91/959-we-dont-monitor-unused-and-untested-i18n-translations

This adds a GOVUKI18nCov class* that generates a coverage report of the
I18n keys used after a script (e.g. rspec) has finished running. I've
removed a couple of unused locales that the report has identified as
being unused - the remainder are used but not covered by the tests.

I'm not really sure where this code should live, but it does seem to be 
beneficial to monitor coverage of our locales :-).

*there are other tools out there, such as i18n-tasks, but I couldn't find one 
that produces a good quality results for our use case - we have a lot of 
dynamic uses of I18n in our code, as well as simple uses in the views.