### PR TITLE
Add back the guidance for email markdown

### DIFF
--- a/app/views/components/_markdown_guidance.html.erb
+++ b/app/views/components/_markdown_guidance.html.erb
@@ -50,11 +50,13 @@
         data_attributes: { gtm: "markdown-guidance-details" },
         margin_bottom: 0
   } do %>
-    <p>Select an email address and use the Link button to make a Mailto link.</p>
-    <p>Or you can add < and > before and after an email address.</p>
-    <pre class="app-c-markdown-guidance__code-snippet">
-    &lt;example@gov.uk&gt;
-    </pre>
+    <div data-gtm="email-link-guidance" data-gtm-action="Email links" data-gtm-visibility-tracking="true">
+      <p>Select an email address and use the Link button to make a Mailto link.</p>
+      <p>Or you can add < and > before and after an email address.</p>
+      <pre class="app-c-markdown-guidance__code-snippet">
+      &lt;example@gov.uk&gt;
+      </pre>
+    </div>
   <% end %>
 
   <%= render "govuk_publishing_components/components/details", {

--- a/app/views/components/_markdown_guidance.html.erb
+++ b/app/views/components/_markdown_guidance.html.erb
@@ -46,6 +46,18 @@
   <% end %>
 
   <%= render "govuk_publishing_components/components/details", {
+        title: "Email links",
+        data_attributes: { gtm: "markdown-guidance-details" },
+        margin_bottom: 0
+  } do %>
+    <p>Select an email address and use the Link button to make a Mailto link.</p>
+    <p>Or you can add < and > before and after an email address.</p>
+    <pre class="app-c-markdown-guidance__code-snippet">
+    &lt;example@gov.uk&gt;
+    </pre>
+  <% end %>
+
+  <%= render "govuk_publishing_components/components/details", {
         title: "Tables",
         data_attributes: { gtm: "markdown-guidance-details" },
         margin_bottom: 0


### PR DESCRIPTION
We recently [removed the email markdown link](https://github.com/alphagov/content-publisher/pull/1035/commits/44efa4fcbea2ac105e077683bb04963e7f73c16b) from the  sidebar and [updated the link button so it can be used for email](https://github.com/alphagov/markdown-toolbar-element/pull/8). During research, most users did not use the link button and tried to find the markdown instructions.

In this PR we want re-add this instruction while we explore other ways of helping users add email correctly.

[Trello card](https://trello.com/c/srCexKrZ)