### PR TITLE
Standardise copy/paste listener

### DIFF
--- a/app/assets/javascripts/modules/gtm-copy-paste-listener.js
+++ b/app/assets/javascripts/modules/gtm-copy-paste-listener.js
@@ -1,28 +1,26 @@
 var GtmCopyPasteListener = {}
 
-GtmCopyPasteListener.handleCopy = function (event) {
-  var element = event.target
+GtmCopyPasteListener.handleCopyPaste = function (prefix) {
+  return function (event) {
+    var element = event.target
 
-  if (!element.hasAttribute('data-gtm-copy-paste-tracking')) {
-    return
+    if (!element) {
+      return
+    }
+
+    var suffix = element.dataset.gtmSuffix
+    var tracked = element.dataset.gtmCopyPasteTracking
+
+    if (!suffix || !tracked) {
+      return
+    }
+
+    window.dataLayer.push({
+      event: prefix,
+      dataGtm: prefix.toLowerCase() + '-' + suffix
+    })
   }
-
-  window.dataLayer.push({
-    'event': 'text-copied'
-  })
 }
 
-GtmCopyPasteListener.handlePaste = function (event) {
-  var element = event.target
-
-  if (!element.hasAttribute('data-gtm-copy-paste-tracking')) {
-    return
-  }
-
-  window.dataLayer.push({
-    'event': 'text-pasted'
-  })
-}
-
-window.addEventListener('copy', GtmCopyPasteListener.handleCopy)
-window.addEventListener('paste', GtmCopyPasteListener.handlePaste)
+window.addEventListener('copy', GtmCopyPasteListener.handleCopyPaste('Copy'))
+window.addEventListener('paste', GtmCopyPasteListener.handleCopyPaste('Paste'))

--- a/app/views/components/_page_preview.html.erb
+++ b/app/views/components/_page_preview.html.erb
@@ -10,10 +10,10 @@
         copyable_content: utm_uri.to_s,
         button_text: "Copy link",
         button_data_attributes: {
-          gtm: "copy-url-for-preview-cta"
+          gtm: "copy-url-for-preview"
         },
         input_data_attributes: {
-          gtm: "copy-url-for-preview-manual",
+          "gtm-suffix": "url-for-preview-input",
           "gtm-copy-paste-tracking": true
         }
       %>

--- a/app/views/documents/fields/_govspeak_input.html.erb
+++ b/app/views/documents/fields/_govspeak_input.html.erb
@@ -8,7 +8,7 @@
       textarea: {
         data: {
           gramm: "false", # Disables grammerly plugin for markdown editor
-          gtm: "#{field.id}-input",
+          "gtm-suffix": "#{field.id}-input",
           "gtm-copy-paste-tracking": true,
         },
         id: "#{field.id}-field",

--- a/app/views/documents/show/_submitted_for_review.html.erb
+++ b/app/views/documents/show/_submitted_for_review.html.erb
@@ -4,10 +4,10 @@
     copyable_content: document_url(@edition.document, utm_content: "2i-link"),
     button_text: "Copy link",
     button_data_attributes: {
-      gtm: "copy-url-for-2i-approval-cta"
+      gtm: "copy-url-for-2i-approval"
     },
     input_data_attributes: {
-      gtm: "copy-url-for-2i-approval-manual",
+      "gtm-suffix": "url-for-2i-approval-input",
       "gtm-copy-paste-tracking": true
     }
 ) %>

--- a/app/views/publish/published.html.erb
+++ b/app/views/publish/published.html.erb
@@ -27,10 +27,10 @@
         copyable_content: document_url(@edition.document, utm_content: "2i-link"),
         button_text: "Copy link",
         button_data_attributes: {
-          gtm: "published-content-copy-link-cta"
+          gtm: "copy-published-content-link"
         },
         input_data_attributes: {
-          gtm: "published-content-copy-link-manual",
+          "gtm-suffix": "published-content-link-input",
           "gtm-copy-paste-tracking": true
         }
       %>

--- a/spec/javascripts/modules/gtm-copy-paste-listener-spec.js
+++ b/spec/javascripts/modules/gtm-copy-paste-listener-spec.js
@@ -5,37 +5,73 @@ describe('Gtm copy paste listener', function () {
 
   var container
 
-  beforeEach(function () {
-    container = document.createElement('div')
-    container.innerHTML = '<input data-gtm-copy-paste-tracking=true>'
+  describe('when all attributes are specified', function () {
+    beforeEach(function () {
+      container = document.createElement('div')
+      container.innerHTML = '<input data-gtm-copy-paste-tracking=true data-gtm-suffix="my-input">'
 
-    document.body.appendChild(container)
-    window.dataLayer = []
+      document.body.appendChild(container)
+      window.dataLayer = []
+    })
+
+    afterEach(function () {
+      document.body.removeChild(container)
+    })
+
+    it('should push to the dataLayer on copy/paste', function () {
+      var input = container.querySelector('input')
+
+      input.dispatchEvent(new window.Event('copy', { bubbles: true }))
+      input.dispatchEvent(new window.Event('paste', { bubbles: true }))
+
+      expect(window.dataLayer).toContain({ dataGtm: 'copy-my-input', event: 'Copy' })
+      expect(window.dataLayer).toContain({ dataGtm: 'paste-my-input', event: 'Paste' })
+    })
   })
 
-  afterEach(function () {
-    document.body.removeChild(container)
+  describe('when no suffix is specified', function () {
+    beforeEach(function () {
+      container = document.createElement('div')
+      container.innerHTML = '<input data-gtm-copy-paste-tracking=true>'
+
+      document.body.appendChild(container)
+      window.dataLayer = []
+    })
+
+    afterEach(function () {
+      document.body.removeChild(container)
+    })
+
+    it('should not push to the dataLayer on copy/paste', function () {
+      var input = container.querySelector('input')
+
+      input.dispatchEvent(new window.Event('copy', { bubbles: true }))
+      input.dispatchEvent(new window.Event('paste', { bubbles: true }))
+
+      expect(window.dataLayer).toEqual([])
+    })
   })
 
-  it('should push to the dataLayer on copy', function () {
-    var input = container.querySelector('input')
-    input.dispatchEvent(new window.Event('copy', { bubbles: true }))
+  describe('when listener attribute is specified', function () {
+    beforeEach(function () {
+      container = document.createElement('div')
+      container.innerHTML = '<input data-gtm-suffix="my-input">'
 
-    expect(window.dataLayer).toContain(
-      {
-        'event': 'text-copied'
-      }
-    )
-  })
+      document.body.appendChild(container)
+      window.dataLayer = []
+    })
 
-  it('should push to the dataLayer on paste', function () {
-    var input = container.querySelector('input')
-    input.dispatchEvent(new window.Event('paste', { bubbles: true }))
+    afterEach(function () {
+      document.body.removeChild(container)
+    })
 
-    expect(window.dataLayer).toContain(
-      {
-        'event': 'text-pasted'
-      }
-    )
+    it('should not push to the dataLayer on copy/paste', function () {
+      var input = container.querySelector('input')
+
+      input.dispatchEvent(new window.Event('copy', { bubbles: true }))
+      input.dispatchEvent(new window.Event('paste', { bubbles: true }))
+
+      expect(window.dataLayer).toEqual([])
+    })
   })
 })


### PR DESCRIPTION
https://trello.com/c/tAXP6pf1/948-analytics-for-topics

Previously we had a single listener to emit custom copy/paste events to
GTM. In order to accommodate more listeners to support analytics for
topics, this modifies the copy/paste listener to emit a new 'dataGtm'
variable directly on the dataLayer, with the same meaning as the current
'data-gtm' attribute present on many elements, but formed dynamically
out of the event being tracked by the listener, and a 'data-gtm-suffix'
attribute coming from the element itself; in contrast, using 'data-gtm'
statically on an element generally implies it only supports one event.