### PR TITLE
Link and highlight issues for edit and tag forms

### DIFF
--- a/app/controllers/documents_controller.rb
+++ b/app/controllers/documents_controller.rb
@@ -44,11 +44,11 @@ class DocumentsController < ApplicationController
     if issues
       flash.now["alert_with_items"] = {
         "title" => I18n.t!("documents.edit.flashes.requirements"),
-        "items" => issues.items,
+        "items" => issues.items(link_options: issues_link_options(edition)),
       }
 
       render :edit,
-             assigns: { edition: edition, revision: revision },
+             assigns: { edition: edition, revision: revision, issues: issues },
              status: :unprocessable_entity
     elsif params[:submit] == "add_contact"
       redirect_to search_contacts_path(edition.document)
@@ -72,5 +72,16 @@ private
       page: params[:page],
       per_page: 50,
     }
+  end
+
+  def issues_link_options(edition)
+    format_specific_options = edition.document_type.contents.each_with_object({}) do |field, memo|
+      memo[field.id.to_sym] = { href: "##{field.id}-field" }
+    end
+
+    {
+      title: { href: "#title-field" },
+      summary: { href: "#summary-field" },
+    }.merge(Hash[format_specific_options])
   end
 end

--- a/app/controllers/tags_controller.rb
+++ b/app/controllers/tags_controller.rb
@@ -18,13 +18,21 @@ class TagsController < ApplicationController
     if issues
       flash.now["alert_with_items"] = {
         "title" => I18n.t!("tags.edit.flashes.requirements"),
-        "items" => issues.items,
+        "items" => issues.items(link_options: issues_link_options(edition)),
       }
       render :edit,
-             assigns: { edition: edition, revision: revision },
+             assigns: { edition: edition, revision: revision, issues: issues },
              status: :unprocessable_entity
     else
       redirect_to document_path(params[:document])
+    end
+  end
+
+private
+
+  def issues_link_options(edition)
+    edition.document_type.tags.each_with_object({}) do |field, memo|
+      memo[field.id.to_sym] = { href: "##{field.id}-field" }
     end
   end
 end

--- a/app/controllers/tags_controller.rb
+++ b/app/controllers/tags_controller.rb
@@ -17,7 +17,7 @@ class TagsController < ApplicationController
 
     if issues
       flash.now["alert_with_items"] = {
-        "title" => I18n.t!("documents.edit.flashes.requirements"),
+        "title" => I18n.t!("tags.edit.flashes.requirements"),
         "items" => issues.items,
       }
       render :edit,

--- a/app/views/documents/edit.html.erb
+++ b/app/views/documents/edit.html.erb
@@ -22,7 +22,7 @@
           text: t("documents.edit.form_labels.title"),
           bold: true
         },
-        id: "revision_title",
+        id: "title-field",
         name: "revision[title]",
         value: @revision.title,
         error_items: @issues&.items_for(:title),
@@ -35,7 +35,7 @@
         }
       } do %>
         <%= render "components/input_length_suggester", {
-          for_id: "revision_title",
+          for_id: "title-field",
           show_from: 55,
           message: "Title should be under 65 characters. Current length: {count}",
         } %>
@@ -70,7 +70,7 @@
           text: t("documents.edit.form_labels.summary"),
           bold: true
         },
-        id: "revision_summary",
+        id: "summary-field",
         name: "revision[summary]",
         value: @revision.summary,
         error_items: @issues&.items_for(:summary),
@@ -82,7 +82,7 @@
         }
       } do %>
         <%= render "components/input_length_suggester", {
-          for_id: "revision_summary",
+          for_id: "summary-field",
           show_from: 120,
           message: "Summary should be under 160 characters. Current length: {count}",
         } %>

--- a/app/views/documents/fields/_govspeak_input.html.erb
+++ b/app/views/documents/fields/_govspeak_input.html.erb
@@ -11,7 +11,7 @@
           gtm: "#{field.id}-input",
           "gtm-copy-paste-tracking": true,
         },
-        id: "revision_#{field.id}",
+        id: "#{field.id}-field",
         name: "revision[contents][#{field.id}]",
         value: revision.contents[field.id],
         rows: 20,

--- a/app/views/tags/edit.html.erb
+++ b/app/views/tags/edit.html.erb
@@ -13,7 +13,8 @@
       <div class="govuk-grid-column-two-thirds" id="<%= tag_field.id %>">
         <%= render "tags/tags/#{tag_field.type}_input",
           tag_field: tag_field,
-          tags: @revision.tags %>
+          tags: @revision.tags,
+          issues: @issues %>
       </div>
     </div>
   <% end %>

