### PR TITLE
Remove superfluous delegations in interactors

### DIFF
--- a/app/interactors/documents/destroy_interactor.rb
+++ b/app/interactors/documents/destroy_interactor.rb
@@ -5,7 +5,6 @@ class Documents::DestroyInteractor
   delegate :params,
            :user,
            :edition,
-           :api_error,
            to: :context
 
   def call

--- a/app/interactors/editions/create_interactor.rb
+++ b/app/interactors/editions/create_interactor.rb
@@ -6,7 +6,6 @@ class Editions::CreateInteractor
            :user,
            :live_edition,
            :next_edition,
-           :draft_current_edition,
            :discarded_edition,
            to: :context
 

--- a/app/interactors/images/destroy_interactor.rb
+++ b/app/interactors/images/destroy_interactor.rb
@@ -6,7 +6,6 @@ class Images::DestroyInteractor
            :user,
            :edition,
            :image_revision,
-           :removed_lead_image,
            to: :context
 
   def call

--- a/app/interactors/lead_image/remove_interactor.rb
+++ b/app/interactors/lead_image/remove_interactor.rb
@@ -7,7 +7,6 @@ class LeadImage::RemoveInteractor
            :user,
            :edition,
            :image_revision,
-           :no_lead_image,
            to: :context
 
   def call

--- a/app/interactors/preview/create_interactor.rb
+++ b/app/interactors/preview/create_interactor.rb
@@ -7,7 +7,6 @@ class Preview::CreateInteractor
            :user,
            :edition,
            :issues,
-           :preview_failed,
            to: :context
 
   def call

--- a/app/interactors/publish/publish_interactor.rb
+++ b/app/interactors/publish/publish_interactor.rb
@@ -7,7 +7,6 @@ class Publish::PublishInteractor
            :user,
            :edition,
            :issues,
-           :publish_failed,
            to: :context
 
   def call

--- a/app/interactors/review/approve_interactor.rb
+++ b/app/interactors/review/approve_interactor.rb
@@ -6,7 +6,6 @@ class Review::ApproveInteractor
   delegate :params,
            :user,
            :edition,
-           :wrong_status,
            to: :context
 
   def call

--- a/app/interactors/review/submit_for2i_interactor.rb
+++ b/app/interactors/review/submit_for2i_interactor.rb
@@ -7,7 +7,6 @@ class Review::SubmitFor2iInteractor
            :user,
            :edition,
            :issues,
-           :api_error,
            to: :context
 
   def call

--- a/app/interactors/topics/update_interactor.rb
+++ b/app/interactors/topics/update_interactor.rb
@@ -6,8 +6,6 @@ class Topics::UpdateInteractor
   delegate :params,
            :user,
            :document,
-           :api_conflict,
-           :api_error,
            to: :context
 
   def call

--- a/app/interactors/unwithdraw/unwithdraw_interactor.rb
+++ b/app/interactors/unwithdraw/unwithdraw_interactor.rb
@@ -3,7 +3,10 @@
 class Unwithdraw::UnwithdrawInteractor
   include Interactor
 
-  delegate :params, :user, :edition, :api_error, to: :context
+  delegate :params,
+           :user,
+           :edition,
+           to: :context
 
   def call
     Edition.transaction do

--- a/app/interactors/withdraw/create_interactor.rb
+++ b/app/interactors/withdraw/create_interactor.rb
@@ -6,9 +6,7 @@ class Withdraw::CreateInteractor
   delegate :params,
            :user,
            :edition,
-           :no_permission,
            :issues,
-           :api_error,
            to: :context
 
   def call


### PR DESCRIPTION
There is a number of superfluous delegations in our interactors which
all concern our fail state variables. I'm not sure if this was a
conscious decision to delegate everything we set in the context but it
seems unnecessary when some of them are not used.