### PR TITLE
Use modal for attachments

### DIFF
--- a/app/assets/javascripts/application.js
+++ b/app/assets/javascripts/application.js
@@ -30,6 +30,7 @@
 //= require modules/gtm-checked-inputs-listener.js
 //= require modules/gtm-copy-paste-listener.js
 //= require modules/gtm-selected-topics-listener.js
+//= require modules/inline-attachment-modal.js
 //= require modules/inline-image-modal.js
 //= require modules/video-embed-modal.js
 //= require modules/warn-before-unload.js

--- a/app/assets/javascripts/modules/inline-attachment-modal.js
+++ b/app/assets/javascripts/modules/inline-attachment-modal.js
@@ -42,6 +42,15 @@ InlineAttachmentModal.prototype.performAction = function (item) {
       this.$modal.resize('narrow')
       this.$modal.open()
       this.render(window.ModalFetch.getLink(item))
+    },
+    'upload': function () {
+      this.render(window.ModalFetch.postForm(item))
+    },
+    'insert': function () {
+      this.render(window.ModalFetch.getLink(item))
+    },
+    'back': function () {
+      this.render(window.ModalFetch.getLink(item))
     }
   }
 

--- a/app/assets/javascripts/modules/inline-attachment-modal.js
+++ b/app/assets/javascripts/modules/inline-attachment-modal.js
@@ -49,6 +49,15 @@ InlineAttachmentModal.prototype.performAction = function (item) {
     'insert': function () {
       this.render(window.ModalFetch.getLink(item))
     },
+    'delete': function () {
+      this.render(window.ModalFetch.postForm(item))
+    },
+    'edit': function () {
+      this.render(window.ModalFetch.getLink(item))
+    },
+    'update': function () {
+      this.render(window.ModalFetch.postForm(item))
+    },
     'back': function () {
       this.render(window.ModalFetch.getLink(item))
     }

--- a/app/assets/javascripts/modules/inline-attachment-modal.js
+++ b/app/assets/javascripts/modules/inline-attachment-modal.js
@@ -1,0 +1,54 @@
+function InlineAttachmentModal ($module) {
+  this.$module = $module
+  this.$modal = document.getElementById('modal')
+  this.workflow = new window.ModalWorkflow(this.$modal)
+}
+
+InlineAttachmentModal.prototype.init = function () {
+  if (!this.$module || !this.$modal) {
+    return
+  }
+
+  this.$multiSectionViewer = this.$modal
+    .querySelector('[data-module="multi-section-viewer"]')
+
+  this.$module.addEventListener('click', function (event) {
+    event.preventDefault()
+    this.performAction(this.$module)
+  }.bind(this))
+}
+
+InlineAttachmentModal.prototype.render = function (response) {
+  response
+    .then(this.renderSuccess.bind(this))
+    .catch(this.renderError.bind(this))
+}
+
+InlineAttachmentModal.prototype.renderError = function (result) {
+  window.Raven.captureException(result)
+  console.error(result)
+  this.$multiSectionViewer.showStaticSection('error')
+}
+
+InlineAttachmentModal.prototype.renderSuccess = function (result) {
+  this.$multiSectionViewer.showDynamicSection(result.body)
+  this.workflow.overrideActions(this.performAction.bind(this))
+  this.workflow.initComponents()
+}
+
+InlineAttachmentModal.prototype.performAction = function (item) {
+  var handlers = {
+    'open': function () {
+      this.$modal.resize('narrow')
+      this.$modal.open()
+      this.render(window.ModalFetch.getLink(item))
+    }
+  }
+
+  this.$modal.focusDialog()
+  this.$multiSectionViewer.showStaticSection('loading')
+  handlers[item.dataset.modalAction].bind(this)()
+}
+
+var element = document.querySelector('[data-module="inline-attachment-modal"]')
+new InlineAttachmentModal(element).init()

--- a/app/controllers/file_attachments_controller.rb
+++ b/app/controllers/file_attachments_controller.rb
@@ -5,6 +5,7 @@ class FileAttachmentsController < ApplicationController
 
   def index
     @edition = Edition.find_current(document: params[:document])
+    render layout: rendering_context
   end
 
   def show

--- a/app/controllers/file_attachments_controller.rb
+++ b/app/controllers/file_attachments_controller.rb
@@ -10,9 +10,10 @@ class FileAttachmentsController < ApplicationController
 
   def show
     @edition = Edition.find_current(document: params[:document])
-
     @attachment = @edition.file_attachment_revisions
       .find_by!(file_attachment_id: params[:file_attachment_id])
+
+    render layout: rendering_context
   end
 
   def preview
@@ -44,6 +45,7 @@ class FileAttachmentsController < ApplicationController
       render :index,
              assigns: { edition: edition,
                         issues: issues },
+             layout: rendering_context,
              status: :unprocessable_entity
     else
       redirect_to file_attachment_path(edition.document, attachment_revision.file_attachment)

--- a/app/controllers/file_attachments_controller.rb
+++ b/app/controllers/file_attachments_controller.rb
@@ -65,6 +65,8 @@ class FileAttachmentsController < ApplicationController
     @edition = Edition.find_current(document: params[:document])
     @attachment = @edition.file_attachment_revisions
       .find_by!(file_attachment_id: params[:file_attachment_id])
+
+    render layout: rendering_context
   end
 
   def update
@@ -85,6 +87,7 @@ class FileAttachmentsController < ApplicationController
              assigns: { edition: edition,
                         issues: issues,
                         attachment: attachment_revision },
+             layout: rendering_context,
              status: :unprocessable_entity
     else
       flash[:notice] = I18n.t!("file_attachments.edit.flashes.update_confirmation")

--- a/app/views/components/_markdown_editor.html.erb
+++ b/app/views/components/_markdown_editor.html.erb
@@ -53,6 +53,10 @@
           text: "Attachment",
           href: file_attachments_path(edition.document),
           target: "_blank",
+          data_attributes: {
+            module: "inline-attachment-modal",
+            "modal-action": "open",
+          }
         }
       )
     end

