### PR TITLE
Insert file attachments via modal

### DIFF
--- a/app/assets/javascripts/application.js
+++ b/app/assets/javascripts/application.js
@@ -25,6 +25,7 @@
 //= require vendor/@alphagov/miller-columns-element/dist/index.umd.js
 
 //= require modal/modal-fetch.js
+//= require modal/modal-editor.js
 //= require modal/modal-workflow.js
 
 //= require modules/gtm-checked-inputs-listener.js

--- a/app/assets/javascripts/modal/modal-editor.js
+++ b/app/assets/javascripts/modal/modal-editor.js
@@ -1,0 +1,12 @@
+function ModalEditor ($module) {
+  this.$module = $module
+  this.$editor = this.$module.closest('[data-module="markdown-editor"]')
+}
+
+ModalEditor.prototype.insertBlock = function (data) {
+  this.$editor.selectionReplace(data, { surroundWithNewLines: true })
+}
+
+ModalEditor.prototype.insertInline = function (data) {
+  this.$editor.selectionReplace(data)
+}

--- a/app/assets/javascripts/modal/modal-workflow.js
+++ b/app/assets/javascripts/modal/modal-workflow.js
@@ -11,9 +11,9 @@ ModalWorkflow.prototype.initComponents = function () {
 
 ModalWorkflow.prototype.overrideActions = function (actions) {
   var formItems = this.$modal.querySelectorAll('form[data-modal-action]')
-  var linkItems = this.$modal.querySelectorAll('a[data-modal-action]')
+  var clickItems = document.querySelectorAll('a[data-modal-action], button[data-modal-action]')
 
-  linkItems.forEach(function (item) {
+  clickItems.forEach(function (item) {
     item.addEventListener('click', function (event) {
       event.preventDefault()
       actions(item)

--- a/app/assets/javascripts/modules/inline-attachment-modal.js
+++ b/app/assets/javascripts/modules/inline-attachment-modal.js
@@ -12,6 +12,8 @@ InlineAttachmentModal.prototype.init = function () {
   this.$multiSectionViewer = this.$modal
     .querySelector('[data-module="multi-section-viewer"]')
 
+  this.editor = new window.ModalEditor(this.$module)
+
   this.$module.addEventListener('click', function (event) {
     event.preventDefault()
     this.performAction(this.$module)
@@ -34,16 +36,6 @@ InlineAttachmentModal.prototype.renderSuccess = function (result) {
   this.$multiSectionViewer.showDynamicSection(result.body)
   this.workflow.overrideActions(this.performAction.bind(this))
   this.workflow.initComponents()
-}
-
-InlineAttachmentModal.prototype.insertAttachmentBlockSnippet = function (item) {
-  var editor = this.$module.closest('[data-module="markdown-editor"]')
-  editor.selectionReplace(item.dataset.modalData, { surroundWithNewLines: true })
-}
-
-InlineAttachmentModal.prototype.insertAttachmentLinkSnippet = function (item) {
-  var editor = this.$module.closest('[data-module="markdown-editor"]')
-  editor.selectionReplace(item.dataset.modalData)
 }
 
 InlineAttachmentModal.prototype.performAction = function (item) {
@@ -73,11 +65,11 @@ InlineAttachmentModal.prototype.performAction = function (item) {
     },
     'insert-attachment-block': function () {
       this.$modal.close()
-      this.insertAttachmentBlockSnippet(item)
+      this.editor.insertBlock(item.dataset.modalData)
     },
     'insert-attachment-link': function () {
       this.$modal.close()
-      this.insertAttachmentLinkSnippet(item)
+      this.editor.insertInline(item.dataset.modalData)
     }
   }
 

--- a/app/assets/javascripts/modules/inline-attachment-modal.js
+++ b/app/assets/javascripts/modules/inline-attachment-modal.js
@@ -41,6 +41,11 @@ InlineAttachmentModal.prototype.insertAttachmentBlockSnippet = function (item) {
   editor.selectionReplace(item.dataset.modalData, { surroundWithNewLines: true })
 }
 
+InlineAttachmentModal.prototype.insertAttachmentLinkSnippet = function (item) {
+  var editor = this.$module.closest('[data-module="markdown-editor"]')
+  editor.selectionReplace(item.dataset.modalData)
+}
+
 InlineAttachmentModal.prototype.performAction = function (item) {
   var handlers = {
     'open': function () {
@@ -69,6 +74,10 @@ InlineAttachmentModal.prototype.performAction = function (item) {
     'insert-attachment-block': function () {
       this.$modal.close()
       this.insertAttachmentBlockSnippet(item)
+    },
+    'insert-attachment-link': function () {
+      this.$modal.close()
+      this.insertAttachmentLinkSnippet(item)
     }
   }
 

--- a/app/assets/javascripts/modules/inline-attachment-modal.js
+++ b/app/assets/javascripts/modules/inline-attachment-modal.js
@@ -36,6 +36,11 @@ InlineAttachmentModal.prototype.renderSuccess = function (result) {
   this.workflow.initComponents()
 }
 
+InlineAttachmentModal.prototype.insertAttachmentBlockSnippet = function (item) {
+  var editor = this.$module.closest('[data-module="markdown-editor"]')
+  editor.selectionReplace(item.dataset.modalData, { surroundWithNewLines: true })
+}
+
 InlineAttachmentModal.prototype.performAction = function (item) {
   var handlers = {
     'open': function () {
@@ -60,6 +65,10 @@ InlineAttachmentModal.prototype.performAction = function (item) {
     },
     'back': function () {
       this.render(window.ModalFetch.getLink(item))
+    },
+    'insert-attachment-block': function () {
+      this.$modal.close()
+      this.insertAttachmentBlockSnippet(item)
     }
   }
 

--- a/app/assets/javascripts/modules/inline-image-modal.js
+++ b/app/assets/javascripts/modules/inline-image-modal.js
@@ -12,6 +12,8 @@ InlineImageModal.prototype.init = function () {
   this.$multiSectionViewer = this.$modal
     .querySelector('[data-module="multi-section-viewer"]')
 
+  this.editor = new window.ModalEditor(this.$module)
+
   this.$module.addEventListener('click', function (event) {
     event.preventDefault()
     this.performAction(this.$module)
@@ -36,11 +38,6 @@ InlineImageModal.prototype.renderSuccess = function (result) {
   this.workflow.initComponents()
 }
 
-InlineImageModal.prototype.insertSnippet = function (item) {
-  var editor = this.$module.closest('[data-module="markdown-editor"]')
-  editor.selectionReplace(item.dataset.modalData, { surroundWithNewLines: true })
-}
-
 InlineImageModal.prototype.performAction = function (item) {
   var handlers = {
     'open': function () {
@@ -50,7 +47,7 @@ InlineImageModal.prototype.performAction = function (item) {
     },
     'insert': function () {
       this.$modal.close()
-      this.insertSnippet(item)
+      this.editor.insertBlock(item.dataset.modalData)
     },
     'upload': function () {
       this.render(window.ModalFetch.postForm(item))
@@ -80,7 +77,7 @@ InlineImageModal.prototype.performAction = function (item) {
             this.renderSuccess(result)
           } else {
             this.$modal.close()
-            this.insertSnippet(item)
+            this.editor.insertBlock(item.dataset.modalData)
           }
         }.bind(this))
         .catch(this.renderError.bind(this))

--- a/app/assets/javascripts/modules/video-embed-modal.js
+++ b/app/assets/javascripts/modules/video-embed-modal.js
@@ -12,6 +12,8 @@ VideoEmbedModal.prototype.init = function () {
   this.$multiSectionViewer = this.$modal
     .querySelector('[data-module="multi-section-viewer"]')
 
+  this.editor = new window.ModalEditor(this.$module)
+
   this.$module.addEventListener('click', function (event) {
     event.preventDefault()
     this.performAction(this.$module)
@@ -36,11 +38,6 @@ VideoEmbedModal.prototype.renderSuccess = function (result) {
   this.workflow.initComponents()
 }
 
-VideoEmbedModal.prototype.insertSnippet = function (text) {
-  var editor = this.$module.closest('[data-module="markdown-editor"]')
-  editor.selectionReplace(text, { surroundWithNewLines: true })
-}
-
 VideoEmbedModal.prototype.performAction = function (item) {
   var handlers = {
     'open': function () {
@@ -55,7 +52,7 @@ VideoEmbedModal.prototype.performAction = function (item) {
             this.renderSuccess(result)
           } else {
             this.$modal.close()
-            this.insertSnippet(result.body)
+            this.editor.insertBlock(result.body)
           }
         }.bind(this))
         .catch(this.renderError.bind(this))

--- a/app/views/file_attachments/show.html.erb
+++ b/app/views/file_attachments/show.html.erb
@@ -39,16 +39,28 @@
         target: "_blank"
       } %>
     </div>
-    <%= render "components/metadata", {
-      items: [
-        {
-          field: t("file_attachments.show.markdown_code"),
-          value: t("file_attachments.show.attachment_link_markdown", filename: @attachment.filename)
-        },
-      ],
-      inline: true,
-      margin_bottom: 3,
-    } %>
-    <p class="govuk-body"><%= t("file_attachments.show.attachment_link_instructions") %></p>
+    <% if rendering_context == "modal" %>
+      <%= render "govuk_publishing_components/components/button", {
+            text: "Insert attachment as link",
+            data_attributes: { "modal-action": "insert-attachment-link",
+                               "modal-data": I18n.t(
+                                 "file_attachments.show.attachment_link_markdown",
+                                 filename: @attachment.filename
+                               ) },
+            margin_bottom: true,
+      } %>
+    <% else %>
+      <%= render "components/metadata", {
+        items: [
+          {
+            field: t("file_attachments.show.markdown_code"),
+            value: t("file_attachments.show.attachment_link_markdown", filename: @attachment.filename)
+          },
+        ],
+        inline: true,
+        margin_bottom: 3,
+      } %>
+      <p class="govuk-body"><%= t("file_attachments.show.attachment_link_instructions") %></p>
+    <% end %>
   </div>
 </div>

--- a/app/views/file_attachments/show.html.erb
+++ b/app/views/file_attachments/show.html.erb
@@ -9,18 +9,28 @@
       target: "_blank",
     } %>
 
-    <%= render "components/metadata", {
-      items: [
-        {
-          field: t("file_attachments.show.markdown_code"),
-          value: t("file_attachments.show.attachment_markdown", filename: @attachment.filename)
-        },
-      ],
-      inline: true,
-      margin_bottom: 3,
-    } %>
-    <p class="govuk-body"><%= t("file_attachments.show.attachment_instructions") %></p>
-
+    <% if rendering_context == "modal" %>
+      <%= render "govuk_publishing_components/components/button", {
+            text: "Insert attachment",
+            data_attributes: { "modal-action": "insert-attachment-block",
+                               "modal-data": I18n.t(
+                                 "file_attachments.show.attachment_markdown",
+                                 filename: @attachment.filename
+                               ) },
+      } %>
+    <% else %>
+      <%= render "components/metadata", {
+        items: [
+          {
+            field: t("file_attachments.show.markdown_code"),
+            value: t("file_attachments.show.attachment_markdown", filename: @attachment.filename)
+          },
+        ],
+        inline: true,
+        margin_bottom: 3,
+      } %>
+      <p class="govuk-body"><%= t("file_attachments.show.attachment_instructions") %></p>
+    <% end %>
     <hr class="govuk-section-break govuk-section-break--visible govuk-section-break--l"/>
 
     <div class="govuk-body">

--- a/spec/features/editing_content/insert_inline_file_attachment_no_js_spec.rb
+++ b/spec/features/editing_content/insert_inline_file_attachment_no_js_spec.rb
@@ -1,0 +1,50 @@
+# frozen_string_literal: true
+
+RSpec.feature "Insert inline file attachment without Javascript" do
+  scenario do
+    given_there_is_an_edition_with_file_attachments
+    when_i_go_to_edit_the_edition
+    and_i_click_to_insert_a_file_attachment
+    and_i_choose_one_of_the_file_attachments
+    then_i_see_the_attachment_markdown_snippet
+    and_i_see_the_attachment_link_markdown_snippet
+  end
+
+  def given_there_is_an_edition_with_file_attachments
+    body_field = build(:field, id: "body", type: "govspeak")
+    document_type = build(:document_type, contents: [body_field])
+    @file_attachment_revision = create(:file_attachment_revision,
+                                       :on_asset_manager,
+                                       filename: "foo.pdf")
+    @edition = create(:edition,
+                      document_type_id: document_type.id,
+                      file_attachment_revisions: [@file_attachment_revision])
+  end
+
+  def when_i_go_to_edit_the_edition
+    visit edit_document_path(@edition.document)
+  end
+
+  def and_i_click_to_insert_a_file_attachment
+    within(".app-c-markdown-editor") do
+      find("markdown-toolbar details").click
+      click_on "Attachment"
+    end
+  end
+
+  def and_i_choose_one_of_the_file_attachments
+    click_on "Insert attachment"
+  end
+
+  def then_i_see_the_attachment_markdown_snippet
+    snippet = I18n.t("file_attachments.show.attachment_markdown",
+                     filename: @file_attachment_revision.filename)
+    expect(page).to have_content(snippet)
+  end
+
+  def and_i_see_the_attachment_link_markdown_snippet
+    snippet = I18n.t("file_attachments.show.attachment_link_markdown",
+                     filename: @file_attachment_revision.filename)
+    expect(page).to have_content(snippet)
+  end
+end

--- a/spec/features/editing_content/insert_inline_file_attachment_spec.rb
+++ b/spec/features/editing_content/insert_inline_file_attachment_spec.rb
@@ -1,0 +1,49 @@
+# frozen_string_literal: true
+
+RSpec.feature "Insert inline file attachment", js: true do
+  scenario "Attachment" do
+    given_there_is_an_edition_with_file_attachments
+    when_i_go_to_edit_the_edition
+    and_i_click_to_insert_a_file_attachment
+    and_i_choose_one_of_the_file_attachments
+    and_i_click_on_insert_attachment
+    then_i_see_the_attachment_snippet_is_inserted
+  end
+
+  def given_there_is_an_edition_with_file_attachments
+    body_field = build(:field, id: "body", type: "govspeak")
+    document_type = build(:document_type, contents: [body_field])
+    @file_attachment_revision = create(:file_attachment_revision,
+                                       :on_asset_manager,
+                                       filename: "foo.pdf")
+    @edition = create(:edition,
+                      document_type_id: document_type.id,
+                      file_attachment_revisions: [@file_attachment_revision])
+  end
+
+  def when_i_go_to_edit_the_edition
+    visit edit_document_path(@edition.document)
+  end
+
+  def and_i_click_to_insert_a_file_attachment
+    within(".app-c-markdown-editor") do
+      find("markdown-toolbar details").click
+      click_on "Attachment"
+    end
+  end
+
+  def and_i_choose_one_of_the_file_attachments
+    click_on "Insert attachment"
+  end
+
+  def and_i_click_on_insert_attachment
+    click_on "Insert attachment"
+  end
+
+  def then_i_see_the_attachment_snippet_is_inserted
+    expect(page).to_not have_selector(".gem-c-modal-dialogue")
+    snippet = I18n.t("file_attachments.show.attachment_markdown",
+                     filename: @file_attachment_revision.filename)
+    expect(find("#body").value).to match snippet
+  end
+end

--- a/spec/features/editing_content/insert_inline_file_attachment_spec.rb
+++ b/spec/features/editing_content/insert_inline_file_attachment_spec.rb
@@ -10,6 +10,15 @@ RSpec.feature "Insert inline file attachment", js: true do
     then_i_see_the_attachment_snippet_is_inserted
   end
 
+  scenario "Attachment link" do
+    given_there_is_an_edition_with_file_attachments
+    when_i_go_to_edit_the_edition
+    and_i_click_to_insert_a_file_attachment
+    and_i_choose_one_of_the_file_attachments
+    and_i_click_on_insert_attachment_as_link
+    then_i_see_the_attachment_link_snippet_is_inserted
+  end
+
   def given_there_is_an_edition_with_file_attachments
     body_field = build(:field, id: "body", type: "govspeak")
     document_type = build(:document_type, contents: [body_field])
@@ -40,9 +49,20 @@ RSpec.feature "Insert inline file attachment", js: true do
     click_on "Insert attachment"
   end
 
+  def and_i_click_on_insert_attachment_as_link
+    click_on "Insert attachment as link"
+  end
+
   def then_i_see_the_attachment_snippet_is_inserted
     expect(page).to_not have_selector(".gem-c-modal-dialogue")
     snippet = I18n.t("file_attachments.show.attachment_markdown",
+                     filename: @file_attachment_revision.filename)
+    expect(find("#body").value).to match snippet
+  end
+
+  def then_i_see_the_attachment_link_snippet_is_inserted
+    expect(page).to_not have_selector(".gem-c-modal-dialogue")
+    snippet = I18n.t("file_attachments.show.attachment_link_markdown",
                      filename: @file_attachment_revision.filename)
     expect(find("#body").value).to match snippet
   end

--- a/spec/features/editing_file_attachments/upload_file_attachment_spec.rb
+++ b/spec/features/editing_file_attachments/upload_file_attachment_spec.rb
@@ -6,8 +6,7 @@ RSpec.feature "Upload file attachment", js: true do
     when_i_go_to_edit_the_edition
     and_i_go_to_insert_an_attachment
     and_i_upload_a_file_attachment
-    then_i_can_see_the_attachment_markdown
-    and_i_can_see_previews_of_the_attachment
+    then_i_can_see_previews_of_the_attachment
     and_the_attachment_has_been_uploaded_successfully
   end
 
@@ -39,12 +38,7 @@ RSpec.feature "Upload file attachment", js: true do
     click_on "Upload"
   end
 
-  def then_i_can_see_the_attachment_markdown
-    expect(page).to have_content("[Attachment: #{@attachment_filename}]")
-    expect(page).to have_content("[AttachmentLink: #{@attachment_filename}]")
-  end
-
-  def and_i_can_see_previews_of_the_attachment
+  def then_i_can_see_previews_of_the_attachment
     metadata = "PDF, 13 KB, 1 page"
 
     within(".gem-c-attachment") do


### PR DESCRIPTION
For https://trello.com/c/gPfQ2lBT/819-interface-with-a-documents-attachments-via-a-modal

This enables users with Javascript enabled to auto-insert file attachment markdown via the modal.
I've tested inserting the markdown before text, after text and within text for both attachment types. All renders correctly bar the attachment link when inserted before text, however this is being dealt with here https://github.com/alphagov/govspeak/pull/154

<img width="668" alt="Screen Shot 2019-05-22 at 14 46 51" src="https://user-images.githubusercontent.com/13434452/58180128-72da5180-7ca1-11e9-8f24-2ec154b746bc.png">
 


