### PR TITLE
Fix missing class for edit page guidance

### DIFF
--- a/app/views/documents/edit.html.erb
+++ b/app/views/documents/edit.html.erb
@@ -8,7 +8,7 @@
 
 <%= form_for(
   @edition.document,
-  class: "app-c-contextual-guidance__form",
+  html: { class: "app-c-contextual-guidance__form" },
   data: {
     module: "edit-document-form",
     "url-preview-path": generate_path_path,


### PR DESCRIPTION
Looks like form_for is hairier than I gave it credit for :-|.