### PR TITLE
Fix edge case for video embed checker

### DIFF
--- a/app/services/requirements/video_embed_checker.rb
+++ b/app/services/requirements/video_embed_checker.rb
@@ -28,7 +28,7 @@ module Requirements
       return true if uri.host.to_s.end_with?(YOUTU_HOST)
 
       uri.host.to_s.end_with?(YOUTUBE_HOST) &&
-        uri.path == "/watch" && uri.query.match(/v=/)
+        uri.path == "/watch" && uri.query.to_s.match(/v=/)
     end
   end
 end

--- a/spec/services/requirements/video_embed_checker_spec.rb
+++ b/spec/services/requirements/video_embed_checker_spec.rb
@@ -39,5 +39,11 @@ RSpec.describe Requirements::VideoEmbedChecker do
       form_message = issues.items_for(:video_embed_url).first[:text]
       expect(form_message).to eq(I18n.t!("requirements.video_embed_url.non_youtube.form_message"))
     end
+
+    it "returns an issue for incomplete YouTube URLs" do
+      issues = Requirements::VideoEmbedChecker.new.pre_embed_issues(url: "https://www.youtube.com/watch")
+      form_message = issues.items_for(:video_embed_url).first[:text]
+      expect(form_message).to eq(I18n.t!("requirements.video_embed_url.non_youtube.form_message"))
+    end
   end
 end


### PR DESCRIPTION
https://trello.com/c/Rf4RSnKZ/147-user-can-embed-video-from-markdown-toolbar

Previously the video embed checker would raise an error if the user
pasted the hint text into the URL input. This fixes that.