### PR TITLE
Align image and file upload

### DIFF
--- a/app/assets/stylesheets/components/_attachment-meta.scss
+++ b/app/assets/stylesheets/components/_attachment-meta.scss
@@ -1,3 +1,15 @@
+.app-c-attachment-meta {
+  @include govuk-font(19);
+
+  margin-bottom: govuk-spacing(6);
+  padding-bottom: govuk-spacing(6);
+  border-bottom: 1px solid $govuk-border-colour;
+
+  .app-c-metadata {
+    margin-bottom: govuk-spacing(3);
+  }
+}
+
 .app-c-attachment-meta:last-child {
   border-bottom: 0;
 }

--- a/app/views/file_attachments/index.html.erb
+++ b/app/views/file_attachments/index.html.erb
@@ -3,17 +3,24 @@
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
     <div class="app-pane">
+      <% upload_attachment_heading = capture do %>
+        <h2 class="govuk-heading-m">
+          <%= t("file_attachments.index.upload.title") %>
+        </h2>
+      <% end %>
+
       <%= form_tag(
         create_file_attachment_path(@edition.document),
         multipart: true,
       ) do %>
-        <h2 class="govuk-heading-m">
-          <%= t("file_attachments.index.upload.title") %>
-        </h2>
-        <%= render_govspeak(t("file_attachments.index.upload.description_govspeak")) %>
         <%= render "govuk_publishing_components/components/file_upload", {
+          label: {
+            text: upload_attachment_heading,
+          },
+          hint: render_govspeak(t("file_attachments.index.upload.description_govspeak")),
           name: "file"
         } %>
+
         <%= render "govuk_publishing_components/components/input", {
           label: {
             text: t("file_attachments.index.attachment_title.heading"),
@@ -29,11 +36,7 @@
         } %>
       <% end %>
     </div>
-  </div>
-</div>
 
-<div class="govuk-grid-row">
-  <div class="govuk-grid-column-two-thirds">
     <% attachments = @edition.file_attachment_revisions %>
 
     <% if attachments.any? %>

--- a/app/views/file_attachments/show.html.erb
+++ b/app/views/file_attachments/show.html.erb
@@ -19,9 +19,8 @@
       margin_bottom: 3,
     } %>
     <p class="govuk-body"><%= t("file_attachments.show.attachment_instructions") %></p>
-    </p>
 
-    <hr class="govuk-!-margin-bottom-6 govuk-!-margin-top-6"/>
+    <hr class="govuk-section-break govuk-section-break--visible govuk-section-break--l"/>
 
     <div class="govuk-body">
       <%= render "govuk_publishing_components/components/attachment_link", {

--- a/app/views/images/index.html.erb
+++ b/app/views/images/index.html.erb
@@ -28,10 +28,9 @@ content_for :title, t(title_key, title: @edition.title_or_fallback)
           label: {
             text: upload_image_heading,
           },
+          hint: render_govspeak(t("images.index.description_govspeak")),
           name: "image"
         } %>
-
-        <%= render_govspeak(t("images.index.description_govspeak")) %>
 
         <%= render "govuk_publishing_components/components/button", {
           text: "Upload",


### PR DESCRIPTION
Fix visual styles on attachments. This includes:
- Update image upload page to have the guidance as hint
- Update attachment form markup
- Fix hr styling an fix `</p>` when showing attachments
- Fix style attachment meta for group listing

Trello:
https://trello.com/c/zMYmFTPx