### PR TITLE
Allow all orgs to access content-data link

### DIFF
--- a/app/services/content_data_url.rb
+++ b/app/services/content_data_url.rb
@@ -1,11 +1,6 @@
 # frozen_string_literal: true
 
 class ContentDataUrl
-  # department-for-work-pensions, department-of-health-and-social-care, government-digital-service
-  CONTENT_DATA_BETA_PARTNERS = %w(b548a09f-8b35-4104-89f4-f1a40bf3136d
-                                  7cd6bf12-bbe9-4118-8523-f927b0442156
-                                  af07d5a5-df63-4ddc-9383-6a666845ebe9).freeze
-
   attr_reader :document
 
   def initialize(document)
@@ -17,15 +12,11 @@ class ContentDataUrl
     content_data_root + "/metrics" + document.live_edition.base_path
   end
 
-  def displayable?(user)
-    has_content_data_access?(user) && expected_in_content_data?
+  def displayable?
+    expected_in_content_data?
   end
 
 private
-
-  def has_content_data_access?(user)
-    CONTENT_DATA_BETA_PARTNERS.include?(user.organisation_content_id)
-  end
 
   def expected_in_content_data?
     # Content Data ETL runs around 7am each day and pulls in data from the

--- a/app/views/documents/show/_actions.html.erb
+++ b/app/views/documents/show/_actions.html.erb
@@ -89,7 +89,7 @@
           <%= link_to "View on GOV.UK", edition_public_url(@edition.document.live_edition), class: "govuk-link govuk-link--no-visited-state" %>
         </li>
         <% content_data_url = ContentDataUrl.new(@edition.document) %>
-        <% if content_data_url.displayable?(current_user) %>
+        <% if content_data_url.displayable? %>
           <li>
             <%= link_to "View data about this page",
                         content_data_url.url,

--- a/app/views/publisher_information/how_to_use_publisher.govspeak.md
+++ b/app/views/publisher_information/how_to_use_publisher.govspeak.md
@@ -1,9 +1,21 @@
-Content Publisher is a new way of publishing content on GOV.UK. It is designed to make it 
-easier to publish useful content and to help you use data to manage that content.
+Content Publisher is a new way of publishing content on GOV.UK. It is designed to make it easier to publish useful content and to help you use data to manage that content.
 
-We are now beta testing Content Publisher with government publishers. The beta version will have limited functionality at first. We are adding and improving features. 
+We are beta testing Content Publisher. The beta version has limited functionality. We are adding and improving features. Read more about [what Content Publisher can and cannot do](/beta-capabilities).
 
-Read more about [what Content Publisher can and cannot do](/beta-capabilities).
+##Whitehall users
+
+Content Publisher works differently to Whitehall. If you are familiar with Whitehall there are some differences to be aware of:
+
+- Markdown can be added using a menu to format text
+- Text pasted into the content body will be automatically converted to markdown
+- There is an Insert menu to use to add pictures, contacts, or video embeds
+- Pictures can be any size larger than 960px wide and 640px high
+- Content is tagged to one Primary Organisation and they are responsible for managing that content
+- Pictures to go at the top of content are added in the Lead Image section
+- Previews can be shared to show other people the page
+- You don’t need a second user to publish content if it has already been approved
+
+---
 
 ##How to create content
 
@@ -23,11 +35,11 @@ When you paste text into the body field Content Publisher will try to convert it
 
 This works best when copy and pasting from text editing software like Word. It is less likely to recognise formatting from PDFs.
 
-Content publisher has a toolbar to make it easier to add common markdown. You can use the buttons to add headings, links, or lists. 
+Content publisher has a toolbar to make it easier to add common markdown. You can use the buttons to add headings, links, or lists.
 
 Use the Insert menu to add other media or special content. For example, you can insert images, videos, or contact addresses.
 
