### PR TITLE
Make publishing requirement prompt target accurate

### DIFF
--- a/app/views/documents/edit.html.erb
+++ b/app/views/documents/edit.html.erb
@@ -16,7 +16,7 @@
     gtm: "edit-document-submit",
   }) do |f| %>
   <div class="govuk-grid-row">
-    <div class="govuk-grid-column-two-thirds">
+    <div class="govuk-grid-column-two-thirds" id="title">
       <%= render "govuk_publishing_components/components/textarea", {
         label: {
           text: t("documents.edit.form_labels.title"),
@@ -65,7 +65,7 @@
   </div>
 
   <div class="govuk-grid-row">
-    <div class="govuk-grid-column-two-thirds">
+    <div class="govuk-grid-column-two-thirds" id="summary">
       <%= render "govuk_publishing_components/components/textarea", {
         label: {
           text: t("documents.edit.form_labels.summary"),

--- a/app/views/documents/edit/_change_notes.html.erb
+++ b/app/views/documents/edit/_change_notes.html.erb
@@ -12,7 +12,7 @@
     } %>
 <% end %>
 <div class="govuk-grid-row">
-  <div class="govuk-grid-column-two-thirds">
+  <div class="govuk-grid-column-two-thirds" id="change-note">
     <% legend_text = tag.p(
       tag.strong(t("documents.edit.update_type.title")),
       class: "govuk-!-margin-bottom-3")

--- a/app/views/documents/fields/_govspeak_input.html.erb
+++ b/app/views/documents/fields/_govspeak_input.html.erb
@@ -1,5 +1,5 @@
 <div class="govuk-grid-row">
-  <div class="govuk-grid-column-two-thirds">
+  <div class="govuk-grid-column-two-thirds" id="<%= field.id %>">
     <%= render "components/markdown_editor", {
       label: {
         text: field.label,
@@ -11,7 +11,7 @@
           gtm: "#{field.id}-input",
           "gtm-copy-paste-tracking": true,
         },
-        id: field.id,
+        id: "revision_#{field.id}",
         name: "revision[contents][#{field.id}]",
         value: revision.contents[field.id],
         rows: 20,

--- a/app/views/documents/show/_requirements.html.erb
+++ b/app/views/documents/show/_requirements.html.erb
@@ -1,13 +1,13 @@
 <% issue_params = {
   style: "summary",
   link_options: {
-    title: { href: "#content" },
-    summary: { href: "#content" },
-    body: { href: "#content" },
-    change_note: { href: "#content" },
+    title: { href: edit_document_path(@edition.document, anchor: "title") },
+    summary: { href: edit_document_path(@edition.document, anchor: "summary") },
+    body: { href: edit_document_path(@edition.document, anchor: "body") },
+    change_note: { href: edit_document_path(@edition.document, anchor: "change-note") },
     alt_text: { href: "#lead-image" },
     caption: { href: "#lead-image" },
-    topics: { href: "#topics" }
+    topics: { href: update_topics_path(@edition.document) },
   }
 } %>
 

--- a/spec/features/editing_content/insert_inline_file_attachment_spec.rb
+++ b/spec/features/editing_content/insert_inline_file_attachment_spec.rb
@@ -57,13 +57,13 @@ RSpec.feature "Insert inline file attachment", js: true do
     expect(page).to_not have_selector(".gem-c-modal-dialogue")
     snippet = I18n.t("file_attachments.show.attachment_markdown",
                      filename: @file_attachment_revision.filename)
-    expect(find("#body").value).to match snippet
+    expect(find("#revision_body").value).to match snippet
   end
 
   def then_i_see_the_attachment_link_snippet_is_inserted
     expect(page).to_not have_selector(".gem-c-modal-dialogue")
     snippet = I18n.t("file_attachments.show.attachment_link_markdown",
                      filename: @file_attachment_revision.filename)
-    expect(find("#body").value).to match snippet
+    expect(find("#revision_body").value).to match snippet
   end
 end

--- a/spec/features/editing_content/insert_inline_image_spec.rb
+++ b/spec/features/editing_content/insert_inline_image_spec.rb
@@ -37,6 +37,6 @@ RSpec.feature "Insert inline image", js: true do
 
   def then_i_see_the_snippet_is_inserted
     snippet = I18n.t("images.index.meta.inline_code.value", filename: @image_revision.filename)
-    expect(find("#body").value).to match snippet
+    expect(find("#revision_body").value).to match snippet
   end
 end

--- a/spec/features/editing_content/insert_video_embed_spec.rb
+++ b/spec/features/editing_content/insert_video_embed_spec.rb
@@ -34,6 +34,6 @@ RSpec.describe "Insert video embed", js: true do
 
   def then_i_see_the_snippet_is_inserted
     snippet = "[A title](https://www.youtube.com/watch?v=G8KpPw303PY)"
-    expect(find("#body").value).to match snippet
+    expect(find("#revision_body").value).to match snippet
   end
 end

--- a/spec/features/editing_images/upload_image_spec.rb
+++ b/spec/features/editing_images/upload_image_spec.rb
@@ -85,7 +85,7 @@ RSpec.feature "Upload an image", js: true do
   def then_i_see_the_snippet_is_inserted
     expect(page).to_not have_selector(".gem-c-modal-dialogue")
     snippet = I18n.t("images.index.meta.inline_code.value", filename: @image_filename)
-    expect(find("#body").value).to match snippet
+    expect(find("#revision_body").value).to match snippet
   end
 
   def and_the_preview_creation_succeeded


### PR DESCRIPTION
Adjusted links found in the warning message box of a draft document such that they bring the user to the required location (e.g. the content edit field of the document) for further editing.

Changed the ID for the govuk content field to refer to revision_field.id instead of just field.id so we avoid conflicts in the use of anchors. Updated related tests that were affected by this.

Trello Card: https://trello.com/c/Ml6qt5on/845-make-publishing-requirement-prompt-target-accurate