### PR TITLE
Change FileAttachment assets from one-to-many to one-to-one

### DIFF
--- a/app/helpers/file_attachment_helper.rb
+++ b/app/helpers/file_attachment_helper.rb
@@ -4,7 +4,7 @@ module FileAttachmentHelper
   def file_attachment_preview_url(attachment_revision, document)
     service = PreviewAuthBypassService.new(document)
     params = { token: service.preview_token }.to_query
-    attachment_revision.asset_url("file") + "?" + params
+    attachment_revision.asset_url + "?" + params
   end
 
   def file_attachment_attributes(attachment_revision, document)

--- a/app/interactors/file_attachments/preview_interactor.rb
+++ b/app/interactors/file_attachments/preview_interactor.rb
@@ -29,8 +29,7 @@ private
   end
 
   def find_or_upload_asset
-    attachment_revision.ensure_assets
-    context.asset = attachment_revision.asset("file")
+    context.asset = attachment_revision.asset
 
     if asset.absent?
       PreviewAssetService.new(edition).upload_asset(asset)

--- a/app/models/file_attachment/asset.rb
+++ b/app/models/file_attachment/asset.rb
@@ -18,8 +18,6 @@ class FileAttachment::Asset < ApplicationRecord
                 live: "live",
                 superseded: "superseded" }
 
-  enum variant: { file: "file", thumbnail: "thumbnail" }
-
   delegate :filename, :content_type, to: :blob_revision
 
   def asset_manager_id
@@ -29,6 +27,6 @@ class FileAttachment::Asset < ApplicationRecord
   end
 
   def bytes
-    blob_revision.bytes_for_asset(variant)
+    blob_revision.bytes_for_asset
   end
 end

--- a/app/models/file_attachment/blob_revision.rb
+++ b/app/models/file_attachment/blob_revision.rb
@@ -6,7 +6,10 @@ class FileAttachment::BlobRevision < ApplicationRecord
 
   belongs_to :created_by, class_name: "User", optional: true
 
-  has_many :assets, class_name: "FileAttachment::Asset"
+  has_one :asset,
+          class_name: "FileAttachment::Asset",
+          inverse_of: :blob_revision,
+          required: true
 
   delegate :content_type, :byte_size, to: :blob
 
@@ -14,25 +17,11 @@ class FileAttachment::BlobRevision < ApplicationRecord
     !new_record?
   end
 
-  def asset(variant)
-    assets.find { |v| v.variant == variant }
+  def asset_url
+    asset.file_url
   end
 
-  def asset_url(variant)
-    asset(variant)&.file_url
-  end
-
-  def bytes_for_asset(variant)
-    if variant == "file"
-      blob.download
-    else
-      raise RuntimeError, "Unsupported blob revision variant #{variant}"
-    end
-  end
-
-  def ensure_assets
-    unless asset("file")
-      assets << FileAttachment::Asset.new(blob_revision: self, variant: "file")
-    end
+  def bytes_for_asset
+    blob.download
   end
 end

--- a/app/models/file_attachment/revision.rb
+++ b/app/models/file_attachment/revision.rb
@@ -18,8 +18,6 @@ class FileAttachment::Revision < ApplicationRecord
   delegate :filename,
            :asset,
            :asset_url,
-           :assets,
-           :ensure_assets,
            :content_type,
            :byte_size,
            :number_of_pages,

--- a/app/models/revision.rb
+++ b/app/models/revision.rb
@@ -84,6 +84,6 @@ class Revision < ApplicationRecord
   end
 
   def assets
-    image_revisions.flat_map(&:assets) + file_attachment_revisions.flat_map(&:assets)
+    image_revisions.flat_map(&:assets) + file_attachment_revisions.map(&:asset)
   end
 end

--- a/app/services/draft_asset_cleanup_service.rb
+++ b/app/services/draft_asset_cleanup_service.rb
@@ -7,7 +7,7 @@ class DraftAssetCleanupService
 
     return unless previous_revision
 
-    delete_assets(previous_assets(previous_revision) - current_assets(current_revision))
+    delete_assets(previous_revision.assets - current_revision.assets)
   end
 
 private
@@ -24,17 +24,5 @@ private
 
       asset.absent!
     end
-  end
-
-  def current_assets(current_revision)
-    current_image_assets = current_revision.image_revisions.flat_map(&:assets)
-    current_file_attachment_assets = current_revision.file_attachment_revisions.flat_map(&:assets)
-    current_image_assets + current_file_attachment_assets
-  end
-
-  def previous_assets(previous_revision)
-    previous_image_assets = previous_revision.image_revisions.flat_map(&:assets)
-    previous_file_attachment_assets = previous_revision.file_attachment_revisions.flat_map(&:assets)
-    previous_image_assets + previous_file_attachment_assets
   end
 end

