### PR TITLE
Show scheduling errors with their respective fields

### DIFF
--- a/app/assets/javascripts/components/autocomplete.js
+++ b/app/assets/javascripts/components/autocomplete.js
@@ -99,7 +99,7 @@ window.GOVUK.Modules = window.GOVUK.Modules || {};
     if (!$selectedOption) {
       $selectedOption = $options[0]
     }
-    var defaultValue = $selectedOption.textContent
+    var defaultValue = this.$module.dataset.initialValue || $selectedOption.textContent
 
     new window.accessibleAutocomplete({ // eslint-disable-line no-new, new-cap
       id: $select.id,

--- a/app/controllers/schedule_controller.rb
+++ b/app/controllers/schedule_controller.rb
@@ -10,7 +10,8 @@ class ScheduleController < ApplicationController
         "title" => I18n.t!("schedule.scheduled_publishing_datetime.flashes.requirements"),
         "items" => issues.items(
           link_options: {
-            scheduled_datetime: { href: "#scheduled_publishing_datetime" },
+            scheduled_date: { href: "#date" },
+            scheduled_time: { href: "#time" },
           },
         ),
       }

--- a/app/controllers/schedule_controller.rb
+++ b/app/controllers/schedule_controller.rb
@@ -10,8 +10,9 @@ class ScheduleController < ApplicationController
         "title" => I18n.t!("schedule.scheduled_publishing_datetime.flashes.requirements"),
         "items" => issues.items(
           link_options: {
-            scheduled_date: { href: "#date" },
-            scheduled_time: { href: "#time" },
+            schedule_date: { href: "#date" },
+            schedule_time: { href: "#time" },
+            schedule_action: { href: "#action" },
           },
         ),
       }
@@ -19,7 +20,7 @@ class ScheduleController < ApplicationController
       render :scheduled_publishing_datetime,
              assigns: { edition: edition, issues: issues },
              status: :unprocessable_entity
-    elsif params[:schedule][:action] == "schedule"
+    elsif params.dig(:schedule, :action) == "schedule"
       redirect_to scheduling_confirmation_path(edition.document)
     else
       redirect_to document_path(edition.document)

--- a/app/helpers/scheduling_helper.rb
+++ b/app/helpers/scheduling_helper.rb
@@ -6,6 +6,6 @@ module SchedulingHelper
   end
 
   def format_scheduled_time(datetime)
-    datetime&.strftime("%l:%M%P")
+    datetime&.strftime("%-l:%M%P")
   end
 end

--- a/app/helpers/scheduling_helper.rb
+++ b/app/helpers/scheduling_helper.rb
@@ -1,11 +1,11 @@
 # frozen_string_literal: true
 
-module ScheduledDatetimeHelper
-  def scheduled_date(datetime)
+module SchedulingHelper
+  def format_scheduled_date(datetime)
     datetime&.strftime("%-d %B %Y")
   end
 
-  def scheduled_time(datetime)
+  def format_scheduled_time(datetime)
     datetime&.strftime("%l:%M%P")
   end
 end

--- a/app/helpers/time_options_helper.rb
+++ b/app/helpers/time_options_helper.rb
@@ -1,40 +1,24 @@
 # frozen_string_literal: true
 
 module TimeOptionsHelper
-  DEFAULT_PUBLISHING_TIME = "9:00am"
+  def time_options(additional_time = nil)
+    match = additional_time&.match(%r{\A(?<hour>\d{1,2}):(?<minute>\d{1,2})(?<period>(am|pm))\Z})
 
-  def time_options(selected = nil)
-    extended_times = extend_times_with_selection(times, selected)
-    options = extended_times.map { |time| [time, time] }
-    selected_options = extended_times.select { |time| time == (selected || DEFAULT_PUBLISHING_TIME) }.compact
-    options_for_select = { options: options, selected_options: selected_options }
-    options_for_select
-  end
+    %w[am pm].flat_map do |period|
+      hours = [12] + (1..11).to_a
+      hours.flat_map do |hour|
+        intervals = if hour == 12 && period == "am"
+                      ["12:01am", "12:30am"]
+                    else
+                      ["#{hour}:00#{period}", "#{hour}:30#{period}"]
+                    end
 
-private
+        if match && match[:hour].to_i == hour && match[:period] == period
+          intervals << additional_time
+        end
 
-  def times
-    hours = [12] + (1..11).to_a
-    incremented_hours = hours.map do |hour|
-      [hour.to_s + ":00", hour.to_s + ":30"]
-    end
-
-    meridiem_hours = incremented_hours.flatten!.map { |hour| hour + "am" }
-    incremented_hours.each { |hour| meridiem_hours << hour + "pm" }
-    meridiem_hours[0] = "12:01am"
-    meridiem_hours
-  end
-
-  def extend_times_with_selection(times, selected)
-    if times && selected
-      position = 0
-      selected_meridiem = selected.chars.last(2).join
-      times.each_with_index do |time, index|
-        time_meridiem = time.chars.last(2).join
-        position = index if selected < time && time_meridiem == selected_meridiem && !position
+        intervals.uniq.sort
       end
-      times.insert(position, selected)
     end
-    times
   end
 end

--- a/app/interactors/schedule/save_datetime_interactor.rb
+++ b/app/interactors/schedule/save_datetime_interactor.rb
@@ -39,7 +39,7 @@ private
   end
 
   def schedule_params
-    params.require(:schedule).permit(:time, date: %i[day month year])
+    params.require(:schedule).permit(:time, :action, date: %i[day month year])
   end
 
   def set_scheduled_publishing_datetime
@@ -54,8 +54,8 @@ private
   def action_issues
     return [] if scheduled_datetime_already_exists?
 
