### PR TITLE
Fix rollback when creating assets for preview

### DIFF
--- a/spec/features/editing_file_attachments/preview_file_attachment_unavailable_spec.rb
+++ b/spec/features/editing_file_attachments/preview_file_attachment_unavailable_spec.rb
@@ -11,7 +11,7 @@ RSpec.feature "Preview file attachment when unavailable" do
   def given_there_is_an_edition_with_attachments
     body_field = build(:field, id: "body", type: "govspeak")
     document_type = build(:document_type, contents: [body_field])
-    @attachment_revision = create(:file_attachment_revision)
+    @attachment_revision = create(:file_attachment_revision, assets: [])
     @asset = @attachment_revision.asset("file")
 
     @edition = create(:edition,
@@ -20,7 +20,7 @@ RSpec.feature "Preview file attachment when unavailable" do
   end
 
   def when_i_preview_the_attachment
-    @request = stub_asset_manager_receives_an_asset(filename: @asset.filename)
+    @request = stub_asset_manager_receives_an_asset(filename: /.*/)
     visit edit_document_path(@edition.document)
     find("markdown-toolbar details").click
     click_on "Attachment"


### PR DESCRIPTION
https://trello.com/c/xpS0zlU4/803-download-an-attachment-file-through-content-publisher

Previously we did a 'context.fail' when initially uploading an asset for
preview, which caused the wrapping transaction to rollback and the
created asset to be removed, even though it exists in Asset Manager.

This modifies the PreviewInteractor to combine and rename the associated
'check_' methods to better describe what they achieve, which also means
we can short-circuit return and avoid any erreneous rollback.