### PR TITLE
Replace File Attachment file

### DIFF
--- a/app/assets/stylesheets/utilities/_overwrites.scss
+++ b/app/assets/stylesheets/utilities/_overwrites.scss
@@ -69,3 +69,11 @@
     @include govuk-font(19);
   }
 }
+
+.govuk-inset-text {
+  .govuk-govspeak {
+    p:last-child {
+      margin-bottom: 0;
+    }
+  }
+}

--- a/app/controllers/file_attachments_controller.rb
+++ b/app/controllers/file_attachments_controller.rb
@@ -84,8 +84,7 @@ class FileAttachmentsController < ApplicationController
                         attachment: attachment_revision },
              status: :unprocessable_entity
     else
-      redirect_to file_attachment_path(edition.document,
-                                       attachment_revision.file_attachment)
+      redirect_to file_attachments_path(edition.document)
     end
   end
 end

--- a/app/controllers/file_attachments_controller.rb
+++ b/app/controllers/file_attachments_controller.rb
@@ -84,6 +84,7 @@ class FileAttachmentsController < ApplicationController
                         attachment: attachment_revision },
              status: :unprocessable_entity
     else
+      flash[:notice] = I18n.t!("file_attachments.edit.flashes.update_confirmation")
       redirect_to file_attachments_path(edition.document)
     end
   end

--- a/app/interactors/file_attachments/update_interactor.rb
+++ b/app/interactors/file_attachments/update_interactor.rb
@@ -60,7 +60,8 @@ private
   end
 
   def check_for_issues
-    checker = Requirements::FileAttachmentChecker.new(title: file_attachment_revision.title)
+    checker = Requirements::FileAttachmentChecker.new(file: params.dig(:file_attachment, :file),
+                                                      title: file_attachment_revision.title)
     issues = checker.pre_update_issues
 
     context.fail!(issues: issues) if issues.any?

--- a/app/interactors/file_attachments/update_interactor.rb
+++ b/app/interactors/file_attachments/update_interactor.rb
@@ -12,9 +12,10 @@ class FileAttachments::UpdateInteractor
   def call
     Edition.transaction do
       find_and_lock_edition
-      find_and_update_file_attachment
-
+      find_file_attachment
       check_for_issues
+
+      update_file_attachment
       update_edition
 
       create_timeline_entry
@@ -28,43 +29,26 @@ private
     context.edition = Edition.lock.find_current(document: params[:document])
   end
 
-  def find_and_update_file_attachment
-    current_attachment_revision = edition.file_attachment_revisions
-                                         .find_by!(file_attachment_id: params[:file_attachment_id])
-
-    updater = Versioning::FileAttachmentRevisionUpdater.new(current_attachment_revision, user)
-    attributes = attachment_params.slice(:title)
-                                  .merge(file_attachment_attributes(current_attachment_revision))
-
-    updater.assign(attributes)
-
-    context.file_attachment_revision = updater.next_revision
-  end
-
-  def attachment_params
-    params.require(:file_attachment).permit(:file, :title)
-  end
-
-  def file_attachment_attributes(file_attachment_revision)
-    return {} unless attachment_params[:file]
-
-    blob_service = FileAttachmentBlobService.new(file: attachment_params[:file],
-                                                 revision: edition.revision,
-                                                 replacement: file_attachment_revision)
-
-    {
-      blob_id: blob_service.blob_id,
-      filename: blob_service.filename,
-      number_of_pages: blob_service.number_of_pages,
-    }
+  def find_file_attachment
+    context.file_attachment_revision = edition.file_attachment_revisions
+                                              .find_by!(file_attachment_id: params[:file_attachment_id])
   end
 
   def check_for_issues
-    checker = Requirements::FileAttachmentChecker.new(file: params.dig(:file_attachment, :file),
-                                                      title: file_attachment_revision.title)
+    checker = Requirements::FileAttachmentChecker.new(file: attachment_params[:file],
+                                                      title: attachment_params[:title])
     issues = checker.pre_update_issues
 
     context.fail!(issues: issues) if issues.any?
