### PR TITLE
Ensure all actions have GTM attributes

### DIFF
--- a/app/helpers/actions_helper.rb
+++ b/app/helpers/actions_helper.rb
@@ -1,40 +1,55 @@
 # frozen_string_literal: true
 
 module ActionsHelper
-  def delete_draft_link(edition, extra_classes = [])
-    link_to("Delete draft",
-            delete_draft_path(edition.document),
-            class: %w(govuk-link app-link--destructive) + Array(extra_classes),
-            data: { gtm: "delete-draft" })
-  end
-
   def create_edition_button(edition, secondary: false)
     form_tag create_edition_path(edition.document), data: { gtm: "create-new-edition" } do
-      render "govuk_publishing_components/components/button", text: "Create new edition", secondary: secondary
+      render "govuk_publishing_components/components/button",
+             text: "Create new edition",
+             data_attributes: { gtm: "create-edition" },
+             secondary: secondary
     end
   end
 
   def preview_button(edition, secondary: false)
     render "govuk_publishing_components/components/button",
            text: "Preview",
+           data_attributes: { gtm: "preview" },
            href: preview_document_path(edition.document),
            secondary: secondary
   end
 
+  def delete_draft_link(edition, extra_classes = [])
+    link_to "Delete draft",
+            delete_draft_path(edition.document),
+            class: %w(govuk-link app-link--destructive) + Array(extra_classes),
+            data: { gtm: "delete-draft" }
+  end
+
   def withdraw_link(edition)
-    link_to "Withdraw", withdraw_path(edition.document), class: "govuk-link govuk-link--no-visited-state"
+    link_to "Withdraw",
+            withdraw_path(edition.document),
+            class: "govuk-link govuk-link--no-visited-state",
+            data: { gtm: "withdraw" }
   end
 
   def remove_link(edition)
-    link_to "Remove", remove_path(edition.document), class: "govuk-link app-link--destructive app-link--right"
+    link_to "Remove", remove_path(edition.document),
+            class: "govuk-link app-link--destructive app-link--right",
+            data: { gtm: "remove" }
   end
 
   def schedule_link(edition)
-    link_to "Schedule", scheduling_confirmation_path(edition.document), class: "govuk-link govuk-link--no-visited-state"
+    link_to "Schedule",
+            scheduling_confirmation_path(edition.document),
+            class: "govuk-link govuk-link--no-visited-state",
+            data: { gtm: "schedule" }
   end
 
   def publish_link(edition)
-    link_to "Publish", publish_confirmation_path(edition.document), class: "govuk-link govuk-link--no-visited-state"
+    link_to "Publish",
+            publish_confirmation_path(edition.document),
+            class: "govuk-link govuk-link--no-visited-state",
+            data: { gtm: "publish" }
   end
 
   def undo_withdraw_button(edition)
@@ -47,29 +62,30 @@ module ActionsHelper
   def publish_button(edition)
     render "govuk_publishing_components/components/button",
            text: "Publish",
+           data_attributes: { gtm: "publish" },
            href: publish_confirmation_path(edition.document)
   end
 
   def create_preview_button(edition)
-    form_tag create_preview_path(edition.document) do
+    form_tag create_preview_path(edition.document), data: { gtm: "preview" } do
       render "govuk_publishing_components/components/button", text: "Preview"
     end
   end
 
   def approve_button(edition)
-    form_tag approve_document_path(edition.document) do
+    form_tag approve_document_path(edition.document), data: { gtm: "approve" } do
       render "govuk_publishing_components/components/button", text: "Approve"
     end
   end
 
   def unschedule_button(edition)
-    form_tag unschedule_path(edition.document) do
+    form_tag unschedule_path(edition.document), data: { gtm: "unschedule" } do
       render "govuk_publishing_components/components/button", text: "Stop scheduled publishing", secondary: true
     end
   end
 
   def submit_for_2i_button(edition)
-    form_tag submit_document_for_2i_path(edition.document) do
+    form_tag submit_document_for_2i_path(edition.document), data: { gtm: "submit-for-2i" } do
       render "govuk_publishing_components/components/button", text: "Submit for 2i review"
     end
   end


### PR DESCRIPTION
https://trello.com/c/B9rVHJTh/876-audit-and-fix-gtm-issues

Previously only a couple of actions had data-gtm attributes to support
automatic analytics on them, while others (2i and preview) were picked
up with unconventional CSS-style tags in GTM. This ensures each action
link or button/form has an appropriate 'data-gtm' attribute.