### PR TITLE
Enforce earliest date for backdating

### DIFF
--- a/app/services/requirements/backdate_checker.rb
+++ b/app/services/requirements/backdate_checker.rb
@@ -2,6 +2,8 @@
 
 module Requirements
   class BackdateChecker
+    EARLIEST_DATE = Date.new(1995, 1, 1)
+
     def initialize(backdate)
       @backdate = backdate
     end
@@ -13,6 +15,11 @@ module Requirements
         issues << Issue.new(:backdate_date, :in_the_future)
       end
 
+      if too_long_ago?
+        date = EARLIEST_DATE.strftime("%-d %B %Y")
+        issues << Issue.new(:backdate_date, :too_long_ago, date: date)
+      end
+
       CheckerIssues.new(issues)
     end
 
@@ -22,6 +29,10 @@ module Requirements
 
     def in_the_future?
       backdate > Time.zone.today
+    end
+
+    def too_long_ago?
+      backdate < EARLIEST_DATE
     end
   end
 end

--- a/app/views/backdate/edit.html.erb
+++ b/app/views/backdate/edit.html.erb
@@ -26,17 +26,17 @@
           {
             name: "day",
             width: 2,
-            value: params.dig(:backdate, :day) || date&.day,
+            value: params.dig(:backdate, :date, :day) || date&.day,
           },
           {
             name: "month",
             width: 2,
-            value: params.dig(:backdate, :month) || date&.month,
+            value: params.dig(:backdate, :date, :month) || date&.month,
           },
           {
             name: "year",
             width: 4,
-            value: params.dig(:backdate, :year) || date&.year,
+            value: params.dig(:backdate, :date, :year) || date&.year,
           }
         ]
       } %>

--- a/config/locales/en/requirements.yml
+++ b/config/locales/en/requirements.yml
@@ -109,6 +109,8 @@ en:
         form_message: Enter a date in the past
       invalid:
         form_message: Enter a valid date
+      too_long_ago:
+        form_message: Enter a date from %{date} onwards
     document_type:
       not_selected:
         form_message: Select an option

--- a/spec/services/requirements/backdate_checker_spec.rb
+++ b/spec/services/requirements/backdate_checker_spec.rb
@@ -17,5 +17,17 @@ RSpec.describe Requirements::BackdateChecker do
       expect(issues.items_for(:backdate_date))
         .to include(a_hash_including(text: future_date_issue))
     end
+
+    it "returns an issue if the date is too long ago" do
+      earliest_date = Requirements::BackdateChecker::EARLIEST_DATE
+      issues = Requirements::BackdateChecker.new(earliest_date - 1).pre_submit_issues
+      distant_past_issue = I18n.t!(
+        "requirements.backdate_date.too_long_ago.form_message",
+        date: earliest_date.strftime("%-d %B %Y"),
+      )
+
+      expect(issues.items_for(:backdate_date))
+        .to include(a_hash_including(text: distant_past_issue))
+    end
   end
 end


### PR DESCRIPTION
For https://trello.com/c/aBHXR82t/932-user-can-backdate-or-set-document-as-new

This ensures that users can't backdate content to a date that is unreasonably
far in the past.

<img width="995" alt="Screen Shot 2019-06-20 at 15 57 23" src="https://user-images.githubusercontent.com/13434452/59859231-45ea8e80-9374-11e9-95e9-feb96db77f7a.png">