--- a/app/views/tags/tags/_multi_tag_input.html.erb
+++ b/app/views/tags/tags/_multi_tag_input.html.erb
@@ -1,5 +1,5 @@
 <%= render "components/autocomplete", {
-  id: tag_field.id,
+  id: "#{tag_field.id}-field",
   name: "tags[#{tag_field.id}][]",
   label: {
     text: tag_field.label,
@@ -8,6 +8,7 @@
   hint: tag_field.hint,
   options: LinkablesService.new(tag_field.document_type).select_options,
   selected_options: tags[tag_field.id],
+  error_items: issues&.items_for(tag_field.id.to_sym),
   multiple: true,
   size: 10,
 } %>

--- a/app/views/tags/tags/_single_tag_input.html.erb
+++ b/app/views/tags/tags/_single_tag_input.html.erb
@@ -1,5 +1,5 @@
 <%= render "components/autocomplete", {
-  id: tag_field.id,
+  id: "#{tag_field.id}-field",
   name: "tags[#{tag_field.id}][]",
   label: {
     text: tag_field.label,
@@ -8,4 +8,5 @@
   hint: tag_field.hint,
   options: [""] + LinkablesService.new(tag_field.document_type).select_options,
   selected_options: tags[tag_field.id],
+  error_items: issues&.items_for(tag_field.id.to_sym),
 } %>

--- a/config/locales/en/tags/edit.yml
+++ b/config/locales/en/tags/edit.yml
@@ -4,3 +4,5 @@ en:
       title: "Tags for ‘%{title}’"
       description: Add tags which describe what the content is about. Content will appear in lists on GOV.UK based on each tag.
       api_down: This content can't be edited right now. We're having trouble getting the data we need for you to make changes on this page.
+      flashes:
+        requirements: You need to

--- a/spec/features/editing_content/insert_inline_file_attachment_spec.rb
+++ b/spec/features/editing_content/insert_inline_file_attachment_spec.rb
@@ -57,13 +57,13 @@ RSpec.feature "Insert inline file attachment", js: true do
     expect(page).to_not have_selector(".gem-c-modal-dialogue")
     snippet = I18n.t("file_attachments.show.attachment_markdown",
                      filename: @file_attachment_revision.filename)
-    expect(find("#revision_body").value).to match snippet
+    expect(find("#body-field").value).to match snippet
   end
 
   def then_i_see_the_attachment_link_snippet_is_inserted
     expect(page).to_not have_selector(".gem-c-modal-dialogue")
     snippet = I18n.t("file_attachments.show.attachment_link_markdown",
                      filename: @file_attachment_revision.filename)
-    expect(find("#revision_body").value).to match snippet
+    expect(find("#body-field").value).to match snippet
   end
 end

--- a/spec/features/editing_content/insert_inline_image_spec.rb
+++ b/spec/features/editing_content/insert_inline_image_spec.rb
@@ -37,6 +37,6 @@ RSpec.feature "Insert inline image", js: true do
 
   def then_i_see_the_snippet_is_inserted
     snippet = I18n.t("images.index.meta.inline_code.value", filename: @image_revision.filename)
-    expect(find("#revision_body").value).to match snippet
+    expect(find("#body-field").value).to match snippet
   end
 end

--- a/spec/features/editing_content/insert_video_embed_spec.rb
+++ b/spec/features/editing_content/insert_video_embed_spec.rb
@@ -34,6 +34,6 @@ RSpec.describe "Insert video embed", js: true do
 
   def then_i_see_the_snippet_is_inserted
     snippet = "[A title](https://www.youtube.com/watch?v=G8KpPw303PY)"
-    expect(find("#revision_body").value).to match snippet
+    expect(find("#body-field").value).to match snippet
   end
 end

--- a/spec/features/editing_images/upload_image_spec.rb
+++ b/spec/features/editing_images/upload_image_spec.rb
@@ -85,7 +85,7 @@ RSpec.feature "Upload an image", js: true do
   def then_i_see_the_snippet_is_inserted
     expect(page).to_not have_selector(".gem-c-modal-dialogue")
     snippet = I18n.t("images.index.meta.inline_code.value", filename: @image_filename)
-    expect(find("#revision_body").value).to match snippet
+    expect(find("#body-field").value).to match snippet
   end
 
   def and_the_preview_creation_succeeded


### PR DESCRIPTION
Trello: https://trello.com/c/4Uc4JL4T/870-add-a-publishing-requirement-to-select-a-primary-organisation

This corrects these two forms where we weren't linking to and highlighting issues.

## Edit form

Before:
<img width="982" alt="Screen Shot 2019-06-20 at 09 47 07" src="https://user-images.githubusercontent.com/282717/59835029-e0c97580-9340-11e9-9d78-82e04a700b0b.png">

After:
<img width="982" alt="Screen Shot 2019-06-20 at 09 47 46" src="https://user-images.githubusercontent.com/282717/59835042-e3c46600-9340-11e9-884c-f26119387a94.png">

## Tags Form

Before:
<img width="974" alt="Screen Shot 2019-06-20 at 09 51 52" src="https://user-images.githubusercontent.com/282717/59835174-24bc7a80-9341-11e9-9154-b2876e155d53.png">

After:
<img width="975" alt="Screen Shot 2019-06-20 at 09 52 27" src="https://user-images.githubusercontent.com/282717/59835179-25eda780-9341-11e9-94b9-b4368aa7b6d7.png">