### PR TITLE
Stop relying on data import for alt email

### DIFF
--- a/app/services/organisation_service.rb
+++ b/app/services/organisation_service.rb
@@ -22,6 +22,8 @@ class OrganisationService
     primary_org = self.class.by_content_id(primary_org_content_id)
     email = primary_org.dig("details", "alternative_format_contact_email")
     email.presence || DEFAULT_ALTERNATIVE_FORMAT_CONTACT_EMAIL
+  rescue GdsApi::HTTPNotFound
+    DEFAULT_ALTERNATIVE_FORMAT_CONTACT_EMAIL
   end
 
 private

--- a/spec/services/organisation_service_spec.rb
+++ b/spec/services/organisation_service_spec.rb
@@ -40,6 +40,17 @@ RSpec.describe OrganisationService do
           expect(email).to eq OrganisationService::DEFAULT_ALTERNATIVE_FORMAT_CONTACT_EMAIL
         end
       end
+
+      context "when the primary org is not found" do
+        before do
+          stub_any_publishing_api_call_to_return_not_found
+        end
+
+        it "returns the default alt email" do
+          email = OrganisationService.new(edition).alternative_format_contact_email
+          expect(email).to eq OrganisationService::DEFAULT_ALTERNATIVE_FORMAT_CONTACT_EMAIL
+        end
+      end
     end
 
     context "when the edition has no primary org" do


### PR DESCRIPTION
https://trello.com/c/OcuVomSb/820-show-the-alternative-format-email-address-for-an-attachment

This changes the OrganisationService to handle the case where the
primary org for an edition is not found in the Publishing API, when
attempting to lookup its alternative format contact email.

Although this is unlikely to be an issue in production, in development
we create a seed user who's primary org may not be in sync with the
development data for the Publishing API.

We should avoid coupling to specific data in remote systems so that our
app continues to work well in a variety of environments, and to minimise
the prerequisites required to begin developing on it.