### PR TITLE
Resolve test problems for Chrome 75.0.3770.90 and up

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -37,9 +37,6 @@ end
 
 group :development, :test do
   gem "byebug", "~> 11"
-  # Using this fork until https://github.com/dbalatero/capybara-chromedriver-logger/issues/6
-  # is resolved and released
-  gem "capybara-chromedriver-logger", git: "https://github.com/ThriveTRM/capybara-chromedriver-logger", ref: "77b9c9a"
   gem "climate_control"
   gem "factory_bot_rails", "~> 5"
   gem "govuk-lint", "~> 3"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,12 +1,3 @@
-GIT
-  remote: https://github.com/ThriveTRM/capybara-chromedriver-logger
-  revision: 77b9c9a11d8ed18719fb2288dd74952bb87b4c44
-  ref: 77b9c9a
-  specs:
-    capybara-chromedriver-logger (0.3.0)
-      capybara
-      colorize
-
 GEM
   remote: https://rubygems.org/
   specs:
@@ -91,7 +82,6 @@ GEM
     childprocess (1.0.1)
       rake (< 13.0)
     climate_control (0.2.0)
-    colorize (0.8.1)
     concurrent-ruby (1.1.5)
     connection_pool (2.2.2)
     crack (0.4.3)
@@ -458,7 +448,6 @@ DEPENDENCIES
   bootsnap (~> 1)
   brakeman (~> 4)
   byebug (~> 11)
-  capybara-chromedriver-logger!
   climate_control
   factory_bot_rails (~> 5)
   gds-api-adapters (~> 59)

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -25,6 +25,7 @@ ActiveRecord::Migration.maintain_test_schema!
 Rails.application.load_tasks
 Sidekiq::Testing.inline!
 
+Capybara.javascript_driver = :selenium_chrome_headless
 Capybara.server = :puma, { Silent: true }
 
 RSpec.configure do |config|

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -26,10 +26,6 @@ Rails.application.load_tasks
 Sidekiq::Testing.inline!
 
 Capybara.server = :puma, { Silent: true }
-Capybara::Chromedriver::Logger.raise_js_errors = true
-Capybara::Chromedriver::Logger.filters = [
-  /the server responded with a status of 422/i,
-]
 
 RSpec.configure do |config|
   config.expose_dsl_globally = false
@@ -60,9 +56,5 @@ RSpec.configure do |config|
 
   config.after :each, type: :feature do
     reset_authentication
-  end
-
-  config.after :each, type: :feature, js: true do
-    # Capybara::Chromedriver::Logger::TestHooks.after_example!
   end
 end


### PR DESCRIPTION
Rather embarrassingly I accidentally committed a commented out line that disabled chromedriver logger in https://github.com/alphagov/content-publisher/commit/b85a3d52c9585f7c52b4037d15cf7227d3095047#diff-93830fa29d616f7c87903d08b5b1b29aR66 since that no longer works with newer versions of Chrome.

Since we've been on a fork of capybara-chromedriver-logger for a while now and it no longer works I think it makes sense to remove it. 

This also sets the javascript driver to be selenium_chrome_headless until govuk_test is fixed to work with newer versions of Chrome. I have a pr to raise for that.