### PR TITLE
Replace "change" links with "edit"

### DIFF
--- a/app/assets/stylesheets/components/_summary.scss
+++ b/app/assets/stylesheets/components/_summary.scss
@@ -16,12 +16,12 @@
   }
 }
 
-.app-c-summary__change-link {
+.app-c-summary__edit-link {
   @include govuk-link-common;
   @include govuk-link-style-no-visited-state;
 }
 
-.app-c-summary__change-section-link {
+.app-c-summary__edit-section-link {
   @include govuk-link-common;
   @include govuk-link-style-no-visited-state;
 
@@ -85,7 +85,7 @@
 
 .app-c-summary__question,
 .app-c-summary__answer,
-.app-c-summary__change {
+.app-c-summary__edit {
   display: block;
   margin: 0;
 
@@ -106,7 +106,7 @@
   padding-bottom: govuk-em(9, 19);
 }
 
-.app-c-summary__change {
+.app-c-summary__edit {
   position: absolute;
   top: 0;
   right: 0;

--- a/app/views/components/_summary.html.erb
+++ b/app/views/components/_summary.html.erb
@@ -1,18 +1,20 @@
 <%
   id ||= nil
   title ||= nil
+  edit ||= {}
   block ||= nil
   items ||= []
 %>
 
 <%= tag.div class: "app-c-summary", id: id do %>
   <% if title %>
-    <%= tag.h2 title[:text], class:"govuk-heading-m" %>
-    <% if title[:edit_url] %>
-      <%= link_to title[:edit_url], class: "app-c-summary__edit-section-link",
-        title: "Edit #{title[:text]}",
-        data: { gtm: "content-change" } do %>
-        Edit<span class="govuk-visually-hidden"> <%= title[:text] %></span>
+    <%= tag.h2 title, class: "govuk-heading-m" %>
+    <% if edit.any? %>
+      <%= link_to edit.fetch(:href),
+                  class: "app-c-summary__edit-section-link",
+                  title: "Edit #{title}",
+                  data: edit.fetch(:data_attributes, {}) do %>
+        Edit<span class="govuk-visually-hidden"> <%= title %></span>
       <% end %>
     <% end %>
   <% end %>
@@ -25,14 +27,16 @@
           <%= tag.dt item[:field], class:"app-c-summary__question" %>
           <%= tag.dd item[:value], class:"app-c-summary__answer" %>
 
-          <% if item[:edit_url] %>
+          <% if item.fetch(:edit, {}).any? %>
             <%= tag.dd link_to, class:"app-c-summary__edit" do %>
-              <%= link_to item[:edit_url], class:"app-c-summary__edit-link" do %>
+              <%= link_to item[:edit].fetch(:href),
+                          class: "app-c-summary__edit-link",
+                          title: "Edit #{item[:field]}",
+                          data: item[:edit].fetch(:data_attributes, {}) do %>
                 Edit<span class="govuk-visually-hidden"> <%= item[:field] %></span>
               <% end %>
             <% end %>
           <% end %>
-
         <% end %>
       <% end %>
     <% end %>

--- a/app/views/components/_summary.html.erb
+++ b/app/views/components/_summary.html.erb
@@ -8,11 +8,11 @@
 <%= tag.div class: "app-c-summary", id: id do %>
   <% if title %>
     <%= tag.h2 title[:text], class:"govuk-heading-m" %>
-    <% if title[:change_url] %>
-      <%= link_to title[:change_url], class: "app-c-summary__change-section-link",
-        title: "Change #{title[:text]}",
+    <% if title[:edit_url] %>
+      <%= link_to title[:edit_url], class: "app-c-summary__edit-section-link",
+        title: "Edit #{title[:text]}",
         data: { gtm: "content-change" } do %>
-        Change<span class="govuk-visually-hidden"> <%= title[:text] %></span>
+        Edit<span class="govuk-visually-hidden"> <%= title[:text] %></span>
       <% end %>
     <% end %>
   <% end %>
@@ -25,10 +25,10 @@
           <%= tag.dt item[:field], class:"app-c-summary__question" %>
           <%= tag.dd item[:value], class:"app-c-summary__answer" %>
 
-          <% if item[:change_url] %>
-            <%= tag.dd link_to, class:"app-c-summary__change" do %>
-              <%= link_to item[:change_url], class:"app-c-summary__change-link" do %>
-                Change<span class="govuk-visually-hidden"> <%= item[:field] %></span>
+          <% if item[:edit_url] %>
+            <%= tag.dd link_to, class:"app-c-summary__edit" do %>
+              <%= link_to item[:edit_url], class:"app-c-summary__edit-link" do %>
+                Edit<span class="govuk-visually-hidden"> <%= item[:field] %></span>
               <% end %>
             <% end %>
           <% end %>

--- a/app/views/components/docs/summary.yml
+++ b/app/views/components/docs/summary.yml
@@ -6,7 +6,7 @@ part_of_admin_layout: true
 accessibility_criteria: |
   The links in this component must:
 
-  * indicate which item or section refers to (e.g. Change title)
+  * indicate which item or section refers to (e.g. Edit title)
 shared_accessibility_criteria:
 - link
 examples:
@@ -14,7 +14,7 @@ examples:
     data:
       title:
         text: "Title, summary and body"
-        change_url: "#change-title-summary-body"
+        edit_url: "#edit-title-summary-body"
       items:
       - field: "Title"
         value: "Ethical standards for public service providers"
@@ -30,10 +30,10 @@ examples:
       items:
       - field: "Title"
         value: "Ethical standards for public service providers"
-        change_url: "#change-title"
+        edit_url: "#edit-title"
       - field: "Summary"
         value: "Find out more about our reviews on the subject of ethical standards for public service providers, including our 2014 report, 2015 guidance and 2018 follow-up publication."
-        change_url: "#change-summary"
+        edit_url: "#edit-summary"
       - field: "Body"
         value: "After the government decided in 2013 to expand the remit of the Committee to include public service providers, the Committee on Standards in Public Life produced our first report on the issue: Ethical Standards for Providers of Public Services in 2014."
-        change_url: "#change-body"
+        edit_url: "#edit-body"

--- a/app/views/components/docs/summary.yml
+++ b/app/views/components/docs/summary.yml
@@ -12,9 +12,7 @@ shared_accessibility_criteria:
 examples:
   default:
     data:
-      title:
-        text: "Title, summary and body"
-        edit_url: "#edit-title-summary-body"
+      title: "Title, summary and body"
       items:
       - field: "Title"
         value: "Ethical standards for public service providers"
@@ -23,17 +21,40 @@ examples:
       - field: "Body"
         value: "After the government decided in 2013 to expand the remit of the Committee to include public service providers, the Committee on Standards in Public Life produced our first report on the issue: Ethical Standards for Providers of Public Services in 2014."
 
-  change-item:
+  with_edit:
     data:
-      title:
-        text: "Title, summary and body"
+      title: "Title, summary and body"
+      edit:
+        href: "#edit-title-summary-body"
+        data_attributes:
+          gtm: edit-title-summary-body
       items:
       - field: "Title"
         value: "Ethical standards for public service providers"
-        edit_url: "#edit-title"
       - field: "Summary"
         value: "Find out more about our reviews on the subject of ethical standards for public service providers, including our 2014 report, 2015 guidance and 2018 follow-up publication."
-        edit_url: "#edit-summary"
       - field: "Body"
         value: "After the government decided in 2013 to expand the remit of the Committee to include public service providers, the Committee on Standards in Public Life produced our first report on the issue: Ethical Standards for Providers of Public Services in 2014."
-        edit_url: "#edit-body"
+
+  edit_individual_items:
+    data:
+      title: "Title, summary and body"
+      items:
+      - field: "Title"
+        value: "Ethical standards for public service providers"
+        edit:
+          href: "#edit-title"
+          data_attributes:
+            gtm: edit-title
+      - field: "Summary"
+        value: "Find out more about our reviews on the subject of ethical standards for public service providers, including our 2014 report, 2015 guidance and 2018 follow-up publication."
+        edit:
+          href: "#edit-summary"
+      - field: "Body"
+        value: "After the government decided in 2013 to expand the remit of the Committee to include public service providers, the Committee on Standards in Public Life produced our first report on the issue: Ethical Standards for Providers of Public Services in 2014."
+
+  with_block:
+    data:
+      title: "With a block of HTML"
+      block: |
+        <p class="govuk-body">Some HTML</p>

--- a/app/views/documents/show/_contents.html.erb
+++ b/app/views/documents/show/_contents.html.erb
@@ -25,7 +25,7 @@
   id: "content",
   title: {
     text: t("documents.show.contents.title"),
-    change_url: @edition.editable? && edit_document_path(@edition.document)
+    edit_url: @edition.editable? && edit_document_path(@edition.document)
   },
   items: [
     {

--- a/app/views/documents/show/_contents.html.erb
+++ b/app/views/documents/show/_contents.html.erb
@@ -23,10 +23,12 @@
 
 <%= render "components/summary", {
   id: "content",
-  title: {
-    text: t("documents.show.contents.title"),
-    edit_url: @edition.editable? && edit_document_path(@edition.document)
-  },
+  title: t("documents.show.contents.title"),
+  edit: (
+    if @edition.editable?
+      { href: edit_document_path(@edition.document) }
+    end
+  ),
   items: [
     {
       field: t("documents.show.contents.items.title"),

--- a/app/views/documents/show/_contents.html.erb
+++ b/app/views/documents/show/_contents.html.erb
@@ -26,7 +26,8 @@
   title: t("documents.show.contents.title"),
   edit: (
     if @edition.editable?
-      { href: edit_document_path(@edition.document) }
+      { href: edit_document_path(@edition.document),
+        data_attributes: { gtm: "edit-summary" } }
     end
   ),
   items: [

--- a/app/views/documents/show/_lead_image.html.erb
+++ b/app/views/documents/show/_lead_image.html.erb
@@ -34,7 +34,7 @@
   id: "lead-image",
   title: {
     text: t("documents.show.lead_image.title"),
-    change_url: @edition.editable? && images_path(@edition.document),
+    edit_url: @edition.editable? && images_path(@edition.document),
   },
   block: lead_image_block
 } %>

--- a/app/views/documents/show/_lead_image.html.erb
+++ b/app/views/documents/show/_lead_image.html.erb
@@ -32,9 +32,11 @@
 
 <%= render "components/summary", {
   id: "lead-image",
-  title: {
-    text: t("documents.show.lead_image.title"),
-    edit_url: @edition.editable? && images_path(@edition.document),
-  },
+  title: t("documents.show.lead_image.title"),
+  edit: (
+    if @edition.editable?
+      { href: images_path(@edition.document) }
+    end
+  ),
   block: lead_image_block
 } %>

--- a/app/views/documents/show/_lead_image.html.erb
+++ b/app/views/documents/show/_lead_image.html.erb
@@ -35,7 +35,8 @@
   title: t("documents.show.lead_image.title"),
   edit: (
     if @edition.editable?
-      { href: images_path(@edition.document) }
+      { href: images_path(@edition.document),
+        data_attributes: { gtm: "edit-lead-image" } }
     end
   ),
   block: lead_image_block

--- a/app/views/documents/show/_tags.html.erb
+++ b/app/views/documents/show/_tags.html.erb
@@ -15,7 +15,7 @@
     id: "tags",
     title: {
       text: t("documents.show.tags.title"),
-      change_url: @edition.editable? && tags_path(@edition.document)
+      edit_url: @edition.editable? && tags_path(@edition.document)
     },
     items: tags
   } %>

--- a/app/views/documents/show/_tags.html.erb
+++ b/app/views/documents/show/_tags.html.erb
@@ -13,10 +13,12 @@
 
   <%= render "components/summary", {
     id: "tags",
-    title: {
-      text: t("documents.show.tags.title"),
-      edit_url: @edition.editable? && tags_path(@edition.document)
-    },
+    title: t("documents.show.tags.title"),
+    edit: (
+      if @edition.editable?
+        { href: tags_path(@edition.document) }
+      end
+    ),
     items: tags
   } %>
 <% rescue GdsApi::BaseError => e %>
@@ -24,9 +26,7 @@
 
   <%= render "components/summary", {
     id: "tags",
-    title: {
-      text: t("documents.show.tags.title")
-    },
+    title: t("documents.show.tags.title"),
     block: t("documents.show.tags.api_down")
   } %>
 <% end %>

--- a/app/views/documents/show/_tags.html.erb
+++ b/app/views/documents/show/_tags.html.erb
@@ -16,7 +16,8 @@
     title: t("documents.show.tags.title"),
     edit: (
       if @edition.editable?
-        { href: tags_path(@edition.document) }
+        { href: tags_path(@edition.document),
+          data_attributes: { gtm: "edit-tags" } }
       end
     ),
     items: tags

--- a/app/views/documents/show/_topics.html.erb
+++ b/app/views/documents/show/_topics.html.erb
@@ -20,6 +20,7 @@
     title: t("documents.show.topics.title"),
     edit: {
       href: topics_path(@edition.document),
+      data_attributes: { gtm: "edit-topics" },
     },
     block: breadcrumbs
   } %>

--- a/app/views/documents/show/_topics.html.erb
+++ b/app/views/documents/show/_topics.html.erb
@@ -19,7 +19,7 @@
     id: "topics",
     title: {
       text: t("documents.show.topics.title"),
-      change_url: topics_path(@edition.document)
+      edit_url: topics_path(@edition.document)
     },
     block: breadcrumbs
   } %>

--- a/app/views/documents/show/_topics.html.erb
+++ b/app/views/documents/show/_topics.html.erb
@@ -17,9 +17,9 @@
 
   <%= render "components/summary", {
     id: "topics",
-    title: {
-      text: t("documents.show.topics.title"),
-      edit_url: topics_path(@edition.document)
+    title: t("documents.show.topics.title"),
+    edit: {
+      href: topics_path(@edition.document),
     },
     block: breadcrumbs
   } %>
@@ -28,9 +28,7 @@
 
   <%= render "components/summary", {
     id: "topics",
-    title: {
-      text: t("documents.show.topics.title")
-    },
+    title: t("documents.show.topics.title"),
     block: t("documents.show.topics.api_down")
   } %>
 <% end %>

--- a/spec/features/editing_content/edit_edition_spec.rb
+++ b/spec/features/editing_content/edit_edition_spec.rb
@@ -21,7 +21,7 @@ RSpec.feature "Edit an edition" do
   def when_i_go_to_edit_the_edition
     visit document_path(@edition.document)
     expect(page).to have_content("Existing body")
-    click_on "Change Content"
+    click_on "Edit Content"
   end
 
   def and_i_fill_in_the_content_fields

--- a/spec/features/editing_content/edit_edition_with_line_breaks_and_spaces_spec.rb
+++ b/spec/features/editing_content/edit_edition_with_line_breaks_and_spaces_spec.rb
@@ -18,7 +18,7 @@ RSpec.feature "Edit an edition with fields containing line breaks and spaces" do
   def when_i_go_to_edit_the_edition
     visit document_path(@edition.document)
     expect(page).to have_content("Existing title")
-    click_on "Change Content"
+    click_on "Edit Content"
   end
 
   def and_i_fill_in_the_title_with_leading_and_trailing_line_breaks_and_spaces

--- a/spec/features/editing_content/govspeak_preview_spec.rb
+++ b/spec/features/editing_content/govspeak_preview_spec.rb
@@ -17,7 +17,7 @@ RSpec.feature "Shows a preview of Govspeak", js: true do
 
   def when_i_go_to_edit_the_edition
     visit document_path(@edition.document)
-    click_on "Change Content"
+    click_on "Edit Content"
   end
 
   def and_i_enter_some_govspeak

--- a/spec/features/editing_content/insert_contact_publishing_api_down_spec.rb
+++ b/spec/features/editing_content/insert_contact_publishing_api_down_spec.rb
@@ -16,7 +16,7 @@ RSpec.feature "Insert contact when the Publishing API down" do
 
   def when_i_go_to_edit_the_edition
     visit document_path(@edition.document)
-    click_on "Change Content"
+    click_on "Edit Content"
   end
 
   def and_i_go_to_add_a_contact_with_the_publishing_api_down

--- a/spec/features/editing_content/insert_contact_spec.rb
+++ b/spec/features/editing_content/insert_contact_spec.rb
@@ -33,7 +33,7 @@ RSpec.feature "Insert contact", js: true do
 
   def when_i_go_to_edit_the_edition
     visit document_path(@edition.document)
-    click_on "Change Content"
+    click_on "Edit Content"
   end
 
   def and_i_go_to_add_a_contact

--- a/spec/features/editing_content/url_preview_spec.rb
+++ b/spec/features/editing_content/url_preview_spec.rb
@@ -25,7 +25,7 @@ RSpec.feature "Shows a preview of the URL", js: true do
 
   def when_i_go_to_edit_the_edition
     visit document_path(@edition.document)
-    click_on "Change Content"
+    click_on "Edit Content"
   end
 
   def and_i_interact_with_the_title_but_leave_it_unedited

--- a/spec/features/editing_file_attachments/upload_file_attachment_requirements_spec.rb
+++ b/spec/features/editing_file_attachments/upload_file_attachment_requirements_spec.rb
@@ -17,7 +17,7 @@ RSpec.feature "Upload a file attachment with requirements issues", js: true do
 
   def when_i_go_to_edit_the_edition
     visit document_path(@edition.document)
-    click_on "Change Content"
+    click_on "Edit Content"
   end
 
   def and_i_go_to_insert_an_attachment

--- a/spec/features/editing_file_attachments/upload_file_attachment_spec.rb
+++ b/spec/features/editing_file_attachments/upload_file_attachment_spec.rb
@@ -18,7 +18,7 @@ RSpec.feature "Upload file attachment", js: true do
 
   def when_i_go_to_edit_the_edition
     visit document_path(@edition.document)
-    click_on "Change Content"
+    click_on "Edit Content"
   end
 
   def and_i_go_to_insert_an_attachment

--- a/spec/features/editing_images/upload_image_requirements_spec.rb
+++ b/spec/features/editing_images/upload_image_requirements_spec.rb
@@ -23,7 +23,7 @@ RSpec.feature "Upload an image with requirements issues", js: true do
 
   def when_i_visit_the_images_page
     visit document_path(@edition.document)
-    click_on "Change Lead image"
+    click_on "Edit Lead image"
   end
 
   def when_i_insert_an_inline_image

--- a/spec/features/editing_tags/edit_tags_publishing_api_down_spec.rb
+++ b/spec/features/editing_tags/edit_tags_publishing_api_down_spec.rb
@@ -25,7 +25,7 @@ RSpec.feature "Edit tags when the API is down" do
   end
 
   def and_i_try_to_change_the_tags
-    click_on "Change Tags"
+    click_on "Edit Tags"
   end
 
   def then_i_should_see_an_error_message

--- a/spec/features/editing_tags/edit_tags_spec.rb
+++ b/spec/features/editing_tags/edit_tags_spec.rb
@@ -39,7 +39,7 @@ RSpec.feature "Edit tags" do
   end
 
   def and_i_click_on_edit_tags
-    click_on "Change Tags"
+    click_on "Edit Tags"
   end
 
   def then_i_see_the_current_selections

--- a/spec/features/editing_topics/edit_topics_spec.rb
+++ b/spec/features/editing_topics/edit_topics_spec.rb
@@ -31,7 +31,7 @@ RSpec.feature "Edit topics" do
   end
 
   def and_i_click_on_edit_topics
-    click_on "Change Topics"
+    click_on "Edit Topics"
   end
 
   def then_i_see_the_current_selections

--- a/spec/features/workflow/edition_spec.rb
+++ b/spec/features/workflow/edition_spec.rb
@@ -53,7 +53,7 @@ RSpec.feature "Editions" do
   def then_i_see_it_is_the_first_edition
     expect(page).to_not have_content(I18n.t!("documents.show.contents.items.update_type"))
     expect(page).to_not have_content(I18n.t!("documents.show.contents.items.change_note"))
-    expect(page).to_not have_link "Change Content"
+    expect(page).to_not have_link "Edit Content"
   end
 
   def and_i_click_to_create_a_new_edition
@@ -79,7 +79,7 @@ RSpec.feature "Editions" do
   def then_i_see_there_is_a_new_major_edition
     expect(page).to have_content(I18n.t!("documents.show.contents.update_type.major"))
     expect(page).to have_content("I made a change")
-    expect(page).to have_link "Change Content"
+    expect(page).to have_link "Edit Content"
 
     within find("#document-history") do
       expect(page).to have_content "2nd edition"

--- a/spec/features/workflow/submit_for_2i_spec.rb
+++ b/spec/features/workflow/submit_for_2i_spec.rb
@@ -44,7 +44,7 @@ RSpec.feature "Submit for 2i" do
 
   def when_i_edit_the_edition
     stub_any_publishing_api_put_content
-    click_on "Change Content"
+    click_on "Edit Content"
     fill_in "revision[title]", with: "a new title"
     click_on "Save"
   end

--- a/spec/formats/news_story_spec.rb
+++ b/spec/formats/news_story_spec.rb
@@ -45,7 +45,7 @@ RSpec.feature "Create a news story", format: true do
     stub_publishing_api_has_linkables([linkable], document_type: "organisation")
     stub_publishing_api_has_linkables([linkable], document_type: "role_appointment")
 
-    click_on "Change Tags"
+    click_on "Edit Tags"
 
     select linkable["internal_name"], from: "tags[topical_events][]"
     select linkable["internal_name"], from: "tags[world_locations][]"

--- a/spec/formats/press_release_spec.rb
+++ b/spec/formats/press_release_spec.rb
@@ -45,7 +45,7 @@ RSpec.feature "Create a press release", format: true do
     stub_publishing_api_has_linkables([linkable], document_type: "organisation")
     stub_publishing_api_has_linkables([linkable], document_type: "role_appointment")
 
-    click_on "Change Tags"
+    click_on "Edit Tags"
 
     select linkable["internal_name"], from: "tags[topical_events][]"
     select linkable["internal_name"], from: "tags[world_locations][]"


### PR DESCRIPTION
Trello: https://trello.com/c/R0SXPvK1/900-change-change-link-on-content-summary-to-edit

This replaces the wording of the links on the summary page to have "Edit" rather than "Change".
This also refactors the summary component to accept data attributes and updates the tag manager attributes for each of the edit links

Before: 

<img width="692" alt="Screen Shot 2019-06-04 at 13 37 56" src="https://user-images.githubusercontent.com/282717/58879842-7f619f80-86ce-11e9-84f0-3e828297affe.png">

After:

<img width="658" alt="Screen Shot 2019-06-04 at 13 42 06" src="https://user-images.githubusercontent.com/282717/58879900-9c966e00-86ce-11e9-981f-98d2393efde1.png">

