### PR TITLE
Require 'zip' instead of 'rubyzip'

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -23,7 +23,7 @@ gem "pdf-reader", "~> 2"
 gem "pg", "~> 1"
 gem "plek", "~> 2"
 gem "rinku", "~> 2"
-gem "rubyzip", "~> 1"
+gem "rubyzip", "~> 1", require: "zip"
 gem "uglifier", "~> 4"
 
 group :development do


### PR DESCRIPTION
This is necessary because the name of the library differs from the
naming used in its code, so it isn't auto-required.