### PR TITLE
Schedule back link

### DIFF
--- a/app/controllers/schedule_proposal_controller.rb
+++ b/app/controllers/schedule_proposal_controller.rb
@@ -21,7 +21,7 @@ class ScheduleProposalController < ApplicationController
              assigns: { edition: edition, issues: issues },
              status: :unprocessable_entity
     elsif params.dig(:schedule, :action) == "schedule"
-      redirect_to new_schedule_path(edition.document)
+      redirect_to new_schedule_path(edition.document, wizard: params[:wizard])
     else
       redirect_to document_path(edition.document)
     end

--- a/app/helpers/actions_helper.rb
+++ b/app/helpers/actions_helper.rb
@@ -54,7 +54,7 @@ module ActionsHelper
 
   def schedule_proposal_link(edition, extra_classes = [])
     link_to "Schedule",
-            schedule_proposal_path(edition.document),
+            schedule_proposal_path(edition.document, wizard: "schedule"),
             class: %w(govuk-link govuk-link--no-visited-state) + Array(extra_classes),
             data: { gtm: "schedule-date" }
   end

--- a/app/interactors/schedule_proposal/update_interactor.rb
+++ b/app/interactors/schedule_proposal/update_interactor.rb
@@ -28,7 +28,7 @@ private
       raise "Can't save a scheduling date unless edition is a draft or has been submitted for 2i"
     end
 
-    checker = Requirements::ScheduledDatetimeChecker.new(schedule_params)
+    checker = Requirements::ScheduleDatetimeChecker.new(schedule_params)
     issues = checker.pre_submit_issues.to_a
     issues += action_issues if params[:wizard] == "schedule"
 

--- a/app/interactors/schedule_proposal/update_interactor.rb
+++ b/app/interactors/schedule_proposal/update_interactor.rb
@@ -29,12 +29,10 @@ private
     end
 
     checker = Requirements::ScheduledDatetimeChecker.new(schedule_params)
-    pre_issues = checker.pre_submit_issues.issues
+    issues = checker.pre_submit_issues.to_a
+    issues += action_issues if params[:wizard] == "schedule"
 
-    issues = Requirements::CheckerIssues.new(pre_issues + action_issues)
-
-    context.fail!(issues: issues) if issues.any?
-
+    context.fail!(issues: Requirements::CheckerIssues.new(issues)) if issues.any?
     context.datetime = checker.parsed_datetime
   end
 
@@ -52,13 +50,9 @@ private
   end
 
   def action_issues
-    return [] if scheduled_datetime_already_exists?
+    return [] if schedule_params[:action].present?
 
-    if schedule_params[:action].blank?
-      [Requirements::Issue.new(:schedule_action, :not_selected)]
-    else
-      []
-    end
+    [Requirements::Issue.new(:schedule_action, :not_selected)]
   end
 
   def scheduled_datetime_already_exists?

--- a/app/services/requirements/schedule_datetime_checker.rb
+++ b/app/services/requirements/schedule_datetime_checker.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 module Requirements
-  class ScheduledDatetimeChecker
+  class ScheduleDatetimeChecker
     attr_reader :params
 
     MAXIMUM_FUTURE_TIME_PERIOD = { months: 14 }.freeze

--- a/app/views/schedule/new.html.erb
+++ b/app/views/schedule/new.html.erb
@@ -1,4 +1,9 @@
-<% content_for :back_link, render_back_link(href: document_path(@edition.document)) %>
+<% if params[:wizard] == "schedule" %>
+  <% content_for :back_link, render_back_link(href: schedule_proposal_path(@edition.document, wizard: "schedule")) %>
+<% else %>
+  <% content_for :back_link, render_back_link(href: document_path(@edition.document)) %>
+<% end %>
+
 <% content_for :title, t("schedule.new.title") %>
 
 <% datetime = @edition.scheduled_publishing_datetime %>

--- a/app/views/schedule_proposal/edit.html.erb
+++ b/app/views/schedule_proposal/edit.html.erb
@@ -94,7 +94,7 @@
       <% end %>
     <% end %>
 
