### PR TITLE
Report page name for all events

### DIFF
--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -7,7 +7,8 @@
   <script>
     var dataLayer = [{
       'user-organisation': '<%= current_user.organisation_slug %>',
-      'cp-uid': '<%= current_user.uid %>'
+      'cp-uid': '<%= current_user.uid %>',
+      'page-name': '<%= "#{controller_name}-#{action_name}" %>'
     }];
     dataLayer.push({ 'gtm.blacklist': ['html', 'customScripts', 'nonGoogleScripts', 'customPixels'] });
   </script>


### PR DESCRIPTION
https://trello.com/c/B9rVHJTh/876-audit-and-fix-gtm-issues

Previously we defined data-gtm tags in order to support robust analytics
for user actions, as more volatile things like CSS and link text change
over time. When a user action can occur on multiple pages, such when in
the context of a modal, it can be difficult to filter by workflow. This
adds an automated 'page-name' attribute to make it easier to filter by
workflow when the same user actions can occur on multiple pages.