### PR TITLE
Notify users of failed scheduled publishing

### DIFF
--- a/app/jobs/scheduled_publishing_job.rb
+++ b/app/jobs/scheduled_publishing_job.rb
@@ -2,9 +2,10 @@
 
 class ScheduledPublishingJob < ApplicationJob
   # retry at 3s, 18s, 83s, 258s, 627s
-  retry_on(StandardError,
-           wait: :exponentially_longer,
-           attempts: 5)
+  retry_on(StandardError, wait: :exponentially_longer, attempts: 5) do |job|
+    edition = Edition.find_current(id: job.arguments.first)
+    send_failure_notifications(edition)
+  end
 
   discard_and_log(ActiveRecord::RecordNotFound)
 
@@ -18,8 +19,16 @@ class ScheduledPublishingJob < ApplicationJob
                     .publish(user: user, with_review: reviewed)
     end
 
-    send_notifications(published_edition)
+    send_success_notifications(published_edition)
   end
+
+  def self.send_failure_notifications(edition)
+    edition.editors.each do |editor|
+      ScheduledPublishMailer.failure_email(edition, editor).deliver_later
+    end
+  end
+
+  private_class_method :send_failure_notifications
 
 private
 
@@ -37,7 +46,7 @@ private
     end
   end
 
-  def send_notifications(edition)
+  def send_success_notifications(edition)
     edition.editors.each do |editor|
       ScheduledPublishMailer.success_email(edition, editor).deliver_later
     end

--- a/app/mailers/scheduled_publish_mailer.rb
+++ b/app/mailers/scheduled_publish_mailer.rb
@@ -14,12 +14,20 @@ class ScheduledPublishMailer < ApplicationMailer
       raise "Cannot send publish email with a non-published state"
     end
 
-    mail(to: user.email, subject: subject)
+    mail(to: user.email, subject: success_subject)
+  end
+
+  def failure_email(edition, user)
+    @edition = edition
+    @status = edition.status
+
+    mail(to: user.email,
+         subject: I18n.t("scheduled_publish_mailer.failure_email.subject"))
   end
 
 private
 
-  def subject
+  def success_subject
     if @edition.number > 1
       I18n.t("scheduled_publish_mailer.success_email.subject.update",
              title: @edition.title)

--- a/app/views/scheduled_publish_mailer/failure_email.text.erb
+++ b/app/views/scheduled_publish_mailer/failure_email.text.erb
@@ -1,0 +1,15 @@
+<%= t("scheduled_publish_mailer.failure_email.problem", title: @edition.title) %>
+
+<%= t("scheduled_publish_mailer.failure_email.schedule_date",
+  time: @status.created_at.strftime("%-l:%M%P"),
+  date: @status.created_at.strftime("%d %B %Y")
+) %>
+
+<%= t("scheduled_publish_mailer.failure_email.try_again") %>
+
+<%= t("scheduled_publish_mailer.failure_email.edit_in_app") %>
+<%= document_url(@edition.document) %>
+
+<%= t("scheduled_publish_mailer.failure_email.raise_ticket") %>
+
+<%= t("scheduled_publish_mailer.failure_email.check_govuk_status") %>

--- a/config/locales/en/scheduled_publish_mailer/failure_email.yml
+++ b/config/locales/en/scheduled_publish_mailer/failure_email.yml
@@ -1,0 +1,10 @@
+en:
+  scheduled_publish_mailer:
+    failure_email:
+      subject: "Error publishing ‘%{title}’"
+      problem: "There has been a problem publishing news story ‘%{title}’"
+      schedule_date: "Content was scheduled for %{time} on %{date} but has not gone live."
+      try_again: Please try again or raise a support request.
+      edit_in_app: Edit in Content Publisher
+      raise_ticket: "[Raise a support request](https://support.publishing.service.gov.uk/technical_fault_report/new)"
+      check_govuk_status: "[Check GOV.UK status](https://status.publishing.service.gov.uk)"

--- a/spec/jobs/scheduled_publishing_job_spec.rb
+++ b/spec/jobs/scheduled_publishing_job_spec.rb
@@ -23,7 +23,7 @@ RSpec.describe ScheduledPublishingJob, inline: true do
         ScheduledPublishingJob.perform_now(edition.id)
       end
 