-    if params[:schedule][:action].blank?
-      [Requirements::Issue.new(:scheduled_datetime, :action_not_selected)]
+    if schedule_params[:action].blank?
+      [Requirements::Issue.new(:schedule_action, :not_selected)]
     else
       []
     end

--- a/app/interactors/schedule/save_datetime_interactor.rb
+++ b/app/interactors/schedule/save_datetime_interactor.rb
@@ -39,7 +39,7 @@ private
   end
 
   def schedule_params
-    params.require(:schedule).permit(:day, :month, :year, :time)
+    params.require(:schedule).permit(:time, date: %i[day month year])
   end
 
   def set_scheduled_publishing_datetime

--- a/app/services/requirements/scheduled_datetime_checker.rb
+++ b/app/services/requirements/scheduled_datetime_checker.rb
@@ -44,13 +44,13 @@ module Requirements
         day, month, year = params[:date]&.values_at(:day, :month, :year)
         Date.strptime("#{day}-#{month}-#{year}", DATE_FORMAT)
       rescue ArgumentError
-        issues << Issue.new(:scheduled_date, :invalid)
+        issues << Issue.new(:schedule_date, :invalid)
       end
 
       begin
         Time.strptime(params[:time].to_s, TIME_FORMAT)
       rescue ArgumentError
-        issues << Issue.new(:scheduled_time, :invalid)
+        issues << Issue.new(:schedule_time, :invalid)
       end
 
       issues
@@ -59,7 +59,7 @@ module Requirements
     def scheduled_in_the_past_issues
       return [] unless parsed_datetime < Time.current
 
-      field = parsed_datetime.today? ? :scheduled_time : :scheduled_date
+      field = parsed_datetime.today? ? :schedule_time : :schedule_date
       [Issue.new(field, :in_the_past)]
     end
 
