### PR TITLE
Stop scheduled publishing

### DIFF
--- a/app/controllers/unschedule_controller.rb
+++ b/app/controllers/unschedule_controller.rb
@@ -4,6 +4,11 @@ class UnscheduleController < ApplicationController
   def unschedule
     result = Unschedule::UnscheduleInteractor.call(params: params, user: current_user)
 
-    redirect_to document_path(params[:document])
+    if result.api_error
+      redirect_to document_path(params[:document]),
+                  alert_with_description: t("documents.show.flashes.unschedule_error")
+    else
+      redirect_to document_path(params[:document])
+    end
   end
 end

--- a/app/controllers/unschedule_controller.rb
+++ b/app/controllers/unschedule_controller.rb
@@ -2,18 +2,8 @@
 
 class UnscheduleController < ApplicationController
   def unschedule
-    Edition.find_and_lock_current(document: params[:document]) do |edition|
-      schedule = edition.status.details
+    result = Unschedule::UnscheduleInteractor.call(params: params, user: current_user)
 
-      updater = Versioning::RevisionUpdater.new(edition.revision, current_user)
-      updater.assign(scheduled_publishing_datetime: nil)
-      edition.assign_revision(updater.next_revision, current_user)
-
-      state = schedule.reviewed? ? "submitted_for_review" : "draft"
-      edition.assign_status(state, current_user).save!
-
-      TimelineEntry.create_for_status_change(entry_type: :unscheduled, status: edition.status)
-      redirect_to document_path(edition.document)
-    end
+    redirect_to document_path(params[:document])
   end
 end

--- a/app/interactors/unschedule/unschedule_interactor.rb
+++ b/app/interactors/unschedule/unschedule_interactor.rb
@@ -9,6 +9,7 @@ class Unschedule::UnscheduleInteractor
     Edition.transaction do
       find_and_lock_edition
       set_edition_status
+      destroy_publishing_intent
       create_timeline_entry
     end
   end
@@ -28,6 +29,10 @@ private
     scheduling = edition.status.details
     state = scheduling.reviewed? ? :submitted_for_review : :draft
     edition.assign_status(state, user).save!
+  end
+
+  def destroy_publishing_intent
+    GdsApi.publishing_api.destroy_intent(edition.base_path)
   end
 
   def create_timeline_entry

--- a/app/interactors/unschedule/unschedule_interactor.rb
+++ b/app/interactors/unschedule/unschedule_interactor.rb
@@ -22,10 +22,6 @@ private
   end
 
   def set_edition_status
-    updater = Versioning::RevisionUpdater.new(edition.revision, user)
-    updater.assign(scheduled_publishing_datetime: nil)
-    edition.assign_revision(updater.next_revision, user).save!
-
     scheduling = edition.status.details
     state = scheduling.reviewed? ? :submitted_for_review : :draft
     edition.assign_status(state, user).save!

--- a/app/interactors/unschedule/unschedule_interactor.rb
+++ b/app/interactors/unschedule/unschedule_interactor.rb
@@ -1,0 +1,39 @@
+# frozen_string_literal: true
+
+class Unschedule::UnscheduleInteractor
+  include Interactor
+
+  delegate :params, :edition, :user, to: :context
+
+  def call
+    Edition.transaction do
+      find_and_lock_edition
+      set_edition_status
+      create_timeline_entry
+    end
+  end
+
+private
+
+  def find_and_lock_edition
+    context.edition = Edition.lock.find_current(document: params[:document])
+    context.fail! unless edition.scheduled?
+  end
+
+  def set_edition_status
+    updater = Versioning::RevisionUpdater.new(edition.revision, user)
+    updater.assign(scheduled_publishing_datetime: nil)
+    edition.assign_revision(updater.next_revision, user).save!
+
+    scheduling = edition.status.details
+    state = scheduling.reviewed? ? :submitted_for_review : :draft
+    edition.assign_status(state, user).save!
+  end
+
+  def create_timeline_entry
+    TimelineEntry.create_for_status_change(
+      entry_type: :unscheduled,
+      status: edition.status,
+    )
+  end
+end

