### PR TITLE
Add/update analytics attributes for scheduling

### DIFF
--- a/app/helpers/actions_helper.rb
+++ b/app/helpers/actions_helper.rb
@@ -42,13 +42,13 @@ module ActionsHelper
     link_to "Schedule",
             new_schedule_path(edition.document),
             class: %w(govuk-link govuk-link--no-visited-state) + Array(extra_classes),
-            data: { gtm: "schedule-confirm" }
+            data: { gtm: "schedule" }
   end
 
   def schedule_button(edition)
     render "govuk_publishing_components/components/button",
            text: "Schedule to publish",
-           data_attributes: { gtm: "schedule-confirm" },
+           data_attributes: { gtm: "schedule" },
            href: new_schedule_path(edition.document)
   end
 
@@ -56,7 +56,7 @@ module ActionsHelper
     link_to "Schedule",
             schedule_proposal_path(edition.document, wizard: "schedule"),
             class: %w(govuk-link govuk-link--no-visited-state) + Array(extra_classes),
-            data: { gtm: "schedule-date" }
+            data: { gtm: "propose-schedule" }
   end
 
   def publish_link(edition)

--- a/app/views/documents/show/_proposed_scheduling_notice.html.erb
+++ b/app/views/documents/show/_proposed_scheduling_notice.html.erb
@@ -11,7 +11,8 @@
 
   <%= link_to "Change date",
               schedule_proposal_path(@edition.document),
-              class: "govuk-link govuk-link--no-visited-state" %>
+              class: "govuk-link govuk-link--no-visited-state",
+              data: { gtm: "change-proposed-schedule" } %>
 <% end %>
 
 <% if issues.any? %>
@@ -19,6 +20,11 @@
     title: issues.items(style: "summary").first[:text],
     description: proposed_scheduling_description,
     margin_bottom: 4,
+    data_attributes: {
+      gtm: "pre-schedule-issues",
+      "gtm-action": issues.items(style: "summary").first[:text],
+      "gtm-visibility-tracking": true
+    }
   } %>
 <% else %>
   <%= render "govuk_publishing_components/components/notice", {

--- a/app/views/documents/show/_scheduled_notice.html.erb
+++ b/app/views/documents/show/_scheduled_notice.html.erb
@@ -1,4 +1,5 @@
 <% publish_time = @edition.status.details.publish_time %>
+
 <% scheduled_description = capture do %>
   <p class="govuk-body govuk-!-margin-bottom-1">
     <%= t("documents.show.scheduled_notice.title",
@@ -10,7 +11,8 @@
     <li>
       <%= link_to "Change date",
                   edit_schedule_path(@edition.document),
-                  class: "govuk-link govuk-link--no-visited-state" %>
+                  class: "govuk-link govuk-link--no-visited-state",
+                  data: { gtm: "change-schedule" } %>
     </li>
     <li>
       <%= form_tag schedule_path(@edition.document),

--- a/app/views/schedule/edit.html.erb
+++ b/app/views/schedule/edit.html.erb
@@ -3,7 +3,7 @@
 
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
-    <%= form_tag edit_schedule_path(@edition.document) do %>
+    <%= form_tag edit_schedule_path(@edition.document), data: { gtm: "confirm-proposed-schedule" } do %>
       <%= hidden_field_tag(:wizard, params[:wizard]) %>
 
       <% scheduling = @edition.status.details %>

--- a/app/views/schedule/new.html.erb
+++ b/app/views/schedule/new.html.erb
@@ -12,7 +12,7 @@
 
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
-    <%= form_tag create_schedule_path(@edition.document) do %>
+    <%= form_tag create_schedule_path(@edition.document), data: { gtm: "confirm-schedule" } do %>
       <%= render_govspeak(t("schedule.new.hint_text", time: time, date: date)) %>
       <%= render "govuk_publishing_components/components/radio", {
         name: "review_status",
@@ -20,11 +20,19 @@
         items: [
           {
             value: "reviewed",
-            text: t("schedule.new.review_status.reviewed")
+            text: t("schedule.new.review_status.reviewed"),
+            data_attributes: {
+              gtm: "choose-schedule-publish-review-status",
+              "gtm-action": t("schedule.new.review_status.reviewed")
+            }
           },
           {
             value: "not_reviewed",
-            text: t("schedule.new.review_status.not_reviewed")
+            text: t("schedule.new.review_status.not_reviewed"),
+            data_attributes: {
+              gtm: "choose-schedule-publish-review-status",
+              "gtm-action": t("schedule.new.review_status.not_reviewed")
+            }
           },
         ]
       } %>

--- a/app/views/schedule/scheduled.html.erb
+++ b/app/views/schedule/scheduled.html.erb
@@ -11,9 +11,11 @@
     <%= render "govuk_publishing_components/components/panel", {
       title: t("schedule.scheduled.title")
     } %>
+
     <%= render "govuk_publishing_components/components/govspeak" do %>
       <%= govspeak_to_html t("schedule.scheduled.body_govspeak", title: @edition.title, time: time, date: date) %>
     <% end %>
+
     <%= render "govuk_publishing_components/components/inset_text", {
       text: strip_scheme_from_url(public_url)
     } %>

--- a/app/views/schedule_proposal/edit.html.erb
+++ b/app/views/schedule_proposal/edit.html.erb
@@ -3,7 +3,7 @@
 
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
-    <%= form_tag schedule_proposal_path(@edition.document) do %>
+    <%= form_tag schedule_proposal_path(@edition.document), data: { gtm: "confirm-schedule-proposal" } do %>
       <%= hidden_field_tag(:wizard, params[:wizard]) %>
 
       <%= render "schedule/datetime", {
@@ -21,11 +21,19 @@
               value: "save",
               text: t("schedule_proposal.edit.actions.save"),
               checked: params.dig(:schedule, :action) == "save",
+              data_attributes: {
+                gtm: "schedule-action",
+                "gtm-action": t("schedule_proposal.edit.actions.save")
+              }
             },
             {
               value: "schedule",
               text: t("schedule_proposal.edit.actions.schedule"),
               checked: params.dig(:schedule, :action) == "schedule",
+              data_attributes: {
+                gtm: "schedule-action",
+                "gtm-action": t("schedule_proposal.edit.actions.schedule")
+              }
             },
           ]
         } %>
@@ -43,7 +51,9 @@
     <% end %>
 
     <% if @edition.proposed_publish_time.present? %>
-      <%= form_tag schedule_proposal_path(@edition.document), method: :delete do %>
+      <%= form_tag schedule_proposal_path(@edition.document),
+          method: :delete,
+          data: { gtm: "clear-schedule-proposal" } do %>
         <button class="govuk-link app-link--button govuk-link--no-visited-state">Clear schedule date</button>
       <% end %>
     <% end %>

--- a/app/views/scheduled_publish_mailer/success_email.text.erb
+++ b/app/views/scheduled_publish_mailer/success_email.text.erb
@@ -34,4 +34,4 @@
 <% end -%>
 
 <%= t("scheduled_publish_mailer.success_email.edit_in_app") %>
-<%= document_url(@edition.document, utm_content: "publish-email-link") %>
+<%= document_url(@edition.document, utm_content: "scheduled-publish-email-link") %>


### PR DESCRIPTION
https://trello.com/c/fjVo0aK9/877-analytics-for-scheduling

This adds tracking for all scheduling actions to match the level of
tracking we have elsewhere in the app. One small piece of this is 
covered by https://github.com/alphagov/content-publisher/pull/1151.