### PR TITLE
Create Clear Datetime interactor

### DIFF
--- a/app/interactors/schedule/clear_datetime_interactor.rb
+++ b/app/interactors/schedule/clear_datetime_interactor.rb
@@ -1,0 +1,33 @@
+# frozen_string_literal: true
+
+class Schedule::ClearDatetimeInteractor
+  include Interactor
+  delegate :params,
+           :edition,
+           :user,
+           to: :context
+
+  def call
+    Edition.transaction do
+      find_and_lock_edition
+      clear_scheduled_publishing_datetime
+    end
+  end
+
+private
+
+  def find_and_lock_edition
+    context.edition = Edition.lock.find_current(document: params[:document])
+  end
+
+  def clear_scheduled_publishing_datetime
+    context.fail! unless edition.editable?
+
+    updater = Versioning::RevisionUpdater.new(edition.revision, user)
+    updater.assign(scheduled_publishing_datetime: nil)
+
+    if updater.changed?
+      edition.assign_revision(updater.next_revision, user).save!
+    end
+  end
+end

--- a/app/models/timeline_entry.rb
+++ b/app/models/timeline_entry.rb
@@ -45,7 +45,6 @@ class TimelineEntry < ApplicationRecord
                      draft_reset: "draft_reset",
                      scheduled: "scheduled",
                      unscheduled: "unscheduled",
-                     scheduled_publishing_datetime_cleared: "scheduled_publishing_datetime_cleared",
                      file_attachment_uploaded: "file_attachment_uploaded",
                      file_attachment_deleted: "file_attachment_deleted",
                      file_attachment_updated: "file_attachment_updated" }

--- a/spec/features/scheduling/clear_scheduled_publishing_datetime_spec.rb
+++ b/spec/features/scheduling/clear_scheduled_publishing_datetime_spec.rb
@@ -45,9 +45,5 @@ RSpec.feature "Clear scheduled publishing datetime" do
   def then_the_content_no_longer_has_a_scheduled_publishing_date_and_time
     scheduled_date = @datetime.strftime("%-d %B %Y")
     expect(page).to_not have_content("Proposed to publish at 12:00pm on #{scheduled_date}")
-
-    within first(".app-timeline-entry") do
-      expect(page).to have_content I18n.t!("documents.history.entry_types.scheduled_publishing_datetime_cleared")
-    end
   end
 end


### PR DESCRIPTION
For https://trello.com/c/bFymOdvj/850-allow-updating-and-clearing-of-a-proposed-scheduling-date

This extracts the logic for clearing a scheduled publishing datetime into an
interactor.  We have made a content decision that we no longer need to create a
timeline entry when a scheduled publishing datetime is clearer as this is an
edit. This is consistent with not creating a timeline entry when a scheduled
publishing datetime is updated.  We have also decided not to check if a
scheduled publishing datetime is present before clearing it, as if it's not
present the updater won't assign a new revision as it won't have changed.