### PR TITLE
Fix yml for url_preview component

### DIFF
--- a/app/views/components/docs/url_preview.yml
+++ b/app/views/components/docs/url_preview.yml
@@ -3,7 +3,7 @@ description: Generates URL from an input value and validates it with a server en
 body: |
   This component uses an text input field to get the input value, sends the value to
   a server endpoint and returns the appropriate response
-shared_accessibility_criteria: |
+accessibility_criteria: |
   The component must:
 
   * update its content to reflect changes in the referenced input field


### PR DESCRIPTION
This criteria wasn't meant to be a shared one, so the component guide is currently failing to render the preview page as it's expecting for `shared_accessibility_criteria` to be iterable.