--- a/app/views/file_attachments/_file_attachment.html.erb
+++ b/app/views/file_attachments/_file_attachment.html.erb
@@ -4,6 +4,9 @@
   "Insert attachment",
   file_attachment_path(document, attachment.file_attachment),
   class: "govuk-link govuk-link--no-visited-state app-link--button",
+  data: {
+    "modal-action": "insert",
+  },
 ) %>
 
 <% actions << link_to(

--- a/app/views/file_attachments/_file_attachment.html.erb
+++ b/app/views/file_attachments/_file_attachment.html.erb
@@ -20,6 +20,9 @@
   "Edit file",
   edit_file_attachment_path(document, attachment.file_attachment_id),
   class: "govuk-link govuk-link--no-visited-state app-link--button",
+  data: {
+    "modal-action": "edit",
+  },
 ) %>
 
 <% actions << capture do %>
@@ -27,6 +30,9 @@
     destroy_file_attachment_path(document, attachment.file_attachment_id),
     method: :delete,
     class: "app-inline-block",
+    data: {
+      "modal-action": "delete",
+    },
   ) do %>
     <button class="govuk-link app-link--button app-link--destructive">Delete attachment</button>
   <% end %>

--- a/app/views/file_attachments/edit.html.erb
+++ b/app/views/file_attachments/edit.html.erb
@@ -3,7 +3,7 @@
                                             data_attributes: { "modal-action": "back" }) %>
 
 <div class="govuk-grid-row">
-  <div class="govuk-grid-column-two-thirds">
+  <div class="govuk-grid-column-full">
     <%= form_tag(
       update_file_attachment_path(@edition.document, @attachment.file_attachment_id),
       method: :patch,

--- a/app/views/file_attachments/edit.html.erb
+++ b/app/views/file_attachments/edit.html.erb
@@ -21,12 +21,14 @@
         value: params[:title] || @attachment.title,
         hint: t("file_attachments.edit.attachment_title.hint_text"),
       } %>