--- a/app/services/file_attachment_blob_service.rb
+++ b/app/services/file_attachment_blob_service.rb
@@ -21,6 +21,7 @@ class FileAttachmentBlobService
       filename: filename,
       number_of_pages: number_of_pages(file, mime_type),
       created_by: user,
+      asset: FileAttachment::Asset.new,
     )
   end
 

--- a/app/services/govspeak_document/payload_options.rb
+++ b/app/services/govspeak_document/payload_options.rb
@@ -38,7 +38,7 @@ private
     attributes = file_attachment_attributes(attachment_revision, edition.document)
 
     attributes.merge(
-      url: attachment_revision.asset_url("file"),
+      url: attachment_revision.asset_url,
       alternative_format_contact_email: alt_email,
     )
   end

--- a/app/services/preview_asset_service.rb
+++ b/app/services/preview_asset_service.rb
@@ -14,8 +14,7 @@ class PreviewAssetService
     end
 
     edition.file_attachment_revisions.each do |file_attachment_revision|
-      file_attachment_revision.ensure_assets
-      file_attachment_revision.assets.each { |asset| upload_asset(asset) }
+      upload_asset(file_attachment_revision.asset)
     end
   end
 

--- a/app/services/publish_asset_service.rb
+++ b/app/services/publish_asset_service.rb
@@ -23,9 +23,9 @@ private
       current_revision = find_file_attachment_revision(edition, live_revision)
 
       if current_revision
-        redirect_assets(live_revision, current_revision)
+        redirect_asset(live_revision.asset, current_revision.asset)
       else
-        live_revision.assets.each { |a| delete_asset(a) }
+        delete_asset(live_revision.asset)
       end
     end
   end

--- a/db/migrate/20190530175303_remove_variant_from_file_attachment_assets.rb
+++ b/db/migrate/20190530175303_remove_variant_from_file_attachment_assets.rb
@@ -1,0 +1,17 @@
+# frozen_string_literal: true
+
+class RemoveVariantFromFileAttachmentAssets < ActiveRecord::Migration[5.2]
+  def change
+    remove_index :file_attachment_assets,
+                 column: %i[blob_revision_id variant],
+                 unique: true
+    remove_column :file_attachment_assets,
+                  :variant,
+                  :string,
+                  default: "file",
+                  null: false
+
+    remove_index :file_attachment_assets, :blob_revision_id
+    add_index :file_attachment_assets, :blob_revision_id, unique: true
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2019_05_01_145759) do
+ActiveRecord::Schema.define(version: 2019_05_30_175303) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -91,14 +91,12 @@ ActiveRecord::Schema.define(version: 2019_05_01_145759) do
 
   create_table "file_attachment_assets", force: :cascade do |t|
     t.bigint "blob_revision_id", null: false
-    t.string "variant", default: "file", null: false
     t.string "file_url"
     t.string "state", default: "absent", null: false
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.bigint "superseded_by_id"
-    t.index ["blob_revision_id", "variant"], name: "index_file_attachment_assets_on_blob_revision_id_and_variant", unique: true
-    t.index ["blob_revision_id"], name: "index_file_attachment_assets_on_blob_revision_id"
+    t.index ["blob_revision_id"], name: "index_file_attachment_assets_on_blob_revision_id", unique: true
     t.index ["file_url"], name: "index_file_attachment_assets_on_file_url", unique: true
   end
 

--- a/spec/factories/file_attachment_blob_revision_factory.rb
+++ b/spec/factories/file_attachment_blob_revision_factory.rb
@@ -8,7 +8,7 @@ FactoryBot.define do
 
     transient do
       fixture { "text-file.txt" }
-      assets { nil }
+      asset { nil }
     end
 
     after(:build) do |blob_revision, evaluator|
@@ -19,11 +19,7 @@ FactoryBot.define do
         filename: blob_revision.filename,
       )
 
-      if evaluator.assets
-        blob_revision.assets = evaluator.assets
-      else
-        blob_revision.ensure_assets
-      end
+      blob_revision.asset = FileAttachment::Asset.new unless blob_revision.asset
     end
 
     trait :on_asset_manager do
@@ -32,11 +28,9 @@ FactoryBot.define do
       end
 
       after(:build) do |blob_revision, evaluator|
