### PR TITLE
Display content data link for all orgs

### DIFF
--- a/app/services/content_data_url.rb
+++ b/app/services/content_data_url.rb
@@ -18,7 +18,11 @@ class ContentDataUrl
   end
 
   def displayable?(user)
-    has_content_data_access?(user) && expected_in_content_data?
+    if user.has_permission?(User::PRE_RELEASE_FEATURES_PERMISSION)
+      expected_in_content_data?
+    else
+      has_content_data_access?(user) && expected_in_content_data?
+    end
   end
 
 private

--- a/spec/services/content_data_url_spec.rb
+++ b/spec/services/content_data_url_spec.rb
@@ -20,6 +20,11 @@ RSpec.describe ContentDataUrl do
       expect(ContentDataUrl.new(document).displayable?(beta_partner)).to be true
     end
 
+    it "returns true if the user has pre-release permission and edition was published before yesterday" do
+      pre_release_user = build(:user, permissions: [User::PRE_RELEASE_FEATURES_PERMISSION])
+      expect(ContentDataUrl.new(document).displayable?(pre_release_user)).to be true
+    end
+
     it "returns false if the user is not part of a Content Data beta partner organisation" do
       user = build(:user, organisation_content_id: SecureRandom.uuid)
       expect(ContentDataUrl.new(document).displayable?(user)).to be false


### PR DESCRIPTION
This code is a little bit redundant as to allow all orgs to view the
link would actually require removing the code around filtering which we can't do
due to it needing to be released at the same time as its communicated.

I've discussed with Tobi and she thinks it should stay behing a flag
until the content is ready to go out communicating the changes.

Trello:
https://trello.com/c/MdKhnoLP/847-link-from-our-app-to-content-data-all-organisations