### PR TITLE
Pass error items into components rather than convert to strings

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -151,7 +151,7 @@ GEM
     govuk_frontend_toolkit (8.2.0)
       railties (>= 3.1.0)
       sass (>= 3.2.0)
-    govuk_publishing_components (16.28.0)
+    govuk_publishing_components (16.29.0)
       gds-api-adapters
       govuk_app_config
       govuk_frontend_toolkit

--- a/app/views/components/_autocomplete.html.erb
+++ b/app/views/components/_autocomplete.html.erb
@@ -27,7 +27,7 @@
     <% if error_items.any? %>
       <%= render "govuk_publishing_components/components/error_message", {
         id: error_id,
-        text: raw(error_items.map { |item| item[:text] }.join("<br/>"))
+        items: error_items,
       } %>
     <% end %>
 

--- a/app/views/components/_markdown_editor.html.erb
+++ b/app/views/components/_markdown_editor.html.erb
@@ -70,7 +70,7 @@
 
   <% if error_items.any? %>
     <%= render "govuk_publishing_components/components/error_message", {
-      text: error_items.map { |item| html_escape(item[:text]) }.join("<br/>").html_safe
+      items: error_items,
     } %>
   <% end %>
 

--- a/app/views/schedule/scheduled_publishing_datetime.html.erb
+++ b/app/views/schedule/scheduled_publishing_datetime.html.erb
@@ -8,10 +8,6 @@
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
     <%= form_tag save_scheduled_publishing_datetime_path(@edition.document) do %>
-      <%
-        errors = (@issues&.items_for(:schedule_date) || [])
-        error_message = errors.map { |item| item[:text] }.join("<br/>").html_safe
-      %>
       <% legend = capture do %>
         <span class="govuk-heading-s govuk-!-margin-bottom-0">
           <%= t("schedule.scheduled_publishing_datetime.date") %>
@@ -22,7 +18,7 @@
         name: "schedule[date]",
         hint: t("schedule.scheduled_publishing_datetime.date_hint_text"),
         id: "date",
-        error_message: error_message.presence,
+        error_items: @issues&.items_for(:schedule_date),
         items: [
           {
             name: "day",


### PR DESCRIPTION
Trello: https://trello.com/c/rGjDviSL/848-adapt-scheduling-implementation-for-iterated-workflow

This updates to govuk_publishing_components 16.29.0 which allows us to pass in error_items to the error_message component and the date_input component.

This then updates our code to make use of this.