### PR TITLE
Attachment alt email

### DIFF
--- a/app/helpers/file_attachment_helper.rb
+++ b/app/helpers/file_attachment_helper.rb
@@ -1,27 +1,13 @@
 # frozen_string_literal: true
 
 module FileAttachmentHelper
-  def file_attachment_in_app_attributes(attachment_revision, document)
-    file_attachment_attributes(attachment_revision).merge(
-      url: preview_file_attachment_path(document, attachment_revision.file_attachment),
-    )
-  end
-
-  def file_attachment_payload_attributes(attachment_revision)
-    file_attachment_attributes(attachment_revision).merge(
-      url: attachment_revision.asset_url("file"),
-    )
-  end
-
   def file_attachment_preview_url(attachment_revision, document)
     service = PreviewAuthBypassService.new(document)
     params = { token: service.preview_token }.to_query
     attachment_revision.asset_url("file") + "?" + params
   end
 
-private
-
-  def file_attachment_attributes(attachment_revision)
+  def file_attachment_attributes(attachment_revision, document)
     {
       id: attachment_revision.filename,
       title: attachment_revision.title,
@@ -29,6 +15,7 @@ private
       content_type: attachment_revision.content_type,
       file_size: attachment_revision.byte_size,
       number_of_pages: attachment_revision.number_of_pages,
+      url: preview_file_attachment_path(document, attachment_revision.file_attachment),
     }
   end
 end

--- a/app/models/edition.rb
+++ b/app/models/edition.rb
@@ -68,6 +68,7 @@ class Edition < ApplicationRecord
            :scheduled_publishing_datetime,
            :file_attachment_revisions,
            :assets,
+           :primary_publishing_organisation_id,
            to: :revision
 
   MINIMUM_SCHEDULING_TIME = { minutes: 15 }.freeze

--- a/app/models/revision.rb
+++ b/app/models/revision.rb
@@ -56,7 +56,9 @@ class Revision < ApplicationRecord
            :scheduled_publishing_datetime,
            to: :metadata_revision
 
-  delegate :tags, to: :tags_revision
+  delegate :tags,
+           :primary_publishing_organisation_id,
+           to: :tags_revision
 
   def self.create_initial(document, user = nil, tags = {})
     Revision.create!(

--- a/app/models/tags_revision.rb
+++ b/app/models/tags_revision.rb
@@ -10,4 +10,8 @@ class TagsRevision < ApplicationRecord
   def readonly?
     !new_record?
   end
+
+  def primary_publishing_organisation_id
+    tags["primary_publishing_organisation"].to_a.first
+  end
 end

--- a/app/services/govspeak_document/in_app_options.rb
+++ b/app/services/govspeak_document/in_app_options.rb
@@ -14,13 +14,15 @@ class GovspeakDocument::InAppOptions < GovspeakDocument::Options
 private
 
   def in_app_images
-    edition.revision.image_revisions.map { |image_revision| image_attributes(image_revision) }
+    edition.revision.image_revisions.map(&method(:image_attributes))
   end
 
   def in_app_attachments
-    edition.file_attachment_revisions.map do |attachment_revision|
-      file_attachment_in_app_attributes(attachment_revision, edition.document)
-    end
+    edition.file_attachment_revisions.map(&method(:attachment_attributes))
+  end
+
+  def attachment_attributes(attachment_revision)
+    file_attachment_attributes(attachment_revision, edition.document)
   end
 
   def image_attributes(image_revision)

--- a/app/services/govspeak_document/in_app_options.rb
+++ b/app/services/govspeak_document/in_app_options.rb
@@ -22,7 +22,9 @@ private
   end
 
   def attachment_attributes(attachment_revision)
-    file_attachment_attributes(attachment_revision, edition.document)
+    alt_email = OrganisationService.new(edition).alternative_format_contact_email
+    attributes = file_attachment_attributes(attachment_revision, edition.document)
+    attributes.merge(alternative_format_contact_email: alt_email)
   end
 
   def image_attributes(image_revision)

--- a/app/services/govspeak_document/payload_options.rb
+++ b/app/services/govspeak_document/payload_options.rb
@@ -2,6 +2,7 @@
 
 
 class GovspeakDocument::PayloadOptions < GovspeakDocument::Options
+  include Rails.application.routes.url_helpers
   include FileAttachmentHelper
 
   attr_reader :text, :edition
@@ -16,11 +17,11 @@ class GovspeakDocument::PayloadOptions < GovspeakDocument::Options
 private
 
   def payload_images
-    edition.revision.image_revisions.map { |image_revision| image_attributes(image_revision) }
+    edition.revision.image_revisions.map(&method(:image_attributes))
   end
 
   def payload_attachments
-    edition.file_attachment_revisions.map { |far| file_attachment_payload_attributes(far) }
+    edition.file_attachment_revisions.map(&method(:attachment_attributes))
   end
 
   def image_attributes(image_revision)
@@ -31,5 +32,11 @@ private
       credit: image_revision.credit,
       id: image_revision.filename,
     }
