### PR TITLE
Enhance input element rather than select for time input

### DIFF
--- a/app/assets/javascripts/components/autocomplete.js
+++ b/app/assets/javascripts/components/autocomplete.js
@@ -9,24 +9,21 @@ window.GOVUK.Modules = window.GOVUK.Modules || {};
     this.$module = $module[0]
     var type = this.$module.dataset.autocompleteType
 
+    var $select = this.$module.querySelector('select')
+    var $input = this.$module.querySelector('input')
+
     if (type === 'with-hint-on-options') {
       this.initAutoCompleteWithHintOnOptions()
-    } else if (type === 'without-narrowing-results') {
-      this.initAutoCompleteWithoutNarrowingResults()
     } else if (type === 'topics') {
       this.initAutoCompleteSearchTopics()
-    } else {
-      this.initAutoComplete()
+    } else if ($select) {
+      this.initAutoCompleteSelect($select)
+    } else if ($input) {
+      this.initAutoCompleteInput($input)
     }
   }
 
-  Autocomplete.prototype.initAutoComplete = function () {
-    var $select = this.$module.querySelector('select')
-
-    if (!$select) {
-      return
-    }
-
+  Autocomplete.prototype.initAutoCompleteSelect = function ($select) {
     // disabled eslint because we can not control the name of the constructor (expected to be EnhanceSelectElement)
     new window.accessibleAutocomplete.enhanceSelectElement({ // eslint-disable-line no-new, new-cap
       selectElement: $select,
@@ -88,51 +85,44 @@ window.GOVUK.Modules = window.GOVUK.Modules || {};
     $select.id = $select.id + '-select'
   }
 
-  Autocomplete.prototype.initAutoCompleteWithoutNarrowingResults = function () {
-    // Read options and associated data attributes and feed that as results for inputValueTemplate
-    var $select = this.$module.querySelector('select')
+  Autocomplete.prototype.initAutoCompleteInput = function ($input) {
+    var withoutNarrowingResults = this.$module.dataset.autocompleteWithoutNarrowingResults
 
-    if (!$select) {
+    var list = document.getElementById($input.getAttribute('list'))
+    var options = []
+
+    if (list) {
+      options = [].map.call(list.querySelectorAll('option'), function (option) {
+        return option.value
+      })
+    }
+
+    if (!options.length) {
       return
     }
 
-    var $options = $select.querySelectorAll('option')
-    var $selectedOption = $select.querySelector('option[selected]')
-    if (!$selectedOption) {
-      $selectedOption = $options[0]
-    }
-    var defaultValue = this.$module.dataset.initialValue || $selectedOption.textContent
-
     new window.accessibleAutocomplete({ // eslint-disable-line no-new, new-cap
-      id: $select.id,
-      name: $select.name,
+      id: $input.id,
+      name: $input.name,
       element: this.$module,
-      showAllValues: true,
-      defaultValue: defaultValue,
-      autoselect: false,
-      dropdownArrow: function (config) {
-        return '<svg class="' + config.className + '" style="top: 8px;" viewBox="0 0 512 512" ><path d="M256,298.3L256,298.3L256,298.3l174.2-167.2c4.3-4.2,11.4-4.1,15.8,0.2l30.6,29.9c4.4,4.3,4.5,11.3,0.2,15.5L264.1,380.9  c-2.2,2.2-5.2,3.2-8.1,3c-3,0.1-5.9-0.9-8.1-3L35.2,176.7c-4.3-4.2-4.2-11.2,0.2-15.5L66,131.3c4.4-4.3,11.5-4.4,15.8-0.2L256,298.3  z"/></svg>'
-      },
+      showAllValues: withoutNarrowingResults,
+      defaultValue: $input.value,
+      autoselect: !withoutNarrowingResults,
+      dropdownArrow: withoutNarrowingResults ? this.dropdownArrow : null,
       source: function (query, syncResults) {
-        var results = []
-        $options.forEach(function ($el) {
-          results.push($el.textContent)
-        })
-        syncResults(results)
-      },
-      onConfirm: function (result) {
-        var value = result && result.value
-        var options = [].filter.call($options, function (option) {
-          return option.value === value
-        })
-
-        if (options.length) {
-          options[0].selected = true
+        if (withoutNarrowingResults) {
+          syncResults(options)
+        } else {
+          syncResults(query
+            ? options.filter(function (option) {
+              return option.toLowerCase().indexOf(query.toLowerCase()) !== -1
+            }) : []
+          )
         }
       }
     })
 
-    $select.parentNode.removeChild($select)
+    $input.parentNode.removeChild($input)
   }
 
   Autocomplete.prototype.initAutoCompleteSearchTopics = function () {
@@ -198,6 +188,10 @@ window.GOVUK.Modules = window.GOVUK.Modules || {};
     })
 
     $input.parentNode.parentNode.removeChild($input.parentNode)
+  }
+
+  Autocomplete.prototype.dropdownArrow = function (config) {
+    return '<svg class="' + config.className + '" style="top: 8px;" viewBox="0 0 512 512" ><path d="M256,298.3L256,298.3L256,298.3l174.2-167.2c4.3-4.2,11.4-4.1,15.8,0.2l30.6,29.9c4.4,4.3,4.5,11.3,0.2,15.5L264.1,380.9  c-2.2,2.2-5.2,3.2-8.1,3c-3,0.1-5.9-0.9-8.1-3L35.2,176.7c-4.3-4.2-4.2-11.2,0.2-15.5L66,131.3c4.4-4.3,11.5-4.4,15.8-0.2L256,298.3  z"/></svg>'
   }
 
   Modules.Autocomplete = Autocomplete

--- a/app/helpers/time_options_helper.rb
+++ b/app/helpers/time_options_helper.rb
@@ -1,23 +1,13 @@
 # frozen_string_literal: true
 
 module TimeOptionsHelper
-  def time_options(additional_time = nil)
-    match = additional_time&.match(%r{\A(?<hour>\d{1,2}):(?<minute>\d{1,2})(?<period>(am|pm))\Z})
-
+  def time_options
     %w[am pm].flat_map do |period|
       hours = [12] + (1..11).to_a
       hours.flat_map do |hour|
-        intervals = if hour == 12 && period == "am"
-                      ["12:01am", "12:30am"]
-                    else
-                      ["#{hour}:00#{period}", "#{hour}:30#{period}"]
-                    end
+        next ["12:01am", "12:30am"] if hour == 12 && period == "am"
 
-        if match && match[:hour].to_i == hour && match[:period] == period
-          intervals << additional_time
-        end
-
-        intervals.uniq.sort
+        ["#{hour}:00#{period}", "#{hour}:30#{period}"]
       end
     end
   end

--- a/app/views/components/_autocomplete.html.erb
+++ b/app/views/components/_autocomplete.html.erb
@@ -1,17 +1,15 @@
 <%
   id ||= "autocomplete-#{SecureRandom.hex(4)}"
-  options ||= []
-  selected_options ||= []
-  multiple ||= nil
   type ||= nil
-  size ||= nil
   error_id = "error-#{SecureRandom.hex(4)}"
   error_items ||= []
   hint ||= nil
   width ||= nil
-  search ||= nil
   aria = error_id if error_items.any?
   data_attributes ||= {}
+  select ||= {}
+  input ||= {}
+  search ||= false
 
   root_classes = %w(app-c-autocomplete govuk-form-group)
   root_classes << "app-c-autocomplete--#{width}" if width
@@ -33,27 +31,38 @@
       } %>
     <% end %>
 
-    <% if options.any? %>
-      <%= tag.span "To select multiple items in a list, hold down Ctrl (PC) or Command (Mac) key.", class: "govuk-hint app-c-autocomplete__multiselect-instructions" if multiple %>
+    <%= tag.span hint, class: "govuk-hint" if hint %>
 
-      <%= tag.span hint, class: "govuk-hint" if hint %>
+    <% if select.any? %>
+      <% if select[:multiple] %>
+        <%= tag.span "To select multiple items in a list, hold down Ctrl (PC) or Command (Mac) key.",
+                     class: "govuk-hint app-c-autocomplete__multiselect-instructions" %>
+      <% end %>
 
       <%= select_tag name,
-        options_for_select(options, selected_options),
+        options_for_select(select[:options], select[:selected]),
         id: id,
         class: "govuk-select",
-        size: size,
-        multiple: multiple
+        size: select[:size],
+        multiple: select[:multiple]
       %>
     <% else %>
-      <%= tag.p "No options available", class: "govuk-hint" if multiple %>
+      <% options = Array(input[:options]) %>
 
-      <%= render "govuk_publishing_components/components/input", {
-        id: id,
-        name: name,
-        type: "search",
-        search_icon: true
-      } if search %>
+      <%= tag.input name: name,
+                    value: input[:value],
+                    class: "govuk-input",
+                    id: id,
+                    list: options.any? ? "#{id}-list" : nil,
+                    type: search ? "search" : "text" %>
+
+      <% if options.any? %>
+        <%= tag.datalist id: "#{id}-list" do %>
+          <% options.each do |option| %>
+            <%= tag.option(value: option) %>
+          <% end %>
+        <% end %>
+      <% end %>
     <% end %>
   <% end %>
 <% end %>

--- a/app/views/components/docs/autocomplete.yml
+++ b/app/views/components/docs/autocomplete.yml
@@ -1,7 +1,9 @@
 name: Autocomplete
 description: An autocomplete component, built to be accessible
 body: |
-  This component is build using [Accessible Autocomplete](https://github.com/alphagov/accessible-autocomplete)
+  This component is build using [Accessible Autocomplete](https://github.com/alphagov/accessible-autocomplete).
+
+  Typically it is used to enhance a select element with autocomplete options.
 part_of_admin_layout: true
 accessibility_criteria: |
   [Accessibility acceptance criteria](https://github.com/alphagov/accessible-autocomplete/blob/master/accessibility-criteria.md)
@@ -12,18 +14,19 @@ examples:
       name: autocomplete
       label:
         text: Select your country
-      options:
-        -
+      select:
+        options:
           -
-        -
-          - France
-          - fr
-        -
-          - Germany
-          - de
-        -
-          - United Kingdom
-          - uk
+            -
+          -
+            - France
+            - fr
+          -
+            - Germany
+            - de
+          -
+            - United Kingdom
+            - uk
 
   with_selected_value:
     data:
@@ -31,171 +34,155 @@ examples:
       name: autocomplete-selected
       label:
         text: Select your country
-      options:
-        -
-          - France
-          - fr
-        -
-          - Germany
-          - de
-        -
-          - United Kingdom
-          - uk
-      selected_options:
-          - de
+        bold: true
+      hint: Only a few countries are available
+      select:
+        options:
+          -
+            - France
+            - fr
+          -
+            - Germany
+            - de
+          -
+            - United Kingdom
+            - uk
+        selected: de
 
   with_error:
     data:
       name: autocomplete-with-error
       label:
         text: Autocomplete with error
-      options:
-        -
-          - France
-          - fr
-        -
-          - Germany
-          - de
-        -
-          - United Kingdom
-          - uk
+      select:
+        options:
+          -
+            - France
+            - fr
+          -
+            - Germany
+            - de
+          -
+            - United Kingdom
+            - uk
       error_items:
         - text: There is a problem with this input
 
-  multiselect:
+  select_multiple:
     data:
       id: autocomplete-multiselect
       name: autocomplete-multiselect
       label:
         text: Select your country
-      multiple: true
-      options:
-        -
-          - France
-          - fr
-        -
-          - Germany
-          - de
-        -
-          - United Kingdom
-          - uk
+      select:
+        multiple: true
+        options:
+          -
+            - France
+            - fr
+          -
+            - Germany
+            - de
+          -
+            - United Kingdom
+            - uk
+        selected:
+            - fr
+            - de
 
-  multiselect_with_selected_values:
+  autocomplete_narrow_width:
     data:
-      id: autocomplete-multiselect-selected
-      name: autocomplete-multiselect-selected
+      id: autocomplete-narrow
+      name: autocomplete-narrow
       label:
-        text: Select your country
-      multiple: true
-      options:
-        -
-          - France
-          - fr
-        -
-          - Germany
-          - de
-        -
-          - United Kingdom
-          - uk
-      selected_options:
-          - fr
-          - de
+        text: Status
+      width: narrow
+      select:
+        options:
+          -
+            - Draft
+          -
+            - Published
+          -
+            - Removed
+
   autocomplete_with_hint_on_options:
+    description: |
+      Used to enhance a select element. A data attribute on each option provides
+      a second piece of information, which is also matched against user input.
     data:
       id: autocomplete-with-hint-on-options
       name: autocomplete-with-hint-on-options
       type: with-hint-on-options
       label:
         text: Select your country
-      options:
-        -
+      select:
+        options:
           -
-        -
+            - ""
+          -
+            - France
+            - fr
+            - data-hint: Paris
+          -
+            - United Arab Emirates
+            - uae
+            - data-hint: Abu Dhabi
+          -
+            - United Kingdom
+            - uk
+            - data-hint: London
+
+  autocomplete_input:
+    description: |
+      An enhancement to an input element. Options are provided via a datalist.
+      A user can enter a value outside the list of options.
+    data:
+      id: autocomplete-input
+      name: autocomplete-input
+      label:
+        text: Select your country
+      input:
+        value: France
+        options:
           - France
-          - fr
-          - data-hint: Paris
-        -
           - United Arab Emirates
-          - uae
-          - data-hint: Abu Dhabi
-        -
           - United Kingdom
-          - uk
-          - data-hint: London
+
   autocomplete_without_narrowing_results:
+    description: |
+      An enhancement to an input element. All options (provided by a datalist)
+      are shown whenever the input is focused. A user can enter a value outside
+      the list of options.
     data:
       id: autocomplete-without-narrowing-results
       name: autocomplete-without-narrowing-results
-      type: without-narrowing-results
-      label:
-        text: Select your country
-      options:
-        -
-          - France
-          - fr
-        -
-          - United Arab Emirates
-          - uae
-        -
-          - United Kingdom
-          - uk
-  autocomplete_narrow_width:
-    data:
-      id: autocomplete-narrow
-      name: autocomplete-narrow
-      type: without-narrowing-results
-      label:
-        text: Status
-      width: narrow
-      options:
-        -
-          - Draft
-        -
-          - Published
-        -
-          - Removed
-  autocomplete_without_narrowing_results_and_initial_value:
-    description: |
-      This is used to display a value that a user has entered erroneously
-      without altering the underlying select. This only makes sense for the
-      without narrowing results variant as this removes the select element.
-    data:
-      id: autocomplete-with-initial-value
-      name: autocomplete-with-initial-value
-      type: without-narrowing-results
-      label:
-        text: Select your country
       data_attributes:
-        initial_value: "Invalid Country"
-      options:
-        -
+        autocomplete-without-narrowing-results: true
+      label:
+        text: Select your country
+        bold: true
+      hint: The full list will show when you interact with the input
+      input:
+        value: France
+        options:
           - France
-          - fr
-        -
           - United Arab Emirates
-          - uae
-        -
           - United Kingdom
-          - uk
+
   autocomplete_search:
     description: |
-      This is used to display an autocomplete with a search input
+      This is used to style the autocomplete as a search. If applied to an
+      input element the underlying input is rendered with type "search" rather
+      than "text".
     data:
       id: autocomplete-search
       name: autocomplete-search
       label:
         text: Search
-      data_module: autocomplete
       search: true
-      options:
-        -
-          -
-        -
+      input:
+        options:
           - France
-          - fr
-        -
           - Germany
-          - de
-        -
           - United Kingdom
-          - uk

--- a/app/views/contacts/search.html.erb
+++ b/app/views/contacts/search.html.erb
@@ -19,8 +19,11 @@
       text: %{<h1 class="govuk-heading-l">#{t("contacts.search.title")}</h1>}.html_safe,
     },
     id: "contact-id",
-    options: [["", ""]] + contact_options,
-    type: "with-hint-on-options"
+    select: {
+      options: [""] + contact_options,
+    },
+    type: "with-hint-on-options",
+    search: true,
   } %>
 
   <%= render "govuk_publishing_components/components/button", {

--- a/app/views/schedule/_datetime.html.erb
+++ b/app/views/schedule/_datetime.html.erb
@@ -1,7 +1,5 @@
 <%
   publish_time ||= Time.current.tomorrow.change(hour: 9)
-  persistent_time = publish_time.strftime("%-l:%M%P")
-  selected_time = params.dig(:schedule, :time) || persistent_time
 %>
 
 <% legend = capture do %>
@@ -35,7 +33,6 @@
   ]
 } %>
 
-
 <%= render "components/autocomplete", {
   id: "time",
   name: "schedule[time]",
@@ -44,12 +41,12 @@
     bold: true,
   },
   error_items: issues&.items_for(:schedule_time),
-  options: time_options(persistent_time),
-  selected_options: [persistent_time],
-  data_attributes: {
-    initial_value: selected_time,
+  input: {
+    value: params.dig(:schedule, :time) || publish_time.strftime("%-l:%M%P"),
+    options: time_options,
   },
-  type: "without-narrowing-results",
-  size: 5,
+  data_attributes: {
+    "autocomplete-without-narrowing-results": true,
+  },
   width: "narrow",
 } %>

--- a/app/views/tags/tags/_multi_tag_input.html.erb
+++ b/app/views/tags/tags/_multi_tag_input.html.erb
@@ -6,9 +6,11 @@
     bold: true
   },
   hint: tag_field.hint,
-  options: LinkablesService.new(tag_field.document_type).select_options,
-  selected_options: tags[tag_field.id],
+  select: {
+    options: LinkablesService.new(tag_field.document_type).select_options,
+    selected: tags[tag_field.id],
+    multiple: true,
+    size: 10,
+  },
   error_items: issues&.items_for(tag_field.id.to_sym),
-  multiple: true,
-  size: 10,
 } %>

--- a/app/views/tags/tags/_single_tag_input.html.erb
+++ b/app/views/tags/tags/_single_tag_input.html.erb
@@ -6,7 +6,9 @@
     bold: true,
   },
   hint: tag_field.hint,
-  options: [""] + LinkablesService.new(tag_field.document_type).select_options,
-  selected_options: tags[tag_field.id],
+  select: {
+    options: [""] + LinkablesService.new(tag_field.document_type).select_options,
+    selected: tags[tag_field.id],
+  },
   error_items: issues&.items_for(tag_field.id.to_sym),
 } %>