-        blob_revision.assets.each do |asset|
-          url = "https://asset-manager.test.gov.uk/media/" +
-            "asset-id#{SecureRandom.hex(8)}/#{blob_revision.filename}"
-          asset.assign_attributes(state: evaluator.state, file_url: url)
-        end
+        url = "https://asset-manager.test.gov.uk/media/" +
+          "asset-id#{SecureRandom.hex(8)}/#{blob_revision.filename}"
+        blob_revision.asset.assign_attributes(state: evaluator.state, file_url: url)
       end
     end
   end

--- a/spec/factories/file_attachment_revision_factory.rb
+++ b/spec/factories/file_attachment_revision_factory.rb
@@ -10,7 +10,7 @@ FactoryBot.define do
       number_of_pages { nil }
       fixture { "text-file.txt" }
       title { SecureRandom.hex(8) }
-      assets { nil }
+      asset { nil }
     end
 
     after(:build) do |revision, evaluator|
@@ -20,7 +20,7 @@ FactoryBot.define do
           filename: evaluator.filename,
           number_of_pages: evaluator.number_of_pages,
           fixture: evaluator.fixture,
-          assets: evaluator.assets,
+          asset: evaluator.asset,
         )
       end
 
@@ -45,7 +45,7 @@ FactoryBot.define do
           number_of_pages: evaluator.number_of_pages,
           fixture: evaluator.fixture,
           state: evaluator.state,
