### PR TITLE
Add missing rubyzip gem in production

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -23,6 +23,7 @@ gem "pdf-reader", "~> 2"
 gem "pg", "~> 1"
 gem "plek", "~> 2"
 gem "rinku", "~> 2"
+gem "rubyzip", "~> 1"
 gem "uglifier", "~> 4"
 
 group :development do

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -483,6 +483,7 @@ DEPENDENCIES
   rails (~> 5.2)
   rinku (~> 2)
   rspec-rails (~> 3)
+  rubyzip (~> 1)
   simplecov (~> 0.16)
   uglifier (~> 4)
   webmock (~> 3)


### PR DESCRIPTION
https://trello.com/c/EL9jPXIl/802-validation-requirements-for-uploading-file-attachments

Previously we were unknowingly relying on this depedency to be provided
by a gem that was only installed in the dev/test environments. This adds
the gem explicitly to ensure it's available in the prod environment.