### PR TITLE
Scope overwrite actions to the modal content

### DIFF
--- a/app/assets/javascripts/modal/modal-workflow.js
+++ b/app/assets/javascripts/modal/modal-workflow.js
@@ -15,7 +15,7 @@ ModalWorkflow.prototype.initComponents = function () {
 
 ModalWorkflow.prototype.overrideActions = function (actions) {
   var formItems = this.$modal.querySelectorAll('form[data-modal-action]')
-  var clickItems = document.querySelectorAll('a[data-modal-action], button[data-modal-action]')
+  var clickItems = this.$modal.querySelectorAll('a[data-modal-action], button[data-modal-action]')
 
   clickItems.forEach(function (item) {
     item.addEventListener('click', function (event) {


### PR DESCRIPTION
This PR scopes overwrite actions to the modal content instead of the entire document.

We're currently doing this at the document level and every time we open a modal we create an exponential chain of events attached to the elements that initialise modals (which also rely on `data-modal-action` attributes, set to "open"). This is not only a waste of resources but it creates a series of `ModalWorkflow` instances that race in configuring and opening the modal, which results in a series of bugs captured by the card where the modal size config is not respected (a race of `this.$modal.resize('narrow')` in different instances) or the content of the modal changes without interacting with it (a race of `this.$modal.open()`).

<img width="1353" alt="Screen Shot 2019-06-18 at 17 30 01" src="https://user-images.githubusercontent.com/788096/59763229-0dbe4f80-9291-11e9-9d64-2d0ae98f7b38.png">

Thinking to add a test to prevent this from happening again I realised we don't have any tests for the modal scripts yet, so I [added a card to look into this](https://trello.com/c/GVp3CoMH).

[Trello card](https://trello.com/c/eXHSmgJU)