### PR TITLE
Standardise tracking for MD toolbar buttons

### DIFF
--- a/app/views/components/_markdown_editor.html.erb
+++ b/app/views/components/_markdown_editor.html.erb
@@ -82,22 +82,22 @@
       </div>
       <div class="app-c-markdown-editor__toolbar">
         <markdown-toolbar class="app-c-markdown-editor__toolbar-group" for="<%= textarea[:id] %>">
-          <md-header-2 class="app-c-markdown-editor__toolbar-button" title="Heading level 2" aria-label="Heading level 2" data-gtm="markdown-toolbar-selection">
+          <md-header-2 class="app-c-markdown-editor__toolbar-button" title="Heading level 2" aria-label="Heading level 2" data-gtm="markdown-toolbar-h2">
             <%= render "components/markdown_editor/heading_two.svg" %>
           </md-header-2>
-          <md-header-3 class="app-c-markdown-editor__toolbar-button" title="Heading level 3" aria-label="Heading level 3" data-gtm="markdown-toolbar-selection">
+          <md-header-3 class="app-c-markdown-editor__toolbar-button" title="Heading level 3" aria-label="Heading level 3" data-gtm="markdown-toolbar-h3">
             <%= render "components/markdown_editor/heading_three.svg" %>
           </md-header-3>
-          <md-link class="app-c-markdown-editor__toolbar-button" title="Link" aria-label="Link" data-gtm="markdown-toolbar-selection">
+          <md-link class="app-c-markdown-editor__toolbar-button" title="Link" aria-label="Link" data-gtm="markdown-toolbar-link">
             <%= render "components/markdown_editor/link.svg" %>
           </md-link>
-          <md-quote class="app-c-markdown-editor__toolbar-button" title="Blockquote" aria-label="Blockquote" data-gtm="markdown-toolbar-selection">
+          <md-quote class="app-c-markdown-editor__toolbar-button" title="Blockquote" aria-label="Blockquote" data-gtm="markdown-toolbar-blockquote">
             <%= render "components/markdown_editor/blockquote.svg" %>
           </md-quote>
-          <md-ordered-list class="app-c-markdown-editor__toolbar-button" title="Numbered list" aria-label="Numbered list" data-gtm="markdown-toolbar-selection">
+          <md-ordered-list class="app-c-markdown-editor__toolbar-button" title="Numbered list" aria-label="Numbered list" data-gtm="markdown-toolbar-list">
             <%= render "components/markdown_editor/numbered_list.svg" %>
           </md-ordered-list>
-          <md-unordered-list class="app-c-markdown-editor__toolbar-button" title="Bullets" aria-label="Bullets" data-gtm="markdown-toolbar-selection">
+          <md-unordered-list class="app-c-markdown-editor__toolbar-button" title="Bullets" aria-label="Bullets" data-gtm="markdown-toolbar-bullets">
             <%= render "components/markdown_editor/bullets.svg" %>
           </md-unordered-list>
           <% if insert_items.any? %>


### PR DESCRIPTION
https://trello.com/c/B9rVHJTh/876-audit-and-fix-gtm-ga-issues

    Previously we set the same data-gtm attribute for all MD toolbar
    buttons, which was used to scope the associated GTM trigger. This
    modifies the data-gtm attributes to consistently reflect the action
    performed, making events for these elements equivalent to other
    data-gtm actions, avoiding premature grouping. Using the common
    'markdown-toolbar' prefix to scope the GTM trigger should suffice.
