### PR TITLE
Fix lint task so it uses bundle exec

### DIFF
--- a/lib/tasks/lint.rake
+++ b/lib/tasks/lint.rake
@@ -2,8 +2,8 @@
 
 desc "lint Ruby, FactoryBot, Sass and Javascript"
 task "lint" do
-  sh "govuk-lint-ruby --format clang"
+  sh "bundle exec govuk-lint-ruby --format clang"
   sh "bundle exec rake factorybot:lint RAILS_ENV='test'"
-  sh "govuk-lint-sass app/assets/stylesheets"
+  sh "bundle exec govuk-lint-sass app/assets/stylesheets"
   sh "yarn run lint"
 end


### PR DESCRIPTION
Previously this would break, depending on how you run 'rake'.