### PR TITLE
Failed to publish user interface

### DIFF
--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -15,6 +15,7 @@
 @import "components/image-cropper";
 @import "components/image-meta";
 @import "components/input-length-suggester";
+@import "components/inset-prompt";
 @import "components/loading-spinner";
 @import "components/markdown-editor";
 @import "components/markdown-guidance";
@@ -26,7 +27,6 @@
 @import "components/summary";
 @import "components/toolbar-dropdown";
 @import "components/url-preview";
-@import "components/warning-summary";
 
 @import "utilities/display";
 @import "utilities/overwrites";

--- a/app/assets/stylesheets/components/_inset-prompt.scss
+++ b/app/assets/stylesheets/components/_inset-prompt.scss
@@ -1,7 +1,7 @@
 $govuk-notice-border-color: govuk-colour("grey-1");
 $govuk-notice-background-color: govuk-colour("grey-4");
 
-.app-c-warning-summary {
+.app-c-inset-prompt {
   @include govuk-text-colour;
   @include govuk-responsive-padding(4);
   @include govuk-responsive-margin(6, "bottom");
@@ -16,14 +16,14 @@ $govuk-notice-background-color: govuk-colour("grey-4");
   background-color: $govuk-notice-background-color;
 }
 
-.app-c-warning-summary__title {
+.app-c-inset-prompt__title {
   @include govuk-font($size: 24, $weight: bold);
 
   margin-top: 0;
   @include govuk-responsive-margin(4, "bottom");
 }
 
-.app-c-warning-summary__body {
+.app-c-inset-prompt__body {
   @include govuk-font($size: 19);
 
   p {
@@ -36,12 +36,12 @@ $govuk-notice-background-color: govuk-colour("grey-4");
   }
 }
 
-.app-c-warning-summary__list {
+.app-c-inset-prompt__list {
   margin-top: 0;
   margin-bottom: 0;
 }
 
-.app-c-warning-summary__list a {
+.app-c-inset-prompt__list a {
   @include govuk-focusable-fill;
 
   &:link,

--- a/app/assets/stylesheets/components/_inset-prompt.scss
+++ b/app/assets/stylesheets/components/_inset-prompt.scss
@@ -16,6 +16,11 @@ $govuk-notice-background-color: govuk-colour("grey-4");
   background-color: $govuk-notice-background-color;
 }
 
+.app-c-inset-prompt--error {
+  background-color: govuk-tint($govuk-error-colour, 90%);
+  border-color: $govuk-error-colour;
+}
+
 .app-c-inset-prompt__title {
   @include govuk-font($size: 24, $weight: bold);
 

--- a/app/models/status.rb
+++ b/app/models/status.rb
@@ -23,5 +23,6 @@ class Status < ApplicationRecord
                 removed: "removed",
                 discarded: "discarded",
                 superseded: "superseded",
-                scheduled: "scheduled" }
+                scheduled: "scheduled",
+                failed_to_publish: "failed_to_publish" }
 end

--- a/app/views/components/_inset_prompt.html.erb
+++ b/app/views/components/_inset_prompt.html.erb
@@ -3,9 +3,12 @@
   description ||= false
   items ||= []
   id ||= nil
+  error = false if error.nil?
+  root_classes = %w[app-c-inset-prompt]
+  root_classes << "app-c-inset-prompt--error" if error
 %>
 
-<%= tag.div class: "app-c-inset-prompt", id: id do %>
+<%= tag.div class: root_classes, id: id do %>
   <%= tag.h2 title, class: "app-c-inset-prompt__title" %>
 
   <%= tag.div class: "app-c-inset-prompt__body" do %>

--- a/app/views/components/_inset_prompt.html.erb
+++ b/app/views/components/_inset_prompt.html.erb
@@ -5,16 +5,14 @@
   id ||= nil
 %>
 
-<%= tag.div class: "app-c-warning-summary", id: id do %>
-  <%= tag.h2 title, class: "app-c-warning-summary__title" %>
+<%= tag.div class: "app-c-inset-prompt", id: id do %>
+  <%= tag.h2 title, class: "app-c-inset-prompt__title" %>
 
-  <%= tag.div class: "app-c-warning-summary__body" do %>
-    <% if description %>
-      <%= description %>
-    <% end %>
+  <%= tag.div class: "app-c-inset-prompt__body" do %>
+    <%= description if description %>
 
     <% if items.any? %>
-      <%= tag.ul class:"govuk-list app-c-warning-summary__list" do %>
+      <%= tag.ul class: "govuk-list inset-prompt__list" do %>
         <% items.each_with_index do |item, index| %>
           <% if item[:href] %>
             <%= tag.li link_to(item[:text], item[:href], class: "govuk-link govuk-link--no-visited-state") %>

--- a/app/views/components/docs/inset_prompt.yml
+++ b/app/views/components/docs/inset_prompt.yml
@@ -20,3 +20,9 @@ examples:
         href: '#content'
       - text: Document needs a summary before publishing (at least 10 characters)
         href: '#content'
+  error:
+    data:
+      error: true
+      title: There is a problem
+      description: |
+        <p class="govuk-body">&lsquo;Title here&rsquo; was not published</p>

--- a/app/views/components/docs/inset_prompt.yml
+++ b/app/views/components/docs/inset_prompt.yml
@@ -1,7 +1,10 @@
-name: Warning summary
-description: A summary of warnings
+name: Inset prompt
+description: A prompt to users represented as inset content
 body: |
-  Optional markdown providing further detail about the component
+  This is similar to the [inset text][] component, however it has more of an
+  emphasis of informing a user they need to take an action.
+
+  [inset text]: https://design-system.service.gov.uk/components/inset-text/
 shared_accessibility_criteria:
   - link
 examples:

--- a/app/views/documents/index/_filters.html.erb
+++ b/app/views/documents/index/_filters.html.erb
@@ -48,6 +48,11 @@
                               published_but_needs_2i
                               withdrawn
                               removed]
+
+    if current_user.has_permission?(User::PRE_RELEASE_FEATURES_PERMISSION)
+      selectable_states += %w[scheduled failed_to_publish]
+    end
+
     state_select = selectable_states.map do |state|
       [t("user_facing_states.#{state}.name"), state]
     end

--- a/app/views/documents/show/_actions.html.erb
+++ b/app/views/documents/show/_actions.html.erb
@@ -11,7 +11,7 @@
       <%= remove_link(@edition) %>
     <% elsif @edition.removed? %>
       <%= create_edition_button(@edition) %>
-    <% elsif @edition.submitted_for_review? %>
+    <% elsif @edition.submitted_for_review? || @edition.failed_to_publish? %>
       <% if @edition.proposed_publish_time.present? && current_user.has_permission?(User::PRE_RELEASE_FEATURES_PERMISSION) %>
         <%= schedule_button(@edition) %>
         <%= preview_button(@edition, secondary: true) %>

--- a/app/views/documents/show/_failed_to_publish_notice.html.erb
+++ b/app/views/documents/show/_failed_to_publish_notice.html.erb
@@ -1,0 +1,13 @@
+<%
+  scheduling = @edition.status.details
+  description_govspeak = t("documents.show.failed_to_publish.description_govspeak",
+                           title: @edition.title,
+                           date: format_scheduled_date(scheduling.publish_time),
+                           time: format_scheduled_time(scheduling.publish_time))
+
+%>
+<%= render "components/inset_prompt", {
+  error: true,
+  title: t("documents.show.failed_to_publish.title"),
+  description: render_govspeak(description_govspeak),
+} %>

--- a/app/views/documents/show/_requirements.html.erb
+++ b/app/views/documents/show/_requirements.html.erb
@@ -31,7 +31,7 @@
         items: draft_issues.items(issue_params),
       } %>
     <% else %>
-      <%= render "/components/warning_summary", {
+      <%= render "/components/inset_prompt", {
         title: t("documents.show.flashes.pre_preview_issues.warning"),
         items: draft_issues.items(issue_params),
       } %>
@@ -49,7 +49,7 @@
         items: publish_issues.items(issue_params),
       } %>
     <% else %>
-      <%= render "/components/warning_summary", {
+      <%= render "/components/inset_prompt", {
         title: t("documents.show.flashes.pre_publish_issues.warning"),
         items: publish_issues.items(issue_params),
       } %>

--- a/app/views/documents/show/_summary_tab.html.erb
+++ b/app/views/documents/show/_summary_tab.html.erb
@@ -9,6 +9,11 @@
     <% end %>
 
     <%= render "documents/show/requirements" %>
+
+    <% if @edition.failed_to_publish? %>
+      <%= render "documents/show/failed_to_publish_notice" %>
+    <% end %>
+
     <%= render "documents/show/contents" %>
 
     <% if @edition.document_type.images %>

--- a/config/locales/en/documents/show.yml
+++ b/config/locales/en/documents/show.yml
@@ -46,6 +46,13 @@ en:
         title: Scheduled to publish at %{time} on %{date}
       proposed_scheduling_notice:
         title: Proposed to publish at %{time} on %{date}
+      failed_to_publish:
+        title: There is a problem
+        description_govspeak: |
+          '%{title}' has not been published.<br>
+          It was scheduled to publish at %{time} on %{date}
+
+          You can publish it now, schedule it to publish later, or edit it.
       flashes:
         pre_preview_issues:
           warning: To preview this document you need to

--- a/config/locales/en/states.yml
+++ b/config/locales/en/states.yml
@@ -8,6 +8,10 @@ en:
       name: Published but needs 2i review
     published:
       name: Published
+    scheduled:
+      name: Scheduled to publish
+    failed_to_publish:
+      name: Failed to publish
     withdrawn:
       name: Withdrawn
     removed:
@@ -16,5 +20,3 @@ en:
       name: Discarded
     superseded:
       name: Superseded
-    scheduled:
-      name: Scheduled to publish

--- a/spec/factories/edition_factory.rb
+++ b/spec/factories/edition_factory.rb
@@ -135,5 +135,23 @@ FactoryBot.define do
         )
       end
     end
+
+    trait :failed_to_publish do
+      summary { SecureRandom.alphanumeric(10) }
+
+      transient do
+        scheduling { nil }
+      end
+
+      after(:build) do |edition, evaluator|
+        edition.status = evaluator.association(
+          :status,
+          :failed_to_publish,
+          created_by: edition.created_by,
+          revision_at_creation: edition.revision,
+          scheduling: evaluator.scheduling,
+        )
+      end
+    end
   end
 end

--- a/spec/factories/scheduling_factory.rb
+++ b/spec/factories/scheduling_factory.rb
@@ -5,5 +5,9 @@ FactoryBot.define do
     reviewed { false }
     publish_time { Time.current.advance(days: 2) }
     association :pre_scheduled_status, factory: :status
+
+    trait :failed do
+      publish_time { Time.current.advance(hour: -1) }
+    end
   end
 end

--- a/spec/factories/status_factory.rb
+++ b/spec/factories/status_factory.rb
@@ -36,5 +36,17 @@ FactoryBot.define do
         status.details = evaluator.scheduling || new_scheduling
       end
     end
+
+    trait :failed_to_publish do
+      state { :failed_to_publish }
+
+      transient do
+        scheduling { nil }
+      end
+
+      after(:build) do |status, evaluator|
+        status.details = evaluator.scheduling || evaluator.association(:scheduling, :failed)
+      end
+    end
   end
 end

--- a/spec/features/scheduling/resolve_failed_to_publish_spec.rb
+++ b/spec/features/scheduling/resolve_failed_to_publish_spec.rb
@@ -1,0 +1,44 @@
+# frozen_string_literal: true
+
+RSpec.feature "Resolve a 'failed to publish' scheduling" do
+  scenario do
+    given_there_is_a_edition_that_failed_to_publish
+    when_i_visit_the_summary_page
+    then_i_see_a_failed_to_publish_prompt
+    and_i_can_edit_the_edition
+    when_i_go_to_publish_the_edition
+    then_i_see_it_published
+  end
+
+  def given_there_is_a_edition_that_failed_to_publish
+    @edition = create(:edition, :failed_to_publish)
+  end
+
+  def when_i_visit_the_summary_page
+    visit document_path(@edition.document)
+  end
+
+  def then_i_see_a_failed_to_publish_prompt
+    within(".app-c-inset-prompt") do
+      expect(page).to have_content(I18n.t!("documents.show.failed_to_publish.title"))
+    end
+  end
+
+  def and_i_can_edit_the_edition
+    expect(page).to have_content("Edit Content")
+  end
+
+  def when_i_go_to_publish_the_edition
+    click_on "Publish"
+    choose I18n.t!("publish.confirmation.should_be_reviewed")
+    @request = stub_publishing_api_publish(@edition.content_id,
+                                           locale: @edition.locale,
+                                           update_type: nil)
+    click_on "Confirm publish"
+  end
+
+  def then_i_see_it_published
+    expect(@request).to have_been_requested
+    expect(page).to have_content(I18n.t!("publish.published.published_without_review.title"))
+  end
+end

--- a/spec/features/scheduling/schedule_requirements_spec.rb
+++ b/spec/features/scheduling/schedule_requirements_spec.rb
@@ -54,7 +54,7 @@ RSpec.feature "Schedule an edition with requirements issues" do
   end
 
   def then_i_see_a_warning_to_fix_the_publish_issues
-    within(".app-c-warning-summary") do
+    within(".app-c-inset-prompt") do
       expect(page).to have_content(I18n.t!("requirements.summary.blank.summary_message"))
     end
   end

--- a/spec/features/workflow/preview_requirements_spec.rb
+++ b/spec/features/workflow/preview_requirements_spec.rb
@@ -25,7 +25,7 @@ RSpec.feature "Preview requirements" do
   end
 
   def then_i_see_a_warning_to_fix_the_issues
-    within(".app-c-warning-summary") do
+    within(".app-c-inset-prompt") do
       expect(page).to have_content(I18n.t!("requirements.alt_text.blank.summary_message", filename: @image_revision.filename))
     end
   end

--- a/spec/features/workflow/publish_requirements_publishing_api_down_spec.rb
+++ b/spec/features/workflow/publish_requirements_publishing_api_down_spec.rb
@@ -26,7 +26,7 @@ RSpec.feature "Publish requirements when the Publishing API is down" do
   end
 
   def then_i_do_not_see_warnings_that_require_it
-    within(".app-c-warning-summary") do
+    within(".app-c-inset-prompt") do
       expect(page).to_not have_content(I18n.t!("requirements.topics.none.summary_message"))
       expect(page).to have_content(I18n.t!("requirements.summary.blank.summary_message"))
     end

--- a/spec/features/workflow/publish_requirements_spec.rb
+++ b/spec/features/workflow/publish_requirements_spec.rb
@@ -24,7 +24,7 @@ RSpec.feature "Publish requirements" do
   end
 
   def then_i_see_a_warning_to_fix_the_issues
-    within(".app-c-warning-summary") do
+    within(".app-c-inset-prompt") do
       expect(page).to have_content(I18n.t!("requirements.summary.blank.summary_message"))
     end
   end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -63,6 +63,6 @@ RSpec.configure do |config|
   end
 
   config.after :each, type: :feature, js: true do
-    Capybara::Chromedriver::Logger::TestHooks.after_example!
+    # Capybara::Chromedriver::Logger::TestHooks.after_example!
   end
 end


### PR DESCRIPTION
Trello: https://trello.com/c/rBYaERp4/708-handle-scheduled-publishing-errors

This builds off of https://github.com/alphagov/content-publisher/pull/1137 I've set that as the base branch for it to be clearer what this PR introduces.

This sets up the UI for handling failed_to_publish and makes it (and scheduled) selectable statuses on the index page.

Part of this involved setting up a component to show the "Failed to publish" error to the user. To do this I renamed the warning summary component to be inset prompt, then I gave it an error option. I'm not sure I've achieved setting the background colour of this in a standard way.

<img width="978" alt="Screen Shot 2019-06-14 at 16 12 22" src="https://user-images.githubusercontent.com/282717/59519350-9454e480-8ebf-11e9-9b79-8dd5268162d8.png">


