### PR TITLE
Remove gtm-doc-status and gtm-doc-type attributes

### DIFF
--- a/app/views/components/_metadata.html.erb
+++ b/app/views/components/_metadata.html.erb
@@ -3,12 +3,11 @@
   inline ||= false
   list_classes = %w(app-c-metadata__list)
   list_classes << 'app-c-metadata__list--inline' if inline
-  data_attributes ||= nil
   margin_bottom ||= 0
   component_classes = %w(app-c-metadata)
   component_classes << "govuk-!-margin-bottom-#{margin_bottom}" unless margin_bottom.zero?
 %>
-<%= tag.div class: component_classes, data: data_attributes do %>
+<%= tag.div class: component_classes do %>
   <% if items.any? %>
     <%= tag.dl class: list_classes do %>
       <% items.each do |item| %>

--- a/app/views/components/docs/metadata.yml
+++ b/app/views/components/docs/metadata.yml
@@ -5,9 +5,6 @@ shared_accessibility_criteria:
 examples:
   default:
     data:
-      data_attributes:
-        gtm-document-type: "News story"
-        gtm-document-status: "Draft"
       items:
       - field: "Status"
         value: "Saved as draft"

--- a/app/views/documents/show/_document_metadata.html.erb
+++ b/app/views/documents/show/_document_metadata.html.erb
@@ -22,10 +22,6 @@
 
 <div class="app-side">
   <%= render "components/metadata", {
-    data_attributes: {
-      "gtm-document-type": @edition.document_type.label,
-      "gtm-document-status": t("user_facing_states.#{@edition.state}.name")
-    },
     items: [
       {
         field: t("documents.show.metadata.status"),

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -12,6 +12,7 @@
     }];
     dataLayer.push({ 'gtm.blacklist': ['html', 'customScripts', 'nonGoogleScripts', 'customPixels'] });
   </script>
+
   <% if ENV["GOOGLE_TAG_MANAGER_ID"] %>
     <%= render "govuk_publishing_components/components/google_tag_manager_script", {
       gtm_id: ENV["GOOGLE_TAG_MANAGER_ID"],


### PR DESCRIPTION
https://trello.com/c/a4sDMtqD/844-ensure-publishers-meet-requirements-before-they-schedule

Previously we had two custom GTM attributes to communicate the visible
document status and type, although the latter was never actually used.
Both can now be inferred from other events, but we should ideally use
the app DB as the source of this kind of non-eventful information.

This removes both attributes and the associated field of the metadata
component, as it is now redundant.