-    <% if @edition.scheduled_publishing_datetime.present? && !@edition.scheduled? %>
+    <% if @edition.scheduled_publishing_datetime.present? %>
       <%= form_tag schedule_proposal_path(@edition.document), method: :delete do %>
         <button class="govuk-link app-link--button govuk-link--no-visited-state">Clear schedule date</button>
       <% end %>

--- a/app/views/schedule_proposal/edit.html.erb
+++ b/app/views/schedule_proposal/edit.html.erb
@@ -9,11 +9,14 @@
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
     <%= form_tag schedule_proposal_path(@edition.document) do %>
+      <%= hidden_field_tag(:wizard, params[:wizard]) %>
+
       <% legend = capture do %>
         <span class="govuk-heading-s govuk-!-margin-bottom-0">
           <%= t("schedule_proposal.edit.date") %>
         </span>
       <% end %>
+
       <%= render "govuk_publishing_components/components/date_input", {
         legend_text: legend,
         name: "schedule[date]",
@@ -38,8 +41,10 @@
           }
         ]
       } %>
+
       <% persistent_time = publish_datetime.strftime("%-l:%M%P") %>
       <% selected_time = params.dig(:schedule, :time) || persistent_time %>
+
       <%= render "components/autocomplete", {
         id: "time",
         name: "schedule[time]",
@@ -58,12 +63,7 @@
         width: "narrow",
       } %>
 
-      <% if @edition.scheduled_publishing_datetime.present? %>
-        <%= render "govuk_publishing_components/components/button", {
-          text: "Save date",
-          margin_bottom: true
-        } %>,
-      <% else %>
+      <% if params[:wizard] == "schedule" %>
         <%= render "govuk_publishing_components/components/radio", {
           name: "schedule[action]",
           error_items: @issues&.items_for(:schedule_action),
@@ -83,9 +83,14 @@
         } %>
 
         <%= render "govuk_publishing_components/components/button", {
-          text: "Continue"
+          text: "Continue",
+          margin_bottom: true
         } %>
-
+      <% else %>
+        <%= render "govuk_publishing_components/components/button", {
+          text: "Save date",
+          margin_bottom: true
+        } %>,
       <% end %>
     <% end %>
 

--- a/spec/services/requirements/schedule_datetime_checker_spec.rb
+++ b/spec/services/requirements/schedule_datetime_checker_spec.rb
@@ -1,12 +1,12 @@
 # frozen_string_literal: true
 
-RSpec.describe Requirements::ScheduledDatetimeChecker do
+RSpec.describe Requirements::ScheduleDatetimeChecker do
   include ActiveSupport::Testing::TimeHelpers
 
   describe "#pre_submit_issues" do
     it "returns no issues if there are none" do
       tomorrow = Time.zone.tomorrow