@@ -68,7 +68,7 @@ module Requirements
       return [] unless parsed_datetime.between?(Time.current, minimum_time)
 
       [
-        Issue.new(:scheduled_time,
+        Issue.new(:schedule_time,
                   :too_close_to_now,
                   time_period: time_period_for_issue(MINIMUM_FUTURE_TIME_PERIOD)),
       ]
@@ -79,7 +79,7 @@ module Requirements
       return [] unless parsed_datetime > maximum_future_time
 
       [
-        Issue.new(:scheduled_date,
+        Issue.new(:schedule_date,
                   :too_far_in_future,
                   time_period: time_period_for_issue(MAXIMUM_FUTURE_TIME_PERIOD)),
       ]

--- a/app/views/components/_autocomplete.html.erb
+++ b/app/views/components/_autocomplete.html.erb
@@ -10,13 +10,15 @@
   hint ||= nil
   width ||= nil
   aria = error_id if error_items.any?
+  data_attributes ||= {}
 
   root_classes = %w(app-c-autocomplete govuk-form-group)
   root_classes << "app-c-autocomplete--#{width}" if width
   root_classes << "govuk-form-group--error" if error_items.any?
 %>
 
-<%= tag.div class: root_classes, data: { module: "autocomplete", "autocomplete-type": type } do %>
+<%= tag.div class: root_classes,
+            data: data_attributes.merge(module: "autocomplete", "autocomplete-type": type) do %>
   <%= tag.fieldset class: "govuk-fieldset", "aria-describedby": aria do %>
     <%= render "govuk_publishing_components/components/label", {
       html_for: id

--- a/app/views/components/_autocomplete.html.erb
+++ b/app/views/components/_autocomplete.html.erb
@@ -5,30 +5,44 @@
   multiple ||= nil
   type ||= nil
   size ||= nil
+  error_id = "error-#{SecureRandom.hex(4)}"
+  error_items ||= []
   hint ||= nil
   width ||= nil
-  css_classes = %w(app-c-autocomplete govuk-form-group)
-  css_classes << "app-c-autocomplete--#{width}" if width
+  aria = error_id if error_items.any?
+
+  root_classes = %w(app-c-autocomplete govuk-form-group)
+  root_classes << "app-c-autocomplete--#{width}" if width
+  root_classes << "govuk-form-group--error" if error_items.any?
 %>
 
-<%= tag.div class: css_classes, data: { module: "autocomplete", "autocomplete-type": type } do %>
-  <%= render "govuk_publishing_components/components/label", {
-    html_for: id
-  }.merge(label.symbolize_keys) %>
+<%= tag.div class: root_classes, data: { module: "autocomplete", "autocomplete-type": type } do %>
+  <%= tag.fieldset class: "govuk-fieldset", "aria-describedby": aria do %>
+    <%= render "govuk_publishing_components/components/label", {
+      html_for: id
+    }.merge(label.symbolize_keys) %>
 
-  <% if options.any? %>
-    <%= tag.span "To select multiple items in a list, hold down Ctrl (PC) or Command (Mac) key.", class: "govuk-hint app-c-autocomplete__multiselect-instructions" if multiple %>
+    <% if error_items.any? %>
+      <%= render "govuk_publishing_components/components/error_message", {
+        id: error_id,
+        text: raw(error_items.map { |item| item[:text] }.join("<br/>"))
+      } %>
+    <% end %>
 
-    <%= tag.span hint, class: "govuk-hint" if hint %>
+    <% if options.any? %>
+      <%= tag.span "To select multiple items in a list, hold down Ctrl (PC) or Command (Mac) key.", class: "govuk-hint app-c-autocomplete__multiselect-instructions" if multiple %>
 
-    <%= select_tag name,
-      options_for_select(options, selected_options),
-      id: id,
-      class: "govuk-select",
-      size: size,
-      multiple: multiple
-    %>
-  <% else %>
-    <%= tag.p "No options available", class: "govuk-hint" %>
+      <%= tag.span hint, class: "govuk-hint" if hint %>
+
+      <%= select_tag name,
+        options_for_select(options, selected_options),
+        id: id,
+        class: "govuk-select",
+        size: size,
+        multiple: multiple
+      %>
+    <% else %>
+      <%= tag.p "No options available", class: "govuk-hint" %>
+    <% end %>
   <% end %>
 <% end %>

--- a/app/views/components/docs/autocomplete.yml
+++ b/app/views/components/docs/autocomplete.yml
@@ -154,3 +154,26 @@ examples:
           - Published
         -
           - Removed
+  autocomplete_without_narrowing_results_and_initial_value:
+    description: |
+      This is used to display a value that a user has entered erroneously
+      without altering the underlying select. This only makes sense for the
+      without narrowing results variant as this removes the select element.
+    data:
+      id: autocomplete-with-initial-value
+      name: autocomplete-with-initial-value
+      type: without-narrowing-results
+      label:
+        text: Select your country
+      data_attributes:
+        initial_value: "Invalid Country"
+      options:
+        -
+          - France
+          - fr
+        -
+          - United Arab Emirates
+          - uae
+        -
+          - United Kingdom
+          - uk

--- a/app/views/components/docs/autocomplete.yml
+++ b/app/views/components/docs/autocomplete.yml
@@ -107,7 +107,6 @@ examples:
       type: with-hint-on-options
       label:
         text: Select your country
-      data_module: autocomplete
       options:
         -
           -
@@ -130,7 +129,6 @@ examples:
       type: without-narrowing-results
       label:
         text: Select your country
-      data_module: autocomplete
       options:
         -
           - France
@@ -148,7 +146,6 @@ examples:
       type: without-narrowing-results
       label:
         text: Status
-      data_module: autocomplete
       width: narrow
       options:
         -

--- a/app/views/components/docs/autocomplete.yml
+++ b/app/views/components/docs/autocomplete.yml
@@ -44,6 +44,24 @@ examples:
       selected_options:
           - de
 
+  with_error:
+    data:
+      name: autocomplete-with-error
+      label:
+        text: Autocomplete with error
+      options:
+        -
+          - France
+          - fr
+        -
+          - Germany
+          - de
+        -
+          - United Kingdom
+          - uk
+      error_items:
+        - text: There is a problem with this input
+
   multiselect:
     data:
       id: autocomplete-multiselect

--- a/app/views/documents/show/_scheduling_notice.html.erb
+++ b/app/views/documents/show/_scheduling_notice.html.erb
@@ -1,6 +1,6 @@
 <% datetime = @edition.scheduled_publishing_datetime %>
-<% time = scheduled_time(datetime) %>
-<% date = scheduled_date(datetime) %>
+<% time = format_scheduled_time(datetime) %>
+<% date = format_scheduled_date(datetime) %>
 
 <% change_date_link = capture do %>
   <%= link_to "Change date",

--- a/app/views/schedule/confirmation.html.erb
+++ b/app/views/schedule/confirmation.html.erb
@@ -1,8 +1,8 @@
 <% content_for :back_link, render_back_link(href: document_path(@edition.document)) %>
 <% content_for :title, t("schedule.confirmation.title") %>
 <% datetime = @edition.scheduled_publishing_datetime %>
-<% time = scheduled_time(datetime) %>
-<% date = scheduled_date(datetime) %>
+<% time = format_scheduled_time(datetime) %>
+<% date = format_scheduled_date(datetime) %>
 
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">

--- a/app/views/schedule/scheduled.html.erb
+++ b/app/views/schedule/scheduled.html.erb
@@ -1,8 +1,8 @@
 <% content_for :back_link, render_back_link(text: "Return to dashboard", href: document_path(@edition.document)) %>
 <% content_for :browser_title, t("schedule.scheduled.title") %>
 <% datetime = @edition.scheduled_publishing_datetime %>
-<% scheduled_time = scheduled_time(datetime) %>
-<% scheduled_date = scheduled_date(datetime) %>
+<% time = format_scheduled_time(datetime) %>
+<% date = format_scheduled_date(datetime) %>
 <% public_url = edition_public_url(@edition) %>
 
 <div class="govuk-grid-row">
@@ -11,7 +11,7 @@
       title: t("schedule.scheduled.title")
     } %>
     <%= render "govuk_publishing_components/components/govspeak" do %>
-      <%= govspeak_to_html t("schedule.scheduled.body_govspeak", title: @edition.title, time: scheduled_time, date: scheduled_date) %>
+      <%= govspeak_to_html t("schedule.scheduled.body_govspeak", title: @edition.title, time: time, date: date) %>
     <% end %>
     <%= render "govuk_publishing_components/components/inset_text", {
       text: strip_scheme_from_url(public_url)

--- a/app/views/schedule/scheduled_publishing_datetime.html.erb
+++ b/app/views/schedule/scheduled_publishing_datetime.html.erb
@@ -2,7 +2,7 @@
 <% content_for :title, t("schedule.scheduled_publishing_datetime.title") %>
 <%
   current_scheduled_publish_datetime = @edition.scheduled_publishing_datetime
-  default_datetime = Time.current.tomorrow
+  default_datetime = Time.current.tomorrow.change(hour: 9)
   publish_datetime = current_scheduled_publish_datetime || default_datetime
 %>
 <div class="govuk-grid-row">
@@ -40,10 +40,8 @@
           }
         ]
       } %>
-      <%
-        selected_time = params.dig(:schedule, :time) || publish_datetime.strftime("%l:%M%P")
-        time_options = time_options(selected_time)
-      %>
+      <% persistent_time = publish_datetime.strftime("%-l:%M%P") %>
+      <% selected_time = params.dig(:schedule, :time) || persistent_time %>
       <%= render "components/autocomplete", {
         id: "time",
         name: "schedule[time]",
@@ -52,8 +50,11 @@
           bold: true,
         },
         error_items: @issues&.items_for(:schedule_time),