-          assets: evaluator.assets,
+          asset: evaluator.asset,
         )
 
         revision.metadata_revision = evaluator.association(

--- a/spec/features/editing_file_attachments/preview_file_attachment_spec.rb
+++ b/spec/features/editing_file_attachments/preview_file_attachment_spec.rb
@@ -12,7 +12,7 @@ RSpec.feature "Preview file attachment", js: true do
     body_field = build(:field, id: "body", type: "govspeak")
     document_type = build(:document_type, contents: [body_field])
     @attachment_revision = create(:file_attachment_revision, :on_asset_manager)
-    @asset = @attachment_revision.asset("file")
+    @asset = @attachment_revision.asset
 
     @edition = create(:edition,
                       document_type_id: document_type.id,

--- a/spec/features/editing_file_attachments/preview_file_attachment_unavailable_spec.rb
+++ b/spec/features/editing_file_attachments/preview_file_attachment_unavailable_spec.rb
@@ -11,8 +11,8 @@ RSpec.feature "Preview file attachment when unavailable", js: true do
   def given_there_is_an_edition_with_attachments
     body_field = build(:field, id: "body", type: "govspeak")
     document_type = build(:document_type, contents: [body_field])
-    @attachment_revision = create(:file_attachment_revision, assets: [])
-    @asset = @attachment_revision.asset("file")
+    @attachment_revision = create(:file_attachment_revision)
+    @asset = @attachment_revision.asset
 
     @edition = create(:edition,
                       document_type_id: document_type.id,

--- a/spec/features/editing_file_attachments/replace_file_attachment_file_spec.rb
+++ b/spec/features/editing_file_attachments/replace_file_attachment_file_spec.rb
@@ -36,7 +36,7 @@ RSpec.feature "Replace a file attachment file", js: true do
 
   def and_i_upload_a_replacement_attachment_file
     @put_content_request = stub_publishing_api_put_content(@edition.content_id, {})
-    existing_asset = @attachment_revision.assets.first
+    existing_asset = @attachment_revision.asset
     @delete_current_file_request = stub_asset_manager_delete_asset(existing_asset.asset_manager_id)
     @create_new_file_request = stub_asset_manager_receives_an_asset(filename: attachment_filename)
 

--- a/spec/interactors/file_attachments/preview_interactor_spec.rb
+++ b/spec/interactors/file_attachments/preview_interactor_spec.rb
@@ -46,7 +46,7 @@ RSpec.describe FileAttachments::PreviewInteractor do
 
     context "when the asset is absent from Asset Manager" do
       let(:attachment_revision) do
-        create :file_attachment_revision, file_attachment: file_attachment, assets: []
+        create :file_attachment_revision, file_attachment: file_attachment
       end
 
       before do
@@ -62,11 +62,6 @@ RSpec.describe FileAttachments::PreviewInteractor do
       it "returns a can_preview flag" do
         result = FileAttachments::PreviewInteractor.call(params: params)
         expect(result.can_preview).to be_falsey
-      end
-
-      it "saves the new asset(s)" do
-        FileAttachments::PreviewInteractor.call(params: params)
-        expect(attachment_revision.reload.assets.any?).to be_truthy
       end
 
       it "returns an api_error flag when Asset Manager is down" do

--- a/spec/models/file_attachment/blob_revision_spec.rb
+++ b/spec/models/file_attachment/blob_revision_spec.rb
@@ -1,40 +1,13 @@
 # frozen_string_literal: true
 
 RSpec.describe FileAttachment::BlobRevision do
-  describe "#ensure_assets" do
-    it "doesn't change the assets when they already exist" do
-      blob_revision = build(:file_attachment_blob_revision)
-      assets = blob_revision.assets.to_a
-
-      blob_revision.ensure_assets
-
-      expect(blob_revision.assets.to_a).to eq(assets)
-      expect(blob_revision.assets.map(&:variant)).to match(%w[file])
-    end
-
-    it "creates variants for those that don't exist" do
-      blob_revision = build(:file_attachment_blob_revision, assets: [])
-
-      expect(blob_revision.assets).to be_empty
-
-      blob_revision.ensure_assets
-
-      expect(blob_revision.assets.map(&:variant)).to match(%w[file])
-    end
-  end
-
   describe "#bytes_for_asset" do
     let(:blob_revision) { build(:file_attachment_blob_revision) }
 
-    it "returns a string of bytes for a known variant" do
-      response = blob_revision.bytes_for_asset("file")
+    it "returns a string of bytes" do
+      response = blob_revision.bytes_for_asset
 
       expect(response).to be_a(String)
-    end
-
-    it "raises an error for an unknown variant" do
-      expect { blob_revision.bytes_for_asset("huh") }
-        .to raise_error("Unsupported blob revision variant huh")
     end
   end
 end

--- a/spec/services/delete_draft_service_spec.rb
+++ b/spec/services/delete_draft_service_spec.rb
@@ -41,7 +41,7 @@ RSpec.describe DeleteDraftService do
 
       expect(delete_request).to have_been_requested.at_least_once
       expect(image_revision.reload.assets.map(&:state).uniq).to eq(%w[absent])
-      expect(file_attachment_revision.reload.assets.map(&:state).uniq).to eq(%w[absent])
+      expect(file_attachment_revision.reload.asset).to be_absent
     end
 
     it "attempts to delete path reservations for a first draft" do
@@ -121,7 +121,7 @@ RSpec.describe DeleteDraftService do
 
       expect(edition.reload.status).to be_discarded
       expect(image_revision.reload.assets.map(&:state).uniq).to eq(%w[absent])
-      expect(file_attachment_revision.reload.assets.map(&:state).uniq).to eq(%w[absent])
+      expect(file_attachment_revision.reload.asset).to be_absent
     end
 
     it "copes if the base path is not reserved" do
@@ -150,7 +150,7 @@ RSpec.describe DeleteDraftService do
                        lead_image_revision: image_revision,
                        file_attachment_revisions: [file_attachment_revision])
 
-      (image_revision.assets + file_attachment_revision.assets).map do |asset|
+      (image_revision.assets + [file_attachment_revision.asset]).map do |asset|
         stub_asset_manager_delete_asset(asset.asset_manager_id)
       end
 
@@ -160,7 +160,7 @@ RSpec.describe DeleteDraftService do
 
       expect(edition.reload.status).to be_discarded
       expect(image_revision.reload.assets.map(&:state).uniq).to eq(%w[absent])
-      expect(file_attachment_revision.reload.assets.map(&:state).uniq).to eq(%w[absent])
+      expect(file_attachment_revision.reload.asset).to be_absent
     end
 
     it "raises an error when a base path cannot be deleted" do

--- a/spec/services/draft_asset_cleanup_service_spec.rb
+++ b/spec/services/draft_asset_cleanup_service_spec.rb
@@ -20,7 +20,7 @@ RSpec.describe DraftAssetCleanupService do
 
         expect(request).to have_been_requested.at_least_once
         expect(image_revision.assets.map(&:state).uniq).to match(%w[absent])
-        expect(file_attachment_revision.assets.map(&:state).uniq).to match(%w[absent])
+        expect(file_attachment_revision.asset).to be_absent
       end
     end
 
@@ -46,7 +46,7 @@ RSpec.describe DraftAssetCleanupService do
 
         expect(request).not_to have_been_requested
         expect(image_revision.assets.map(&:state).uniq).to match(%w[draft])
-        expect(file_attachment_revision.assets.map(&:state).uniq).to match(%w[draft])
+        expect(file_attachment_revision.asset).to be_draft
       end
     end
 
@@ -68,7 +68,7 @@ RSpec.describe DraftAssetCleanupService do
 
         expect(request).not_to have_been_requested
         expect(image_revision.assets.map(&:state).uniq).to match(%w[live])
-        expect(file_attachment_revision.assets.map(&:state).uniq).to match(%w[live])
+        expect(file_attachment_revision.asset).to be_live
       end
     end
 
@@ -99,7 +99,7 @@ RSpec.describe DraftAssetCleanupService do
         DraftAssetCleanupService.new.call(edition)
 
         expect(image_revision.assets.map(&:state).uniq).to match(%w[absent])
-        expect(file_attachment_revision.assets.map(&:state).uniq).to match(%w[absent])
+        expect(file_attachment_revision.asset).to be_absent
       end
     end
   end

--- a/spec/services/publish_asset_service_spec.rb
+++ b/spec/services/publish_asset_service_spec.rb
@@ -12,8 +12,8 @@ RSpec.describe PublishAssetService do
 
       stub_asset_manager_updates_any_asset
       PublishAssetService.new.publish_assets(edition, nil)
-      expect(file_attachment_revision.assets.map(&:state).uniq).to eq(%w[live])
       expect(image_revision.assets.map(&:state).uniq).to eq(%w[live])
+      expect(file_attachment_revision.asset).to be_live
     end
 
     it "doesn't republish the assets that are already live" do
@@ -61,8 +61,8 @@ RSpec.describe PublishAssetService do
       delete_request = stub_asset_manager_deletes_any_asset
 
       PublishAssetService.new.publish_assets(edition, live_edition)
-      expect(file_attachment_revision_to_remove.assets.map(&:state).uniq).to eq(%w[absent])
       expect(image_revision_to_remove.assets.map(&:state).uniq).to eq(%w[absent])
+      expect(file_attachment_revision_to_remove.asset).to be_absent
       expect(delete_request).to have_been_requested.at_least_once
     end
   end
@@ -84,7 +84,7 @@ RSpec.describe PublishAssetService do
     PublishAssetService.new.publish_assets(edition, live_edition)
 
     expect(image_revision_to_keep.assets.map(&:state).uniq).to eq(%w[live])
-    expect(file_attachment_revision_to_keep.assets.map(&:state).uniq).to eq(%w[live])
+    expect(file_attachment_revision_to_keep.asset).to be_live
   end
 
   it "redirects and supersedes the old asset to the new asset" do
@@ -108,8 +108,8 @@ RSpec.describe PublishAssetService do
 
     PublishAssetService.new.publish_assets(edition, live_edition)
 
-    expect(old_file_attachment_revision.assets.map(&:state).uniq).to eq(%w[superseded])
     expect(old_image_revision.assets.map(&:state).uniq).to eq(%w[superseded])
+    expect(old_file_attachment_revision.asset).to be_superseded
     expect(request).to have_been_requested.at_least_once
   end
 end

--- a/spec/services/remove_service_spec.rb
+++ b/spec/services/remove_service_spec.rb
@@ -104,7 +104,7 @@ RSpec.describe RemoveService do
 
         expect(delete_request).to have_been_requested.at_least_once
         expect(image_revision.assets.map(&:state).uniq).to eq(%w[absent])
-        expect(file_attachment_revision.assets.map(&:state).uniq).to eq(%w[absent])
+        expect(file_attachment_revision.asset).to be_absent
       end
 
       it "copes with assets that 404" do
@@ -121,7 +121,7 @@ RSpec.describe RemoveService do
 
         expect(delete_request).to have_been_requested.at_least_once
         expect(image_revision.assets.map(&:state).uniq).to eq(%w[absent])
-        expect(file_attachment_revision.assets.map(&:state).uniq).to eq(%w[absent])
+        expect(file_attachment_revision.asset).to be_absent
       end
 
       it "ignores assets that are absent" do


### PR DESCRIPTION
Trello: https://trello.com/c/BQ5bBkMw/881-wrap-up-technical-loose-ends-on-attachments

This PR builds on work in https://github.com/alphagov/content-publisher/pull/1092 and is thus marked as a draft until that is merged.

Previously we expected file attachments to potentially multiple assets
associated with each one, as is the case with images. This was based on
the expectation that PDFs would have a file and a thumbnail asset.
However later it was decided that PDF preview images would not be a part
of Content Publisher.

This therefore simplifies the model code to only deal with a single
asset association for a FileAttachment::BlobRevision. This allows for
numerous methods to be simplified to avoid a loop.

The owner of the association remains to be the Asset model, this allows
us to switch back to the old one-to-many approach without too much
effort. However this comes at the expense that we can't guarantee an
asset existence by a foreign key, therefore instead we use the Rails
required method to validate the existence.