### PR TITLE
This adds a spec for the PublishMailer

### DIFF
--- a/spec/features/workflow/publish_spec.rb
+++ b/spec/features/workflow/publish_spec.rb
@@ -3,7 +3,7 @@
 RSpec.feature "Publishing an edition" do
   include ActiveSupport::Testing::TimeHelpers
 
-  scenario "first edition" do
+  scenario do
     given_there_is_an_edition_in_draft
     when_i_visit_the_summary_page
     and_i_publish_the_edition
@@ -11,20 +11,6 @@ RSpec.feature "Publishing an edition" do
     and_the_content_is_shown_as_published
     and_there_is_a_history_entry
     and_i_receive_a_confirmation_email
-  end
-
-  scenario "major change" do
-    given_there_is_a_major_change_to_a_live_edition
-    when_i_visit_the_summary_page
-    and_i_publish_the_edition
-    then_i_receive_an_email_about_the_major_change
-  end
-
-  scenario "minor change" do
-    given_there_is_a_minor_change_to_a_live_edition
-    when_i_visit_the_summary_page
-    and_i_publish_the_edition
-    then_i_receive_an_email_about_the_minor_change
   end
 
   def given_there_is_a_major_change_to_a_live_edition
@@ -96,27 +82,5 @@ RSpec.feature "Publishing an edition" do
                                            time: publish_time,
                                            date: publish_date,
                                            user: publish_user))
-  end
-
-  def then_i_receive_an_email_about_the_major_change
-    message = ActionMailer::Base.deliveries.first
-
-    publish_time = @publish_date.strftime("%l:%M%P").strip
-    publish_date = @publish_date.strftime("%d %B %Y")
-    publish_user = current_user.name
-    expect(message.body).to include(@edition.change_note)
-
-    expect(message.subject).to eq(I18n.t("publish_mailer.publish_email.subject.update",
-                                         title: @edition.title))
-
-    expect(message.body).to include(I18n.t("publish_mailer.publish_email.details.update",
-                                           time: publish_time,
-                                           date: publish_date,
-                                           user: publish_user))
-  end
-
-  def then_i_receive_an_email_about_the_minor_change
-    message = ActionMailer::Base.deliveries.first
-    expect(message.body).to include(I18n.t!("publish_mailer.publish_email.minor_update"))
   end
 end

--- a/spec/mailers/publish_mailer_spec.rb
+++ b/spec/mailers/publish_mailer_spec.rb
@@ -1,0 +1,91 @@
+# frozen_string_literal: true
+
+RSpec.describe PublishMailer do
+  let(:recipient) { build(:user) }
+
+  describe "#publish_email" do
+    it "creates an email for the user" do
+      edition = build(:edition, :published, base_path: "/news/some-great-news")
+
+      mail = PublishMailer.publish_email(recipient, edition, edition.status)
+      mail_subject = I18n.t!("publish_mailer.publish_email.subject.published",
+                             title: edition.title)
+
+      expect(mail.to).to eq([recipient.email])
+      expect(mail.subject).to eq(mail_subject)
+      expect(mail.body.to_s).to include("https://www.test.gov.uk/news/some-great-news")
+      expect(mail.body.to_s).to include(document_path(edition.document))
+    end
+
+    it "includes when the edition was published" do
+      edition = build(:edition,
+                      :published,
+                      published_at: Time.zone.parse("2019-06-17 9:00"))
+
+      mail = PublishMailer.publish_email(recipient, edition, edition.status)
+      publish_time = I18n.t!("publish_mailer.publish_email.details.publish",
+                             date: "17 June 2019",
+                             time: "9:00am",
+                             user: recipient.name)
+
+      expect(mail.body.to_s).to include(publish_time)
+    end
+
+    context "when the edition published needs 2i review" do
+      it "informs recipients" do
+        edition = build(:edition, :published, state: :published_but_needs_2i)
+
+        mail = PublishMailer.publish_email(recipient, edition, edition.status)
+
+        review_notice = I18n.t!("publish_mailer.publish_email.2i_warning")
+        expect(mail.body.to_s).to include(review_notice)
+      end
+    end
+
+    context "when a subsequent edition is published" do
+      it "includes when the edition was updated" do
+        edition = build(:edition,
+                        :published,
+                        number: 2,
+                        published_at: Time.zone.parse("2019-06-17 23:00"))
+
+        mail = PublishMailer.publish_email(recipient, edition, edition.status)
+        update_text = I18n.t!("publish_mailer.publish_email.details.update",
+                              date: "17 June 2019",
+                              time: "11:00pm",
+                              user: recipient.name)
+        mail_subject = I18n.t!("publish_mailer.publish_email.subject.update",
+                               title: edition.title)
+
+        expect(mail.subject).to eq(mail_subject)
+        expect(mail.body.to_s).to include(update_text)
+      end
+
+      it "includes the change note for a major change" do
+        edition = build(:edition,
+                        :published,
+                        number: 2,
+                        update_type: "major",
+                        change_note: "Massive sweeping change")
+
+        mail = PublishMailer.publish_email(recipient, edition, edition.status)
+
+        expect(mail.body.to_s).to include("Massive sweeping change")
+      end
+
+      it "has a generic change note for a minor change" do
+        edition = build(:edition,
+                        :published,
+                        number: 2,
+                        update_type: "minor",
+                        change_note: "Tiny change")
+
+        mail = PublishMailer.publish_email(recipient, edition, edition.status)
+
+        expect(mail.body.to_s).not_to include("Tiny change")
+        expect(mail.body.to_s)
+          .to include(I18n.t!("publish_mailer.publish_email.minor_update"))
+      end
+    end
+  end
+end


### PR DESCRIPTION
As the ScheduledPublishMailer needs a mailer spec, we thought it would
be a good idea to include a PublishMailer spec. This also means we can
make the feature for publishing simpler by removing alternative publishing
scenarios which actually only tested the different variations of the
email (now covered by the tests in the publish_mailer_spec).

Trello:
https://trello.com/c/uC28c63Y/949-tie-up-scheduling-loose-ends