+
       <% file_upload_id = "file-upload-#{SecureRandom.hex(4)}" %>
       <%= render "govuk_publishing_components/components/label", {
         text: t("file_attachments.edit.attachment_file.heading"),
         html_for: file_upload_id,
         bold: true,
       } %>
+
       <%= render_govspeak(t("file_attachments.edit.attachment_file.description_govspeak")) %>
       <%= render "govuk_publishing_components/components/inset_text", {
         text: render_govspeak(
@@ -34,11 +36,14 @@
             filename: @attachment.filename)
         ),
       } %>
+
       <%= render "govuk_publishing_components/components/file_upload", {
         name: "file_attachment[file]",
         id: file_upload_id,
       } %>
+
       <%= render "govuk_publishing_components/components/button", {
+        margin_bottom: true,
         text: "Save",
       } %>
     <% end %>

--- a/app/views/file_attachments/edit.html.erb
+++ b/app/views/file_attachments/edit.html.erb
@@ -1,5 +1,6 @@
 <% content_for :title, t("file_attachments.edit.title", title: @edition.title_or_fallback) %>
-<% content_for :back_link, render_back_link(href: file_attachments_path(@edition.document)) %>
+<% content_for :back_link, render_back_link(href: file_attachments_path(@edition.document),
+                                            data_attributes: { "modal-action": "back" }) %>
 
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
@@ -7,6 +8,9 @@
       update_file_attachment_path(@edition.document, @attachment.file_attachment_id),
       method: :patch,
       multipart: true,
