### PR TITLE
Move form GTM attributes onto form element

### DIFF
--- a/app/views/documents/show/_actions.html.erb
+++ b/app/views/documents/show/_actions.html.erb
@@ -13,24 +13,21 @@
         <%= render "govuk_publishing_components/components/button", text: "Approve" %>
       <% end %>
 
-      <%= form_tag create_edition_path(@edition.document) do %>
-        <%= render "govuk_publishing_components/components/button",
-          text: "Create new edition",
-          secondary: true,
-          data_attributes: { gtm: "create-new-edition" } %>
+      <%= form_tag create_edition_path(@edition.document), data: { gtm: "create-new-edition" } do %>
+        <%= render "govuk_publishing_components/components/button", text: "Create new edition", secondary: true %>
       <% end %>
 
       <%= link_to "Withdraw", withdraw_path(@edition.document), class: "govuk-link govuk-link--no-visited-state" %>
       <%= link_to "Remove", remove_path(@edition.document), class: "govuk-link app-link--destructive app-link--right" %>
     <% elsif @edition.status.published? %>
-      <%= form_tag create_edition_path(@edition.document) do %>
-        <%= render "govuk_publishing_components/components/button", text: "Create new edition", data_attributes: { gtm: "create-new-edition" } %>
+      <%= form_tag create_edition_path(@edition.document), data: { gtm: "create-new-edition" } do %>
+        <%= render "govuk_publishing_components/components/button", text: "Create new edition" %>
       <% end %>
       <%= link_to "Withdraw", withdraw_path(@edition.document), class: "govuk-link govuk-link--no-visited-state" %>
       <%= link_to "Remove", remove_path(@edition.document), class: "govuk-link app-link--destructive app-link--right" %>
     <% elsif @edition.status.removed? %>
-      <%= form_tag create_edition_path(@edition.document) do %>
-        <%= render "govuk_publishing_components/components/button", text: "Create new edition", data_attributes: { gtm: "create-new-edition" } %>
+      <%= form_tag create_edition_path(@edition.document), data: { gtm: "create-new-edition" } do %>
+        <%= render "govuk_publishing_components/components/button", text: "Create new edition" %>
       <% end %>
     <% elsif @edition.status.submitted_for_review? %>
       <%= render "govuk_publishing_components/components/button",

--- a/app/views/file_attachments/edit.html.erb
+++ b/app/views/file_attachments/edit.html.erb
@@ -10,6 +10,7 @@
       multipart: true,
       data: {
         "modal-action": "update",
+        gtm: "save-attachment"
       },
     ) do %>
       <%= render "govuk_publishing_components/components/input", {
@@ -45,9 +46,6 @@
       <%= render "govuk_publishing_components/components/button", {
         margin_bottom: true,
         text: "Save",
-        data_attributes: {
-          gtm: "save-attachment"
-        }
       } %>
     <% end %>
   </div>

--- a/app/views/publish/confirmation.html.erb
+++ b/app/views/publish/confirmation.html.erb
@@ -3,7 +3,11 @@
 
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
-    <%= form_tag publish_confirmation_path(@edition.document), data: { "gtm-checked-inputs": "publish-document" } do %>
+    <%= form_tag publish_confirmation_path(@edition.document),
+      data: {
+        "gtm-checked-inputs": "publish-document",
+        gtm: "confirm-publish"
+    } do %>
       <%= render "govuk_publishing_components/components/radio", {
         name: "review_status",
         error_items: @issues&.items_for(:review_status),
@@ -21,7 +25,6 @@
 
       <%= render "govuk_publishing_components/components/button", {
         text: "Confirm publish",
-        data_attributes: { gtm: "confirm-publish" },
       } %>
     <% end %>
   </div>

--- a/app/views/video_embed/new.html.erb
+++ b/app/views/video_embed/new.html.erb
@@ -5,7 +5,8 @@
 <%= form_tag(
   video_embed_path,
   data: {
-    modal_action: "insert"
+    modal_action: "insert",
+    gtm: "insert-video-embed",
   }
 ) do %>
   <%= render "govuk_publishing_components/components/input", {
@@ -31,9 +32,6 @@
 
   <%= render "govuk_publishing_components/components/button", {
     margin_bottom: true,
-    data_attributes: {
-      gtm: "insert-video-embed"
-    },
     text: "Embed video",
   } %>
 <% end %>


### PR DESCRIPTION
https://trello.com/c/B9rVHJTh/876-audit-and-fix-gtm-issues

Previously we had a mixture of data-gtm attributes on a form element or
its submit button, where the latter don't seem to make it to GTM. This
moves all data-gtm attributes within a form to be on the form element.