### PR TITLE
Move unschedule specs under scheduling/

### DIFF
--- a/spec/features/scheduling/unschedule_publishing_api_down_spec.rb
+++ b/spec/features/scheduling/unschedule_publishing_api_down_spec.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-RSpec.feature "Unschedule a document when Publishing API is down" do
+RSpec.feature "Unschedule when Publishing API is down" do
   scenario do
     given_there_is_a_scheduled_document
     and_the_publishing_api_is_down

--- a/spec/features/scheduling/unschedule_spec.rb
+++ b/spec/features/scheduling/unschedule_spec.rb
@@ -6,16 +6,17 @@ RSpec.feature "Unschedule an edition" do
     when_i_visit_the_summary_page
     and_i_click_stop_scheduled_publishing
     then_the_document_is_no_longer_scheduled
-    and_the_proposed_scheduled_publishing_datetime_is_still_set
+    and_the_proposed_schedule_is_still_set
   end
 
   def given_there_is_a_scheduled_document
-    schedule = create(:scheduling, reviewed: true)
+    scheduling = create(:scheduling, reviewed: true)
     @datetime = Time.current.tomorrow.change(hour: 23)
+
     @edition = create(:edition,
                       :scheduled,
                       scheduled_publishing_datetime: @datetime,
-                      scheduling: schedule)
+                      scheduling: scheduling)
   end
 
   def when_i_visit_the_summary_page
@@ -23,24 +24,21 @@ RSpec.feature "Unschedule an edition" do
   end
 
   def and_i_click_stop_scheduled_publishing
-    stub_publishing_api_destroy_intent(@edition.base_path)
+    @request = stub_publishing_api_destroy_intent(@edition.base_path)
     click_on "Stop scheduled publishing"
   end
 
   def then_the_document_is_no_longer_scheduled
     expect(page).to have_content(I18n.t!("user_facing_states.submitted_for_review.name"))
-
-    within first(".app-timeline-entry") do
-      expect(page).to have_content I18n.t!("documents.history.entry_types.unscheduled")
-    end
+    expect(page).to have_content I18n.t!("documents.history.entry_types.unscheduled")
+    expect(@request).to have_been_requested
   end
 
-  def and_the_proposed_scheduled_publishing_datetime_is_still_set
+  def and_the_proposed_schedule_is_still_set
     scheduled_date = @datetime.strftime("%-d %B %Y")
-    expect(page).to have_content(
-      I18n.t!("documents.show.scheduling.notice.proposed",
-              time: "11:00pm",
-              date: scheduled_date),
-    )
+
+    expect(page).to have_content(I18n.t!("documents.show.scheduling.notice.proposed",
+                                         time: "11:00pm",
+                                         date: scheduled_date))
   end
 end


### PR DESCRIPTION
https://trello.com/c/0Bh5ORiV/705-schedule-an-edition-for-publishing

This also ensures we check the associated intent is actually destroyed.