### PR TITLE
Fix JavaScript-dependent components in markdown preview

### DIFF
--- a/app/assets/javascripts/components/markdown-editor.js
+++ b/app/assets/javascripts/components/markdown-editor.js
@@ -90,6 +90,7 @@ window.GOVUK.Modules = window.GOVUK.Modules || {};
         this.setTargetBlank(this.$preview)
         this.$preview.classList.add('app-c-markdown-editor__govspeak--rendered')
         window.GOVUK.modules.start()
+        window.GOVUKFrontend.initAll(this.$preview)
       }.bind(this))
       .catch(function () {
         this.$preview.innerHTML = 'Error previewing content'

--- a/app/assets/javascripts/components/markdown-editor.js
+++ b/app/assets/javascripts/components/markdown-editor.js
@@ -1,3 +1,4 @@
+/* global $ */
 //= require markdown-toolbar-element/dist/index.umd.js
 //= require paste-html-to-govspeak/dist/paste-html-to-markdown.js
 
@@ -89,7 +90,7 @@ window.GOVUK.Modules = window.GOVUK.Modules || {};
         this.$preview.innerHTML = text
         this.setTargetBlank(this.$preview)
         this.$preview.classList.add('app-c-markdown-editor__govspeak--rendered')
-        window.GOVUK.modules.start()
+        window.GOVUK.modules.start($(this.$preview))
         window.GOVUKFrontend.initAll(this.$preview)
       }.bind(this))
       .catch(function () {


### PR DESCRIPTION
This PR initialises JavaScript components from both GOV.UK Modules and GOV.UK Frontend scoped to the preview container.

This is aligned with how we're currently initialising JavaScript from components in the [modal workflow](https://github.com/alphagov/content-publisher/blob/cfdd485cf5a8372b0839264acf6517551c98bc22/app/assets/javascripts/modal/modal-workflow.js#L12).

[Trello card](https://trello.com/c/tryqn3d2)