+  end
+
+  def update_file_attachment
+    updater = Versioning::FileAttachmentRevisionUpdater.new(file_attachment_revision, user)
+    attributes = attachment_params.slice(:title)
+                                  .merge(blob_attributes(file_attachment_revision))
+
+    updater.assign(attributes)
+    context.file_attachment_revision = updater.next_revision
   end
 
   def update_edition
@@ -83,5 +67,23 @@ private
 
   def update_preview
     PreviewService.new(edition).try_create_preview
+  end
+
+  def attachment_params
+    params.require(:file_attachment).permit(:file, :title)
+  end
+
+  def blob_attributes(file_attachment_revision)
+    return {} unless attachment_params[:file]
+
+    blob_service = FileAttachmentBlobService.new(file: attachment_params[:file],
+                                                 revision: edition.revision,
+                                                 replacement: file_attachment_revision)
+
+    {
+      blob_id: blob_service.blob_id,
+      filename: blob_service.filename,
+      number_of_pages: blob_service.number_of_pages,
+    }
   end
 end

--- a/app/services/file_attachment_blob_service.rb
+++ b/app/services/file_attachment_blob_service.rb
@@ -1,0 +1,33 @@
+# frozen_string_literal: true
+
+class FileAttachmentBlobService
+  attr_reader :file
+
+  def initialize(file)
+    @file = file
+  end
+
+  def blob_id
+    blob.id
+  end
+
+  def blob_filename
+    blob[:filename]
+  end
+
+private
+
+  def blob
+    @blob ||= ActiveStorage::Blob.create_after_upload!(
+      io: file,
+      filename: file.original_filename,
+      content_type: mime_type,
+    )
+  end
+
+  def mime_type
+    Marcel::MimeType.for(file,
+                         declared_type: file.content_type,
+                         name: file.original_filename)
+  end
+end

--- a/app/services/file_attachment_blob_service.rb
+++ b/app/services/file_attachment_blob_service.rb
@@ -1,18 +1,32 @@
 # frozen_string_literal: true
 
 class FileAttachmentBlobService
-  attr_reader :file
+  attr_reader :file, :revision, :replacement
 
-  def initialize(file)
+  def initialize(file:, revision:, replacement: nil)
     @file = file
+    @revision = revision
+    @replacement = replacement
   end
 
   def blob_id
     blob.id
   end
 
-  def blob_filename
-    blob[:filename]
+  def filename
+    @filename ||= begin
+      existing_filenames = revision.file_attachment_revisions.map(&:filename)
+      existing_filenames.delete(replacement.filename) if replacement
+      UniqueFilenameService.new(existing_filenames).call(file.original_filename)
+    end
+  end
+
+  def number_of_pages
+    return unless mime_type == "application/pdf"
+
+    PDF::Reader.new(file.tempfile).page_count
+  rescue PDF::Reader::MalformedPDFError, PDF::Reader::UnsupportedFeatureError, OpenSSL::Cipher::CipherError
+    nil
   end
 
 private
@@ -20,14 +34,14 @@ private
   def blob
     @blob ||= ActiveStorage::Blob.create_after_upload!(
       io: file,
-      filename: file.original_filename,
+      filename: filename,
       content_type: mime_type,
     )
   end
 
   def mime_type
-    Marcel::MimeType.for(file,
-                         declared_type: file.content_type,
-                         name: file.original_filename)
+    @mime_type ||= Marcel::MimeType.for(file,
+                                        declared_type: file.content_type,
+                                        name: file.original_filename)
   end
 end

--- a/app/services/requirements/file_attachment_checker.rb
+++ b/app/services/requirements/file_attachment_checker.rb
@@ -68,7 +68,9 @@ module Requirements
     end
 
     def content_type
-      @content_type ||= Marcel::MimeType.for(file, declared_type: file.content_type, name: file.original_filename)
+      @content_type ||= Marcel::MimeType.for(file,
+                                             declared_type: file.content_type,
+                                             name: file.original_filename)
     end
 
     def title_issues

