### PR TITLE
Refactor rendering/actions into modal workflow

### DIFF
--- a/app/assets/javascripts/modal/modal-workflow.js
+++ b/app/assets/javascripts/modal/modal-workflow.js
@@ -1,7 +1,11 @@
 /* global $ */
 
-function ModalWorkflow ($modal) {
+function ModalWorkflow ($modal, actionCallback) {
   this.$modal = $modal
+  this.actionCallback = actionCallback
+
+  this.$multiSectionViewer = this.$modal
+    .querySelector('[data-module="multi-section-viewer"]')
 }
 
 ModalWorkflow.prototype.initComponents = function () {
@@ -26,4 +30,28 @@ ModalWorkflow.prototype.overrideActions = function (actions) {
       actions(item)
     })
   })
+}
+
+ModalWorkflow.prototype.render = function (response) {
+  response
+    .then(this.renderSuccess.bind(this))
+    .catch(this.renderError.bind(this))
+}
+
+ModalWorkflow.prototype.renderError = function (result) {
+  window.Raven.captureException(result)
+  console.error(result)
+  this.$multiSectionViewer.showStaticSection('error')
+}
+
+ModalWorkflow.prototype.renderSuccess = function (result) {
+  this.$multiSectionViewer.showDynamicSection(result.body)
+  this.overrideActions(this.performAction.bind(this))
+  this.initComponents()
+}
+
+ModalWorkflow.prototype.performAction = function (item) {
+  this.$modal.focusDialog()
+  this.$multiSectionViewer.showStaticSection('loading')
+  this.actionCallback(item)
 }

--- a/app/assets/javascripts/modules/inline-image-modal.js
+++ b/app/assets/javascripts/modules/inline-image-modal.js
@@ -1,7 +1,6 @@
 function InlineImageModal ($module) {
   this.$module = $module
   this.$modal = document.getElementById('modal')
-  this.workflow = new window.ModalWorkflow(this.$modal)
 }
 
 InlineImageModal.prototype.init = function () {
@@ -9,83 +8,65 @@ InlineImageModal.prototype.init = function () {
     return
   }
 
-  this.$multiSectionViewer = this.$modal
-    .querySelector('[data-module="multi-section-viewer"]')
+  this.workflow = new window.ModalWorkflow(
+    this.$modal,
+    this.actionCallback.bind(this)
+  )
 
   this.editor = new window.ModalEditor(this.$module)
 
   this.$module.addEventListener('click', function (event) {
     event.preventDefault()
-    this.performAction(this.$module)
+    this.workflow.performAction(this.$module)
   }.bind(this))
 }
 
