### PR TITLE
Notify users about scheduled publishing

### DIFF
--- a/app/jobs/scheduled_publishing_job.rb
+++ b/app/jobs/scheduled_publishing_job.rb
@@ -18,7 +18,7 @@ class ScheduledPublishingJob < ApplicationJob
                     .publish(user: user, with_review: reviewed)
     end
 
-    ScheduledPublishMailer.success_email(published_edition, user).deliver_later
+    send_notifications(published_edition)
   end
 
 private
@@ -34,6 +34,12 @@ private
     if schedule > Time.zone.now
       Rails.logger.warn("Cannot publish an edition (\##{edition.id}) scheduled in the future")
       return true
+    end
+  end
+
+  def send_notifications(edition)
+    edition.editors.each do |editor|
+      ScheduledPublishMailer.success_email(edition, editor).deliver_later
     end
   end
 end

--- a/app/mailers/scheduled_publish_mailer.rb
+++ b/app/mailers/scheduled_publish_mailer.rb
@@ -1,0 +1,31 @@
+# frozen_string_literal: true
+
+class ScheduledPublishMailer < ApplicationMailer
+  self.delivery_job = EmailDeliveryJob
+
+  add_template_helper(EditionUrlHelper)
+
+  def success_email(edition, user)
+    @user = user
+    @edition = edition
+    @status = edition.status
+
+    unless @status.published? || @status.published_but_needs_2i?
+      raise "Cannot send publish email with a non-published state"
+    end
+
+    mail(to: user.email, subject: subject)
+  end
+
+private
+
+  def subject
+    if @edition.number > 1
+      I18n.t("scheduled_publish_mailer.success_email.subject.update",
+             title: @edition.title)
+    else
+      I18n.t("scheduled_publish_mailer.success_email.subject.#{@status.state}",
+             title: @edition.title)
+    end
+  end
+end

--- a/app/views/scheduled_publish_mailer/success_email.text.erb
+++ b/app/views/scheduled_publish_mailer/success_email.text.erb
@@ -1,0 +1,35 @@
+<%= @edition.document_type.label %> ‘<%= @edition.title %>’
+
+<% if @edition.number > 1 -%>
+<%= t("scheduled_publish_mailer.success_email.details.update",
+  time: @status.created_at.strftime("%-l:%M%P"),
+  date: @status.created_at.strftime("%d %B %Y")
+) %>
+<% else -%>
+<%= t("scheduled_publish_mailer.success_email.details.publish",
+  time: @status.created_at.strftime("%-l:%M%P"),
+  date: @status.created_at.strftime("%d %B %Y")
+) %>
+<% end -%>
+<%= t("scheduled_publish_mailer.success_email.scheduled_by", name: @user.name) %>
+
+<%= t("scheduled_publish_mailer.success_email.delay_warning") %>
+
+<%= t("scheduled_publish_mailer.success_email.page_address") %>
+<%= edition_public_url(@edition) %>
+
+<% if @edition.number > 1 -%>
+<% if @edition.major? -%>
+<%= t("scheduled_publish_mailer.success_email.change_note") %>
+<%= @edition.change_note %>
+<% else -%>
+<%= t("scheduled_publish_mailer.success_email.minor_update") %>
+<% end -%>
+<% end -%>
+
+<% if @edition.published_but_needs_2i? -%>
+<%= t("scheduled_publish_mailer.success_email.2i_warning") %>
+<% end -%>
+
+<%= t("scheduled_publish_mailer.success_email.edit_in_app") %>
+<%= document_url(@edition.document, utm_content: "publish-email-link") %>

--- a/config/locales/en/scheduled_publish_mailer/success_email.yml
+++ b/config/locales/en/scheduled_publish_mailer/success_email.yml
@@ -1,0 +1,17 @@
+en:
+  scheduled_publish_mailer:
+    success_email:
+      subject:
+        published: "Published: ‘%{title}’"
+        published_but_needs_2i: "Published but needs 2i review: ‘%{title}’"
+        update: "Update published: ‘%{title}’"
+      details:
+        publish: "Published at %{time} on %{date}"
+        update: "Update published at %{time} on %{date}"
+      delay_warning: It may take 5 minutes to appear live.
+      page_address: Page address
+      change_note: Public change note
+      edit_in_app: Edit in Content Publisher
+      2i_warning: This content still needs 2i review. It can then be approved or updated.
+      minor_update: A minor style update
+      scheduled_by: "Scheduled by %{name}"

--- a/spec/jobs/scheduled_publishing_job_spec.rb
+++ b/spec/jobs/scheduled_publishing_job_spec.rb
@@ -2,24 +2,45 @@
 
 RSpec.describe ScheduledPublishingJob, inline: true do
   describe "#perform" do
-    it "calls PublishService if edition can be published" do
-      edition = create(:edition,
-                       :scheduled,
-                       scheduled_publishing_datetime: Time.current)
-      user = edition.status.created_by
-      publish_service = double(:publish_service, publish: nil)
+    context "scheduled publishing is successful" do
+      before do
+        @publish_service = instance_double(PublishService, publish: nil)
+        message_delivery = instance_double(ActionMailer::MessageDelivery, deliver_later: nil)
+        allow(ScheduledPublishMailer).to receive(:success_email).and_return(message_delivery)
+      end
 