--- a/app/services/requirements/file_attachment_checker.rb
+++ b/app/services/requirements/file_attachment_checker.rb
@@ -44,6 +44,7 @@ module Requirements
     def pre_update_issues
       issues = []
       issues += title_issues if title_issues.any?
+      issues += file_issues if file.present? && file_issues.any?
 
       CheckerIssues.new(issues)
     end

--- a/app/views/file_attachments/edit.html.erb
+++ b/app/views/file_attachments/edit.html.erb
@@ -16,6 +16,20 @@
         value: params[:title] || @attachment.title,
         hint: t("file_attachments.edit.attachment_title.hint_text"),
       } %>
+      <% file_upload_id = "file-upload-#{SecureRandom.hex(4)}" %>
+      <%= render "govuk_publishing_components/components/label", {
+        text: t("file_attachments.edit.attachment_file.heading"),
+        html_for: file_upload_id,
+        bold: true,
+      } %>
+      <%= render_govspeak(t("file_attachments.edit.attachment_file.description_govspeak")) %>
+      <%= render "govuk_publishing_components/components/inset_text", {
+        text: t("file_attachments.edit.attachment_file.filename_change_callout"),
+      } %>
+      <%= render "govuk_publishing_components/components/file_upload", {
+        name: "file_attachment[file]",
+        id: file_upload_id,
+      } %>
       <%= render "govuk_publishing_components/components/button", {
         text: "Save",
       } %>