-        options: time_options[:options],
-        selected_options: time_options[:selected_options],
+        options: time_options(persistent_time),
+        selected_options: [persistent_time],
+        data_attributes: {
+          initial_value: selected_time,
+        },
         type: "without-narrowing-results",
         size: 5,
         width: "narrow",

--- a/app/views/schedule/scheduled_publishing_datetime.html.erb
+++ b/app/views/schedule/scheduled_publishing_datetime.html.erb
@@ -1,48 +1,52 @@
 <% content_for :back_link, render_back_link(href: document_path(@edition.document)) %>
 <% content_for :title, t("schedule.scheduled_publishing_datetime.title") %>
-
-<% current_scheduled_publish_datetime = @edition.revision.scheduled_publishing_datetime %>
-<% default_date = Time.zone.now.tomorrow %>
-<% publish_date = current_scheduled_publish_datetime || default_date %>
-<% schedule_param = params["schedule"] ? params["schedule"] : {} %>
-<% selected_time = schedule_param["time"] || scheduled_time(current_scheduled_publish_datetime) %>
-<% action_not_selected = @issues&.select { |i| i.issue_key == :action_not_selected }&.first&.to_item %>
-
+<%
+  current_scheduled_publish_datetime = @edition.scheduled_publishing_datetime
+  default_datetime = Time.current.tomorrow
+  publish_datetime = current_scheduled_publish_datetime || default_datetime
+  action_not_selected = @issues&.select { |i| i.issue_key == :action_not_selected }&.first&.to_item
+%>
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
-    <%= form_tag(save_scheduled_publishing_datetime_path(@edition.document),
-                 id: "scheduled_publishing_datetime") do %>
-      <% date_input_id = "input-#{SecureRandom.hex(4)}" %>
+    <%= form_tag save_scheduled_publishing_datetime_path(@edition.document) do %>
       <%= render "govuk_publishing_components/components/label", {
         bold: true,
         text: t("schedule.scheduled_publishing_datetime.date"),
-        html_for: date_input_id,
+        html_for: "date",
       } %>
+      <%
+        errors = (@issues&.items_for(:scheduled_date) || [])
+        error_message = errors.map { |item| item[:text] }.join("<br/>").html_safe
+      %>
       <%= render "govuk_publishing_components/components/date_input", {
-        name: "schedule",
+        name: "schedule[date]",
         hint: t("schedule.scheduled_publishing_datetime.date_hint_text"),
-        id: date_input_id,
+        id: "date",
+        error_message: error_message.presence,
         items: [
           {
             name: "day",
             width: 2,
-            value: schedule_param["day"] || publish_date&.day
+            value: params.dig(:schedule, :date, :day) || publish_datetime&.day
           },
           {
             name: "month",
             width: 2,
-            value: schedule_param["month"] || publish_date&.month,
+            value: params.dig(:schedule, :date, :month) || publish_datetime&.month,
           },
           {
             name: "year",
             width: 4,
-            value: schedule_param["year"] || publish_date&.year,
+            value: params.dig(:schedule, :date, :year) || publish_datetime&.year,
           }
         ]
       } %>
