### PR TITLE
Add a publishing requirement to select a primary organisation

### DIFF
--- a/app/controllers/documents_controller.rb
+++ b/app/controllers/documents_controller.rb
@@ -2,7 +2,7 @@
 
 class DocumentsController < ApplicationController
   def index
-    if filter_params[:filters].empty?
+    if filter_params[:filters].empty? && current_user.organisation_content_id
       redirect_to documents_path(organisation: current_user.organisation_content_id)
       return
     end

--- a/app/services/requirements/edition_checker.rb
+++ b/app/services/requirements/edition_checker.rb
@@ -17,6 +17,7 @@ module Requirements
       end
 
       issues += ContentChecker.new(edition, revision).pre_preview_issues.to_a
+
       CheckerIssues.new(issues)
     end
 
@@ -24,6 +25,8 @@ module Requirements
       issues = []
       issues += ContentChecker.new(edition, revision).pre_publish_issues.to_a
       issues += TopicChecker.new(edition.document).pre_publish_issues(params).to_a
+      issues += TagChecker.new(edition, revision).pre_publish_issues.to_a
+
       CheckerIssues.new(issues)
     end
   end

--- a/app/services/requirements/tag_checker.rb
+++ b/app/services/requirements/tag_checker.rb
@@ -1,0 +1,23 @@
+# frozen_string_literal: true
+
+module Requirements
+  class TagChecker
+    attr_reader :edition, :revision
+
+    def initialize(edition, revision = nil)
+      @edition = edition
+      @revision = revision || edition.revision
+    end
+
+    def pre_publish_issues
+      issues = []
+      if edition.document_type.tags.map(&:id).include?("primary_publishing_organisation")
+        if revision.primary_publishing_organisation_id.blank?
+          issues << Issue.new(:primary_publishing_organisation, :blank)
+        end
+      end
+
+      CheckerIssues.new(issues)
+    end
+  end
+end

--- a/app/views/documents/show/_requirements.html.erb
+++ b/app/views/documents/show/_requirements.html.erb
@@ -18,6 +18,9 @@
       { href: edit_image_path(@edition.document, image_id, anchor: "caption") }
     end,
     topics: { href: update_topics_path(@edition.document) },
+    primary_publishing_organisation: {
+      href: tags_path(@edition.document, anchor: "primary_publishing_organisation")
+    },
   }
 } %>
 

--- a/app/views/tags/edit.html.erb
+++ b/app/views/tags/edit.html.erb
@@ -10,10 +10,10 @@
 <%= form_tag(tags_path(@edition.document), data: { "warn-before-unload": "true" }, class: "app-c-contextual-guidance__form") do %>
   <% @edition.document_type.tags.each do |tag_field| %>
     <div class="govuk-grid-row">
-      <div class="govuk-grid-column-two-thirds">
+      <div class="govuk-grid-column-two-thirds" id="<%= tag_field.id %>">
         <%= render "tags/tags/#{tag_field.type}_input",
           tag_field: tag_field,
-          tags: @edition.tags %>
+          tags: @revision.tags %>
       </div>
     </div>
   <% end %>

--- a/app/views/tags/tags/_single_tag_input.html.erb
+++ b/app/views/tags/tags/_single_tag_input.html.erb
@@ -3,9 +3,9 @@
   name: "tags[#{tag_field.id}][]",
   label: {
     text: tag_field.label,
-    bold: true
+    bold: true,
   },
   hint: tag_field.hint,
-  options: LinkablesService.new(tag_field.document_type).select_options,
+  options: [""] + LinkablesService.new(tag_field.document_type).select_options,
   selected_options: tags[tag_field.id],
 } %>

--- a/config/locales/en/requirements.yml
+++ b/config/locales/en/requirements.yml
@@ -110,6 +110,10 @@ en:
     review_status:
       not_selected:
         form_message: Select an option
+    primary_publishing_organisation:
+      blank:
+        summary_message: Select a primary organisation
+        form_message: Select a primary organisation
     video_embed_title:
       blank:
         form_message: Enter a title

--- a/spec/features/editing_tags/edit_tags_requirements_spec.rb
+++ b/spec/features/editing_tags/edit_tags_requirements_spec.rb
@@ -1,0 +1,40 @@
+# frozen_string_literal: true
+
+RSpec.feature "Edit tags with requirements issues" do
+  scenario do
+    given_there_is_an_edition
+    when_i_visit_the_edit_tags_page
+    and_i_submit_a_request_with_requirement_issues
+    then_i_should_see_an_error_to_fix_the_issues
+    and_see_my_previous_submission
+  end
+
+  def given_there_is_an_edition
+    organisation_field = build(:tag_field,
+                               type: "single_tag",
+                               id: "primary_publishing_organisation")
+    stub_publishing_api_has_linkables(
+      [{ "content_id" => SecureRandom.uuid, "internal_name" => "Organisation" }],
+      document_type: organisation_field.document_type,
+    )
+    document_type = build(:document_type, tags: [organisation_field])
+    @edition = create(:edition, document_type_id: document_type.id)
+  end
+
+  def when_i_visit_the_edit_tags_page
+    visit tags_path(@edition.document)
+  end
+
+  def and_i_submit_a_request_with_requirement_issues
+    select "", from: "tags[primary_publishing_organisation][]"
+    click_on "Save"
+  end
+
+  def then_i_should_see_an_error_to_fix_the_issues
+    expect(page).to have_content(I18n.t!("requirements.primary_publishing_organisation.blank.form_message"))
+  end
+
+  def and_see_my_previous_submission
+    expect(page).to have_select("tags[primary_publishing_organisation][]", selected: nil)
+  end
+end

--- a/spec/formats/news_story_spec.rb
+++ b/spec/formats/news_story_spec.rb
@@ -49,6 +49,7 @@ RSpec.feature "Create a news story", format: true do
 
     select linkable["internal_name"], from: "tags[topical_events][]"
     select linkable["internal_name"], from: "tags[world_locations][]"
+    select linkable["internal_name"], from: "tags[primary_publishing_organisation][]"
     select linkable["internal_name"], from: "tags[organisations][]"
     select linkable["internal_name"], from: "tags[role_appointments][]"
 

--- a/spec/formats/press_release_spec.rb
+++ b/spec/formats/press_release_spec.rb
@@ -49,6 +49,7 @@ RSpec.feature "Create a press release", format: true do
 
     select linkable["internal_name"], from: "tags[topical_events][]"
     select linkable["internal_name"], from: "tags[world_locations][]"
+    select linkable["internal_name"], from: "tags[primary_publishing_organisation][]"
     select linkable["internal_name"], from: "tags[organisations][]"
     select linkable["internal_name"], from: "tags[role_appointments][]"
 


### PR DESCRIPTION
Trello card: https://trello.com/c/4Uc4JL4T/870-add-a-publishing-requirement-to-select-a-primary-organisation

The Primary Organisation field can now accept a blank string, however using
a new Tag Checker we insist that the user must submit a valid organisation
not only to publish the document, but also to save the Edit Tags page.

Browser no longer in a redirect loop if you have a nil organisation and visit the home page.

Now pass a revision to Edit Tags view instead of an edition to maintain the user's previous form submission.

Moved the point where we fail until after the issues are checked to make sure validation errors were found even with no changes made.