### PR TITLE
Move and fix rogue schedule test

### DIFF
--- a/spec/features/scheduling/schedule_spec.rb
+++ b/spec/features/scheduling/schedule_spec.rb
@@ -3,8 +3,8 @@
 RSpec.feature "Schedule an edition" do
   include ActiveJob::TestHelper
 
-  background do
-    Sidekiq::Testing.fake!
+  around do |example|
+    Sidekiq::Testing.fake! { example.run }
   end
 
   scenario do


### PR DESCRIPTION
As this test changed the Sidekiq Testing mode to fake! and future tests
that expected inline! would fail. By running the example within a block
no global state is changed.