-      <% time_options = time_options(selected_time) %>
+      <%
+        selected_time = params.dig(:schedule, :time) || publish_datetime.strftime("%l:%M%P")
+        time_options = time_options(selected_time)
+      %>
       <%= render "components/autocomplete", {
-        id: "schedule[time]",
+        id: "time",
         name: "schedule[time]",
         label: {
           text: t("schedule.scheduled_publishing_datetime.time"),

--- a/app/views/schedule/scheduled_publishing_datetime.html.erb
+++ b/app/views/schedule/scheduled_publishing_datetime.html.erb
@@ -4,7 +4,6 @@
   current_scheduled_publish_datetime = @edition.scheduled_publishing_datetime
   default_datetime = Time.current.tomorrow
   publish_datetime = current_scheduled_publish_datetime || default_datetime
-  action_not_selected = @issues&.select { |i| i.issue_key == :action_not_selected }&.first&.to_item
 %>
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
@@ -15,7 +14,7 @@
         html_for: "date",
       } %>
       <%
-        errors = (@issues&.items_for(:scheduled_date) || [])
+        errors = (@issues&.items_for(:schedule_date) || [])
         error_message = errors.map { |item| item[:text] }.join("<br/>").html_safe
       %>
       <%= render "govuk_publishing_components/components/date_input", {
@@ -27,7 +26,7 @@
           {
             name: "day",
             width: 2,
-            value: params.dig(:schedule, :date, :day) || publish_datetime&.day
+            value: params.dig(:schedule, :date, :day) || publish_datetime&.day,
           },
           {
             name: "month",
@@ -66,9 +65,10 @@
       <% else %>
         <%= render "govuk_publishing_components/components/radio", {
           name: "schedule[action]",
-          error_message: action_not_selected && action_not_selected[:text],
+          error_items: @issues&.items_for(:schedule_action),
           items: [
             {
+              id: "action",
               value: "save",
               text: t("schedule.scheduled_publishing_datetime.action.save"),
             },

--- a/app/views/schedule/scheduled_publishing_datetime.html.erb
+++ b/app/views/schedule/scheduled_publishing_datetime.html.erb
@@ -51,6 +51,7 @@
           text: t("schedule.scheduled_publishing_datetime.time"),
           bold: true,
         },
+        error_items: @issues&.items_for(:schedule_time),
         options: time_options[:options],
         selected_options: time_options[:selected_options],
         type: "without-narrowing-results",

--- a/app/views/schedule/scheduled_publishing_datetime.html.erb
+++ b/app/views/schedule/scheduled_publishing_datetime.html.erb
@@ -8,16 +8,17 @@
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
     <%= form_tag save_scheduled_publishing_datetime_path(@edition.document) do %>
-      <%= render "govuk_publishing_components/components/label", {
-        bold: true,
-        text: t("schedule.scheduled_publishing_datetime.date"),
-        html_for: "date",
-      } %>
       <%
         errors = (@issues&.items_for(:schedule_date) || [])
         error_message = errors.map { |item| item[:text] }.join("<br/>").html_safe
       %>
+      <% legend = capture do %>
+        <span class="govuk-heading-s govuk-!-margin-bottom-0">
+          <%= t("schedule.scheduled_publishing_datetime.date") %>
+        </span>
+      <% end %>
       <%= render "govuk_publishing_components/components/date_input", {
+        legend_text: legend,
         name: "schedule[date]",
         hint: t("schedule.scheduled_publishing_datetime.date_hint_text"),
         id: "date",

--- a/app/views/schedule/scheduled_publishing_datetime.html.erb
+++ b/app/views/schedule/scheduled_publishing_datetime.html.erb
@@ -72,10 +72,12 @@
               id: "action",
               value: "save",
               text: t("schedule.scheduled_publishing_datetime.action.save"),
+              checked: params.dig(:schedule, :action) == "save",
             },
             {
               value: "schedule",
               text: t("schedule.scheduled_publishing_datetime.action.schedule"),
+              checked: params.dig(:schedule, :action) == "schedule",
             },
           ]
         } %>

--- a/app/views/schedule/scheduled_publishing_datetime.html.erb
+++ b/app/views/schedule/scheduled_publishing_datetime.html.erb
@@ -26,17 +26,17 @@
           {
             name: "day",
             width: 2,
-            value: params.dig(:schedule, :date, :day) || publish_datetime&.day,
+            value: params.dig(:schedule, :date, :day) || publish_datetime.day,
           },
           {
             name: "month",
             width: 2,
-            value: params.dig(:schedule, :date, :month) || publish_datetime&.month,
+            value: params.dig(:schedule, :date, :month) || publish_datetime.month,
           },
           {
             name: "year",
             width: 4,
-            value: params.dig(:schedule, :date, :year) || publish_datetime&.year,
+            value: params.dig(:schedule, :date, :year) || publish_datetime.year,
           }
         ]
       } %>

--- a/config/locales/en/requirements.yml
+++ b/config/locales/en/requirements.yml
@@ -81,20 +81,23 @@ en:
         form_message: Enter a public explanation
       invalid_govspeak:
         form_message: Remove invalid HTML or any JavaScript from the public explanation
-    scheduled_date:
+    schedule_date:
       invalid:
         form_message: Enter a valid date
       in_the_past:
         form_message: Enter a date that is not in the past
       too_far_in_future:
         form_message: "Enter a date within the next %{time_period}"
-    scheduled_time:
+    schedule_time:
       invalid:
         form_message: Enter a valid time
       in_the_past:
         form_message: Enter a time that is not in the past
       too_close_to_now:
         form_message: "Enter a time more than %{time_period} from now"
+    schedule_action:
+      not_selected:
+        form_message: Select an option
     schedule_review:
       not_selected:
         form_message: Select an option

--- a/config/locales/en/requirements.yml
+++ b/config/locales/en/requirements.yml
@@ -81,19 +81,20 @@ en:
         form_message: Enter a public explanation
       invalid_govspeak:
         form_message: Remove invalid HTML or any JavaScript from the public explanation
-    scheduled_datetime:
-      in_the_past:
-        form_message: Enter a date and time that is not in the past
+    scheduled_date:
       invalid:
-        form_message: "Enter a valid %{field}"
+        form_message: Enter a valid date
+      in_the_past:
+        form_message: Enter a date that is not in the past
       too_far_in_future:
         form_message: "Enter a date within the next %{time_period}"
+    scheduled_time:
+      invalid:
+        form_message: Enter a valid time
+      in_the_past:
+        form_message: Enter a time that is not in the past
       too_close_to_now:
         form_message: "Enter a time more than %{time_period} from now"
-      action_not_selected:
-        form_message: Select an option
-      invalid_input:
-        form_message: Enter a valid date and time
     schedule_review:
       not_selected:
         form_message: Select an option

