### PR TITLE
Update autocomplete to allow narrow width needed for time select

### DIFF
--- a/app/assets/stylesheets/components/_autocomplete.scss
+++ b/app/assets/stylesheets/components/_autocomplete.scss
@@ -60,6 +60,14 @@
   }
 }
 
+.app-c-autocomplete--narrow {
+  max-width: 200px;
+
+  @include govuk-media-query($from: tablet) {
+    max-width: 230px;
+  }
+}
+
 .js-enabled {
   .app-c-autocomplete__multiselect-instructions {
     display: none;

--- a/app/views/components/_autocomplete.html.erb
+++ b/app/views/components/_autocomplete.html.erb
@@ -6,21 +6,20 @@
   type ||= nil
   size ||= nil
   hint ||= nil
+  width ||= nil
+  css_classes = %w(app-c-autocomplete govuk-form-group)
+  css_classes << "app-c-autocomplete--#{width}" if width
 %>
 
-<div class="app-c-autocomplete govuk-form-group" data-module="autocomplete" data-autocomplete-type="<%= type %>">
+<%= tag.div class: css_classes, data: { module: "autocomplete", "autocomplete-type": type } do %>
   <%= render "govuk_publishing_components/components/label", {
     html_for: id
   }.merge(label.symbolize_keys) %>
 
   <% if options.any? %>
-    <% if multiple %>
-      <span class="govuk-hint app-c-autocomplete__multiselect-instructions">To select multiple items in a list, hold down Ctrl (PC) or Command (Mac) key.</span>
-    <% end %>
+    <%= tag.span "To select multiple items in a list, hold down Ctrl (PC) or Command (Mac) key.", class: "govuk-hint app-c-autocomplete__multiselect-instructions" if multiple %>
 
-    <% if hint %>
-      <span class="govuk-hint"><%= hint %></span>
-    <% end %>
+    <%= tag.span hint, class: "govuk-hint" if hint %>
 
     <%= select_tag name,
       options_for_select(options, selected_options),
@@ -29,8 +28,7 @@
       size: size,
       multiple: multiple
     %>
-
   <% else %>
-    <p class="govuk-hint">No options available</p>
+    <%= tag.p "No options available", class: "govuk-hint" %>
   <% end %>
-</div>
+<% end %>

--- a/app/views/components/docs/autocomplete.yml
+++ b/app/views/components/docs/autocomplete.yml
@@ -123,3 +123,19 @@ examples:
         -
           - United Kingdom
           - uk
+  autocomplete_narrow_width:
+    data:
+      id: autocomplete-narrow
+      name: autocomplete-narrow
+      type: without-narrowing-results
+      label:
+        text: Status
+      data_module: autocomplete
+      width: narrow
+      options:
+        -
+          - Draft
+        -
+          - Published
+        -
+          - Removed

--- a/app/views/documents/show/_scheduling_form.html.erb
+++ b/app/views/documents/show/_scheduling_form.html.erb
@@ -50,7 +50,8 @@
        },
        options: time_options[:options],
        selected_options: time_options[:selected_options],
-       type: "without-narrowing-results"
+       type: "without-narrowing-results",
+       width: "narrow"
      } %>
     <% if current_scheduled_publish_datetime %>
       <%= render "govuk_publishing_components/components/button", {


### PR DESCRIPTION
Update autocomplete to support a narrow version witch matches the date input component width so it can be used for time select.
Use tag helpers to generate markup for the autocomplete component.

[Trello card](https://trello.com/c/rGjDviSL)