### PR TITLE
Fix mark-up tags on edit document page

### DIFF
--- a/app/views/components/_markdown_guidance.html.erb
+++ b/app/views/components/_markdown_guidance.html.erb
@@ -95,6 +95,6 @@
       <pre class="app-c-markdown-guidance__code-snippet">
       {barchart stacked}
       </pre>
-    <% end %>
-  </div>
+    </div>
+  <% end %>
 </div>

--- a/app/views/documents/edit.html.erb
+++ b/app/views/documents/edit.html.erb
@@ -49,7 +49,6 @@
         base_path: @revision.base_path
       } do %>
       <% end %>
-
     </div>
 
     <% if @edition.document_type.guidance_for("title") %>
@@ -99,8 +98,8 @@
           <p class="govuk-body"><%= @edition.document_type.guidance_for("summary").body_govspeak %></p>
         <% end %>
       </div>
-    </div>
-  <% end %>
+    <% end %>
+  </div>
 
   <% @edition.document_type.contents.each do |field| %>
     <%= render "documents/fields/#{field.type}_input",


### PR DESCRIPTION
It seems like we're carrying wrongly nested erb/html tags for a while now which was probably corrected by the browser up until some recent changes which reveal the problem.

### Before
<img width="1440" alt="edit-document-before" src="https://user-images.githubusercontent.com/788096/59495507-4fad5700-8e87-11e9-8fe1-11fc623190d1.png">


### After
<img width="1440" alt="edit-document-after" src="https://user-images.githubusercontent.com/788096/59495514-520fb100-8e87-11e9-9ab6-e4fc1970d3a4.png">
