### PR TITLE
Gtm for errors

### DIFF
--- a/app/controllers/backdate_controller.rb
+++ b/app/controllers/backdate_controller.rb
@@ -10,8 +10,7 @@ class BackdateController < ApplicationController
     edition, issues = result.to_h.values_at(:edition, :issues)
 
     if issues
-      flash.now["alert_with_items"] = {
-        "title" => I18n.t!("backdate.edit.flashes.requirements"),
+      flash.now["requirements"] = {
         "items" => issues.items(
           link_options: { backdate_date: { href: "#backdate-date" } },
         ),

--- a/app/controllers/documents_controller.rb
+++ b/app/controllers/documents_controller.rb
@@ -42,8 +42,7 @@ class DocumentsController < ApplicationController
     edition, revision, issues, = result.to_h.values_at(:edition, :revision, :issues)
 
     if issues
-      flash.now["alert_with_items"] = {
-        "title" => I18n.t!("documents.edit.flashes.requirements"),
+      flash.now["requirements"] = {
         "items" => issues.items(link_options: issues_link_options(edition)),
       }
 

--- a/app/controllers/file_attachments_controller.rb
+++ b/app/controllers/file_attachments_controller.rb
@@ -37,8 +37,7 @@ class FileAttachmentsController < ApplicationController
     issues = result.issues
 
     if issues
-      flash.now["alert_with_items"] = {
-        "title" => I18n.t!("file_attachments.index.flashes.upload_requirements"),
+      flash.now["requirements"] = {
         "items" => issues.items(
           link_options: {
             file_attachment_upload: { href: how_to_use_publisher_path(anchor: "attachments"),
@@ -83,8 +82,7 @@ class FileAttachmentsController < ApplicationController
     unchanged = result.unchanged
 
     if issues
-      flash.now["alert_with_items"] = {
-        "title" => I18n.t!("file_attachments.index.flashes.upload_requirements"),
+      flash.now["requirements"] = {
         "items" => issues.items(
           link_options: {
             file_attachment_upload: { href: how_to_use_publisher_path(anchor: "attachments"),

--- a/app/controllers/images_controller.rb
+++ b/app/controllers/images_controller.rb
@@ -13,10 +13,7 @@ class ImagesController < ApplicationController
                                                             :issues)
 
     if issues
-      flash.now["alert_with_items"] = {
-        "title" => I18n.t!("images.index.flashes.upload_requirements"),
-        "items" => issues.items,
-      }
+      flash.now["requirements"] = { "items" => issues.items }
 
       render :index,
              assigns: { edition: edition },
@@ -59,10 +56,7 @@ class ImagesController < ApplicationController
     lead_removed = result.removed_lead_image
 
     if issues
-      flash.now["alert_with_items"] = {
-        "title" => I18n.t!("images.edit.flashes.requirements"),
-        "items" => issues.items,
-      }
+      flash.now["requirements"] = { "items" => issues.items }
 
       render :edit,
              assigns: { edition: edition,

--- a/app/controllers/new_document_controller.rb
+++ b/app/controllers/new_document_controller.rb
@@ -7,10 +7,7 @@ class NewDocumentController < ApplicationController
 
   def choose_document_type
     if params[:supertype].blank?
-      flash.now["alert_with_items"] = {
-        "title" => I18n.t!("new_document.choose_supertype.flashes.requirements"),
-        "items" => supertype_issues.items,
-      }
+      flash.now["requirements"] = { "items" => supertype_issues.items }
 
       render :choose_supertype,
              assigns: { issues: supertype_issues, supertypes: Supertype.all },
@@ -28,10 +25,7 @@ class NewDocumentController < ApplicationController
 
   def create
     if params[:document_type].blank?
-      flash.now["alert_with_items"] = {
-        "title" => I18n.t!("new_document.choose_document_type.flashes.requirements"),
-        "items" => document_type_issues.items,
-      }
+      flash.now["requirements"] = { "items" => document_type_issues.items }
 
       render :choose_document_type,
              assigns: { issues: document_type_issues,

--- a/app/controllers/publish_controller.rb
+++ b/app/controllers/publish_controller.rb
@@ -24,10 +24,7 @@ class PublishController < ApplicationController
                                                             :issues,
                                                             :publish_failed)
     if issues
-      flash.now["alert_with_items"] = {
-        "title" => I18n.t!("publish.confirmation.flashes.requirements"),
-        "items" => issues.items,
-      }
+      flash.now["requirements"] = { "items" => issues.items }
 
       render :confirmation,
              assigns: { issues: issues, edition: edition },

--- a/app/controllers/schedule_controller.rb
+++ b/app/controllers/schedule_controller.rb
@@ -21,8 +21,7 @@ class ScheduleController < ApplicationController
     edition, issues = result.to_h.values_at(:edition, :issues)
 
     if issues
-      flash.now["alert_with_items"] = {
-        "title" => I18n.t!("schedule.edit.flashes.requirements"),
+      flash.now["requirements"] = {
         "items" => issues.items(
           link_options: {
             schedule_date: { href: "#date" },
@@ -47,10 +46,7 @@ class ScheduleController < ApplicationController
     edition, issues = result.to_h.values_at(:edition, :issues)
 
     if issues
-      flash.now["alert_with_items"] = {
-        "title" => I18n.t!("schedule.new.flashes.requirements"),
-        "items" => issues.items,
-      }
+      flash.now["requirements"] = { "items" => issues.items }
 
       render :new,
              assigns: { issues: issues, edition: edition },

--- a/app/controllers/schedule_proposal_controller.rb
+++ b/app/controllers/schedule_proposal_controller.rb
@@ -6,8 +6,7 @@ class ScheduleProposalController < ApplicationController
     edition, issues = result.to_h.values_at(:edition, :issues)
 
     if issues
-      flash.now["alert_with_items"] = {
-        "title" => I18n.t!("schedule_proposal.edit.flashes.requirements"),
+      flash.now["requirements"] = {
         "items" => issues.items(
           link_options: {
             schedule_date: { href: "#date" },

--- a/app/controllers/tags_controller.rb
+++ b/app/controllers/tags_controller.rb
@@ -16,8 +16,7 @@ class TagsController < ApplicationController
     edition, revision, issues, = results.to_h.values_at(:edition, :revision, :issues)
 
     if issues
-      flash.now["alert_with_items"] = {
-        "title" => I18n.t!("tags.edit.flashes.requirements"),
+      flash.now["requirements"] = {
         "items" => issues.items(link_options: issues_link_options(edition)),
       }
       render :edit,

--- a/app/controllers/video_embed_controller.rb
+++ b/app/controllers/video_embed_controller.rb
@@ -25,10 +25,7 @@ class VideoEmbedController < ApplicationController
       .pre_embed_issues(title: title, url: url)
 
     if issues.any?
-      flash.now["alert_with_items"] = {
-        "title" => t("video_embed.new.flashes.requirements"),
-        "items" => issues.items,
-      }
+      flash.now["requirements"] = { "items" => issues.items }
 
       render :new,
              assigns: { issues: issues },

--- a/app/controllers/withdraw_controller.rb
+++ b/app/controllers/withdraw_controller.rb
@@ -24,10 +24,7 @@ class WithdrawController < ApplicationController
       # right response - maybe bad request or a redirect with flash?
       raise "Can't withdraw an edition without managing editor permissions"
     elsif issues
-      flash["alert_with_items"] = {
-        "title" => I18n.t!("withdraw.new.flashes.requirements"),
-        "items" => issues.items,
-      }
+      flash["requirements"] = { "items" => issues.items }
 
       render :new,
              assigns: { edition: edition,

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -28,4 +28,16 @@ module ApplicationHelper
   def name_or_fallback(user)
     user&.name || I18n.t("documents.unknown_user")
   end
+
+  def track_requirements(issue_items)
+    issue_items.map do |issue_item|
+      issue_item.merge(
+        data_attributes: {
+          "gtm" => "requirements-issue",
+          "gtm-action" => issue_item[:text],
+          "gtm-visibility-tracking" => true,
+        },
+      )
+    end
+  end
 end

--- a/app/services/requirements/issue.rb
+++ b/app/services/requirements/issue.rb
@@ -21,11 +21,6 @@ module Requirements
         text: message(style: style),
         href: link_options[:href],
         target: link_options[:target],
-        data_attributes: {
-          "gtm" => "requirements-issue",
-          "gtm-action" => message(style: style),
-          "gtm-visibility-tracking" => true,
-        },
       }
     end
   end

--- a/app/services/requirements/issue.rb
+++ b/app/services/requirements/issue.rb
@@ -21,6 +21,11 @@ module Requirements
         text: message(style: style),
         href: link_options[:href],
         target: link_options[:target],
+        data_attributes: {
+          "gtm" => "requirements-issue",
+          "gtm-action" => message(style: style),
+          "gtm-visibility-tracking" => true,
+        },
       }
     end
   end

--- a/app/views/components/_inset_prompt.html.erb
+++ b/app/views/components/_inset_prompt.html.erb
@@ -4,11 +4,12 @@
   items ||= []
   id ||= nil
   error = false if error.nil?
+  data_attributes ||= {}
   root_classes = %w[app-c-inset-prompt]
   root_classes << "app-c-inset-prompt--error" if error
 %>
 
-<%= tag.div class: root_classes, id: id do %>
+<%= tag.div class: root_classes, id: id, data: data_attributes do %>
   <%= tag.h2 title, class: "app-c-inset-prompt__title" %>
 
   <%= tag.div class: "app-c-inset-prompt__body" do %>

--- a/app/views/components/_inset_prompt.html.erb
+++ b/app/views/components/_inset_prompt.html.erb
@@ -17,10 +17,14 @@
     <% if items.any? %>
       <%= tag.ul class: "govuk-list app-c-inset-prompt__list" do %>
         <% items.each_with_index do |item, index| %>
-          <% if item[:href] %>
-            <%= tag.li link_to(item[:text], item[:href], class: "govuk-link govuk-link--no-visited-state") %>
-          <% else %>
-            <%= tag.li item[:text] %>
+          <%= tag.li do %>
+            <% if item[:href] %>
+              <%= link_to(item[:text], item[:href], data: item[:data_attributes], class: "govuk-link govuk-link--no-visited-state") %>
+            <% else %>
+              <%= tag.span data: item[:data_attributes] do %>
+                <%= item[:text] %>
+              <% end %>
+            <% end %>
           <% end %>
         <% end %>
       <% end %>

--- a/app/views/components/docs/inset_prompt.yml
+++ b/app/views/components/docs/inset_prompt.yml
@@ -29,4 +29,10 @@ examples:
       title: There is a problem
       description: |
         <p class="govuk-body">&lsquo;Title here&rsquo; was not published</p>
-
+  with_data_attributes:
+    data:
+      title: Message to alert the user to a problem goes here
+      data_attributes:
+        tracking: GTM-123AB
+      items:
+      - text: Descriptive link to the question with an error 1

--- a/app/views/components/docs/inset_prompt.yml
+++ b/app/views/components/docs/inset_prompt.yml
@@ -18,11 +18,15 @@ examples:
       items:
       - text: Document needs a title before publishing (at least 10 characters)
         href: '#content'
+        data_attributes:
+          tracking: GTM-123AA
       - text: Document needs a summary before publishing (at least 10 characters)
-        href: '#content'
+        data_attributes:
+          tracking: GTM-123AB
   error:
     data:
       error: true
       title: There is a problem
       description: |
         <p class="govuk-body">&lsquo;Title here&rsquo; was not published</p>
+

--- a/app/views/documents/show/_failed_to_publish_notice.html.erb
+++ b/app/views/documents/show/_failed_to_publish_notice.html.erb
@@ -10,4 +10,8 @@
   error: true,
   title: t("documents.show.failed_to_publish.title"),
   description: render_govspeak(description_govspeak),
+  data_attributes: {
+    gtm: "scheduled-publish-failed",
+    "gtm-visibility-tracking": true
+  }
 } %>

--- a/app/views/documents/show/_requirements.html.erb
+++ b/app/views/documents/show/_requirements.html.erb
@@ -32,11 +32,19 @@
       <%= render "govuk_publishing_components/components/error_summary", {
         title: t("documents.show.flashes.pre_preview_issues.error"),
         items: draft_issues.items(issue_params),
+        data_attributes: {
+          gtm: "tried-to-preview",
+          "gtm-visibility-tracking" => true
+        }
       } %>
     <% else %>
       <%= render "/components/inset_prompt", {
         title: t("documents.show.flashes.pre_preview_issues.warning"),
         items: draft_issues.items(issue_params),
+        data_attributes: {
+          gtm: "pre-preview-issues",
+          "gtm-visibility-tracking" => true
+        }
       } %>
     <% end %>
   <% end %>
@@ -50,11 +58,19 @@
       <%= render "govuk_publishing_components/components/error_summary", {
         title: t("documents.show.flashes.pre_publish_issues.error"),
         items: publish_issues.items(issue_params),
+        data_attributes: {
+          gtm: "tried-to-publish",
+          "gtm-visibility-tracking" => true
+        }
       } %>
     <% else %>
       <%= render "/components/inset_prompt", {
         title: t("documents.show.flashes.pre_publish_issues.warning"),
         items: publish_issues.items(issue_params),
+        data_attributes: {
+          gtm: "pre-publish-issues",
+          "gtm-visibility-tracking" => true
+        }
       } %>
     <% end %>
   <% end %>

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -67,7 +67,11 @@
       <% if flash["alert_with_description"] %>
         <%= render "govuk_publishing_components/components/error_alert", {
           message: flash["alert_with_description"].fetch("title"),
-          data_attributes: { gtm: "global-alert" },
+          data_attributes: {
+            gtm: "alert-with-description",
+            "gtm-action" => flash["alert_with_description"]["title"],
+            "gtm-visibility-tracking" => true
+          },
           description: capture do
             render "govuk_publishing_components/components/govspeak" do
               govspeak_to_html(flash["alert_with_description"].fetch("description_govspeak"))
@@ -84,7 +88,11 @@
         <%= render "govuk_publishing_components/components/error_summary", {
           title: flash["alert_with_items"]["title"],
           items: items,
-          data_attributes: { gtm: "global-alert" },
+          data_attributes: {
+            gtm: "alert-with-items",
+            "gtm-action" => flash["alert_with_items"]["title"],
+            "gtm-visibility-tracking" => true
+          },
         } %>
       <% end %>
 

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -80,17 +80,16 @@
         } %>
       <% end %>
 
-      <% if flash["alert_with_items"] %>
-        <% items = flash["alert_with_items"]["message"] ?
-          [{ text: flash["alert_with_items"]["message"] }] :
-          flash["alert_with_items"]["items"].map(&:symbolize_keys) %>
+      <% if flash["requirements"] %>
+        <% items = flash["requirements"]["message"] ?
+          [{ text: flash["requirements"]["message"] }] :
+          flash["requirements"]["items"].map(&:symbolize_keys) %>
 
         <%= render "govuk_publishing_components/components/error_summary", {
-          title: flash["alert_with_items"]["title"],
-          items: items,
+          title: t("documents.flashes.requirements"),
+          items: track_requirements(items),
           data_attributes: {
-            gtm: "alert-with-items",
-            "gtm-action" => flash["alert_with_items"]["title"],
+            gtm: "alert-requirements",
             "gtm-visibility-tracking" => true
           },
         } %>

--- a/app/views/layouts/modal.html.erb
+++ b/app/views/layouts/modal.html.erb
@@ -6,11 +6,18 @@
   } %>
 <% end %>
 
-<% if flash["alert_with_items"] %>
+<% if flash["requirements"] %>
+  <% items = flash["requirements"]["message"] ?
+    [{ text: flash["requirements"]["message"] }] :
+    flash["requirements"]["items"].map(&:symbolize_keys) %>
+
   <%= render "govuk_publishing_components/components/error_summary", {
-    title: flash["alert_with_items"]["title"],
-    items: flash["alert_with_items"]["items"].map(&:symbolize_keys),
-    data_attributes: { gtm: "global-alert" },
+    title: t("documents.flashes.requirements"),
+    items: track_requirements(items),
+    data_attributes: {
+      gtm: "alert-requirements",
+      "gtm-visibility-tracking" => true
+    },
   } %>
 <% end %>
 

--- a/config/locales/en/backdate/edit.yml
+++ b/config/locales/en/backdate/edit.yml
@@ -8,5 +8,3 @@ en:
         information being presented as new.
       date: Date
       date_hint_text: For example, 01 08 2016
-      flashes:
-        requirements: You need to

--- a/config/locales/en/documents.yml
+++ b/config/locales/en/documents.yml
@@ -2,3 +2,5 @@ en:
   documents:
     untitled_document: Untitled document
     unknown_user: Unknown user
+    flashes:
+      requirements: You need to

--- a/config/locales/en/documents/edit.yml
+++ b/config/locales/en/documents/edit.yml
@@ -25,5 +25,3 @@ en:
         title: Is the content change significant to users?
         minor_name: No - a minor style update
         major_name: Yes - information has been added or updated
-      flashes:
-        requirements: You need to

--- a/config/locales/en/file_attachments/index.yml
+++ b/config/locales/en/file_attachments/index.yml
@@ -15,4 +15,3 @@ en:
       other_attachments: Other attachments
       flashes:
         deleted: "Attachment ‘%{file}’ has been deleted"
-        upload_requirements: You need to

--- a/config/locales/en/images/edit.yml
+++ b/config/locales/en/images/edit.yml
@@ -8,8 +8,6 @@ en:
         caption: Image caption
         credit: Image credit
         lead_image: Select as lead image
-      flashes:
-        requirements: You need to
       guidance:
         alt_text_govspeak: A simple and specific description of what the image shows. This helps screen-readers and search engines.
         caption_govspeak: Optional. A description of what the image shows. Caption appears next to the image.

--- a/config/locales/en/images/index.yml
+++ b/config/locales/en/images/index.yml
@@ -15,7 +15,6 @@ en:
           label: Markdown code
           value: "[Image: %{filename}]"
       flashes:
-        upload_requirements: You need to
         deleted: "Image ‘%{file}’ has been deleted"
         lead_image:
           removed: "Image ‘%{file}’ has been deselected. Document will now use the default lead image"

--- a/config/locales/en/new_document/choose_document_type.yml
+++ b/config/locales/en/new_document/choose_document_type.yml
@@ -1,5 +1,0 @@
-en:
-  new_document:
-    choose_document_type:
-      flashes:
-        requirements: You must

--- a/config/locales/en/new_document/choose_supertype.yml
+++ b/config/locales/en/new_document/choose_supertype.yml
@@ -2,5 +2,3 @@ en:
   new_document:
     choose_supertype:
       title: "What is the content for?"
-      flashes:
-        requirements: You must

--- a/config/locales/en/publish/confirmation.yml
+++ b/config/locales/en/publish/confirmation.yml
@@ -4,5 +4,3 @@ en:
       title: Publish
       has_been_reviewed: "This content has been reviewed and approved for publication"
       should_be_reviewed: "This content needs to be published urgently but should be reviewed as soon as possible"
-      flashes:
-        requirements: You must

--- a/config/locales/en/schedule/edit.yml
+++ b/config/locales/en/schedule/edit.yml
@@ -5,5 +5,3 @@ en:
       date: Date
       date_hint_text: For example, 01 08 2027
       time: Time
-      flashes:
-        requirements: You need to

--- a/config/locales/en/schedule/new.yml
+++ b/config/locales/en/schedule/new.yml
@@ -6,5 +6,3 @@ en:
       review_status:
         reviewed: This content has been reviewed and approved for publication
         not_reviewed: This content needs to be reviewed after it has been published
-      flashes:
-        requirements: You need to

--- a/config/locales/en/schedule_proposal/edit.yml
+++ b/config/locales/en/schedule_proposal/edit.yml
@@ -5,5 +5,3 @@ en:
       actions:
         save: Save proposed date and time
         schedule: Schedule to publish
-      flashes:
-        requirements: You need to

--- a/config/locales/en/tags/edit.yml
+++ b/config/locales/en/tags/edit.yml
@@ -4,5 +4,3 @@ en:
       title: "Tags for ‘%{title}’"
       description: Add tags which describe what the content is about. Content will appear in lists on GOV.UK based on each tag.
       api_down: This content can't be edited right now. We're having trouble getting the data we need for you to make changes on this page.
-      flashes:
-        requirements: You need to

--- a/config/locales/en/video_embed/new.yml
+++ b/config/locales/en/video_embed/new.yml
@@ -3,8 +3,6 @@ en:
     new:
       title: Embed YouTube video
       guidance_markdown: Only YouTube videos can be embedded on GOV.UK. [Full guidance on videos on GOV.UK](https://www.gov.uk/guidance/how-to-publish-on-gov-uk/markdown#video){:target="_blank"}.
-      flashes:
-        requirements: You must
       form_labels:
         title: Video title
         url: YouTube video web address

--- a/config/locales/en/withdraw/withdraw.yml
+++ b/config/locales/en/withdraw/withdraw.yml
@@ -10,7 +10,6 @@ en:
 
         [Full guidance on withdrawing content](https://www.gov.uk/guidance/how-to-publish-on-gov-uk/unpublishing-and-archiving)
       flashes:
-        requirements: You need to
         publishing_api_error:
           title: Something has gone wrong
           description_govspeak: Something went wrong when withdrawing this document. Please try again or [raise a support request](https://support.publishing.service.gov.uk/technical_fault_report/new).


### PR DESCRIPTION
https://trello.com/c/B9rVHJTh/876-audit-and-fix-gtm-ga-issues

This introduces separate tracking for requirements issues vs. the flashes they're displayed in.