--- a/spec/features/workflow/change_scheduled_publishing_datetime_spec.rb
+++ b/spec/features/workflow/change_scheduled_publishing_datetime_spec.rb
@@ -27,13 +27,13 @@ RSpec.feature "Change scheduled publishing datetime" do
 
   def then_i_see_the_current_date_and_time_selected
     expect(page).to have_selector(
-      "[@name='schedule[day]'][@value='#{@current_datetime.day}']",
+      "[@name='schedule[date][day]'][@value='#{@current_datetime.day}']",
     )
     expect(page).to have_selector(
-      "[@name='schedule[month]'][@value='#{@current_datetime.month}']",
+      "[@name='schedule[date][month]'][@value='#{@current_datetime.month}']",
     )
     expect(page).to have_selector(
-      "[@name='schedule[year]'][@value='#{@current_datetime.year}']",
+      "[@name='schedule[date][year]'][@value='#{@current_datetime.year}']",
     )
     expect(page).to have_field(
       "schedule[time]", text: "10:00am"
@@ -41,10 +41,10 @@ RSpec.feature "Change scheduled publishing datetime" do
   end
 
   def when_i_choose_a_new_scheduled_date_and_time
-    @new_date = Time.zone.now.advance(days: 2)
-    fill_in "schedule[day]", with: @new_date.day
-    fill_in "schedule[month]", with: @new_date.month
-    fill_in "schedule[year]", with: @new_date.year
+    @new_date = Time.current.advance(days: 2)
+    fill_in "schedule[date][day]", with: @new_date.day
+    fill_in "schedule[date][month]", with: @new_date.month
+    fill_in "schedule[date][year]", with: @new_date.year
     select "11:00pm", from: "schedule[time]"
   end
 

--- a/spec/features/workflow/clear_scheduled_publishing_datetime_spec.rb
+++ b/spec/features/workflow/clear_scheduled_publishing_datetime_spec.rb
@@ -11,7 +11,7 @@ RSpec.feature "Clear scheduled publishing datetime" do
   end
 
   def given_there_is_an_edition_with_a_set_scheduled_publishing_datetime
-    @datetime = Time.zone.now.advance(days: 2).midday
+    @datetime = Time.current.advance(days: 2).midday
     @scheduled_date = @datetime.strftime("%-d %B %Y")
     @edition = create(:edition, scheduled_publishing_datetime: @datetime)
   end
@@ -27,13 +27,13 @@ RSpec.feature "Clear scheduled publishing datetime" do
 
   def then_i_see_the_existing_scheduled_publishing_date_and_time
     expect(page).to have_selector(
-      "[@name='schedule[day]'][@value='#{@datetime.day}']",
+      "[@name='schedule[date][day]'][@value='#{@datetime.day}']",
     )
     expect(page).to have_selector(
-      "[@name='schedule[month]'][@value='#{@datetime.month}']",
+      "[@name='schedule[date][month]'][@value='#{@datetime.month}']",
     )
     expect(page).to have_selector(
-      "[@name='schedule[year]'][@value='#{@datetime.year}']",
+      "[@name='schedule[date][year]'][@value='#{@datetime.year}']",
     )
     expect(page).to have_field("schedule[time]", text: "12:00pm")
   end

--- a/spec/features/workflow/schedule_publishing_datetime_requirements_spec.rb
+++ b/spec/features/workflow/schedule_publishing_datetime_requirements_spec.rb
@@ -34,7 +34,7 @@ RSpec.feature "Scheduled publishing datetime requirements" do
 
   def then_i_see_an_error_about_the_date_being_invalid
     expect(page).to have_content(
-      I18n.t!("requirements.scheduled_date.invalid.form_message"),
+      I18n.t!("requirements.schedule_date.invalid.form_message"),
     )
   end
 end

--- a/spec/features/workflow/schedule_publishing_datetime_requirements_spec.rb
+++ b/spec/features/workflow/schedule_publishing_datetime_requirements_spec.rb
@@ -23,9 +23,9 @@ RSpec.feature "Scheduled publishing datetime requirements" do
   end
 
   def and_i_enter_invalid_date_fields
-    fill_in "schedule[day]", with: ""
-    fill_in "schedule[month]", with: ""
-    fill_in "schedule[year]", with: ""
+    fill_in "schedule[date][day]", with: ""
+    fill_in "schedule[date][month]", with: ""
+    fill_in "schedule[date][year]", with: ""
   end
 
   def and_i_click_continue
@@ -34,8 +34,7 @@ RSpec.feature "Scheduled publishing datetime requirements" do
 
   def then_i_see_an_error_about_the_date_being_invalid
     expect(page).to have_content(
-      I18n.t!("requirements.scheduled_datetime.invalid.form_message",
-              field: "date"),
+      I18n.t!("requirements.scheduled_date.invalid.form_message"),
     )
   end
 end

--- a/spec/features/workflow/schedule_set_datetime_passes_spec.rb
+++ b/spec/features/workflow/schedule_set_datetime_passes_spec.rb
@@ -9,7 +9,7 @@ RSpec.feature "Set scheduled publishing date and time passes before scheduling" 
   end
 
   def given_there_is_an_edition_with_past_scheduled_publishing_datetime
-    datetime = Time.zone.now - 1
+    datetime = Time.current - 1
     @edition = create(:edition, scheduled_publishing_datetime: datetime)
   end
 

--- a/spec/features/workflow/schedule_set_datetime_too_close_to_now_spec.rb
+++ b/spec/features/workflow/schedule_set_datetime_too_close_to_now_spec.rb
@@ -8,7 +8,7 @@ RSpec.feature "Set scheduled publishing date and time passes is too close to now
   end
 
   def given_there_is_an_edition_with_a_scheduled_publishing_date_and_time_set_too_close_to_now
-    datetime = Time.zone.now.advance(Edition::MINIMUM_SCHEDULING_TIME)
+    datetime = Time.current.advance(Edition::MINIMUM_SCHEDULING_TIME)
     @edition = create(:edition, scheduled_publishing_datetime: datetime)
   end
 

--- a/spec/features/workflow/set_scheduled_datetime_action_missing_spec.rb
+++ b/spec/features/workflow/set_scheduled_datetime_action_missing_spec.rb
@@ -5,7 +5,6 @@ RSpec.feature "Set scheduled publishing datetime without selecting scheduling ac
     given_there_is_an_edition
     when_i_visit_the_summary_page
     and_i_click_on_schedule
-    and_i_choose_a_scheduled_date_and_time
     and_i_click_continue
     then_i_see_an_error_about_not_selecting_a_scheduling_option
   end
@@ -22,21 +21,13 @@ RSpec.feature "Set scheduled publishing datetime without selecting scheduling ac
     click_on "Schedule"
   end
 
-  def and_i_choose_a_scheduled_date_and_time
-    @date = Time.current.advance(days: 2)
-    fill_in "schedule[date][day]", with: @date.day
-    fill_in "schedule[date][month]", with: @date.month
-    fill_in "schedule[date][year]", with: @date.year
-    select "11:00pm", from: "schedule[time]"
-  end
-
   def and_i_click_continue
     click_on "Continue"
   end
 
   def then_i_see_an_error_about_not_selecting_a_scheduling_option
     expect(page).to have_content(
-      I18n.t!("requirements.scheduled_datetime.action_not_selected.form_message"),
+      I18n.t!("requirements.schedule_action.not_selected.form_message"),
     )
   end
 end

--- a/spec/features/workflow/set_scheduled_datetime_action_missing_spec.rb
+++ b/spec/features/workflow/set_scheduled_datetime_action_missing_spec.rb
@@ -23,10 +23,10 @@ RSpec.feature "Set scheduled publishing datetime without selecting scheduling ac
   end
 
   def and_i_choose_a_scheduled_date_and_time
-    @date = Time.zone.now.advance(days: 2)
-    fill_in "schedule[day]", with: @date.day
-    fill_in "schedule[month]", with: @date.month
-    fill_in "schedule[year]", with: @date.year
+    @date = Time.current.advance(days: 2)
+    fill_in "schedule[date][day]", with: @date.day
+    fill_in "schedule[date][month]", with: @date.month
+    fill_in "schedule[date][year]", with: @date.year
     select "11:00pm", from: "schedule[time]"
   end
 

--- a/spec/features/workflow/set_scheduled_publishing_datetime_and_schedule_spec.rb
+++ b/spec/features/workflow/set_scheduled_publishing_datetime_and_schedule_spec.rb
@@ -24,10 +24,10 @@ RSpec.feature "Set scheduled publishing datetime and schedule" do
   end
 
   def and_i_choose_a_scheduled_date_and_time
-    @date = Time.zone.now.advance(days: 2)
-    fill_in "schedule[day]", with: @date.day
-    fill_in "schedule[month]", with: @date.month
-    fill_in "schedule[year]", with: @date.year
+    @date = Time.current.advance(days: 2)
+    fill_in "schedule[date][day]", with: @date.day
+    fill_in "schedule[date][month]", with: @date.month
+    fill_in "schedule[date][year]", with: @date.year
     select "11:00pm", from: "schedule[time]"
   end
 

--- a/spec/features/workflow/set_scheduled_publishing_datetime_spec.rb
+++ b/spec/features/workflow/set_scheduled_publishing_datetime_spec.rb
@@ -28,13 +28,13 @@ RSpec.feature "Set scheduled publishing datetime" do
   def then_i_see_a_default_date_and_time_selected
     default_date = Time.zone.tomorrow
     expect(page).to have_selector(
-      "[@name='schedule[day]'][@value='#{default_date.day}']",
+      "[@name='schedule[date][day]'][@value='#{default_date.day}']",
     )
     expect(page).to have_selector(
-      "[@name='schedule[month]'][@value='#{default_date.month}']",
+      "[@name='schedule[date][month]'][@value='#{default_date.month}']",
     )
     expect(page).to have_selector(
-      "[@name='schedule[year]'][@value='#{default_date.year}']",
+      "[@name='schedule[date][year]'][@value='#{default_date.year}']",
     )
     expect(page).to have_field(
       "schedule[time]", text: "9:00am"
@@ -42,10 +42,10 @@ RSpec.feature "Set scheduled publishing datetime" do
   end
 
   def when_i_choose_a_scheduled_date_and_time
-    @date = Time.zone.now.advance(days: 2)
-    fill_in "schedule[day]", with: @date.day
-    fill_in "schedule[month]", with: @date.month
-    fill_in "schedule[year]", with: @date.year
+    @date = Time.current.advance(days: 2)
+    fill_in "schedule[date][day]", with: @date.day
+    fill_in "schedule[date][month]", with: @date.month
+    fill_in "schedule[date][year]", with: @date.year
     select "11:00pm", from: "schedule[time]"
   end
 

--- a/spec/services/requirements/scheduled_datetime_checker_spec.rb
+++ b/spec/services/requirements/scheduled_datetime_checker_spec.rb
@@ -52,6 +52,32 @@ RSpec.describe Requirements::ScheduledDatetimeChecker do
         .to include(a_hash_including(text: invalid_time))
     end
 
+    it "accepts times formatted different from how we present them" do
+      travel_to("2019-01-01 11:00am") do
+        date_options = { day: 2, month: 1, year: 2019 }
+
+        checker = Requirements::ScheduledDatetimeChecker.new(time: "9:34",
+                                                             date: date_options)
+        expect(checker.pre_submit_issues.items).to be_empty
+        expect(checker.parsed_datetime).to eql(Time.zone.parse("2019-01-02 09:34"))
+
+        checker = Requirements::ScheduledDatetimeChecker.new(time: "12:00",
+                                                             date: date_options)
+        expect(checker.pre_submit_issues.items).to be_empty
+        expect(checker.parsed_datetime).to eql(Time.zone.parse("2019-01-02 12:00"))
+
+        checker = Requirements::ScheduledDatetimeChecker.new(time: "6:00 pm",
+                                                             date: date_options)
+        expect(checker.pre_submit_issues.items).to be_empty
+        expect(checker.parsed_datetime).to eql(Time.zone.parse("2019-01-02 18:00"))
+
+        checker = Requirements::ScheduledDatetimeChecker.new(time: "23:32",
+                                                             date: date_options)
+        expect(checker.pre_submit_issues.items).to be_empty
+        expect(checker.parsed_datetime).to eql(Time.zone.parse("2019-01-02 23:32"))
+      end
+    end
+
     it "returns a date issue if the date is in the past" do
       two_days_ago = Time.current - 2.days
 

--- a/spec/services/requirements/scheduled_datetime_checker_spec.rb
+++ b/spec/services/requirements/scheduled_datetime_checker_spec.rb
@@ -17,13 +17,13 @@ RSpec.describe Requirements::ScheduledDatetimeChecker do
     it "returns an issue if the date or time fields are blank" do
       issues = Requirements::ScheduledDatetimeChecker.new({}).pre_submit_issues
 
-      invalid_date = I18n.t!("requirements.scheduled_date.invalid.form_message")
-      invalid_time = I18n.t!("requirements.scheduled_time.invalid.form_message")
+      invalid_date = I18n.t!("requirements.schedule_date.invalid.form_message")
+      invalid_time = I18n.t!("requirements.schedule_time.invalid.form_message")
 
-      expect(issues.items_for(:scheduled_date))
+      expect(issues.items_for(:schedule_date))
         .to include(a_hash_including(text: invalid_date))
 
-      expect(issues.items_for(:scheduled_time))
+      expect(issues.items_for(:schedule_time))
         .to include(a_hash_including(text: invalid_time))
     end
 
@@ -33,9 +33,9 @@ RSpec.describe Requirements::ScheduledDatetimeChecker do
         time: "11:00am",
       ).pre_submit_issues
 
-      invalid_date = I18n.t!("requirements.scheduled_date.invalid.form_message")
+      invalid_date = I18n.t!("requirements.schedule_date.invalid.form_message")
 
-      expect(issues.items_for(:scheduled_date))
+      expect(issues.items_for(:schedule_date))
         .to include(a_hash_including(text: invalid_date))
     end
 
@@ -46,9 +46,9 @@ RSpec.describe Requirements::ScheduledDatetimeChecker do
         time: "1223456",
       ).pre_submit_issues
 