-      it "calls ScheduledPublishMailer for each editor of the edition" do
+      it "calls ScheduledPublishMailer's success_email method for each editor of the edition" do
         editor_one = create(:user, email: "someone@example.com")
         editor_two = create(:user, email: "someone-else@example.com")
         revision = create(:revision,
@@ -43,24 +43,47 @@ RSpec.describe ScheduledPublishingJob, inline: true do
       end
     end
 
-    it "aborts the job if the edition does not exist (e.g. env sync)" do
-      expect_any_instance_of(PublishService).not_to receive(:publish)
-      expect { ScheduledPublishingJob.perform_now(100) }.to_not raise_error
-    end
+    context "scheduled publishing is unsuccessful" do
+      it "calls ScheduledPublishMailer's failure_email method for each editor of the edition" do
+        editor_one = create(:user, email: "someone@example.com")
+        editor_two = create(:user, email: "someone-else@example.com")
+        revision = create(:revision,
+                          created_by: editor_two,
+                          scheduled_publishing_datetime: Time.current)
+        edition = create(:edition,
+                         :scheduled,
+                         revision: revision,
+                         created_by: editor_one)
 
-    it "aborts the job if the user has unscheduled the edition" do
-      edition = create(:edition)
-      expect_any_instance_of(PublishService).not_to receive(:publish)
-      expect { ScheduledPublishingJob.perform_now(edition.id) }.to_not raise_error
-    end
+        message_delivery = instance_double(ActionMailer::MessageDelivery, deliver_later: nil)
+        allow(ScheduledPublishMailer).to receive(:failure_email).and_return(message_delivery)
+        allow(PublishService).to receive(:publish).and_raise(ArgumentError)
 
-    it "aborts the job if the user has rescheduled the edition" do
-      edition = create(:edition,
-                       :scheduled,
-                       scheduled_publishing_datetime: Time.current.tomorrow)
+        expect(ScheduledPublishMailer).to receive(:failure_email).with(edition, editor_one)
+        expect(ScheduledPublishMailer).to receive(:failure_email).with(edition, editor_two)
 
-      expect_any_instance_of(PublishService).not_to receive(:publish)
-      expect { ScheduledPublishingJob.perform_now(edition.id) }.to_not raise_error
+        ScheduledPublishingJob.perform_now(edition.id)
+      end
+
+      it "aborts the job if the edition does not exist (e.g. env sync)" do
+        expect_any_instance_of(PublishService).not_to receive(:publish)
+        expect { ScheduledPublishingJob.perform_now(100) }.to_not raise_error
+      end
+
+      it "aborts the job if the user has unscheduled the edition" do
+        edition = create(:edition)
+        expect_any_instance_of(PublishService).not_to receive(:publish)
+        expect { ScheduledPublishingJob.perform_now(edition.id) }.to_not raise_error
+      end
+
+      it "aborts the job if the user has rescheduled the edition" do
+        edition = create(:edition,
+                         :scheduled,
+                         scheduled_publishing_datetime: Time.current.tomorrow)
+
+        expect_any_instance_of(PublishService).not_to receive(:publish)
+        expect { ScheduledPublishingJob.perform_now(edition.id) }.to_not raise_error
+      end
     end
   end
 end

--- a/spec/mailers/scheduled_publish_mailer_spec.rb
+++ b/spec/mailers/scheduled_publish_mailer_spec.rb
@@ -72,4 +72,24 @@ RSpec.describe ScheduledPublishMailer do
       )
     end
   end
+
+  describe "sending an email when scheduled edition has failed to published" do
+    it "renders failed scheduled publishing mail content" do
+      edition = create(:edition, :scheduled, title: "yolo")
+      mail = ScheduledPublishMailer.failure_email(edition, @user).deliver_now
+      body = mail.body.encoded
+
+      expect(mail.to).to eq([@user.email])
+      expect(body).to include(I18n.t("scheduled_publish_mailer.failure_email.problem", title: edition.title))
+      expect(body).to include(
+        I18n.t("scheduled_publish_mailer.failure_email.schedule_date",
+               time: @publish_time,
+               date: @publish_date),
+      )
+      expect(body).to include(I18n.t("scheduled_publish_mailer.failure_email.try_again"))
+      expect(body).to include(document_path(edition.document))
+      expect(body).to include(I18n.t("scheduled_publish_mailer.failure_email.raise_ticket"))
+      expect(body).to include(I18n.t("scheduled_publish_mailer.failure_email.check_govuk_status"))
+    end
+  end
 end


### PR DESCRIPTION
We need to send users who have edited an edition a notification that
their scheduled content has failed publish. 

The retry limit for the publishing of a scheduled edition is 5 times before a failed schedule
publishing email will be sent to all the editors of that edition.

I have a question around one of the A/C on the trello card  - 'Notify Sentry when the email fails to send'. Looking at the [ADR](https://github.com/alphagov/content-publisher/blob/master/docs/adr/0010-sending-email-notifications.md) for sending email notifications it states, 

`We already use Raven to report errors to Sentry, which automatically integrates with Sidekiq. Note that Raven also integrates with Active Job, but this is disabled when Sidekiq is present. Active Job catches exceptions as part of its retry behaviour, so an error will only get reported to Sentry when the exception is not handled by Active Job, or the retries for an exception we do handle are exhausted`.

In this PR ActiveJob handles the exception thrown if a publishing fails and after all the retries have been exhausted executes some logic to send failure emails, which I assume from reading the above a sentry notification would not be sent but don't really know how to test this? 

Trello:
https://trello.com/c/Bdccoiqd/735-notify-users-that-scheduled-content-has-failed-to-publish

Content for email:
https://docs.google.com/document/d/1K5Ny-wSdpUpiK79ei1NfQrE2DF63EiS6Zi4_ptg-390/edit#