### PR TITLE
Links to image requirement issues

### DIFF
--- a/app/services/requirements/checker_issues.rb
+++ b/app/services/requirements/checker_issues.rb
@@ -12,12 +12,20 @@ module Requirements
     end
 
     def items(params = {})
-      map { |issue| issue.to_item(**params) }
+      map { |issue| issue.to_item(**issue_item_params(issue, params)) }
     end
 
     def items_for(field, params = {})
       select { |issue| issue.field == field }
-        .map { |issue| issue.to_item(**params) }
+        .map { |issue| issue.to_item(**issue_item_params(issue, params)) }
+    end
+
+  private
+
+    def issue_item_params(issue, params)
+      link_options = params.dig(:link_options, issue.field) || {}
+
+      params.slice(:style).merge(link_options: link_options)
     end
   end
 end

--- a/app/services/requirements/image_revision_checker.rb
+++ b/app/services/requirements/image_revision_checker.rb
@@ -16,19 +16,34 @@ module Requirements
       issues = []
 
       if image_revision.alt_text.blank?
-        issues << Issue.new(:alt_text, :blank, filename: image_revision.filename)
+        issues << Issue.new(:alt_text,
+                            :blank,
+                            filename: image_revision.filename,
+                            image_revision: image_revision)
       end
 
       if image_revision.alt_text.to_s.length > ALT_TEXT_MAX_LENGTH
-        issues << Issue.new(:alt_text, :too_long, max_length: ALT_TEXT_MAX_LENGTH, filename: image_revision.filename)
+        issues << Issue.new(:alt_text,
+                            :too_long,
+                            max_length: ALT_TEXT_MAX_LENGTH,
+                            filename: image_revision.filename,
+                            image_revision: image_revision)
       end
 
       if image_revision.caption.to_s.length > CAPTION_MAX_LENGTH
-        issues << Issue.new(:caption, :too_long, max_length: CAPTION_MAX_LENGTH, filename: image_revision.filename)
+        issues << Issue.new(:caption,
+                            :too_long,
+                            max_length: CAPTION_MAX_LENGTH,
+                            filename: image_revision.filename,
+                            image_revision: image_revision)
       end
 
       if image_revision.credit.to_s.length > CREDIT_MAX_LENGTH
-        issues << Issue.new(:credit, :too_long, max_length: CREDIT_MAX_LENGTH, filename: image_revision.filename)
+        issues << Issue.new(:credit,
+                            :too_long,
+                            max_length: CREDIT_MAX_LENGTH,
+                            filename: image_revision.filename,
+                            image_revision: image_revision)
       end
 
       CheckerIssues.new(issues)

--- a/app/services/requirements/issue.rb
+++ b/app/services/requirements/issue.rb
@@ -15,6 +15,8 @@ module Requirements
     end
 
     def to_item(link_options: {}, style: "form")
+      link_options = link_options.call(context) if link_options.is_a?(Proc)
+
       {
         text: message(style: style),
         href: link_options[:href],

--- a/app/services/requirements/issue.rb
+++ b/app/services/requirements/issue.rb
@@ -17,8 +17,8 @@ module Requirements
     def to_item(link_options: {}, style: "form")
       {
         text: message(style: style),
-        href: link_options.dig(field, :href),
-        target: link_options.dig(field, :target),
+        href: link_options[:href],
+        target: link_options[:target],
       }
     end
   end

--- a/app/views/documents/show/_requirements.html.erb
+++ b/app/views/documents/show/_requirements.html.erb
@@ -6,6 +6,7 @@
     body: { href: edit_document_path(@edition.document, anchor: "body") },
     change_note: { href: edit_document_path(@edition.document, anchor: "change-note") },
     alt_text: { href: "#lead-image" },
+    credit: { href: "#lead-image" },
     caption: { href: "#lead-image" },
     topics: { href: update_topics_path(@edition.document) },
   }