--- a/app/interactors/unschedule/unschedule_interactor.rb
+++ b/app/interactors/unschedule/unschedule_interactor.rb
@@ -33,6 +33,9 @@ private
 
   def destroy_publishing_intent
     GdsApi.publishing_api.destroy_intent(edition.base_path)
+  rescue GdsApi::BaseError => e
+    GovukError.notify(e)
+    context.fail!(api_error: true)
   end
 
   def create_timeline_entry

--- a/config/locales/en/documents/show.yml
+++ b/config/locales/en/documents/show.yml
@@ -78,3 +78,6 @@ en:
         unwithdraw_error:
           title: Something has gone wrong
           description_govspeak: Something went wrong when trying to republish the withdrawn document. Please try again or [raise a support request](https://support.publishing.service.gov.uk/technical_fault_report/new).
+        unschedule_error:
+          title: Something has gone wrong
+          description_govspeak: Something went wrong when stopping the scheduling of this document. Please try again or [raise a support request](https://support.publishing.service.gov.uk/technical_fault_report/new).

--- a/spec/features/workflow/unschedule_publishing_api_down_spec.rb
+++ b/spec/features/workflow/unschedule_publishing_api_down_spec.rb
@@ -1,0 +1,37 @@
+# frozen_string_literal: true
+
+RSpec.feature "Unschedule a document when Publishing API is down" do
+  scenario do
+    given_there_is_a_scheduled_document
+    and_the_publishing_api_is_down
+    when_i_visit_the_summary_page
+    and_i_click_stop_scheduled_publishing
+    then_i_see_an_error_message
+    and_the_document_is_still_scheduled
+  end
+
+  def given_there_is_a_scheduled_document
+    schedule = create(:scheduling, reviewed: true)
+    @edition = create(:edition, :scheduled, scheduling: schedule)
+  end
+
+  def and_the_publishing_api_is_down
+    publishing_api_isnt_available
+  end
+
+  def when_i_visit_the_summary_page
+    visit document_path(@edition.document)
+  end
+
+  def and_i_click_stop_scheduled_publishing
+    click_on "Stop scheduled publishing"
+  end
+
+  def then_i_see_an_error_message
+    expect(page).to have_content(I18n.t!("documents.show.flashes.unschedule_error.title"))
+  end
+
+  def and_the_document_is_still_scheduled
+    expect(page).to have_content("Scheduled to publish")
+  end
+end

--- a/spec/features/workflow/unschedule_spec.rb
+++ b/spec/features/workflow/unschedule_spec.rb
@@ -6,11 +6,16 @@ RSpec.feature "Unschedule an edition" do
     when_i_visit_the_summary_page
     and_i_click_stop_scheduled_publishing
     then_the_document_is_no_longer_scheduled
+    and_the_proposed_scheduled_publishing_datetime_is_still_set
   end
 
   def given_there_is_a_scheduled_document
     schedule = create(:scheduling, reviewed: true)
-    @edition = create(:edition, :scheduled, scheduling: schedule)
+    @datetime = Time.current.tomorrow.change(hour: 23)
+    @edition = create(:edition,
+                      :scheduled,
+                      scheduled_publishing_datetime: @datetime,
+                      scheduling: schedule)
   end
 
   def when_i_visit_the_summary_page
@@ -28,5 +33,10 @@ RSpec.feature "Unschedule an edition" do
     within first(".app-timeline-entry") do
       expect(page).to have_content I18n.t!("documents.history.entry_types.unscheduled")
     end
+  end
+
+  def and_the_proposed_scheduled_publishing_datetime_is_still_set
+    scheduled_date = @datetime.strftime("%-d %B %Y - 11:00pm")
+    expect(page).to have_content("Publish date: #{scheduled_date}")
   end
 end

--- a/spec/features/workflow/unschedule_spec.rb
+++ b/spec/features/workflow/unschedule_spec.rb
@@ -18,6 +18,7 @@ RSpec.feature "Unschedule an edition" do
   end
 
   def and_i_click_stop_scheduled_publishing
+    stub_publishing_api_destroy_intent(@edition.base_path)
     click_on "Stop scheduled publishing"
   end
 

--- a/spec/interactors/unschedule/unschedule_interactor_spec.rb
+++ b/spec/interactors/unschedule/unschedule_interactor_spec.rb
@@ -30,6 +30,13 @@ RSpec.describe Unschedule::UnscheduleInteractor do
       expect(@destroy_intent_request).to have_been_requested
     end
 
+    it "returns an api_error flag when Publishing API is down" do
+      stub_publishing_api_isnt_available
+      result = Unschedule::UnscheduleInteractor.call(params: params, user: user)
+
+      expect(result.api_error).to be_truthy
+    end
+
     context "when the scheduling reviewed state is set to true" do
       it "sets the edition's status to 'submitted_for_review'" do
         scheduling = build(:scheduling, reviewed: true)

--- a/spec/interactors/unschedule/unschedule_interactor_spec.rb
+++ b/spec/interactors/unschedule/unschedule_interactor_spec.rb
@@ -11,12 +11,6 @@ RSpec.describe Unschedule::UnscheduleInteractor do
       @destroy_intent_request = stub_publishing_api_destroy_intent(edition.base_path)
     end
 
-    it "sets an edition's scheduled publishing datetime to nil" do
-      result = Unschedule::UnscheduleInteractor.call(params: params, user: user)
-
-      expect(result.edition.scheduled_publishing_datetime).to be nil
-    end
-
     it "creates a timeline entry" do
       result = Unschedule::UnscheduleInteractor.call(params: params, user: user)
       timeline_entry = result.edition.timeline_entries.last

--- a/spec/interactors/unschedule/unschedule_interactor_spec.rb
+++ b/spec/interactors/unschedule/unschedule_interactor_spec.rb
@@ -1,0 +1,43 @@
+# frozen_string_literal: true
+
+RSpec.describe Unschedule::UnscheduleInteractor do
+  let(:scheduling) { build(:scheduling) }
+  let(:edition) { create(:edition, :scheduled, scheduling: scheduling) }
+  let(:user) { build(:user) }
+  let(:params) { { document: edition.document.to_param } }
+
+  describe "#call" do
+    it "sets an edition's scheduled publishing datetime to nil" do
+      result = Unschedule::UnscheduleInteractor.call(params: params, user: user)
+
+      expect(result.edition.scheduled_publishing_datetime).to be nil
+    end
+
+    it "creates a timeline entry" do
+      result = Unschedule::UnscheduleInteractor.call(params: params, user: user)
+      timeline_entry = result.edition.timeline_entries.last
+
+      expect(timeline_entry.entry_type).to eq("unscheduled")
+    end
+
+    context "when the scheduling reviewed state is set to true" do
+      it "sets the edition's status to 'submitted_for_review'" do
+        scheduling = build(:scheduling, reviewed: true)
+        edition = create(:edition, :scheduled, scheduling: scheduling)
+        result = Unschedule::UnscheduleInteractor.call(
+          params: { document: edition.document.to_param }, user: user,
+        )
+
+        expect(result.edition.status).to be_submitted_for_review
+      end
+    end
+
+    context "when the scheduling reviewed state is set to false" do
+      it "sets the edition's status to 'draft'" do
+        result = Unschedule::UnscheduleInteractor.call(params: params, user: user)
+
+        expect(result.edition.status).to be_draft
+      end
+    end
+  end
+end


### PR DESCRIPTION
For https://trello.com/c/FndkZ8gG/843-allow-users-to-stop-a-scheduled-publishing

This extracts the existing unschedule controller action into an interactor and creates a dedicated Unschedule Service to take care of making the appropriate status changes to a scheduled edition and deleting the publish intent that had been created when the edition was scheduled.