--- a/spec/features/scheduling/propose_publish_time_and_schedule_spec.rb
+++ b/spec/features/scheduling/propose_publish_time_and_schedule_spec.rb
@@ -30,7 +30,7 @@ RSpec.feature "Propose publish time and schedule" do
     fill_in "schedule[date][day]", with: "20"
     fill_in "schedule[date][month]", with: "8"
     fill_in "schedule[date][year]", with: "2019"
-    select "3:30pm", from: "schedule[time]"
+    fill_in "schedule[time]", with: "3:30pm"
   end
 
   def and_i_select_schedule_to_publish

--- a/spec/features/scheduling/propose_publish_time_requirements_spec.rb
+++ b/spec/features/scheduling/propose_publish_time_requirements_spec.rb
@@ -39,7 +39,7 @@ RSpec.feature "Propose publish time with requirements issues" do
     fill_in "schedule[date][day]", with: date.day
     fill_in "schedule[date][month]", with: date.month
     fill_in "schedule[date][year]", with: date.year
-    select "11:00pm", from: "schedule[time]"
+    fill_in "schedule[time]", with: "11:00pm"
     click_on "Continue"
   end
 

--- a/spec/features/scheduling/update_proposed_publish_time_spec.rb
+++ b/spec/features/scheduling/update_proposed_publish_time_spec.rb
@@ -41,7 +41,7 @@ RSpec.feature "Update proposed publish time" do
     fill_in "schedule[date][day]", with: "15"
     fill_in "schedule[date][month]", with: "6"
     fill_in "schedule[date][year]", with: "2019"
