### PR TITLE
Backdate content

### DIFF
--- a/app/assets/stylesheets/components/_summary.scss
+++ b/app/assets/stylesheets/components/_summary.scss
@@ -77,7 +77,7 @@
 
 .app-c-summary__contents:first-child .app-c-summary__question,
 .app-c-summary__contents:first-child .app-c-summary__answer,
-.app-c-summary__contents:first-child .app-c-summary__change {
+.app-c-summary__contents:first-child .app-c-summary__edit {
   @include govuk-media-query($from: desktop) {
     padding-top: 0;
   }
@@ -99,7 +99,7 @@
   margin: govuk-em(12, 19) 4em govuk-em(4, 19) 0;
   font-weight: bold;
   vertical-align: top;
-  // using margin instead of padding because of easier absolutely positioning of .app-c-summary__change
+  // using margin instead of padding because of easier absolutely positioning of .app-c-summary__edit
 }
 
 .app-c-summary__answer {

--- a/app/controllers/backdate_controller.rb
+++ b/app/controllers/backdate_controller.rb
@@ -1,0 +1,12 @@
+# frozen_string_literal: true
+
+class BackdateController < ApplicationController
+  def edit
+    @edition = Edition.find_current(document: params[:document])
+  end
+
+  def update
+    @edition = Edition.find_current(document: params[:document])
+    redirect_to document_path(@edition.document)
+  end
+end

--- a/app/controllers/backdate_controller.rb
+++ b/app/controllers/backdate_controller.rb
@@ -7,6 +7,26 @@ class BackdateController < ApplicationController
 
   def update
     @edition = Edition.find_current(document: params[:document])
+    update_backdated_to(@edition)
+
     redirect_to document_path(@edition.document)
+  end
+
+private
+
+  def permitted_params
+    params.require(:backdate).permit(:day, :month, :year)
+  end
+
+  def submitted_date
+    Time.zone.local(permitted_params[:year].to_i,
+                    permitted_params[:month].to_i,
+                    permitted_params[:day].to_i)
+  end
+
+  def update_backdated_to(edition)
+    updater = Versioning::RevisionUpdater.new(edition.revision, current_user)
+    updater.assign(backdated_to: submitted_date)
+    edition.assign_revision(updater.next_revision, current_user).save!
   end
 end

--- a/app/controllers/backdate_controller.rb
+++ b/app/controllers/backdate_controller.rb
@@ -7,8 +7,21 @@ class BackdateController < ApplicationController
 
   def update
     result = Backdate::UpdateInteractor.call(params: params, user: current_user)
-    edition = result[:edition]
+    edition, issues = result.to_h.values_at(:edition, :issues)
 
-    redirect_to document_path(edition.document)
+    if issues
+      flash.now["alert_with_items"] = {
+        "title" => I18n.t!("backdate.edit.flashes.requirements"),
+        "items" => issues.items(
+          link_options: { backdate_date: { href: "#backdate-date" } },
+        ),
+      }
+
+      render :edit,
+             assigns: { edition: edition, issues: issues },
+             status: :unprocessable_entity
+    else
+      redirect_to document_path(edition.document)
+    end
   end
 end

--- a/app/controllers/backdate_controller.rb
+++ b/app/controllers/backdate_controller.rb
@@ -6,27 +6,9 @@ class BackdateController < ApplicationController
   end
 
   def update
-    @edition = Edition.find_current(document: params[:document])
-    update_backdated_to(@edition)
+    result = Backdate::UpdateInteractor.call(params: params, user: current_user)
+    edition = result[:edition]
 
-    redirect_to document_path(@edition.document)
-  end
-
-private
-
-  def permitted_params
-    params.require(:backdate).permit(:day, :month, :year)
-  end
-
-  def submitted_date
-    Time.zone.local(permitted_params[:year].to_i,
-                    permitted_params[:month].to_i,
-                    permitted_params[:day].to_i)
-  end
-
-  def update_backdated_to(edition)
-    updater = Versioning::RevisionUpdater.new(edition.revision, current_user)
-    updater.assign(backdated_to: submitted_date)
-    edition.assign_revision(updater.next_revision, current_user).save!
+    redirect_to document_path(edition.document)
   end
 end

--- a/app/interactors/backdate/update_interactor.rb
+++ b/app/interactors/backdate/update_interactor.rb
@@ -10,6 +10,7 @@ class Backdate::UpdateInteractor
   def call
     Edition.transaction do
       find_and_lock_edition
+      check_for_issues
       update_edition
     end
   end
@@ -34,5 +35,13 @@ private
     Time.zone.local(backdate_params[:year].to_i,
                     backdate_params[:month].to_i,
                     backdate_params[:day].to_i)
+  end
+
+  def check_for_issues
+    unless edition.number == 1
+      # FIXME: this shouldn't be an exception but we've not worked out the
+      # right response - maybe bad request or a redirect with flash?
+      raise "Only first editions can be backdated."
+    end
   end
 end

--- a/app/interactors/backdate/update_interactor.rb
+++ b/app/interactors/backdate/update_interactor.rb
@@ -1,0 +1,38 @@
+# frozen_string_literal: true
+
+class Backdate::UpdateInteractor
+  include Interactor
+  delegate :params,
+           :user,
+           :edition,
+           to: :context
+
+  def call
+    Edition.transaction do
+      find_and_lock_edition
+      update_edition
+    end
+  end
+
+private
+
+  def find_and_lock_edition
+    context.edition = Edition.lock.find_current(document: params[:document])
+  end
+
+  def update_edition
+    updater = Versioning::RevisionUpdater.new(edition.revision, user)
+    updater.assign(backdated_to: submitted_date)
+    edition.assign_revision(updater.next_revision, user).save!
+  end
+
+  def backdate_params
+    params.require(:backdate).permit(:day, :month, :year)
+  end
+
+  def submitted_date
+    Time.zone.local(backdate_params[:year].to_i,
+                    backdate_params[:month].to_i,
+                    backdate_params[:day].to_i)
+  end
+end

--- a/app/interactors/backdate/update_interactor.rb
+++ b/app/interactors/backdate/update_interactor.rb
@@ -13,6 +13,7 @@ class Backdate::UpdateInteractor
       find_and_lock_edition
       check_for_issues
       update_edition
+      create_timeline_entry
     end
   end
 
@@ -45,5 +46,14 @@ private
     context.fail!(issues: issues) if issues.any?
 
     context.date = checker.parsed_date
+  end
+
+  def create_timeline_entry
+    TimelineEntry.create_for_revision(
+      entry_type: :backdated,
+      revision: edition.revision,
+      edition: edition,
+      created_by: user,
+    )
   end
 end

--- a/app/interactors/schedule/update_interactor.rb
+++ b/app/interactors/schedule/update_interactor.rb
@@ -31,7 +31,7 @@ private
   end
 
   def parse_publish_time
-    parser = DatetimeParser.new(**schedule_params)
+    parser = DatetimeParser.new(issue_prefix: :schedule, **schedule_params)
     context.publish_time = parser.parse
     context.fail!(issues: parser.issues) if parser.issues.any?
   end

--- a/app/interactors/schedule_proposal/update_interactor.rb
+++ b/app/interactors/schedule_proposal/update_interactor.rb
@@ -30,7 +30,7 @@ private
   end
 
   def parse_publish_time
-    parser = DatetimeParser.new(**schedule_params.slice(:date, :time))
+    parser = DatetimeParser.new(issue_prefix: :schedule, **schedule_params.slice(:date, :time))
     context.publish_time = parser.parse
     context.fail!(issues: parser.issues) if parser.issues.any?
   end

--- a/app/mailers/publish_mailer.rb
+++ b/app/mailers/publish_mailer.rb
@@ -19,11 +19,11 @@ class PublishMailer < ApplicationMailer
 private
 
   def subject
-    if @edition.number > 1
-      I18n.t("publish_mailer.publish_email.subject.update",
+    if @edition.first?
+      I18n.t("publish_mailer.publish_email.subject.#{@status.state}",
              title: @edition.title)
     else
-      I18n.t("publish_mailer.publish_email.subject.#{@status.state}",
+      I18n.t("publish_mailer.publish_email.subject.update",
              title: @edition.title)
     end
   end

--- a/app/mailers/scheduled_publish_mailer.rb
+++ b/app/mailers/scheduled_publish_mailer.rb
@@ -34,11 +34,11 @@ class ScheduledPublishMailer < ApplicationMailer
 private
 
   def success_subject
-    if @edition.number > 1
-      I18n.t("scheduled_publish_mailer.success_email.subject.update",
+    if @edition.first?
+      I18n.t("scheduled_publish_mailer.success_email.subject.#{@status.state}",
              title: @edition.title)
     else
-      I18n.t("scheduled_publish_mailer.success_email.subject.#{@status.state}",
+      I18n.t("scheduled_publish_mailer.success_email.subject.update",
              title: @edition.title)
     end
   end

--- a/app/models/document.rb
+++ b/app/models/document.rb
@@ -82,7 +82,7 @@ class Document < ApplicationRecord
   end
 
   def newly_created?
-    return false if !current_edition || current_edition.number != 1
+    return false if !current_edition || !current_edition.first?
 
     current_edition.created_at == current_edition.updated_at
   end

--- a/app/models/edition.rb
+++ b/app/models/edition.rb
@@ -131,6 +131,10 @@ class Edition < ApplicationRecord
     !live? && !scheduled?
   end
 
+  def first?
+    number == 1
+  end
+
   def resume_discarded(live_edition, user)
     updater = Versioning::RevisionUpdater.new(live_edition.revision, user)
     updater.assign(change_note: "", update_type: "major")

--- a/app/models/edition.rb
+++ b/app/models/edition.rb
@@ -69,6 +69,7 @@ class Edition < ApplicationRecord
            :file_attachment_revisions,
            :assets,
            :primary_publishing_organisation_id,
+           :backdated_to,
            to: :revision
 
   MINIMUM_SCHEDULING_TIME = { minutes: 15 }.freeze

--- a/app/models/revision.rb
+++ b/app/models/revision.rb
@@ -54,6 +54,7 @@ class Revision < ApplicationRecord
            :major?,
            :minor?,
            :proposed_publish_time,
+           :backdated_to,
            to: :metadata_revision
 
   delegate :tags,

--- a/app/models/timeline_entry.rb
+++ b/app/models/timeline_entry.rb
@@ -51,7 +51,8 @@ class TimelineEntry < ApplicationRecord
                      unscheduled: "unscheduled",
                      file_attachment_uploaded: "file_attachment_uploaded",
                      file_attachment_deleted: "file_attachment_deleted",
-                     file_attachment_updated: "file_attachment_updated" }
+                     file_attachment_updated: "file_attachment_updated",
+                     backdated: "backdated" }
 
   def self.create_for_status_change(entry_type:,
                                     status:,

--- a/app/services/date_parser.rb
+++ b/app/services/date_parser.rb
@@ -4,7 +4,6 @@ class DateParser
   def initialize(date:, issue_prefix:)
     @raw_date = date.to_h
     @issue_prefix = issue_prefix
-    @issue_items = []
   end
 
   def issues
@@ -12,8 +11,10 @@ class DateParser
   end
 
   def parse
+    @issue_items = []
+
     check_date_is_valid
-    issues.any? ? return : parsed_date
+    issue_items.any? ? return : parsed_date
   end
 
 private

--- a/app/services/date_parser.rb
+++ b/app/services/date_parser.rb
@@ -1,0 +1,34 @@
+# frozen_string_literal: true
+
+class DateParser
+  def initialize(date:, issue_prefix:)
+    @raw_date = date.to_h
+    @issue_prefix = issue_prefix
+    @issue_items = []
+  end
+
+  def issues
+    Requirements::CheckerIssues.new(issue_items)
+  end
+
+  def parse
+    check_date_is_valid
+    issues.any? ? return : parsed_date
+  end
+
+private
+
+  attr_reader :raw_date, :issue_prefix, :issue_items
+
+  def check_date_is_valid
+    parsed_date
+  rescue ArgumentError
+    field_name = "#{issue_prefix}_date".to_sym
+    issue_items << Requirements::Issue.new(field_name, :invalid)
+  end
+
+  def parsed_date
+    day, month, year = raw_date.values_at(:day, :month, :year)
+    @parsed_date ||= Date.strptime("#{day}-#{month}-#{year}", "%d-%m-%Y")
+  end
+end

--- a/app/services/datetime_parser.rb
+++ b/app/services/datetime_parser.rb
@@ -1,9 +1,10 @@
 # frozen_string_literal: true
 
 class DatetimeParser
-  def initialize(date:, time:)
+  def initialize(date:, time:, issue_prefix:)
     @raw_date = date.to_h
     @raw_time = time.to_s
+    @issue_prefix = issue_prefix
     @issue_items = []
   end
 
@@ -27,28 +28,31 @@ class DatetimeParser
 
 private
 
-  attr_reader :raw_date, :raw_time, :issue_items
+  attr_reader :raw_date, :raw_time, :issue_items, :issue_prefix
 
   def check_date_is_valid
     day, month, year = raw_date.values_at(:day, :month, :year)
     Date.strptime("#{day}-#{month}-#{year}", "%d-%m-%Y")
   rescue ArgumentError
-    issue_items << Requirements::Issue.new(:schedule_date, :invalid)
+    field_name = "#{issue_prefix}_date".to_sym
+    issue_items << Requirements::Issue.new(field_name, :invalid)
   end
 
   def check_time_is_valid
+    field_name = "#{issue_prefix}_time".to_sym
+
     if !parsed_time_values
-      issue_items << Requirements::Issue.new(:schedule_time, :invalid)
+      issue_items << Requirements::Issue.new(field_name, :invalid)
       return
     end
 
     if parsed_time_values[:hour].to_i > 12 && parsed_time_values[:period]
-      issue_items << Requirements::Issue.new(:schedule_time, :invalid)
+      issue_items << Requirements::Issue.new(field_name, :invalid)
       return
     end
 
     if time[:hour] > 23
-      issue_items << Requirements::Issue.new(:schedule_time, :invalid)
+      issue_items << Requirements::Issue.new(field_name, :invalid)
       return
     end
   end

--- a/app/services/datetime_parser.rb
+++ b/app/services/datetime_parser.rb
@@ -5,17 +5,18 @@ class DatetimeParser
     @raw_date = date.to_h
     @raw_time = time.to_s
     @issue_prefix = issue_prefix
-    @issue_items = []
   end
 
   def issues
-    Requirements::CheckerIssues.new(issue_items)
+    Requirements::CheckerIssues.new(issue_items || [])
   end
 
   def parse
+    @issue_items = []
+
     check_date_is_valid
     check_time_is_valid
-    return if issues.any?
+    return if issue_items.any?
 
     Time.current.change(
       day: raw_date[:day].to_i,

--- a/app/services/delete_draft_service.rb
+++ b/app/services/delete_draft_service.rb
@@ -23,7 +23,7 @@ class DeleteDraftService
     end
 
     reset_live_edition if document.live_edition
-    discard_path_reservations(edition) if edition.number == 1
+    discard_path_reservations(edition) if edition.first?
   end
 
 private

--- a/app/services/publishing_api_payload.rb
+++ b/app/services/publishing_api_payload.rb
@@ -34,6 +34,7 @@ class PublishingApiPayload
       },
     }
     payload["change_note"] = edition.change_note if edition.major?
+    payload["first_published_at"] = edition.backdated_to if edition.backdated_to
     payload
   end
 

--- a/app/services/requirements/backdate_checker.rb
+++ b/app/services/requirements/backdate_checker.rb
@@ -1,0 +1,43 @@
+# frozen_string_literal: true
+
+module Requirements
+  class BackdateChecker
+    attr_reader :params
+
+    def initialize(params)
+      @params = params
+    end
+
+    def pre_submit_issues
+      issues = []
+
+      begin
+        parsed_date
+      rescue ArgumentError
+        issues << Issue.new(:backdate_date, :invalid)
+        return CheckerIssues.new(issues)
+      end
+
+      if in_the_future?
+        issues << Issue.new(:backdate_date, :in_the_future)
+      end
+
+      CheckerIssues.new(issues)
+    end
+
+    def parsed_date
+      @parsed_date ||= begin
+                         day, month, year = params.values_at(:day,
+                                                             :month,
+                                                             :year)
+                         Date.strptime("#{day}-#{month}-#{year}", "%d-%m-%Y")
+                       end
+    end
+
+  private
+
+    def in_the_future?
+      parsed_date > Time.zone.today
+    end
+  end
+end

--- a/app/services/requirements/backdate_checker.rb
+++ b/app/services/requirements/backdate_checker.rb
@@ -2,21 +2,12 @@
 
 module Requirements
   class BackdateChecker
-    attr_reader :params
-
-    def initialize(params)
-      @params = params
+    def initialize(backdate)
+      @backdate = backdate
     end
 
     def pre_submit_issues
       issues = []
-
-      begin
-        parsed_date
-      rescue ArgumentError
-        issues << Issue.new(:backdate_date, :invalid)
-        return CheckerIssues.new(issues)
-      end
 
       if in_the_future?
         issues << Issue.new(:backdate_date, :in_the_future)
@@ -25,19 +16,12 @@ module Requirements
       CheckerIssues.new(issues)
     end
 
-    def parsed_date
-      @parsed_date ||= begin
-                         day, month, year = params.values_at(:day,
-                                                             :month,
-                                                             :year)
-                         Date.strptime("#{day}-#{month}-#{year}", "%d-%m-%Y")
-                       end
-    end
-
   private
 
+    attr_reader :backdate
+
     def in_the_future?
-      parsed_date > Time.zone.today
+      backdate > Time.zone.today
     end
   end
 end

--- a/app/views/backdate/edit.html.erb
+++ b/app/views/backdate/edit.html.erb
@@ -19,6 +19,8 @@
         legend_text: legend,
         hint: t("backdate.edit.date_hint_text"),
         name: "backdate[date]",
+        id: "backdate-date",
+        error_items: @issues&.items_for(:backdate_date),
         items: [
           {
             name: "day",

--- a/app/views/backdate/edit.html.erb
+++ b/app/views/backdate/edit.html.erb
@@ -6,6 +6,7 @@
     <%= t("backdate.edit.date") %>
   </span>
 <% end %>
+<% date = @edition.backdated_to %>
 
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
@@ -25,14 +26,17 @@
           {
             name: "day",
             width: 2,
+            value: params.dig(:backdate, :day) || date&.day,
           },
           {
             name: "month",
             width: 2,
+            value: params.dig(:backdate, :month) || date&.month,
           },
           {
             name: "year",
             width: 4,
+            value: params.dig(:backdate, :year) || date&.year,
           }
         ]
       } %>

--- a/app/views/backdate/edit.html.erb
+++ b/app/views/backdate/edit.html.erb
@@ -1,0 +1,43 @@
+<% content_for :back_link, render_back_link(href: document_path(@edition.document)) %>
+<% content_for :title, t("backdate.edit.title") %>
+
+<% legend = capture do %>
+  <span class="govuk-heading-s govuk-!-margin-bottom-0">
+    <%= t("backdate.edit.date") %>
+  </span>
+<% end %>
+
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-two-thirds">
+    <%= render_govspeak(t("backdate.edit.description_govspeak")) %>
+  </div>
+</div>
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-two-thirds">
+    <%= form_tag backdate_path(@edition.document) do %>
+      <%= render "govuk_publishing_components/components/date_input", {
+        legend_text: legend,
+        hint: t("backdate.edit.date_hint_text"),
+        name: "backdate[date]",
+        items: [
+          {
+            name: "day",
+            width: 2,
+          },
+          {
+            name: "month",
+            width: 2,
+          },
+          {
+            name: "year",
+            width: 4,
+          }
+        ]
+      } %>
+      <%= render "govuk_publishing_components/components/button", {
+        text: "Save",
+        margin_bottom: true
+      } %>
+    <% end %>
+  </div>
+</div>

--- a/app/views/documents/show/_content_settings.html.erb
+++ b/app/views/documents/show/_content_settings.html.erb
@@ -1,0 +1,15 @@
+<%= render "components/summary", {
+  id: "content_settings",
+  title: t("documents.show.content_settings.title"),
+  items: [
+    {
+      field: t("documents.show.content_settings.backdate.title"),
+      edit: {
+        href: backdate_path,
+        data_attributes: {
+          gtm: "edit-backdate",
+        }
+      },
+    }
+  ],
+} %>

--- a/app/views/documents/show/_content_settings.html.erb
+++ b/app/views/documents/show/_content_settings.html.erb
@@ -1,10 +1,18 @@
+<% backdating_status = capture do %>
+  <% if @edition.backdated_to.present? %>
+    <% @edition.backdated_to.strftime("%-d %B %Y") %>
+  <% else %>
+    <% t("documents.show.content_settings.backdate.no_backdate") %>
+  <% end %>
+<% end %>
+
 <%= render "components/summary", {
   id: "content_settings",
   title: t("documents.show.content_settings.title"),
   items: [
     {
       field: t("documents.show.content_settings.backdate.title"),
-      value: @edition.backdated_to&.strftime("%-d %B %Y"),
+      value: backdating_status,
       edit: {
         href: backdate_path,
         data_attributes: {

--- a/app/views/documents/show/_content_settings.html.erb
+++ b/app/views/documents/show/_content_settings.html.erb
@@ -4,6 +4,7 @@
   items: [
     {
       field: t("documents.show.content_settings.backdate.title"),
+      value: @edition.backdated_to&.strftime("%-d %B %Y"),
       edit: {
         href: backdate_path,
         data_attributes: {

--- a/app/views/documents/show/_contents.html.erb
+++ b/app/views/documents/show/_contents.html.erb
@@ -7,14 +7,14 @@
 
 <% edition_metadata = [] %>
 
-<% if @edition.number > 1 %>
+<% unless @edition.first? %>
   <% edition_metadata << {
       field: t("documents.show.contents.items.update_type"),
       value: t("documents.show.contents.update_type.#{@edition.update_type}"),
   } %>
 <% end %>
 
-<% if @edition.number > 1 && @edition.major? %>
+<% if !@edition.first? && @edition.major? %>
   <% edition_metadata << {
     field: t("documents.show.contents.items.change_note"),
     value: @edition.change_note,

--- a/app/views/documents/show/_history_tab.html.erb
+++ b/app/views/documents/show/_history_tab.html.erb
@@ -28,6 +28,11 @@
           <%= entry.details.public_explanation %>
         <% end %>
 
+        <% if entry.backdated? %>
+          <% date = entry.edition.backdated_to.strftime("%d %B %Y") %>
+          <%= t "documents.history.entry_content.backdated", date: date %>
+        <% end %>
+
         <% if entry.removed? && entry.details %>
           <% removal = entry.details %>
           <% if removal.explanatory_note.present? %>

--- a/app/views/documents/show/_summary_tab.html.erb
+++ b/app/views/documents/show/_summary_tab.html.erb
@@ -26,7 +26,7 @@
 
     <%= render "documents/show/tags" %>
 
-    <% if @edition.number == 1 && @edition.editable? %>
+    <% if @edition.first? && @edition.editable? %>
       <%= render "documents/show/content_settings" %>
     <% end %>
   </div>

--- a/app/views/documents/show/_summary_tab.html.erb
+++ b/app/views/documents/show/_summary_tab.html.erb
@@ -25,7 +25,10 @@
     <% end %>
 
     <%= render "documents/show/tags" %>
-    <%= render "documents/show/content_settings" %>
+
+    <% if @edition.number == 1 && @edition.editable? %>
+      <%= render "documents/show/content_settings" %>
+    <% end %>
   </div>
 
   <div class="govuk-grid-column-one-third">

--- a/app/views/documents/show/_summary_tab.html.erb
+++ b/app/views/documents/show/_summary_tab.html.erb
@@ -25,6 +25,7 @@
     <% end %>
 
     <%= render "documents/show/tags" %>
+    <%= render "documents/show/content_settings" %>
   </div>
 
   <div class="govuk-grid-column-one-third">

--- a/app/views/documents/show/_summary_tab.html.erb
+++ b/app/views/documents/show/_summary_tab.html.erb
@@ -26,7 +26,7 @@
 
     <%= render "documents/show/tags" %>
 
-    <% if @edition.first? && @edition.editable? %>
+    <% if @edition.first? && @edition.editable? && current_user.has_permission?(User::PRE_RELEASE_FEATURES_PERMISSION) %>
       <%= render "documents/show/content_settings" %>
     <% end %>
   </div>

--- a/app/views/publish_mailer/publish_email.text.erb
+++ b/app/views/publish_mailer/publish_email.text.erb
@@ -1,15 +1,15 @@
 <%= @edition.document_type.label %> ‘<%= @edition.title %>’
 
-<% if @edition.number > 1 -%>
-<%= t("publish_mailer.publish_email.details.update",
-      time: format_scheduled_time(@status.created_at),
-      date: format_scheduled_date(@status.created_at),
-      user: @status.created_by&.name || I18n.t!("documents.unknown_user")) %>
+<% if @edition.first? -%>
+  <%= t("publish_mailer.publish_email.details.publish",
+        time: format_scheduled_time(@status.created_at),
+        date: format_scheduled_date(@status.created_at),
+        user: @status.created_by&.name || I18n.t!("documents.unknown_user")) %>
 <% else -%>
-<%= t("publish_mailer.publish_email.details.publish",
-      time: format_scheduled_time(@status.created_at),
-      date: format_scheduled_date(@status.created_at),
-      user: @status.created_by&.name || I18n.t!("documents.unknown_user")) %>
+  <%= t("publish_mailer.publish_email.details.update",
+        time: format_scheduled_time(@status.created_at),
+        date: format_scheduled_date(@status.created_at),
+        user: @status.created_by&.name || I18n.t!("documents.unknown_user")) %>
 <% end -%>
 
 <%= t("publish_mailer.publish_email.delay_warning") %>
@@ -17,7 +17,7 @@
 <%= t("publish_mailer.publish_email.page_address") %>
 <%= edition_public_url(@edition) %>
 
-<% if @edition.number > 1 -%>
+<% unless @edition.first? -%>
 <% if @edition.major? -%>
 <%= t("publish_mailer.publish_email.change_note") %>
 <%= @edition.change_note %>

--- a/app/views/scheduled_publish_mailer/success_email.text.erb
+++ b/app/views/scheduled_publish_mailer/success_email.text.erb
@@ -1,13 +1,13 @@
 <%= @edition.document_type.label %> ‘<%= @edition.title %>’
 
-<% if @edition.number > 1 -%>
-<%= t("scheduled_publish_mailer.success_email.details.update",
-      time: format_scheduled_time(@status.created_at),
-      date: format_scheduled_date(@status.created_at)) %>
+<% if @edition.first? -%>
+  <%= t("scheduled_publish_mailer.success_email.details.publish",
+        time: format_scheduled_time(@status.created_at),
+        date: format_scheduled_date(@status.created_at)) %>
 <% else -%>
-<%= t("scheduled_publish_mailer.success_email.details.publish",
-      time: format_scheduled_time(@status.created_at),
-      date: format_scheduled_date(@status.created_at)) %>
+  <%= t("scheduled_publish_mailer.success_email.details.update",
+        time: format_scheduled_time(@status.created_at),
+        date: format_scheduled_date(@status.created_at)) %>
 <% end -%>
 
 <% if @status.created_by -%>
@@ -20,7 +20,7 @@
 <%= t("scheduled_publish_mailer.success_email.page_address") %>
 <%= edition_public_url(@edition) %>
 
-<% if @edition.number > 1 -%>
+<% unless @edition.first? -%>
 <% if @edition.major? -%>
 <%= t("scheduled_publish_mailer.success_email.change_note") %>
 <%= @edition.change_note %>

--- a/config/locales/en/backdate/edit.yml
+++ b/config/locales/en/backdate/edit.yml
@@ -8,3 +8,5 @@ en:
         information being presented as new.
       date: Date
       date_hint_text: For example, 01 08 2016
+      flashes:
+        requirements: You need to

--- a/config/locales/en/backdate/edit.yml
+++ b/config/locales/en/backdate/edit.yml
@@ -1,0 +1,10 @@
+en:
+  backdate:
+    edit:
+      title: Backdate content
+      description_govspeak: |
+        If this content has previously been published on another webpage you must
+        provide the date for when it was first published online. This prevents old
+        information being presented as new.
+      date: Date
+      date_hint_text: For example, 01 08 2016

--- a/config/locales/en/documents/history.yml
+++ b/config/locales/en/documents/history.yml
@@ -32,3 +32,6 @@ en:
         file_attachment_deleted: "Attachment deleted"
         file_attachment_uploaded: "Attachment uploaded"
         file_attachment_updated: "Attachment updated"
+        backdated: "Backdated document"
+      entry_content:
+        backdated: "First published date backdated to %{date}"

--- a/config/locales/en/documents/show.yml
+++ b/config/locales/en/documents/show.yml
@@ -35,6 +35,10 @@ en:
         alt_text: Alt text
         caption: Caption
         credit: Credit
+      content_settings:
+        title: Content settings
+        backdate:
+          title: Backdate
       metadata:
         status: Status
         updated_at: Last updated

--- a/config/locales/en/documents/show.yml
+++ b/config/locales/en/documents/show.yml
@@ -39,6 +39,7 @@ en:
         title: Content settings
         backdate:
           title: Backdate
+          no_backdate: No backdate
       metadata:
         status: Status
         updated_at: Last updated

--- a/config/locales/en/requirements.yml
+++ b/config/locales/en/requirements.yml
@@ -104,6 +104,11 @@ en:
     schedule_review_status:
       not_selected:
         form_message: Select an option
+    backdate_date:
+      in_the_future:
+        form_message: Enter a date in the past
+      invalid:
+        form_message: Enter a valid date
     document_type:
       not_selected:
         form_message: Select an option

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -72,6 +72,9 @@ Rails.application.routes.draw do
     get "/topics" => "topics#edit", as: :topics
     patch "/topics" => "topics#update", as: :update_topics
 
+    get "/backdate" => "backdate#edit", as: :backdate
+    post "/backdate" => "backdate#update"
+
     post "/editions" => "editions#create", as: :create_edition
 
     post "/govspeak-preview" => "govspeak_preview#to_html", as: :govspeak_preview

--- a/db/migrate/20190617142340_add_backdated_to_to_metadata_revision.rb
+++ b/db/migrate/20190617142340_add_backdated_to_to_metadata_revision.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+class AddBackdatedToToMetadataRevision < ActiveRecord::Migration[5.2]
+  def change
+    add_column :metadata_revisions, :backdated_to, :datetime
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2019_06_12_160520) do
+ActiveRecord::Schema.define(version: 2019_06_17_142340) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -197,6 +197,7 @@ ActiveRecord::Schema.define(version: 2019_06_12_160520) do
     t.datetime "created_at"
     t.bigint "created_by_id"
     t.datetime "proposed_publish_time"
+    t.datetime "backdated_to"
   end
 
   create_table "removals", force: :cascade do |t|

--- a/spec/factories/revision_factory.rb
+++ b/spec/factories/revision_factory.rb
@@ -20,6 +20,7 @@ FactoryBot.define do
       update_type { "major" }
       change_note { "First published." }
       proposed_publish_time { nil }
+      backdated_to { nil }
     end
   end
 
@@ -52,6 +53,7 @@ FactoryBot.define do
           change_note: evaluator.change_note,
           created_by: revision.created_by,
           proposed_publish_time: evaluator.proposed_publish_time,
+          backdated_to: evaluator.backdated_to,
         )
       end
 

--- a/spec/features/workflow/backdate_requirements_spec.rb
+++ b/spec/features/workflow/backdate_requirements_spec.rb
@@ -1,0 +1,35 @@
+# frozen_string_literal: true
+
+RSpec.feature "Backdating requirements" do
+  scenario do
+    given_there_is_a_document_with_a_first_edition
+    when_i_visit_the_summary_page
+    and_i_click_to_backdate_the_content
+    and_i_click_save
+    then_i_see_an_error_to_fix_the_issues
+  end
+
+  def given_there_is_a_document_with_a_first_edition
+    @edition = create(:edition)
+  end
+
+  def when_i_visit_the_summary_page
+    visit document_path(@edition.document)
+  end
+
+  def and_i_click_to_backdate_the_content
+    click_on "Edit Backdate"
+  end
+
+  def and_i_click_save
+    click_on "Save"
+  end
+
+  def then_i_see_an_error_to_fix_the_issues
+    within(".gem-c-error-summary") do
+      expect(page).to have_content(
+        I18n.t!("requirements.backdate_date.invalid.form_message"),
+      )
+    end
+  end
+end

--- a/spec/features/workflow/backdate_spec.rb
+++ b/spec/features/workflow/backdate_spec.rb
@@ -1,0 +1,33 @@
+# frozen_string_literal: true
+
+RSpec.feature "Backdate the first edition of a document" do
+  scenario do
+    given_there_is_a_document_with_a_first_edition
+    when_i_visit_the_summary_page
+    and_i_click_to_backdate_the_content
+    and_i_enter_a_date_to_backdate_the_content_to
+    and_i_click_save
+  end
+
+  def given_there_is_a_document_with_a_first_edition
+    @edition = create(:edition)
+  end
+
+  def when_i_visit_the_summary_page
+    visit document_path(@edition.document)
+  end
+
+  def and_i_click_to_backdate_the_content
+    click_on "Edit Backdate"
+  end
+
+  def and_i_enter_a_date_to_backdate_the_content_to
+    fill_in "backdate[date][day]", with: "1"
+    fill_in "backdate[date][month]", with: "1"
+    fill_in "backdate[date][year]", with: "2019"
+  end
+
+  def and_i_click_save
+    click_on "Save"
+  end
+end

--- a/spec/features/workflow/backdate_spec.rb
+++ b/spec/features/workflow/backdate_spec.rb
@@ -7,6 +7,7 @@ RSpec.feature "Backdate the first edition of a document" do
     and_i_click_to_backdate_the_content
     and_i_enter_a_date_to_backdate_the_content_to
     and_i_click_save
+    then_i_see_the_date_the_content_was_backdated_to
   end
 
   def given_there_is_a_document_with_a_first_edition
@@ -29,5 +30,9 @@ RSpec.feature "Backdate the first edition of a document" do
 
   def and_i_click_save
     click_on "Save"
+  end
+
+  def then_i_see_the_date_the_content_was_backdated_to
+    expect(page).to have_content("1 January 2019")
   end
 end

--- a/spec/features/workflow/backdate_spec.rb
+++ b/spec/features/workflow/backdate_spec.rb
@@ -7,7 +7,7 @@ RSpec.feature "Backdate content" do
     and_i_click_to_backdate_the_content
     and_i_enter_a_date_to_backdate_the_content_to
     and_i_click_save
-    then_i_see_the_date_the_content_was_backdated_to
+    then_i_see_the_content_has_been_backdated
   end
 
   scenario "subsequent edition" do
@@ -44,8 +44,10 @@ RSpec.feature "Backdate content" do
     click_on "Save"
   end
 
-  def then_i_see_the_date_the_content_was_backdated_to
+  def then_i_see_the_content_has_been_backdated
     expect(page).to have_content("1 January 2019")
+    expect(page).to have_content(I18n.t!("documents.history.entry_types.backdated",
+                                         date: "01 January 2019"))
   end
 
   def given_there_is_a_document_with_a_second_edition

--- a/spec/features/workflow/backdate_spec.rb
+++ b/spec/features/workflow/backdate_spec.rb
@@ -4,7 +4,8 @@ RSpec.feature "Backdate content" do
   scenario "first edition" do
     given_there_is_a_document_with_a_first_edition
     when_i_visit_the_summary_page
-    and_i_click_to_backdate_the_content
+    then_i_see_that_the_content_has_not_been_backdated
+    when_i_click_to_backdate_the_content
     and_i_enter_a_date_to_backdate_the_content_to
     and_i_click_save
     then_i_see_the_content_has_been_backdated
@@ -30,7 +31,13 @@ RSpec.feature "Backdate content" do
     visit document_path(@edition.document)
   end
 
-  def and_i_click_to_backdate_the_content
+  def then_i_see_that_the_content_has_not_been_backdated
+    expect(page).to have_content(
+      I18n.t!("documents.show.content_settings.backdate.no_backdate"),
+    )
+  end
+
+  def when_i_click_to_backdate_the_content
     click_on "Edit Backdate"
   end
 

--- a/spec/features/workflow/backdate_spec.rb
+++ b/spec/features/workflow/backdate_spec.rb
@@ -1,13 +1,25 @@
 # frozen_string_literal: true
 
-RSpec.feature "Backdate the first edition of a document" do
-  scenario do
+RSpec.feature "Backdate content" do
+  scenario "first edition" do
     given_there_is_a_document_with_a_first_edition
     when_i_visit_the_summary_page
     and_i_click_to_backdate_the_content
     and_i_enter_a_date_to_backdate_the_content_to
     and_i_click_save
     then_i_see_the_date_the_content_was_backdated_to
+  end
+
+  scenario "subsequent edition" do
+    given_there_is_a_document_with_a_second_edition
+    when_i_visit_the_summary_page
+    then_i_cannot_see_a_backdate_section
+  end
+
+  scenario "published edition" do
+    given_there_is_a_published_first_edition
+    when_i_visit_the_summary_page
+    then_i_cannot_see_a_backdate_section
   end
 
   def given_there_is_a_document_with_a_first_edition
@@ -34,5 +46,20 @@ RSpec.feature "Backdate the first edition of a document" do
 
   def then_i_see_the_date_the_content_was_backdated_to
     expect(page).to have_content("1 January 2019")
+  end
+
+  def given_there_is_a_document_with_a_second_edition
+    @edition = create(:edition, number: 2)
+  end
+
+  def then_i_cannot_see_a_backdate_section
+    expect(page).not_to have_content(
+      I18n.t!("documents.show.content_settings.backdate.title"),
+    )
+    expect(page).not_to have_content("Edit Backdate")
+  end
+
+  def given_there_is_a_published_first_edition
+    @edition = create(:edition, :published, number: 1)
   end
 end

--- a/spec/services/date_parser_spec.rb
+++ b/spec/services/date_parser_spec.rb
@@ -1,0 +1,49 @@
+# frozen_string_literal: true
+
+RSpec.describe DateParser do
+  describe "#parse" do
+    it "returns the parsed date when valid" do
+      params = { day: "10", month: "01", year: "2019" }
+      expected_date = Time.zone.local(2019, 1, 10, 0, 0)
+
+      datetime = DateParser.new(date: params, issue_prefix: :backdate).parse
+      expect(datetime).to eq(expected_date)
+    end
+
+    it "returns nil when the date is blank" do
+      expect(DateParser.new(date: nil, issue_prefix: :backdate).parse).to be_nil
+    end
+
+    it "returns nil when the date is invalid" do
+      params = { day: "10", month: "60", year: "11" }
+      expect(DateParser.new(date: params, issue_prefix: :backdate).parse).to be_nil
+    end
+  end
+
+  describe "#issues" do
+    it "returns no issues when there are none" do
+      params = { day: "10", month: "1", year: "2019" }
+      parser = DateParser.new(date: params, issue_prefix: :backdate)
+      parser.parse
+
+      expect(parser.issues.items).to be_empty
+    end
+
+    it "returns issues when the date is blank" do
+      parser = DateParser.new(date: nil, issue_prefix: :backdate)
+      parser.parse
+
+      date_form_message = parser.issues.items_for(:backdate_date).first[:text]
+      expect(date_form_message).to eq(I18n.t!("requirements.backdate_date.invalid.form_message"))
+    end
+
+    it "returns an issue when the date is invalid" do
+      params = { day: "10", month: "60", year: "11" }
+      parser = DateParser.new(date: params, issue_prefix: :backdate)
+      parser.parse
+
+      form_message = parser.issues.items_for(:backdate_date).first[:text]
+      expect(form_message).to eq(I18n.t!("requirements.backdate_date.invalid.form_message"))
+    end
+  end
+end

--- a/spec/services/datetime_parser_spec.rb
+++ b/spec/services/datetime_parser_spec.rb
@@ -6,75 +6,112 @@ RSpec.describe DatetimeParser do
       date_params = { day: "10", month: "01", year: "2019" }
       expected_time = Time.zone.local(2019, 1, 10, 0, 0)
 
-      datetime = DatetimeParser.new(date: date_params, time: "11:00am").parse
-      expect(datetime).to eq expected_time.change(hour: 11)
+      parser = DatetimeParser.new(date: date_params,
+                                  time: "11:00am",
+                                  issue_prefix: :schedule)
+      expect(parser.parse).to eq expected_time.change(hour: 11)
 
-      datetime = DatetimeParser.new(date: date_params, time: "9:34").parse
-      expect(datetime).to eq expected_time.change(hour: 9, min: 34)
+      parser = DatetimeParser.new(date: date_params,
+                                  time: "9:34",
+                                  issue_prefix: :schedule)
+      expect(parser.parse).to eq expected_time.change(hour: 9, min: 34)
 
-      datetime = DatetimeParser.new(date: date_params, time: "12:00").parse
-      expect(datetime).to eq expected_time.change(hour: 12)
+      parser = DatetimeParser.new(date: date_params,
+                                  time: "12:00",
+                                  issue_prefix: :schedule)
+      expect(parser.parse).to eq expected_time.change(hour: 12)
 
-      datetime = DatetimeParser.new(date: date_params, time: "12:00am").parse
-      expect(datetime).to eq expected_time.change(hour: 0)
+      parser = DatetimeParser.new(date: date_params,
+                                  time: "12:00am",
+                                  issue_prefix: :schedule)
+      expect(parser.parse).to eq expected_time.change(hour: 0)
 
-      datetime = DatetimeParser.new(date: date_params, time: "6:00 pm").parse
-      expect(datetime).to eq expected_time.change(hour: 18)
+      parser = DatetimeParser.new(date: date_params,
+                                  time: "6:00 pm",
+                                  issue_prefix: :schedule)
+      expect(parser.parse).to eq expected_time.change(hour: 18)
 
-      datetime = DatetimeParser.new(date: date_params, time: "23:32").parse
-      expect(datetime).to eq expected_time.change(hour: 23, min: 32)
+      parser = DatetimeParser.new(date: date_params,
+                                  time: "23:32",
+                                  issue_prefix: :schedule)
+      expect(parser.parse).to eq expected_time.change(hour: 23, min: 32)
 
-      datetime = DatetimeParser.new(date: date_params, time: "12:30pm").parse
-      expect(datetime).to eq expected_time.change(hour: 12, min: 30)
+      parser = DatetimeParser.new(date: date_params,
+                                  time: "12:30pm",
+                                  issue_prefix: :schedule)
+      expect(parser.parse).to eq expected_time.change(hour: 12, min: 30)
     end
 
     it "returns nil when the date/time is blank" do
-      expect(DatetimeParser.new(date: nil, time: nil).parse).to be_nil
+      parser = DatetimeParser.new(date: nil, time: nil, issue_prefix: :schedule)
+      expect(parser.parse).to be_nil
     end
 
     it "returns nil when the date is invalid" do
-      params = { date: { day: "10", month: "60", year: "11" }, time: "10:00" }
+      params = { date: { day: "10", month: "60", year: "11" },
+                 time: "10:00",
+                 issue_prefix: :schedule }
       expect(DatetimeParser.new(params).parse).to be_nil
     end
 
     it "returns nil when the time is invalid" do
-      params = { date: { day: "10", month: "1", year: "2019" }, time: "13421" }
+      params = { date: { day: "10", month: "1", year: "2019" },
+                 time: "13421",
+                 issue_prefix: :schedule }
       expect(DatetimeParser.new(params).parse).to be_nil
     end
   end
 
   describe "#issues" do
     it "returns no issues when there are none" do
-      parser = DatetimeParser.new(date: { day: "10", month: "1", year: "2019" }, time: "10:00")
+      params = { date: { day: "10", month: "1", year: "2019" },
+                 time: "10:00",
+                 issue_prefix: :schedule }
+      parser = DatetimeParser.new(params)
       parser.parse
+
       expect(parser.issues.items).to be_empty
     end
 
     it "returns issues when the date/time are blank" do
-      parser = DatetimeParser.new(date: nil, time: nil)
+      parser = DatetimeParser.new(date: nil, time: nil, issue_prefix: :schedule)
       parser.parse
 
       date_form_message = parser.issues.items_for(:schedule_date).first[:text]
-      expect(date_form_message).to eq(I18n.t!("requirements.schedule_date.invalid.form_message"))
+      expect(date_form_message).to eq(
+        I18n.t!("requirements.schedule_date.invalid.form_message"),
+      )
 
       time_form_message = parser.issues.items_for(:schedule_time).first[:text]
-      expect(time_form_message).to eq(I18n.t!("requirements.schedule_time.invalid.form_message"))
+      expect(time_form_message).to eq(
+        I18n.t!("requirements.schedule_time.invalid.form_message"),
+      )
     end
 
     it "returns an issue when the date is invalid" do
-      parser = DatetimeParser.new(date: { day: "10", month: "60", year: "11" }, time: "10:00")
+      params = { date: { day: "10", month: "60", year: "11" },
+                 time: "10:00",
+                 issue_prefix: :schedule }
+      parser = DatetimeParser.new(params)
       parser.parse
 
       form_message = parser.issues.items_for(:schedule_date).first[:text]
-      expect(form_message).to eq(I18n.t!("requirements.schedule_date.invalid.form_message"))
+      expect(form_message).to eq(
+        I18n.t!("requirements.schedule_date.invalid.form_message"),
+      )
     end
 
     it "returns an issue when the time is invalid" do
-      parser = DatetimeParser.new(date: { day: "10", month: "1", year: "2019" }, time: "-1:00")
+      params = { date: { day: "10", month: "1", year: "2019" },
+                 time: "-1:00",
+                 issue_prefix: :schedule }
+      parser = DatetimeParser.new(params)
       parser.parse
 
       form_message = parser.issues.items_for(:schedule_time).first[:text]
-      expect(form_message).to eq(I18n.t!("requirements.schedule_time.invalid.form_message"))
+      expect(form_message).to eq(
+        I18n.t!("requirements.schedule_time.invalid.form_message"),
+      )
     end
   end
 end

--- a/spec/services/publishing_api_payload_spec.rb
+++ b/spec/services/publishing_api_payload_spec.rb
@@ -46,6 +46,7 @@ RSpec.describe PublishingApiPayload do
         "title" => "Some title",
       }
       expect(payload).to match a_hash_including(payload_hash)
+      expect(payload).not_to include("first_published_at")
     end
 
     it "includes primary_publishing_organisation in organisations links" do
@@ -163,6 +164,15 @@ RSpec.describe PublishingApiPayload do
       payload = PublishingApiPayload.new(edition).payload
 
       expect(payload).not_to match a_hash_including("change_note" => "A change note")
+    end
+
+    it "includes first_published_at if the edition has a backdated_to value" do
+      date = Time.current.yesterday
+      revision = build(:revision, backdated_to: date)
+      edition = create(:edition, revision: revision)
+      payload = PublishingApiPayload.new(edition).payload
+
+      expect(payload).to match a_hash_including("first_published_at" => date)
     end
   end
 end

--- a/spec/services/requirements/backdate_checker_spec.rb
+++ b/spec/services/requirements/backdate_checker_spec.rb
@@ -1,0 +1,46 @@
+# frozen_string_literal: true
+
+RSpec.describe Requirements::BackdateChecker do
+  describe "#pre_submit_issues" do
+    it "returns no issues if there are none" do
+      params = { day: 1, month: 1, year: 2019 }
+      issues = Requirements::BackdateChecker.new(params).pre_submit_issues
+
+      expect(issues.items).to be_empty
+    end
+
+    it "returns an issue if the date is in the future" do
+      params = { day: 1, month: 1, year: 2020 }
+      issues = Requirements::BackdateChecker.new(params).pre_submit_issues
+      future_date_issue = I18n.t!("requirements.backdate_date.in_the_future.form_message")
+
+      expect(issues.items_for(:backdate_date))
+        .to include(a_hash_including(text: future_date_issue))
+    end
+
+    it "returns an issue if the date is invalid" do
+      invalid_params = { day: 1, month: 15, year: 2019 }
+      invalid_date_issue = I18n.t!("requirements.backdate_date.invalid.form_message")
+
+      issues = Requirements::BackdateChecker.new(invalid_params).pre_submit_issues
+
+      expect(issues.items_for(:backdate_date))
+        .to include(a_hash_including(text: invalid_date_issue))
+
+      non_numerical_params = { day: "first", month: 1, year: 2019 }
+
+      issues = Requirements::BackdateChecker.new(non_numerical_params).pre_submit_issues
+
+      expect(issues.items_for(:backdate_date))
+        .to include(a_hash_including(text: invalid_date_issue))
+    end
+
+    it "returns an issue if the date fields are blank" do
+      invalid_date_issue = I18n.t!("requirements.backdate_date.invalid.form_message")
+      issues = Requirements::BackdateChecker.new({}).pre_submit_issues
+
+      expect(issues.items_for(:backdate_date))
+        .to include(a_hash_including(text: invalid_date_issue))
+    end
+  end
+end

--- a/spec/services/requirements/backdate_checker_spec.rb
+++ b/spec/services/requirements/backdate_checker_spec.rb
@@ -3,44 +3,19 @@
 RSpec.describe Requirements::BackdateChecker do
   describe "#pre_submit_issues" do
     it "returns no issues if there are none" do
-      params = { day: 1, month: 1, year: 2019 }
-      issues = Requirements::BackdateChecker.new(params).pre_submit_issues
+      date = Time.current.change(day: 1, month: 1, year: 2019)
+      issues = Requirements::BackdateChecker.new(date).pre_submit_issues
 
       expect(issues.items).to be_empty
     end
 
     it "returns an issue if the date is in the future" do
-      params = { day: 1, month: 1, year: 2020 }
-      issues = Requirements::BackdateChecker.new(params).pre_submit_issues
+      date = Time.current.change(day: 1, month: 1, year: 2020)
+      issues = Requirements::BackdateChecker.new(date).pre_submit_issues
       future_date_issue = I18n.t!("requirements.backdate_date.in_the_future.form_message")
 
       expect(issues.items_for(:backdate_date))
         .to include(a_hash_including(text: future_date_issue))
-    end
-
-    it "returns an issue if the date is invalid" do
-      invalid_params = { day: 1, month: 15, year: 2019 }
-      invalid_date_issue = I18n.t!("requirements.backdate_date.invalid.form_message")
-
-      issues = Requirements::BackdateChecker.new(invalid_params).pre_submit_issues
-
-      expect(issues.items_for(:backdate_date))
-        .to include(a_hash_including(text: invalid_date_issue))
-
-      non_numerical_params = { day: "first", month: 1, year: 2019 }
-
-      issues = Requirements::BackdateChecker.new(non_numerical_params).pre_submit_issues
-
-      expect(issues.items_for(:backdate_date))
-        .to include(a_hash_including(text: invalid_date_issue))
-    end
-
-    it "returns an issue if the date fields are blank" do
-      invalid_date_issue = I18n.t!("requirements.backdate_date.invalid.form_message")
-      issues = Requirements::BackdateChecker.new({}).pre_submit_issues
-
-      expect(issues.items_for(:backdate_date))
-        .to include(a_hash_including(text: invalid_date_issue))
     end
   end
 end


### PR DESCRIPTION
For https://trello.com/c/x6ImOUSP/918-create-a-form-so-user-can-save-the-backdate-for-their-content

This creates a form for users to backdate content and, if the date is valid, sends the date as `first_published_at` to the Publishing API.  If the date is not valid errors are displayed on the form.

**No backdate set**
> <img width="676" alt="Screen Shot 2019-06-18 at 17 13 51" src="https://user-images.githubusercontent.com/13434452/59750766-3b969a80-9277-11e9-9b24-d6870a765033.png">

**Backdating form**
> <img width="683" alt="Screen Shot 2019-06-18 at 17 14 42" src="https://user-images.githubusercontent.com/13434452/59750779-43563f00-9277-11e9-8c92-bb9a7c3c581b.png">

**Backdating form with errors**
> <img width="988" alt="Screen Shot 2019-06-18 at 17 14 24" src="https://user-images.githubusercontent.com/13434452/59750829-5a952c80-9277-11e9-9526-7c16692f48d8.png">

**Backdated**
> <img width="674" alt="Screen Shot 2019-06-19 at 14 26 07" src="https://user-images.githubusercontent.com/13434452/59769523-3c8ef280-929e-11e9-9075-490b5705d249.png">