-      expect(PublishService).to receive(:new).with(edition) { publish_service }
-      message_delivery = double(ActionMailer::MessageDelivery, deliver_later: nil)
+      it "calls PublishService if edition can be published" do
+        edition = create(:edition,
+                         :scheduled,
+                         scheduled_publishing_datetime: Time.current)
+        user = edition.status.created_by
 
-      expect(publish_service)
-        .to receive(:publish)
-        .with(user: user, with_review: edition.status.details.reviewed)
+        expect(PublishService).to receive(:new).with(edition) { @publish_service }
+        expect(@publish_service)
+          .to receive(:publish)
+          .with(user: user, with_review: edition.status.details.reviewed)
 
-      expect(ScheduledPublishMailer).to receive(:success_email).with(edition, user)
-                                                               .and_return(message_delivery)
+        ScheduledPublishingJob.perform_now(edition.id)
+      end
 
-      ScheduledPublishingJob.perform_now(edition.id)
+      it "calls ScheduledPublishMailer for each editor of the edition" do
+        editor_one = create(:user, email: "someone@example.com")
+        editor_two = create(:user, email: "someone-else@example.com")
+        revision = create(:revision,
+                          created_by: editor_two,
+                          scheduled_publishing_datetime: Time.current)
+        edition = create(:edition,
+                         :scheduled,
+                         revision: revision,
+                         created_by: editor_one)
+
+        allow(PublishService).to receive(:new).with(edition) { @publish_service }
+
+        expect(ScheduledPublishMailer).to receive(:success_email).with(edition, editor_one)
+        expect(ScheduledPublishMailer).to receive(:success_email).with(edition, editor_two)
+
+        ScheduledPublishingJob.perform_now(edition.id)
+      end
     end
 
     it "aborts the job if the edition does not exist (e.g. env sync)" do

--- a/spec/mailers/scheduled_publish_mailer_spec.rb
+++ b/spec/mailers/scheduled_publish_mailer_spec.rb
@@ -1,0 +1,75 @@
+# frozen_string_literal: true
+
+RSpec.describe ScheduledPublishMailer do
+  before do
+    @user = create(:user)
+
+    published_at = Time.current
+    @publish_time = published_at.strftime("%-l:%M%P")
+    @publish_date = published_at.strftime("%d %B %Y")
+  end
+
+  describe "sending an email when scheduled edition is published" do
+    it "renders non-specific mail content" do
+      edition = create(:edition, :published, title: "yolo")
+      mail = ScheduledPublishMailer.success_email(edition, @user).deliver_now
+      body = mail.body.encoded
+
+      expect(mail.to).to eq([@user.email])
+      expect(body).to include("https://www.test.gov.uk/prefix/yolo")
+      expect(body).to include(document_path(edition.document))
+      expect(body).to include(
+        I18n.t("scheduled_publish_mailer.success_email.scheduled_by",
+               name: @user.name),
+      )
+    end
+
+    it "renders mail content for publishing the first edition with 2i" do
+      edition = create(:edition, :published, title: "yolo")
+      mail = ScheduledPublishMailer.success_email(edition, @user).deliver_now
+      body = mail.body.encoded
+
+      expect(mail.subject).to eq(
+        I18n.t("scheduled_publish_mailer.success_email.subject.published",
+               title: edition.title),
+      )
+      expect(body).to include(
+        I18n.t("scheduled_publish_mailer.success_email.details.publish",
+               time: @publish_time,
+               date: @publish_date),
+      )
+    end
+
+    it "renders mail content for publishing the first edition without 2i" do
+      edition = create(:edition, state: "published_but_needs_2i", title: "yolo")
+      mail = ScheduledPublishMailer.success_email(edition, @user).deliver_now
+      body = mail.body.encoded
+
+      expect(mail.subject).to eq(
+        I18n.t("scheduled_publish_mailer.success_email.subject.published_but_needs_2i",
+               title: edition.title),
+      )
+      expect(body).to include(
+        I18n.t("scheduled_publish_mailer.success_email.details.publish",
+               time: @publish_time,
+               date: @publish_date),
+      )
+    end
+
+    it "renders mail content for updating a published edition" do
+      edition = create(:edition, :published, number: 2, title: "yolo")
+      mail = ScheduledPublishMailer.success_email(edition, @user).deliver_now
+      body = mail.body.encoded
+
+      expect(mail.subject).to eq(
+        I18n.t("scheduled_publish_mailer.success_email.subject.update",
+               title: edition.title),
+      )
+      expect(body).to include(
+        I18n.t("scheduled_publish_mailer.success_email.details.update",
+               time: @publish_time,
+               date: @publish_date),
+      )
+    end
+  end
+end


### PR DESCRIPTION
We need to send users who have edited an edition a notification that their scheduled content has been published.

Trello:
https://trello.com/c/utiuH5Q9/736-notify-users-that-scheduled-content-has-been-published