### PR TITLE
Enable autocomplete on edit document form

### DIFF
--- a/app/views/documents/edit.html.erb
+++ b/app/views/documents/edit.html.erb
@@ -8,7 +8,7 @@
 
 <%= form_for(
   @edition.document,
-  html: { "autocomplete": "off", class: "app-c-contextual-guidance__form" },
+  class: "app-c-contextual-guidance__form",
   data: {
     module: "edit-document-form",
     "url-preview-path": generate_path_path,


### PR DESCRIPTION
We initially set `autocomplete="false"` on the edit document form trying to disable suggestions on input elements (such as Title and Summary), but we've found that this behaviour is also disabling the browser from retaining edited inputs when offline resulting in potential loss of content. We're also no longer using input elements for these fields (Title and Summary) so the initial purpose is not being met anymore.

### Example scenario
Edit the main textarea within the markdown editor > Disable WiFi > Submit your changes > The submit will fail > Press the back button to return to the edit page > The updated content is missing.

The scenario above could be achieved by any failed submissions of the edit document form.