### PR TITLE
Replace Edition#schedulable? with inline checks

### DIFF
--- a/app/controllers/schedule_controller.rb
+++ b/app/controllers/schedule_controller.rb
@@ -3,12 +3,6 @@
 class ScheduleController < ApplicationController
   def new
     @edition = Edition.find_current(document: params[:document])
-
-    unless @edition.schedulable?
-      # FIXME: this shouldn't be an exception but we've not worked out the
-      # right response - maybe bad request or a redirect with flash?
-      raise "Document is not in a schedulable state."
-    end
   end
 
   def edit

--- a/app/interactors/schedule/create_interactor.rb
+++ b/app/interactors/schedule/create_interactor.rb
@@ -24,7 +24,7 @@ private
   end
 
   def check_for_issues
-    unless edition.schedulable?
+    unless edition.editable? && edition.scheduled_publishing_datetime.present?
       # FIXME: this shouldn't be an exception but we've not worked out the
       # right response - maybe bad request or a redirect with flash?
       raise "Can't schedule an edition which isn't schedulable"

--- a/app/models/edition.rb
+++ b/app/models/edition.rb
@@ -130,13 +130,6 @@ class Edition < ApplicationRecord
     !live? && !scheduled?
   end
 
-  def schedulable?
-    return false unless editable?
-    return false if scheduled_publishing_datetime.nil?
-
-    scheduled_publishing_datetime > Time.zone.now.advance(MINIMUM_SCHEDULING_TIME)
-  end
-
   def resume_discarded(live_edition, user)
     updater = Versioning::RevisionUpdater.new(live_edition.revision, user)
     updater.assign(change_note: "", update_type: "major")

--- a/app/views/documents/show/_actions.html.erb
+++ b/app/views/documents/show/_actions.html.erb
@@ -12,7 +12,7 @@
     <% elsif @edition.status.removed? %>
       <%= create_edition_button(@edition) %>
     <% elsif @edition.status.submitted_for_review? %>
-      <% if @edition.schedulable? && current_user.has_permission?(User::PRE_RELEASE_FEATURES_PERMISSION) %>
+      <% if @edition.scheduled_publishing_datetime.present? && current_user.has_permission?(User::PRE_RELEASE_FEATURES_PERMISSION) %>
         <%= schedule_button(@edition) %>
         <%= preview_button(@edition, secondary: true) %>
         <%= delete_draft_link(@edition) %>
@@ -37,7 +37,7 @@
     <% else %>
       <%= submit_for_2i_button(@edition) %>
       <%= preview_button(@edition, secondary: true) %>
-      <% if @edition.schedulable? && current_user.has_permission?(User::PRE_RELEASE_FEATURES_PERMISSION) %>
+      <% if @edition.scheduled_publishing_datetime.present? && current_user.has_permission?(User::PRE_RELEASE_FEATURES_PERMISSION) %>
         <%= delete_draft_link(@edition) %>
         <%= schedule_link(@edition, "app-link--right") %>
       <% elsif @edition.editable? && current_user.has_permission?(User::PRE_RELEASE_FEATURES_PERMISSION) %>


### PR DESCRIPTION
https://trello.com/c/a4sDMtqD/844-ensure-publishers-meet-requirements-before-they-schedule

Previously we had a schedulable? method on each edition that was used
for sanity checking in a couple of controller actions, as well as to
modify the actions shown to the user. The latter behaviour conflicts
with the new design for schedule requirements, as the 'Schedule' action
would disappear if the proposed time drifted into the past.

This replaces the schedulable? check for user actions by simply checking
the scheduled_publishing_datetime, noting the edition is editable in
both scenarios. Since it is valid to enqueue a job in the past (?!),
this also inlines and simplifies the schedulable? check when scheduling
a document, and removes it when harmlessly rendering the form.