-InlineImageModal.prototype.render = function (response) {
-  response
-    .then(this.renderSuccess.bind(this))
-    .catch(this.renderError.bind(this))
-}
-
-InlineImageModal.prototype.renderError = function (result) {
-  window.Raven.captureException(result)
-  console.error(result)
-  this.$multiSectionViewer.showStaticSection('error')
-}
-
-InlineImageModal.prototype.renderSuccess = function (result) {
-  this.$multiSectionViewer.showDynamicSection(result.body)
-  this.workflow.overrideActions(this.performAction.bind(this))
-  this.workflow.initComponents()
-}
-
-InlineImageModal.prototype.performAction = function (item) {
+InlineImageModal.prototype.actionCallback = function (item) {
   var handlers = {
     'open': function () {
       this.$modal.resize('wide')
       this.$modal.open()
-      this.render(window.ModalFetch.getLink(item))
+      this.workflow.render(window.ModalFetch.getLink(item))
     },
     'insert': function () {
       this.$modal.close()
       this.editor.insertBlock(item.dataset.modalData)
     },
     'upload': function () {
-      this.render(window.ModalFetch.postForm(item))
+      this.workflow.render(window.ModalFetch.postForm(item))
     },
     'cropBack': function () {
-      this.render(window.ModalFetch.getLink(item))
+      this.workflow.render(window.ModalFetch.getLink(item))
     },
     'metaBack': function () {
-      this.render(window.ModalFetch.getLink(item))
+      this.workflow.render(window.ModalFetch.getLink(item))
     },
     'crop': function () {
-      this.render(window.ModalFetch.postForm(item))
+      this.workflow.render(window.ModalFetch.postForm(item))
     },
     'delete': function () {
-      this.render(window.ModalFetch.postForm(item))
+      this.workflow.render(window.ModalFetch.postForm(item))
     },
     'meta': function () {
-      this.render(window.ModalFetch.postForm(item))
+      this.workflow.render(window.ModalFetch.postForm(item))
     },
     'edit': function () {
-      this.render(window.ModalFetch.getLink(item))
+      this.workflow.render(window.ModalFetch.getLink(item))
     },
     'metaInsert': function () {
       window.ModalFetch.postForm(item)
         .then(function (result) {
           if (result.unprocessableEntity) {
-            this.renderSuccess(result)
+            this.workflow.renderSuccess(result)
           } else {
             this.$modal.close()
             this.editor.insertBlock(item.dataset.modalData)
           }
         }.bind(this))
-        .catch(this.renderError.bind(this))
+        .catch(this.workflow.renderError.bind(this))
     }
   }
 
-  this.$modal.focusDialog()
-  this.$multiSectionViewer.showStaticSection('loading')
   handlers[item.dataset.modalAction].bind(this)()
 }
 

--- a/app/assets/javascripts/modules/video-embed-modal.js
+++ b/app/assets/javascripts/modules/video-embed-modal.js
@@ -1,7 +1,6 @@
 function VideoEmbedModal ($module) {
   this.$module = $module
   this.$modal = document.getElementById('modal')
-  this.workflow = new window.ModalWorkflow(this.$modal)
 }
 
 VideoEmbedModal.prototype.init = function () {
@@ -9,58 +8,40 @@ VideoEmbedModal.prototype.init = function () {
     return
   }
 
-  this.$multiSectionViewer = this.$modal
-    .querySelector('[data-module="multi-section-viewer"]')
+  this.workflow = new window.ModalWorkflow(
+    this.$modal,
+    this.actionCallback.bind(this)
+  )
 
   this.editor = new window.ModalEditor(this.$module)
 
   this.$module.addEventListener('click', function (event) {
     event.preventDefault()
-    this.performAction(this.$module)
+    this.workflow.performAction(this.$module)
   }.bind(this))
 }
 
-VideoEmbedModal.prototype.render = function (response) {
-  response
-    .then(this.renderSuccess.bind(this))
-    .catch(this.renderError.bind(this))
-}
-
-VideoEmbedModal.prototype.renderError = function (result) {
-  window.Raven.captureException(result)
-  console.error(result)
-  this.$multiSectionViewer.showStaticSection('error')
-}
-
-VideoEmbedModal.prototype.renderSuccess = function (result) {
-  this.$multiSectionViewer.showDynamicSection(result.body)
-  this.workflow.overrideActions(this.performAction.bind(this))
-  this.workflow.initComponents()
-}
-
-VideoEmbedModal.prototype.performAction = function (item) {
+VideoEmbedModal.prototype.actionCallback = function (item) {
   var handlers = {
     'open': function () {
       this.$modal.resize('narrow')
       this.$modal.open()
-      this.render(window.ModalFetch.getLink(item))
+      this.workflow.render(window.ModalFetch.getLink(item))
     },
     'insert': function () {
       window.ModalFetch.postForm(item)
         .then(function (result) {
           if (result.unprocessableEntity) {
-            this.renderSuccess(result)
+            this.workflow.renderSuccess(result)
           } else {
             this.$modal.close()
             this.editor.insertBlock(result.body)
           }
         }.bind(this))
-        .catch(this.renderError.bind(this))
+        .catch(this.workflow.renderError.bind(this))
     }
   }
 
-  this.$modal.focusDialog()
-  this.$multiSectionViewer.showStaticSection('loading')
   handlers[item.dataset.modalAction].bind(this)()
 }
 


### PR DESCRIPTION
https://trello.com/c/NwWjLtlX/724-user-can-embed-attachment-links-inline-attachment

Previously we duplicated some of the render and action code in each
modal module. It now appears three times, which is good evidence it
needs DRY-ing up. This refactors the render and action code into the
existing ModalWorkflow utility to avoid duplication.

Originally it was unclear how portable the code we wrote for inline
images would be, so leaving it in each modal module allowed it to be
easily customised in the future, which a refactoring like this could
make harder. But this flexibility has not been useful, so there's no
strong argument for continuing to duplicate the code between modules.