+  end
+
+  def attachment_attributes(attachment_revision)
+    file_attachment_attributes(attachment_revision, edition.document).merge(
+      url: attachment_revision.asset_url("file"),
+    )
   end
 end

--- a/app/services/govspeak_document/payload_options.rb
+++ b/app/services/govspeak_document/payload_options.rb
@@ -1,6 +1,5 @@
 # frozen_string_literal: true
 
-
 class GovspeakDocument::PayloadOptions < GovspeakDocument::Options
   include Rails.application.routes.url_helpers
   include FileAttachmentHelper
@@ -35,8 +34,12 @@ private
   end
 
   def attachment_attributes(attachment_revision)
-    file_attachment_attributes(attachment_revision, edition.document).merge(
+    alt_email = OrganisationService.new(edition).alternative_format_contact_email
+    attributes = file_attachment_attributes(attachment_revision, edition.document)
+
+    attributes.merge(
       url: attachment_revision.asset_url("file"),
+      alternative_format_contact_email: alt_email,
     )
   end
 end

--- a/app/services/organisation_service.rb
+++ b/app/services/organisation_service.rb
@@ -1,0 +1,33 @@
+# frozen_string_literal: true
+
+class OrganisationService
+  DEFAULT_ALTERNATIVE_FORMAT_CONTACT_EMAIL = "govuk-feedback@digital.cabinet-office.gov.uk"
+  CACHE_OPTIONS = { expires_in: 15.minutes, race_condition_ttl: 30.seconds }.freeze
+
+  attr_reader :edition
+
+  def self.by_content_id(content_id)
+    Rails.cache.fetch("organisations.#{content_id}", CACHE_OPTIONS) do
+      GdsApi.publishing_api_v2.get_content(content_id).to_h
+    end
+  end
+
+  def initialize(edition)
+    @edition = edition
+  end
+
+  def alternative_format_contact_email
+    return DEFAULT_ALTERNATIVE_FORMAT_CONTACT_EMAIL unless primary_org_content_id
+
+    primary_org = self.class.by_content_id(primary_org_content_id)
+    email = primary_org.dig("details", "alternative_format_contact_email")
+    email.presence || DEFAULT_ALTERNATIVE_FORMAT_CONTACT_EMAIL
+  end
+
+private
+
+
+  def primary_org_content_id
+    edition.primary_publishing_organisation_id
+  end
+end

--- a/app/views/file_attachments/_file_attachment.html.erb
+++ b/app/views/file_attachments/_file_attachment.html.erb
@@ -30,6 +30,6 @@
 <% end %>
 
 <%= render "components/attachment_meta", {
-  attachment: file_attachment_in_app_attributes(attachment, document),
+  attachment: file_attachment_attributes(attachment, document),
   actions: actions,
 } %>

--- a/app/views/file_attachments/show.html.erb
+++ b/app/views/file_attachments/show.html.erb
@@ -4,7 +4,7 @@
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
     <%= render "govuk_publishing_components/components/attachment", {
-      attachment: file_attachment_in_app_attributes(@attachment, @edition.document),
+      attachment: file_attachment_attributes(@attachment, @edition.document),
       target: "_blank",
     } %>
 
@@ -24,7 +24,7 @@
 
     <div class="govuk-body">
       <%= render "govuk_publishing_components/components/attachment_link", {
-        attachment: file_attachment_in_app_attributes(@attachment, @edition.document),
+        attachment: file_attachment_attributes(@attachment, @edition.document),
         target: "_blank"
       } %>
     </div>

--- a/spec/services/govspeak_document/in_app_options_spec.rb
+++ b/spec/services/govspeak_document/in_app_options_spec.rb
@@ -3,6 +3,12 @@
 RSpec.describe GovspeakDocument::InAppOptions do
   include Rails.application.routes.url_helpers
 
+  let(:organisation_service) { instance_double(OrganisationService) }
+
+  before do
+    allow(OrganisationService).to receive(:new) { organisation_service }
+  end
+
   describe "#to_h" do
     it "returns a hash of image attributes" do
       image_revision = build(:image_revision,
@@ -35,6 +41,9 @@ RSpec.describe GovspeakDocument::InAppOptions do
       edition = build(:edition,
                       file_attachment_revisions: [attachment_revision])
 
+      allow(organisation_service)
+        .to receive(:alternative_format_contact_email) { "foo@bar.com" }
+
       in_app_options = GovspeakDocument::InAppOptions.new("govspeak", edition)
       actual_attachment_options = in_app_options.to_h[:attachments].first
 
@@ -47,6 +56,7 @@ RSpec.describe GovspeakDocument::InAppOptions do
           number_of_pages: 1,
           file_size: 13264,
           url: preview_file_attachment_path(edition.document, attachment_revision.file_attachment),
+          alternative_format_contact_email: "foo@bar.com",
         ),
       )
     end