-      invalid_time = I18n.t!("requirements.scheduled_time.invalid.form_message")
+      invalid_time = I18n.t!("requirements.schedule_time.invalid.form_message")
 
-      expect(issues.items_for(:scheduled_time))
+      expect(issues.items_for(:schedule_time))
         .to include(a_hash_including(text: invalid_time))
     end
 
@@ -62,37 +62,37 @@ RSpec.describe Requirements::ScheduledDatetimeChecker do
         time: "10:00am",
       ).pre_submit_issues
 
-      past_date = I18n.t!("requirements.scheduled_date.in_the_past.form_message")
+      past_date = I18n.t!("requirements.schedule_date.in_the_past.form_message")
 
-      expect(issues.items_for(:scheduled_date))
+      expect(issues.items_for(:schedule_date))
         .to include(a_hash_including(text: past_date))
     end
 
     it "returns a time issue if the date is present but time in the past" do
-      travel_to('2019-01-01 11:00am') do
+      travel_to("2019-01-01 11:00am") do
         issues = Requirements::ScheduledDatetimeChecker.new(
           date: { day: 1, month: 1, year: 2019 },
           time: "10:45am",
         ).pre_submit_issues
 
-        past_time = I18n.t!("requirements.scheduled_time.in_the_past.form_message")
+        past_time = I18n.t!("requirements.schedule_time.in_the_past.form_message")
 
