### PR TITLE
Don't timeout for modal forms that upload files

### DIFF
--- a/app/assets/javascripts/modal/modal-fetch.js
+++ b/app/assets/javascripts/modal/modal-fetch.js
@@ -5,7 +5,7 @@ window.ModalFetch.getLink = function (item) {
   var headers = { 'Content-Publisher-Rendering-Context': 'modal' }
   var options = { credentials: 'include', signal: controller.signal, headers: headers }
   var href = item.dataset.modalActionUrl || item.href
-  setTimeout(function () { controller.abort() }, 5000)
+  setTimeout(function () { controller.abort() }, 15000)
 
   return window.fetch(href, options)
     .then(function (response) {
@@ -23,7 +23,10 @@ window.ModalFetch.getLink = function (item) {
 
 window.ModalFetch.postForm = function (form) {
   var controller = new window.AbortController()
-  setTimeout(function () { controller.abort() }, 10000)
+
+  if (!window.ModalFetch._isFileUpload(form)) {
+    setTimeout(function () { controller.abort() }, 15000)
+  }
 
   var options = {
     credentials: 'include',
@@ -46,6 +49,10 @@ window.ModalFetch.postForm = function (form) {
           return { body: text, unprocessableEntity: response.status === 422 }
         })
     })
+}
+
+window.ModalFetch._isFileUpload = function (form) {
+  return form.getAttribute('enctype') === 'multipart/form-data'
 }
 
 window.ModalFetch.debug = function (response) {


### PR DESCRIPTION
Trello: https://trello.com/c/gPfQ2lBT/819-interface-with-a-documents-attachments-via-a-modal

I had a quick go at seeing if there was a simple way I could stop the risk of timeouts when uploading files since we can't reasonably guess whether the time spent is waiting on the client side or server side.

This was the least invasive/complex way I could think of. May be too simple, comments/suggestions welcome.