--- a/spec/services/govspeak_document/payload_options_spec.rb
+++ b/spec/services/govspeak_document/payload_options_spec.rb
@@ -1,6 +1,12 @@
 # frozen_string_literal: true
 
 RSpec.describe GovspeakDocument::PayloadOptions do
+  let(:organisation_service) { instance_double(OrganisationService) }
+
+  before do
+    allow(OrganisationService).to receive(:new) { organisation_service }
+  end
+
   describe "#to_h" do
     it "returns a hash of image attributes" do
       image_revision = build(:image_revision,
@@ -35,6 +41,9 @@ RSpec.describe GovspeakDocument::PayloadOptions do
       edition = create(:edition,
                        file_attachment_revisions: [file_attachment_revision])
 
+      allow(organisation_service)
+        .to receive(:alternative_format_contact_email) { "foo@bar.com" }
+
       payload_options = GovspeakDocument::PayloadOptions.new("govspeak", edition)
       actual_attachment_options = payload_options.to_h[:attachments].first
 
@@ -47,6 +56,7 @@ RSpec.describe GovspeakDocument::PayloadOptions do
           number_of_pages: 1,
           file_size: 13264,
           url: a_string_matching(%r{/media/.*/13kb-1-page-attachment.pdf}),
+          alternative_format_contact_email: "foo@bar.com",
         ),
       )
     end

--- a/spec/services/govspeak_document/payload_options_spec.rb
+++ b/spec/services/govspeak_document/payload_options_spec.rb
@@ -32,8 +32,8 @@ RSpec.describe GovspeakDocument::PayloadOptions do
                                        filename: "13kb-1-page-attachment.pdf",
                                        title: "A title",
                                        number_of_pages: 1)
-      edition = build(:edition,
-                      file_attachment_revisions: [file_attachment_revision])
+      edition = create(:edition,
+                       file_attachment_revisions: [file_attachment_revision])
 
       payload_options = GovspeakDocument::PayloadOptions.new("govspeak", edition)
       actual_attachment_options = payload_options.to_h[:attachments].first

--- a/spec/services/organisation_service_spec.rb
+++ b/spec/services/organisation_service_spec.rb
@@ -1,0 +1,54 @@
+# frozen_string_literal: true
+
+RSpec.describe OrganisationService do
+  describe "#alternative_format_contact_email" do
+    context "when the edition has a primary org" do
+      let(:org_content_id) { SecureRandom.uuid }
+
+      let(:edition) do
+        build :edition, tags: { primary_publishing_organisation: [org_content_id] }
+      end
+
+      context "when the primary org has an alt email" do
+        before do
+          stub_publishing_api_has_item(
+            content_id: org_content_id,
+            details: {
+              alternative_format_contact_email: "foo@bar.com",
+            },
+          )
+        end
+
+        it "returns the specified email" do
+          email = OrganisationService.new(edition).alternative_format_contact_email
+          expect(email).to eq "foo@bar.com"
+        end
+      end
+
+      context "when the primary org has no alt email" do
+        before do
+          stub_publishing_api_has_item(
+            content_id: org_content_id,
+            details: {
+              alternative_format_contact_email: "",
+            },
+          )
+        end
+
+        it "returns the default alt email" do
+          email = OrganisationService.new(edition).alternative_format_contact_email
+          expect(email).to eq OrganisationService::DEFAULT_ALTERNATIVE_FORMAT_CONTACT_EMAIL
+        end
+      end
+    end
+
+    context "when the edition has no primary org" do
+      let(:edition) { build :edition }
+
+      it "returns the default alt email" do
+        email = OrganisationService.new(edition).alternative_format_contact_email
+        expect(email).to eq OrganisationService::DEFAULT_ALTERNATIVE_FORMAT_CONTACT_EMAIL
+      end
+    end
+  end
+end


### PR DESCRIPTION
https://trello.com/c/OcuVomSb/820-show-the-alternative-format-email-address-for-an-attachment

This makes use of the [upcoming component change](https://github.com/alphagov/govuk_publishing_components/pull/858) to render alternative format contact emails for attachments. More detail in the commits...