-      issues = Requirements::ScheduledDatetimeChecker.new(
+      issues = Requirements::ScheduleDatetimeChecker.new(
         date: { day: tomorrow.day, month: tomorrow.month, year: tomorrow.year },
         time: "11:00am",
       ).pre_submit_issues
@@ -15,7 +15,7 @@ RSpec.describe Requirements::ScheduledDatetimeChecker do
     end
 
     it "returns an issue if the date or time fields are blank" do
-      issues = Requirements::ScheduledDatetimeChecker.new({}).pre_submit_issues
+      issues = Requirements::ScheduleDatetimeChecker.new({}).pre_submit_issues
 
       invalid_date = I18n.t!("requirements.schedule_date.invalid.form_message")
       invalid_time = I18n.t!("requirements.schedule_time.invalid.form_message")
@@ -28,7 +28,7 @@ RSpec.describe Requirements::ScheduledDatetimeChecker do
     end
 
     it "returns an issue if a date is invalid" do
-      issues = Requirements::ScheduledDatetimeChecker.new(
+      issues = Requirements::ScheduleDatetimeChecker.new(
         date: { day: 10, month: 60, year: 11 },
         time: "11:00am",
       ).pre_submit_issues
@@ -41,7 +41,7 @@ RSpec.describe Requirements::ScheduledDatetimeChecker do
 
     it "returns an issue if a time is invalid" do
       tomorrow = Time.zone.tomorrow
-      issues = Requirements::ScheduledDatetimeChecker.new(
+      issues = Requirements::ScheduleDatetimeChecker.new(
         date: { day: tomorrow.day, month: tomorrow.month, year: tomorrow.year },
         time: "1223456",
       ).pre_submit_issues
@@ -56,22 +56,22 @@ RSpec.describe Requirements::ScheduledDatetimeChecker do
       travel_to("2019-01-01 11:00am") do
         date_options = { day: 2, month: 1, year: 2019 }
 
-        checker = Requirements::ScheduledDatetimeChecker.new(time: "9:34",
+        checker = Requirements::ScheduleDatetimeChecker.new(time: "9:34",
                                                              date: date_options)
         expect(checker.pre_submit_issues.items).to be_empty
         expect(checker.parsed_datetime).to eql(Time.zone.parse("2019-01-02 09:34"))
 
-        checker = Requirements::ScheduledDatetimeChecker.new(time: "12:00",
+        checker = Requirements::ScheduleDatetimeChecker.new(time: "12:00",
                                                              date: date_options)
         expect(checker.pre_submit_issues.items).to be_empty
         expect(checker.parsed_datetime).to eql(Time.zone.parse("2019-01-02 12:00"))
 
-        checker = Requirements::ScheduledDatetimeChecker.new(time: "6:00 pm",
+        checker = Requirements::ScheduleDatetimeChecker.new(time: "6:00 pm",
                                                              date: date_options)
         expect(checker.pre_submit_issues.items).to be_empty
         expect(checker.parsed_datetime).to eql(Time.zone.parse("2019-01-02 18:00"))
 
-        checker = Requirements::ScheduledDatetimeChecker.new(time: "23:32",
+        checker = Requirements::ScheduleDatetimeChecker.new(time: "23:32",
                                                              date: date_options)
         expect(checker.pre_submit_issues.items).to be_empty
         expect(checker.parsed_datetime).to eql(Time.zone.parse("2019-01-02 23:32"))
@@ -81,7 +81,7 @@ RSpec.describe Requirements::ScheduledDatetimeChecker do
     it "returns a date issue if the date is in the past" do
       two_days_ago = Time.current - 2.days
 
-      issues = Requirements::ScheduledDatetimeChecker.new(
+      issues = Requirements::ScheduleDatetimeChecker.new(
         date: { day: two_days_ago.day,
                 month: two_days_ago.month,
                 year: two_days_ago.year },
@@ -96,7 +96,7 @@ RSpec.describe Requirements::ScheduledDatetimeChecker do
 
     it "returns a time issue if the date is present but time in the past" do
       travel_to("2019-01-01 11:00am") do
-        issues = Requirements::ScheduledDatetimeChecker.new(
+        issues = Requirements::ScheduleDatetimeChecker.new(
           date: { day: 1, month: 1, year: 2019 },
           time: "10:45am",
         ).pre_submit_issues
@@ -110,7 +110,7 @@ RSpec.describe Requirements::ScheduledDatetimeChecker do
 
     it "returns an issue if the datetime is too close to now" do
       travel_to("2019-01-01 11:00am") do
-        issues = Requirements::ScheduledDatetimeChecker.new(
+        issues = Requirements::ScheduleDatetimeChecker.new(
           date: { day: 1, month: 1, year: 2019 },
           time: "11:10am",
         ).pre_submit_issues
@@ -127,7 +127,7 @@ RSpec.describe Requirements::ScheduledDatetimeChecker do
       time_period = { days: 1, months: 14 }
       future_date = Time.current.advance(time_period)
 
-      issues = Requirements::ScheduledDatetimeChecker.new(
+      issues = Requirements::ScheduleDatetimeChecker.new(
         date: { day: future_date.day,
                 month: future_date.month,
                 year: future_date.year },


### PR DESCRIPTION
https://trello.com/c/rGjDviSL/848-adapt-scheduling-implementation-for-iterated-workflow

This covers a follow-up action on the above card, to fix the 'Back' button on the page to schedule a document. Previously we took the user back to the summary page, but sometimes this needs to be the page to edit the proposed date/time. See the commit for more info...