### PR TITLE
Fix image spec not passing on CI

### DIFF
--- a/spec/features/editing_images/edit_image_metadata_requirements_spec.rb
+++ b/spec/features/editing_images/edit_image_metadata_requirements_spec.rb
@@ -45,7 +45,10 @@ RSpec.feature "Edit image metadata with requirements issues", js: true do
 
     click_on "Edit image"
     click_on "Crop image"
+
+    expect(page).to have_selector(".app-c-image-meta")
     fill_in "image_revision[alt_text]", with: ""
+
     click_on "Save"
   end
 


### PR DESCRIPTION
    This adds a selector check to make Capybara wait before trying to edit
    metadata for an inline image, where the page may not have finished
    loading asynchronously.