-        expect(issues.items_for(:scheduled_time))
+        expect(issues.items_for(:schedule_time))
           .to include(a_hash_including(text: past_time))
       end
     end
 
     it "returns an issue if the datetime is too close to now" do
-      travel_to('2019-01-01 11:00am') do
+      travel_to("2019-01-01 11:00am") do
         issues = Requirements::ScheduledDatetimeChecker.new(
           date: { day: 1, month: 1, year: 2019 },
           time: "11:10am",
         ).pre_submit_issues
 
-        close_time = I18n.t!("requirements.scheduled_time.too_close_to_now.form_message",
+        close_time = I18n.t!("requirements.schedule_time.too_close_to_now.form_message",
                              time_period: "15 minutes")
 
-        expect(issues.items_for(:scheduled_time))
+        expect(issues.items_for(:schedule_time))
           .to include(a_hash_including(text: close_time))
       end
     end
@@ -108,10 +108,10 @@ RSpec.describe Requirements::ScheduledDatetimeChecker do
         time: "10:50am",
       ).pre_submit_issues
 
-      too_far_in_future = I18n.t!("requirements.scheduled_date.too_far_in_future.form_message",
-                               time_period: "14 months")
+      too_far_in_future = I18n.t!("requirements.schedule_date.too_far_in_future.form_message",
+                                  time_period: "14 months")
 
-      expect(issues.items_for(:scheduled_date))
+      expect(issues.items_for(:schedule_date))
         .to include(a_hash_including(text: too_far_in_future))
     end
   end


### PR DESCRIPTION
Trello: https://trello.com/c/rGjDviSL/848-adapt-scheduling-implementation-for-iterated-workflow

This allows each of the requirements issues to link directly to a field. It does this by breaking up the datetime errors into ones that are date or time. To complete this the autocomplete component needed updating to accept errors.

There are few things that aren't quite ideal in this which I'll explain:

- The fields for scheduling are most prefixed with `schedule_` this is done to disambiguate them amongst the many fields in the requirements yaml file, it would have been nicer to have date, time and action as names but they looked rather generic in amongst that file;
- The time parsing is quite strict to limit checking that a time input is actually a time, the alternative is pretty wild west parsing wise without further complication - unless anyone has better ideas?
- the date_input doesn't accept error_items as input, hopefully we can fix that soon
- the date_input doesn't have a label inside it so that's not caught in an error state

Screenshot:

![Screen Shot 2019-06-05 at 09 50 04](https://user-images.githubusercontent.com/282717/58943300-5812dd00-8777-11e9-9482-c0510efdf009.png)
