### PR TITLE
Handle scheduled and revision not synced

### DIFF
--- a/app/views/documents/show/_actions.html.erb
+++ b/app/views/documents/show/_actions.html.erb
@@ -24,6 +24,8 @@
           <%= schedule_proposal_link(@edition, "app-link--right") %>
         <% end %>
       <% end %>
+    <% elsif @edition.scheduled? %>
+      <%= @edition.revision_synced? ? preview_button(@edition) : create_preview_button(@edition) %>
     <% elsif !@edition.revision_synced? %>
       <%= create_preview_button(@edition) %>
       <%= delete_draft_link(@edition) %>
@@ -34,8 +36,6 @@
       <% end %>
     <% elsif @edition.withdrawn? %>
       <%= undo_withdraw_button(@edition) %>
-    <% elsif @edition.scheduled? %>
-      <%= preview_button(@edition) %>
     <% elsif @edition.draft? %>
       <%= submit_for_2i_button(@edition) %>
       <%= preview_button(@edition, secondary: true) %>


### PR DESCRIPTION
Trello: https://trello.com/c/rBYaERp4/708-handle-scheduled-publishing-errors

Previously this edge case was falling into an expectation that the
document was a draft. This provides actions that are not applicable for
a scheduled document.