+      data: {
+        "modal-action": "update",
+      },
     ) do %>
       <%= render "govuk_publishing_components/components/input", {
         label: {

--- a/app/views/file_attachments/index.html.erb
+++ b/app/views/file_attachments/index.html.erb
@@ -1,7 +1,7 @@
 <% content_for :title, t("file_attachments.index.title", title: @edition.title_or_fallback) %>
 
 <div class="govuk-grid-row">
-  <div class="govuk-grid-column-two-thirds">
+  <div class="govuk-grid-column-full">
     <div class="app-pane">
       <% upload_attachment_heading = capture do %>
         <h2 class="govuk-heading-m">

--- a/app/views/file_attachments/index.html.erb
+++ b/app/views/file_attachments/index.html.erb
@@ -12,6 +12,9 @@
       <%= form_tag(
         create_file_attachment_path(@edition.document),
         multipart: true,
+        data: {
+          "modal-action": "upload",
+        },
       ) do %>
         <%= render "govuk_publishing_components/components/file_upload", {
           label: {

--- a/app/views/file_attachments/show.html.erb
+++ b/app/views/file_attachments/show.html.erb
@@ -1,5 +1,6 @@
 <% content_for :title, t("file_attachments.show.title") %>
-<% content_for :back_link, render_back_link(href: file_attachments_path(@edition.document)) %>
+<% content_for :back_link, render_back_link(href: file_attachments_path(@edition.document),
+                                            data_attributes: { "modal-action": "back" }) %>
 
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">

--- a/app/views/file_attachments/show.html.erb
+++ b/app/views/file_attachments/show.html.erb
@@ -3,7 +3,7 @@
                                             data_attributes: { "modal-action": "back" }) %>
 
 <div class="govuk-grid-row">
-  <div class="govuk-grid-column-two-thirds">
+  <div class="govuk-grid-column-full">
     <%= render "govuk_publishing_components/components/attachment", {
       attachment: file_attachment_attributes(@attachment, @edition.document),
       target: "_blank",

--- a/spec/features/editing_file_attachments/delete_file_attachment_spec.rb
+++ b/spec/features/editing_file_attachments/delete_file_attachment_spec.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-RSpec.feature "Delete a file attachment" do
+RSpec.feature "Delete a file attachment", js: true do
   scenario do
     given_there_is_an_edition_with_attachments
     when_i_insert_an_attachment
@@ -28,6 +28,7 @@ RSpec.feature "Delete a file attachment" do
   def and_i_delete_the_attachment
     @put_content_request = stub_publishing_api_put_content(@edition.content_id, {})
     @delete_asset_request = stub_asset_manager_deletes_any_asset
+    expect(page).to have_selector(".gem-c-attachment__metadata")
     click_on "Delete attachment"
   end
 

--- a/spec/features/editing_file_attachments/edit_file_attachment_requirements_spec.rb
+++ b/spec/features/editing_file_attachments/edit_file_attachment_requirements_spec.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-RSpec.feature "Edit a file attachment with requirements issues" do
+RSpec.feature "Edit a file attachment with requirements issues", js: true do
   scenario do
     given_there_is_an_edition_with_a_file_attachment
     when_i_go_to_insert_an_attachment
@@ -25,6 +25,7 @@ RSpec.feature "Edit a file attachment with requirements issues" do
   end
 
   def and_i_click_on_edit_file
+    expect(page).to have_selector(".gem-c-attachment__metadata")
     click_on "Edit file"
   end
 

--- a/spec/features/editing_file_attachments/edit_file_attachment_title_spec.rb
+++ b/spec/features/editing_file_attachments/edit_file_attachment_title_spec.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-RSpec.feature "Edit a file attachment title" do
+RSpec.feature "Edit a file attachment title", js: true do
   scenario do
     given_there_is_an_edition_with_attachments
     when_i_click_to_insert_an_attachment
@@ -28,6 +28,7 @@ RSpec.feature "Edit a file attachment title" do
   end
 
   def and_i_click_on_edit_file
+    expect(page).to have_selector(".gem-c-attachment__metadata")
     click_on "Edit file"
   end
 
@@ -52,6 +53,8 @@ RSpec.feature "Edit a file attachment title" do
     expect(@put_content_request).to have_been_requested
 
     visit document_path(@edition.document)
+    click_on "Document history"
+
     within first(".app-timeline-entry") do
       expect(page).to have_content I18n.t!(
         "documents.history.entry_types.file_attachment_updated",

--- a/spec/features/editing_file_attachments/preview_file_attachment_asset_manager_down_spec.rb
+++ b/spec/features/editing_file_attachments/preview_file_attachment_asset_manager_down_spec.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-RSpec.feature "Preview file attachment when Asset Manager is down" do
+RSpec.feature "Preview file attachment when Asset Manager is down", js: true do
   scenario do
     given_there_is_an_edition_with_attachments
     and_asset_manager_is_down
@@ -26,10 +26,14 @@ RSpec.feature "Preview file attachment when Asset Manager is down" do
     visit edit_document_path(@edition.document)
     find("markdown-toolbar details").click
     click_on "Attachment"
-    click_on "Preview"
+
+    expect(page).to have_selector(".gem-c-attachment__metadata")
+    @preview_window = window_opened_by { click_on "Preview" }
   end
 
   def then_i_should_see_a_pending_page
-    expect(page).to have_content I18n.t!("file_attachments.preview_pending.title")
+    within_window @preview_window do
+      expect(page).to have_content I18n.t!("file_attachments.preview_pending.title")
+    end
   end
 end

--- a/spec/features/editing_file_attachments/preview_file_attachment_spec.rb
+++ b/spec/features/editing_file_attachments/preview_file_attachment_spec.rb
@@ -25,12 +25,13 @@ RSpec.feature "Preview file attachment", js: true do
 
   def when_i_preview_the_attachment
     visit edit_document_path(@edition.document)
-    find("markdown-toolbar details").click
-    @new_window = window_opened_by { click_on "Attachment" }
-
-    within_window(@new_window) do
-      @preview_window = window_opened_by { click_on "Preview" }
+    within(".app-c-markdown-editor") do
+      find("markdown-toolbar details").click
+      click_on "Attachment"
     end
+
+    expect(page).to have_selector(".gem-c-attachment__metadata")
+    @preview_window = window_opened_by { click_on "Preview" }
   end
 
   def then_i_should_see_the_attachment

--- a/spec/features/editing_file_attachments/preview_file_attachment_unavailable_spec.rb
+++ b/spec/features/editing_file_attachments/preview_file_attachment_unavailable_spec.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-RSpec.feature "Preview file attachment when unavailable" do
+RSpec.feature "Preview file attachment when unavailable", js: true do
   scenario do
     given_there_is_an_edition_with_attachments
     when_i_preview_the_attachment
@@ -24,11 +24,15 @@ RSpec.feature "Preview file attachment when unavailable" do
     visit edit_document_path(@edition.document)
     find("markdown-toolbar details").click
     click_on "Attachment"
-    click_on "Preview"
+
+    expect(page).to have_selector(".gem-c-attachment__metadata")
+    @preview_window = window_opened_by { click_on "Preview" }
   end
 
   def then_i_should_see_a_pending_page
-    expect(page).to have_content I18n.t!("file_attachments.preview_pending.title")
+    within_window @preview_window do
+      expect(page).to have_content I18n.t!("file_attachments.preview_pending.title")
+    end
   end
 
   def and_the_preview_creation_was_successful

--- a/spec/features/editing_file_attachments/replace_file_attachment_file_spec.rb
+++ b/spec/features/editing_file_attachments/replace_file_attachment_file_spec.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-RSpec.feature "Replace a file attachment file" do
+RSpec.feature "Replace a file attachment file", js: true do
   scenario do
     given_there_is_an_edition_with_an_attachment
     when_i_click_to_insert_an_attachment
@@ -58,6 +58,8 @@ RSpec.feature "Replace a file attachment file" do
     expect(@create_new_file_request).to have_been_requested
 
     visit document_path(@edition.document)
+    click_on "Document history"
+
     within first(".app-timeline-entry") do
       expect(page).to have_content I18n.t!(
         "documents.history.entry_types.file_attachment_updated",

--- a/spec/features/editing_file_attachments/upload_file_attachment_requirements_spec.rb
+++ b/spec/features/editing_file_attachments/upload_file_attachment_requirements_spec.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-RSpec.feature "Upload a file attachment with requirements issues" do
+RSpec.feature "Upload a file attachment with requirements issues", js: true do
   scenario do
     given_there_is_an_edition
     when_i_go_to_edit_the_edition

--- a/spec/features/editing_file_attachments/upload_file_attachment_spec.rb
+++ b/spec/features/editing_file_attachments/upload_file_attachment_spec.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-RSpec.feature "Upload file attachment" do
+RSpec.feature "Upload file attachment", js: true do
   scenario do
     given_there_is_an_edition
     when_i_go_to_edit_the_edition
@@ -63,6 +63,8 @@ RSpec.feature "Upload file attachment" do
     expect(@asset_manager_request).to have_been_requested.at_least_once
 
     visit document_path(@edition.document)
+    click_on "Document history"
+
     within first(".app-timeline-entry") do
       expect(page).to have_content I18n.t!("documents.history.entry_types.file_attachment_uploaded")
     end


### PR DESCRIPTION
Clicking 'Insert < Attachment' opens the attachment workflow in a modal. If JavaScript is not enabled, the current behaviour of opening the workflow in a new tab is preserved. Previewing an attachment is still opened in a new tab regardless of whether a user is using the modal or not.

<img width="834" alt="Screen Shot 2019-05-22 at 10 43 29" src="https://user-images.githubusercontent.com/24479188/58164829-74465280-7c7e-11e9-89cd-e0e87778f60b.png">

Trello:
https://trello.com/c/gPfQ2lBT/819-interface-with-a-documents-attachments-via-a-modal