-More advanced markdown features can be used by following the guidance and examples in the interface. 
+More advanced markdown features can be used by following the guidance and examples in the interface.
 
 Read full [guidance on markdown](https://www.gov.uk/guidance/how-to-publish-on-gov-uk/markdown).
 
@@ -35,7 +47,7 @@ Read full [guidance on markdown](https://www.gov.uk/guidance/how-to-publish-on-g
 
 ##Lead image
 
-News content has a lead image which appears at the top of the page and is used as the thumbnail image on some links to the content. 
+News content has a lead image which appears at the top of the page and is used as the thumbnail image on some links to the content.
 
 Every page has a default lead image to represent your organisation. You should replace it with a picture that is more relevant to the content.
 
@@ -43,13 +55,13 @@ You can upload any shape or size picture and crop it to the standard shape in Co
 
 You must add alt text for every image, but the caption is optional and the credit may not be required on all images.
 
-You can upload several images but must pick the one you want to be the lead image. 
+You can upload several images but must pick the one you want to be the lead image.
 
 ---
 
 ##Tags
 
-You should add tags that describe things the content is associated with. Tags help users find content on GOV.UK. 
+You should add tags that describe things the content is associated with. Tags help users find content on GOV.UK.
 
 Tags available include the organisations and ministers involved, and the locations the content is relevant to.
 
@@ -87,7 +99,7 @@ Before you publish content you must preview it. This shows you how the content w
 
 ###Fact check or sign off
 
-Some content needs to be checked before it is published to make sure it is accurate. 
+Some content needs to be checked before it is published to make sure it is accurate.
 
 You can share the content preview with others using the link provided so that they can see how it will look on GOV.UK.
 
@@ -105,15 +117,15 @@ You then need to ask someone to do a 2i review. Send them the link to the page i
 
 If they find any mistakes in the content then they can edit it or ask you to edit it.
 
-When it has been reviewed and any improvements made, then either you or they can go ahead and publish it. 
+When it has been reviewed and any improvements made, then either you or they can go ahead and publish it.
 
-Select the ‘Publish’ button, and then confirm that it has been reviewed. 
+Select the ‘Publish’ button, and then confirm that it has been reviewed.
 
 ###2i review before Content publisher
 
-The text may have been thoroughly reviewed before the document is created in Content publisher and the page prepared without any changes. If so it is possible to publish content without needing further review. 
+The text may have been thoroughly reviewed before the document is created in Content publisher and the page prepared without any changes. If so it is possible to publish content without needing further review.
 
-Select the ‘Publish’ button, and then confirm that it has been reviewed. 
+Select the ‘Publish’ button, and then confirm that it has been reviewed.
 
 ###Urgent publishing
 
@@ -133,11 +145,11 @@ If there are no mistakes then they or you can select the ‘Approve’ button to
 
 ##Featured documents
 
-You can feature Content Publisher documents on organisation homepages. 
+You can feature Content Publisher documents on organisation homepages.
 
 They will not appear in the main content search in Whitehall.
 
-You need to use the option to 'Feature non-GOV.UK government link'. It is at the end of the page. This is the same way blog posts are featured. 
+You need to use the option to 'Feature non-GOV.UK government link'. It is at the end of the page. This is the same way blog posts are featured.
 
 We have added document types for Content Publisher documents so that they appear just like Whitehall content.
 

--- a/app/views/publisher_information/publisher_updates.govspeak.md
+++ b/app/views/publisher_information/publisher_updates.govspeak.md
@@ -1,3 +1,21 @@
+
+### Email links, content data, and guidance updates <span class="govuk-caption-m">17 May 2019</span>
+Added a link to [Content Data](https://content-data.publishing.service.gov.uk/content) from the edit screen so you can easily check the performance of published content.
+
+You can now make email links with the link button. Select an email address and the link button will add email markdown.
+
+Updated styling of markdown preview to help you see the difference between editing and preview more easily.
+
+Added [guidance to help users familiar with Whitehall publisher get started](/how-to-use-publisher).
+
+We have also updated the guidance on:
+
+- image captions and credits
+- image cropping
+- organisation tags
+- sending links for 2i review
+- address markdown
+
 ### Body text converted to markdown <span class="govuk-caption-m">17 April 2019</span>
 When you paste text into the body field Content Publisher will try to convert it to markdown. It will recognise headings, links, and lists. Other formatting will be removed and only plain text pasted.
 

--- a/spec/services/content_data_url_spec.rb
+++ b/spec/services/content_data_url_spec.rb
@@ -4,7 +4,6 @@ RSpec.describe ContentDataUrl do
   include ActiveSupport::Testing::TimeHelpers
 
   let(:document) { build(:document, :with_live_edition, first_published_at: 2.days.ago) }
-  let(:beta_partner) { build(:user, organisation_content_id: "af07d5a5-df63-4ddc-9383-6a666845ebe9") }
 
   describe "#url" do
     it "returns a Content Data Admin data page URL for the document" do
@@ -16,20 +15,15 @@ RSpec.describe ContentDataUrl do
   end
 
   describe "#displayable" do
-    it "returns true if the user is part of a Content Data beta partner organisation and edition was published before yesterday" do
-      expect(ContentDataUrl.new(document).displayable?(beta_partner)).to be true
-    end
-
-    it "returns false if the user is not part of a Content Data beta partner organisation" do
-      user = build(:user, organisation_content_id: SecureRandom.uuid)
-      expect(ContentDataUrl.new(document).displayable?(user)).to be false
+    it "returns true if the edition was published before yesterday" do
+      expect(ContentDataUrl.new(document).displayable?).to be true
     end
 
     it "returns false if the document was first published today" do
       document.first_published_at = Time.current
       document.save!
 
-      expect(ContentDataUrl.new(document).displayable?(beta_partner)).to be false
+      expect(ContentDataUrl.new(document).displayable?).to be false
     end
 
     it "returns false if the document was first published yesterday and it is currently before 9am" do
@@ -38,7 +32,7 @@ RSpec.describe ContentDataUrl do
       before_nine_am_today = Time.current.change(hour: 8, min: 59)
 
       travel_to(before_nine_am_today) do
-        expect(ContentDataUrl.new(document).displayable?(beta_partner)).to be false
+        expect(ContentDataUrl.new(document).displayable?).to be false
       end
     end
 
@@ -48,7 +42,7 @@ RSpec.describe ContentDataUrl do
       nine_am_today = Time.current.change(hour: 9)
 
       travel_to(nine_am_today) do
-        expect(ContentDataUrl.new(document).displayable?(beta_partner)).to be true
+        expect(ContentDataUrl.new(document).displayable?).to be true
       end
     end
   end


### PR DESCRIPTION
We should now display a link for every document which points to its content-data page regardless
of a users organisation now content-data is in public beta.

Depends on: (updating 'whats new' section)
https://github.com/alphagov/content-publisher/pull/1037

Trello:
https://trello.com/c/MdKhnoLP/847-link-from-our-app-to-content-data-all-organisations
https://trello.com/c/rX051n9o/837-update-guidance-for-users-expecting-whitehall-publisher
https://trello.com/c/6CurP3Iz/860-change-note-for-recent-fixes