--- a/app/views/documents/show/_requirements.html.erb
+++ b/app/views/documents/show/_requirements.html.erb
@@ -5,9 +5,18 @@
     summary: { href: edit_document_path(@edition.document, anchor: "summary") },
     body: { href: edit_document_path(@edition.document, anchor: "body") },
     change_note: { href: edit_document_path(@edition.document, anchor: "change-note") },
-    alt_text: { href: "#lead-image" },
-    credit: { href: "#lead-image" },
-    caption: { href: "#lead-image" },
+    alt_text: -> (context) do
+      image_id = context[:image_revision].image_id
+      { href: edit_image_path(@edition.document, image_id, anchor: "alt-text") }
+    end,
+    credit: -> (context) do
+      image_id = context[:image_revision].image_id
+      { href: edit_image_path(@edition.document, image_id, anchor: "credit") }
+    end,
+    caption: -> (context) do
+      image_id = context[:image_revision].image_id
+      { href: edit_image_path(@edition.document, image_id, anchor: "caption") }
+    end,
     topics: { href: update_topics_path(@edition.document) },
   }
 } %>

--- a/app/views/images/edit.html.erb
+++ b/app/views/images/edit.html.erb
@@ -88,6 +88,7 @@ content_for :title, t(title_key, title: @edition.title_or_fallback)
         },
         name: "image_revision[credit]",
         value: @image_revision.credit,
+        error_items: @issues&.items_for(:credit),
         data: {
           "contextual-guidance": "credit-guidance"
         }

--- a/app/views/images/edit.html.erb
+++ b/app/views/images/edit.html.erb
@@ -28,7 +28,7 @@ content_for :title, t(title_key, title: @edition.title_or_fallback)
   }
 ) do %>
   <div class="govuk-grid-row">
-    <div class="govuk-grid-column-two-thirds">
+    <div class="govuk-grid-column-two-thirds" id="alt-text">
       <%= render "govuk_publishing_components/components/input", {
         label: {
           text: t("images.edit.form_labels.alt_text"),
@@ -54,7 +54,7 @@ content_for :title, t(title_key, title: @edition.title_or_fallback)
   </div>
 
   <div class="govuk-grid-row">
-    <div class="govuk-grid-column-two-thirds">
+    <div class="govuk-grid-column-two-thirds" id="caption">
       <%= render "govuk_publishing_components/components/input", {
         label: {
           text: t("images.edit.form_labels.caption"),
@@ -80,7 +80,7 @@ content_for :title, t(title_key, title: @edition.title_or_fallback)
   </div>
 
   <div class="govuk-grid-row">
-    <div class="govuk-grid-column-two-thirds">
+    <div class="govuk-grid-column-two-thirds" id="credit">
       <%= render "govuk_publishing_components/components/input", {
         label: {
           text: t("images.edit.form_labels.credit"),

--- a/spec/features/workflow/preview_requirements_spec.rb
+++ b/spec/features/workflow/preview_requirements_spec.rb
@@ -1,8 +1,6 @@
 # frozen_string_literal: true
 
 RSpec.feature "Preview requirements" do
-  include TopicsHelper
-
   scenario do
     given_there_is_an_edition_with_issues_to_fix
     when_i_view_the_summary_page


### PR DESCRIPTION
Trello: https://trello.com/c/Ml6qt5on/845-make-publishing-requirement-prompt-target-accurate

As a companion to https://github.com/alphagov/content-publisher/pull/1078 this adds in the links for image requirement issues. These were somewhat tricky as the URLs require the id of the image which isn't readily available. To resolve this I have made use of the context hash on an Issue and allowed passing in a lambda to generate the link.

![May-29-2019 19-14-36](https://user-images.githubusercontent.com/282717/58580968-46e14200-8246-11e9-81a9-111391d92e07.gif)

This also fixes a couple of issues I spotted along the way, such as missing credit link and errors. 

For further details see commit messages.