### PR TITLE
Fix inset-prompt class name

### DIFF
--- a/app/views/components/_inset_prompt.html.erb
+++ b/app/views/components/_inset_prompt.html.erb
@@ -15,7 +15,7 @@
     <%= description if description %>
 
     <% if items.any? %>
-      <%= tag.ul class: "govuk-list inset-prompt__list" do %>
+      <%= tag.ul class: "govuk-list app-c-inset-prompt__list" do %>
         <% items.each_with_index do |item, index| %>
           <% if item[:href] %>
             <%= tag.li link_to(item[:text], item[:href], class: "govuk-link govuk-link--no-visited-state") %>


### PR DESCRIPTION
Fix inset-prompt class name which results in unnecessary space after the list-item

### Before
<img width="631" alt="Screen Shot 2019-06-18 at 17 49 15" src="https://user-images.githubusercontent.com/788096/59703286-781fb300-91f1-11e9-9633-80bcdb7140bf.png">

### After
<img width="630" alt="Screen Shot 2019-06-18 at 17 49 01" src="https://user-images.githubusercontent.com/788096/59703293-7bb33a00-91f1-11e9-87ca-3a0ee9f7aaac.png">