--- a/app/views/file_attachments/edit.html.erb
+++ b/app/views/file_attachments/edit.html.erb
@@ -6,6 +6,7 @@
     <%= form_tag(
       update_file_attachment_path(@edition.document, @attachment.file_attachment_id),
       method: :patch,
+      multipart: true,
     ) do %>
       <%= render "govuk_publishing_components/components/input", {
         label: {

--- a/app/views/file_attachments/edit.html.erb
+++ b/app/views/file_attachments/edit.html.erb
@@ -25,7 +25,10 @@
       } %>
       <%= render_govspeak(t("file_attachments.edit.attachment_file.description_govspeak")) %>
       <%= render "govuk_publishing_components/components/inset_text", {
-        text: t("file_attachments.edit.attachment_file.filename_change_callout"),
+        text: render_govspeak(
+          t("file_attachments.edit.attachment_file.filename_change_callout_govspeak",
+            filename: @attachment.filename)
+        ),
       } %>
       <%= render "govuk_publishing_components/components/file_upload", {
         name: "file_attachment[file]",

--- a/config/locales/en/file_attachments/edit.yml
+++ b/config/locales/en/file_attachments/edit.yml
@@ -12,4 +12,7 @@ en:
 
           Files must be uploaded in an [open standards file format](https://www.gov.uk/guidance/content-design/planning-content#open-formats){:target="_blank"}.
           For example, .odt not .docx.
-        filename_change_callout: If your new file has a different file name or file type to the original you will need to update the attachment markdown in your content.
+        filename_change_callout_govspeak: |
+          If your new file has a different file name or file type to the original you will need to update the attachment markdown in your content.
+
+          Existing file: %{filename}

--- a/config/locales/en/file_attachments/edit.yml
+++ b/config/locales/en/file_attachments/edit.yml
@@ -16,3 +16,5 @@ en:
           If your new file has a different file name or file type to the original you will need to update the attachment markdown in your content.
 
           Existing file: %{filename}
+      flashes:
+        update_confirmation: Attachment has been updated. If your new file has a different file name or file type to the original then you now need to replace the attachment markdown in your content.

--- a/config/locales/en/file_attachments/edit.yml
+++ b/config/locales/en/file_attachments/edit.yml
@@ -5,3 +5,11 @@ en:
       attachment_title:
         heading: Edit title
         hint_text: Use the official title of the document
+      attachment_file:
+        heading: Replace file
+        description_govspeak: |
+          All files must be [accessible](https://www.gov.uk/guidance/how-to-publish-on-gov-uk/accessible-pdfs){:target="_blank"}.
+
+          Files must be uploaded in an [open standards file format](https://www.gov.uk/guidance/content-design/planning-content#open-formats){:target="_blank"}.
+          For example, .odt not .docx.
+        filename_change_callout: If your new file has a different file name or file type to the original you will need to update the attachment markdown in your content.

--- a/spec/features/editing_file_attachments/replace_file_attachment_file_spec.rb
+++ b/spec/features/editing_file_attachments/replace_file_attachment_file_spec.rb
@@ -1,24 +1,52 @@
 # frozen_string_literal: true
 
 RSpec.feature "Replace a file attachment file" do
-  scenario do
-    given_there_is_an_edition_with_an_attachment
+  scenario "draft file" do
+    given_there_is_an_edition_with_a_draft_attachment
     when_i_click_to_insert_an_attachment
     and_i_click_on_edit_file
-    and_i_upload_a_new_attachment_file_with_the_same_filename_and_click_save
+    and_i_upload_a_replacement_attachment_file
+    and_i_click_save
+    then_i_see_the_replacement_file_on_the_attachment_index_page
+    and_the_preview_creation_succeeded
   end
 
-  def given_there_is_an_edition_with_an_attachment
-    body_field = build(:field, id: "body", type: "govspeak")
-    document_type = build(:document_type, contents: [body_field])
-    @attachment_filename = "replacement-text-file.txt"
+  scenario "live file" do
+    given_there_is_a_draft_edition_with_a_live_attachment
+    when_i_click_to_insert_an_attachment
+    and_i_click_on_edit_file
+    and_i_upload_a_replacement_attachment_file
+    and_i_click_save
+    and_i_publish_the_document
+    then_the_old_attachment_file_has_been_redirected
+  end
+
+  def given_there_is_an_edition_with_a_draft_attachment
     @attachment_revision = create(:file_attachment_revision,
                                   :on_asset_manager,
-                                  title: "A title",
-                                  filename: @attachment_filename)
+                                  filename: attachment_filename)
     @edition = create(:edition,
                       document_type_id: document_type.id,
                       file_attachment_revisions: [@attachment_revision])
+  end
+
+  def given_there_is_a_draft_edition_with_a_live_attachment
+    @attachment_revision = create(:file_attachment_revision,
+                                  :on_asset_manager,
+                                  state: "live",
+                                  filename: attachment_filename)
+    body_content = { body: "Body content" }
+    @live_edition = create(:edition,
+                           :published,
+                           document_type_id: document_type.id,
+                           file_attachment_revisions: [@attachment_revision],
+                           current: false,
+                           contents: body_content)
+    @edition = create(:edition,
+                      :publishable,
+                      file_attachment_revisions: [@attachment_revision],
+                      document: @live_edition.document,
+                      contents: body_content)
   end
 
   def when_i_click_to_insert_an_attachment
@@ -32,8 +60,68 @@ RSpec.feature "Replace a file attachment file" do
     click_on "Edit file"
   end
 
-  def and_i_upload_a_new_attachment_file_with_the_same_filename_and_click_save
-    find('form input[type="file"]').set(Rails.root.join(file_fixture(@attachment_filename)))
+  def and_i_upload_a_replacement_attachment_file
+    @put_content_request = stub_publishing_api_put_content(@edition.content_id, {})
+    @delete_current_file_request = stub_asset_manager_delete_asset(existing_asset.asset_manager_id)
+    @create_new_file_request = stub_asset_manager_receives_an_asset(filename: attachment_filename)
+
+    find('form input[type="file"]').set(Rails.root.join(file_fixture(attachment_filename)))
+  end
+
+  def and_i_click_save
     click_on "Save"
+  end
+
+  def then_i_see_the_replacement_file_on_the_attachment_index_page
+    expect(page).to have_content("58 Bytes")
+    expect(page).not_to have_content("0 Bytes")
+  end
+
+  def and_the_preview_creation_succeeded
+    expect(@put_content_request).to have_been_requested
+    expect(@delete_current_file_request).to have_been_requested
+    expect(@create_new_file_request).to have_been_requested
+
+    visit document_path(@edition.document)
+    within first(".app-timeline-entry") do
+      expect(page).to have_content I18n.t!(
+        "documents.history.entry_types.file_attachment_updated",
+      )
+    end
+  end
+
+  def and_i_publish_the_document
+    stub_any_publishing_api_publish
+    new_file_attachment_asset = @edition.reload.revision.assets.first
+    @update_new_file_request = stub_asset_manager_update_asset(
+      new_file_attachment_asset.asset_manager_id,
+    )
+    @redirect_old_file_request = stub_asset_manager_update_asset(
+      existing_asset.asset_manager_id,
+      redirect_url: new_file_attachment_asset.file_url,
+    )
+
+    visit document_path(@edition.document)
+    click_on "Publish"
+    choose I18n.t!("publish.confirmation.has_been_reviewed")
+    click_on "Confirm publish"
+  end
+
+  def then_the_old_attachment_file_has_been_redirected
+    expect(@update_new_file_request).to have_been_requested
+    expect(@redirect_old_file_request).to have_been_requested
+  end
+
+  def document_type
+    body_field = build(:field, id: "body", type: "govspeak")
+    build(:document_type, contents: [body_field])
+  end
+
+  def existing_asset
+    @attachment_revision.assets.first
+  end
+
+  def attachment_filename
+    "replacement-text-file.txt"
   end
 end

--- a/spec/features/editing_file_attachments/replace_file_attachment_file_spec.rb
+++ b/spec/features/editing_file_attachments/replace_file_attachment_file_spec.rb
@@ -1,8 +1,8 @@
 # frozen_string_literal: true
 
 RSpec.feature "Replace a file attachment file" do
-  scenario "draft file" do
-    given_there_is_an_edition_with_a_draft_attachment
+  scenario do
+    given_there_is_an_edition_with_an_attachment
     when_i_click_to_insert_an_attachment
     and_i_click_on_edit_file
     and_i_upload_a_replacement_attachment_file
@@ -11,42 +11,16 @@ RSpec.feature "Replace a file attachment file" do
     and_the_preview_creation_succeeded
   end
 
-  scenario "live file" do
-    given_there_is_a_draft_edition_with_a_live_attachment
-    when_i_click_to_insert_an_attachment
-    and_i_click_on_edit_file
-    and_i_upload_a_replacement_attachment_file
-    and_i_click_save
-    and_i_publish_the_document
-    then_the_old_attachment_file_has_been_redirected
-  end
-
-  def given_there_is_an_edition_with_a_draft_attachment
+  def given_there_is_an_edition_with_an_attachment
     @attachment_revision = create(:file_attachment_revision,
                                   :on_asset_manager,
                                   filename: attachment_filename)
+
+    body_field = build(:field, id: "body", type: "govspeak")
+    document_type = build(:document_type, contents: [body_field])
     @edition = create(:edition,
                       document_type_id: document_type.id,
                       file_attachment_revisions: [@attachment_revision])
-  end
-
-  def given_there_is_a_draft_edition_with_a_live_attachment
-    @attachment_revision = create(:file_attachment_revision,
-                                  :on_asset_manager,
-                                  state: "live",
-                                  filename: attachment_filename)
-    body_content = { body: "Body content" }
-    @live_edition = create(:edition,
-                           :published,
-                           document_type_id: document_type.id,
-                           file_attachment_revisions: [@attachment_revision],
-                           current: false,
-                           contents: body_content)
-    @edition = create(:edition,
-                      :publishable,
-                      file_attachment_revisions: [@attachment_revision],
-                      document: @live_edition.document,
-                      contents: body_content)
   end
 
   def when_i_click_to_insert_an_attachment
@@ -62,6 +36,7 @@ RSpec.feature "Replace a file attachment file" do
 
   def and_i_upload_a_replacement_attachment_file
     @put_content_request = stub_publishing_api_put_content(@edition.content_id, {})
+    existing_asset = @attachment_revision.assets.first
     @delete_current_file_request = stub_asset_manager_delete_asset(existing_asset.asset_manager_id)
     @create_new_file_request = stub_asset_manager_receives_an_asset(filename: attachment_filename)
 
@@ -88,37 +63,6 @@ RSpec.feature "Replace a file attachment file" do
         "documents.history.entry_types.file_attachment_updated",
       )
     end
-  end
-
-  def and_i_publish_the_document
-    stub_any_publishing_api_publish
-    new_file_attachment_asset = @edition.reload.revision.assets.first
-    @update_new_file_request = stub_asset_manager_update_asset(
-      new_file_attachment_asset.asset_manager_id,
-    )
-    @redirect_old_file_request = stub_asset_manager_update_asset(
-      existing_asset.asset_manager_id,
-      redirect_url: new_file_attachment_asset.file_url,
-    )
-
-    visit document_path(@edition.document)
-    click_on "Publish"
-    choose I18n.t!("publish.confirmation.has_been_reviewed")
-    click_on "Confirm publish"
-  end
-
-  def then_the_old_attachment_file_has_been_redirected
-    expect(@update_new_file_request).to have_been_requested
-    expect(@redirect_old_file_request).to have_been_requested
-  end
-
-  def document_type
-    body_field = build(:field, id: "body", type: "govspeak")
-    build(:document_type, contents: [body_field])
-  end
-
-  def existing_asset
-    @attachment_revision.assets.first
   end
 
   def attachment_filename

--- a/spec/features/editing_file_attachments/replace_file_attachment_file_spec.rb
+++ b/spec/features/editing_file_attachments/replace_file_attachment_file_spec.rb
@@ -1,0 +1,39 @@
+# frozen_string_literal: true
+
+RSpec.feature "Replace a file attachment file" do
+  scenario do
+    given_there_is_an_edition_with_an_attachment
+    when_i_click_to_insert_an_attachment
+    and_i_click_on_edit_file
+    and_i_upload_a_new_attachment_file_with_the_same_filename_and_click_save
+  end
+
+  def given_there_is_an_edition_with_an_attachment
+    body_field = build(:field, id: "body", type: "govspeak")
+    document_type = build(:document_type, contents: [body_field])
+    @attachment_filename = "replacement-text-file.txt"
+    @attachment_revision = create(:file_attachment_revision,
+                                  :on_asset_manager,
+                                  title: "A title",
+                                  filename: @attachment_filename)
+    @edition = create(:edition,
+                      document_type_id: document_type.id,
+                      file_attachment_revisions: [@attachment_revision])
+  end
+
+  def when_i_click_to_insert_an_attachment
+    visit edit_document_path(@edition.document)
+    find("markdown-toolbar details").click
+    click_on "Attachment"
+    expect(page).to have_content("0 Bytes")
+  end
+
+  def and_i_click_on_edit_file
+    click_on "Edit file"
+  end
+
+  def and_i_upload_a_new_attachment_file_with_the_same_filename_and_click_save
+    find('form input[type="file"]').set(Rails.root.join(file_fixture(@attachment_filename)))
+    click_on "Save"
+  end
+end

--- a/spec/fixtures/files/replacement-text-file.txt
+++ b/spec/fixtures/files/replacement-text-file.txt
@@ -1,0 +1,1 @@
+This is to be used as a replacement file attachment file.

--- a/spec/services/file_attachment_blob_service_spec.rb
+++ b/spec/services/file_attachment_blob_service_spec.rb
@@ -1,0 +1,19 @@
+# frozen_string_literal: true
+
+RSpec.describe FileAttachmentBlobService do
+  let(:file) { fixture_file_upload("files/text-file.txt") }
+
+  describe "#blob_id" do
+    it "returns the id for the newly created blob" do
+      service = FileAttachmentBlobService.new(file: file)
+      expect(service.blob_id).to be(ActiveStorage::Blob.last.id)
+    end
+  end
+
+  describe "#blob_filename" do
+    it "returns the file's filename" do
+      service = FileAttachmentBlobService.new(file: file)
+      expect(service.blob_filename).to eq(file.original_filename)
+    end
+  end
+end

--- a/spec/services/file_attachment_blob_service_spec.rb
+++ b/spec/services/file_attachment_blob_service_spec.rb
@@ -2,18 +2,50 @@
 
 RSpec.describe FileAttachmentBlobService do
   let(:file) { fixture_file_upload("files/text-file.txt") }
+  let(:revision) do
+    build(:revision, file_attachment_revisions: [file_attachment_revision])
+  end
+  let(:file_attachment_revision) do
+    build(:file_attachment_revision, filename: "text-file.txt")
+  end
 
   describe "#blob_id" do
     it "returns the id for the newly created blob" do
-      service = FileAttachmentBlobService.new(file: file)
+      service = FileAttachmentBlobService.new(file: file, revision: revision)
       expect(service.blob_id).to be(ActiveStorage::Blob.last.id)
     end
   end
 
-  describe "#blob_filename" do
-    it "returns the file's filename" do
-      service = FileAttachmentBlobService.new(file: file)
-      expect(service.blob_filename).to eq(file.original_filename)
+  describe "#filename" do
+    context "the file is a replacement for an existing file attachment file" do
+      it "returns the file's filename" do
+        service = FileAttachmentBlobService.new(
+          file: file,
+          revision: revision,
+          replacement: file_attachment_revision,
+        )
+        expect(service.filename).to eq(file.original_filename)
+      end
+    end
+
+    context "the file is not a replacement for an existing file attachment file" do
+      it "returns a unique filename if the file has existing file attachments" do
+        service = FileAttachmentBlobService.new(file: file, revision: revision)
+        expect(service.filename).to eq("text-file-1.txt")
+      end
+    end
+  end
+
+  describe "#number_of_pages" do
+    it "returns the number of pages for a PDF" do
+      pdf = fixture_file_upload("files/13kb-1-page-attachment.pdf", "application/pdf")
+      service = FileAttachmentBlobService.new(file: pdf, revision: revision)
+      expect(service.number_of_pages).to eq(1)
+    end
+
+    it "returns nil if the file is not a PDF" do
+      service = FileAttachmentBlobService.new(file: file, revision: revision)
+      expect(service.number_of_pages).to be nil
     end
   end
 end


### PR DESCRIPTION
For https://trello.com/c/WvCPILCl/817-provide-means-to-edit-replace-an-attachment

This allows users to replace an existing file attachment's file with a new one.  If a file attachment is live then the original file will be redirected to the new file.  When upload a replacement file it is validated against the existing requirements for a file upload.  A separate PR will look at making additional checks as per the comments in the Trello card.

**Current file attachment**
<img width="692" alt="Screen Shot 2019-05-15 at 14 44 45" src="https://user-images.githubusercontent.com/13434452/57780768-d522d780-7720-11e9-977e-798fc83fe46e.png">
 
**Upload a new file**
<img width="706" alt="Screen Shot 2019-05-16 at 17 28 29" src="https://user-images.githubusercontent.com/13434452/58081913-d1260800-7bad-11e9-969c-ced7344dd6f8.png">

**Replacement file**
<img width="677" alt="Screen Shot 2019-05-15 at 14 43 45" src="https://user-images.githubusercontent.com/13434452/57780821-ee2b8880-7720-11e9-9218-32f4b4e28041.png">

**Update confirmation**
<img width="1011" alt="Screen Shot 2019-05-21 at 08 52 49" src="https://user-images.githubusercontent.com/13434452/58081750-7f7d7d80-7bad-11e9-8174-f2387f80c9f9.png">