-    select "11:00pm", from: "schedule[time]"
+    fill_in "schedule[time]", with: "11:00pm"
     click_on "Save date"
   end
 

--- a/spec/features/scheduling/update_publish_time_requirements_spec.rb
+++ b/spec/features/scheduling/update_publish_time_requirements_spec.rb
@@ -39,7 +39,7 @@ RSpec.feature "Update publish time with requirements issues" do
     fill_in "schedule[date][day]", with: date.day
     fill_in "schedule[date][month]", with: date.month
     fill_in "schedule[date][year]", with: date.year
-    select "11:00pm", from: "schedule[time]"
+    fill_in "schedule[time]", with: "11:00pm"
     click_on "Save date"
   end
 

--- a/spec/features/scheduling/update_publish_time_spec.rb
+++ b/spec/features/scheduling/update_publish_time_spec.rb
@@ -42,7 +42,7 @@ RSpec.feature "Update publish time" do
     fill_in "schedule[date][day]", with: "15"
     fill_in "schedule[date][month]", with: "8"
     fill_in "schedule[date][year]", with: "2019"
-    select "11:00pm", from: "schedule[time]"
+    fill_in "schedule[time]", with: "11:00pm"
 
     click_on "Save date"
   end


### PR DESCRIPTION
Trello: https://trello.com/c/uC28c63Y/949-tie-up-scheduling-loose-ends

This refactors the autocomplete component to allow initialising based off on an input or a select element. See commits for further details.