### PR TITLE
Standardise copy/paste GTM attributes

### DIFF
--- a/app/assets/javascripts/modules/gtm-copy-paste-listener.js
+++ b/app/assets/javascripts/modules/gtm-copy-paste-listener.js
@@ -8,8 +8,7 @@ GtmCopyPasteListener.handleCopy = function (event) {
   }
 
   window.dataLayer.push({
-    'event': 'text-copied',
-    'element': element.dataset.gtmCopyPasteTracking
+    'event': 'text-copied'
   })
 }
 
@@ -21,8 +20,7 @@ GtmCopyPasteListener.handlePaste = function (event) {
   }
 
   window.dataLayer.push({
-    'event': 'text-pasted',
-    'element': element.dataset.gtmCopyPasteTracking
+    'event': 'text-pasted'
   })
 }
 

--- a/app/views/components/_page_preview.html.erb
+++ b/app/views/components/_page_preview.html.erb
@@ -14,7 +14,7 @@
         },
         input_data_attributes: {
           gtm: "copy-url-for-preview-manual",
-          "gtm-copy-paste-tracking": "copy-url-for-preview-manual"
+          "gtm-copy-paste-tracking": true
         }
       %>
     <% end %>

--- a/app/views/documents/fields/_govspeak_input.html.erb
+++ b/app/views/documents/fields/_govspeak_input.html.erb
@@ -9,7 +9,7 @@
         data: {
           gramm: "false", # Disables grammerly plugin for markdown editor
           gtm: "#{field.id}-input",
-          "gtm-copy-paste-tracking": "copy-url-for-2i-approval-cta",
+          "gtm-copy-paste-tracking": true,
         },
         id: field.id,
         name: "revision[contents][#{field.id}]",

--- a/app/views/documents/show/_submitted_for_review.html.erb
+++ b/app/views/documents/show/_submitted_for_review.html.erb
@@ -8,7 +8,7 @@
     },
     input_data_attributes: {
       gtm: "copy-url-for-2i-approval-manual",
-      "gtm-copy-paste-tracking": "copy-url-for-2i-approval-manual"
+      "gtm-copy-paste-tracking": true
     }
 ) %>
 

--- a/app/views/publish/published.html.erb
+++ b/app/views/publish/published.html.erb
@@ -30,7 +30,8 @@
           gtm: "published-content-copy-link-cta"
         },
         input_data_attributes: {
-          "gtm-copy-paste-tracking": "published-content-copy-link-manual"
+          gtm: "published-content-copy-link-manual",
+          "gtm-copy-paste-tracking": true
         }
       %>
     <% else %>

--- a/spec/javascripts/modules/gtm-copy-paste-listener-spec.js
+++ b/spec/javascripts/modules/gtm-copy-paste-listener-spec.js
@@ -7,7 +7,7 @@ describe('Gtm copy paste listener', function () {
 
   beforeEach(function () {
     container = document.createElement('div')
-    container.innerHTML = '<input data-gtm-copy-paste-tracking="my-input">'
+    container.innerHTML = '<input data-gtm-copy-paste-tracking=true>'
 
     document.body.appendChild(container)
     window.dataLayer = []
@@ -23,8 +23,7 @@ describe('Gtm copy paste listener', function () {
 
     expect(window.dataLayer).toContain(
       {
-        'event': 'text-copied',
-        'element': 'my-input'
+        'event': 'text-copied'
       }
     )
   })
@@ -35,8 +34,7 @@ describe('Gtm copy paste listener', function () {
 
     expect(window.dataLayer).toContain(
       {
-        'event': 'text-pasted',
-        'element': 'my-input'
+        'event': 'text-pasted'
       }
     )
   })


### PR DESCRIPTION
https://trello.com/c/B9rVHJTh/876-audit-and-fix-gtm-issues

Previously we enabled tracking for copy/paste events using a particular
'data-gtm-copy-paste-tracking' attribute. In some cases, we also set the
'data-gtm' attribute, which we conventionally use the identify the
element. This ensures 'data-gtm' is populated in all places where we
track copy/paste events, and replaces the (now) redundant value of the
'data-gtm-copy-paste-tracking' attribute with 'true' so it still works.