### PR TITLE
Fix misaligned text in autocomplete

### DIFF
--- a/app/assets/stylesheets/components/_autocomplete.scss
+++ b/app/assets/stylesheets/components/_autocomplete.scss
@@ -4,6 +4,7 @@
   background: govuk-colour('white');
 }
 
+.autocomplete__hint,
 .autocomplete__input {
   @include govuk-font(19);
   color: $govuk-text-colour;


### PR DESCRIPTION
While typing in an autocomplete the suggestion text is misaligned with the typed text.

Before: 
<img width="660" alt="Screen Shot 2019-05-14 at 10 51 44" src="https://user-images.githubusercontent.com/788096/57689109-d5df3f00-7636-11e9-8612-a4bd28e4ab69.png">

After:
