### PR TITLE
Remove schedule action if preview not synced

### DIFF
--- a/app/views/documents/show/_actions.html.erb
+++ b/app/views/documents/show/_actions.html.erb
@@ -27,11 +27,6 @@
     <% elsif !@edition.revision_synced? %>
       <%= create_preview_button(@edition) %>
       <%= delete_draft_link(@edition) %>
-      <% if @edition.proposed_publish_time.present? && current_user.has_permission?(User::PRE_RELEASE_FEATURES_PERMISSION) %>
-        <%= schedule_link(@edition, "app-link--right") %>
-      <% elsif current_user.has_permission?(User::PRE_RELEASE_FEATURES_PERMISSION) %>
-        <%= schedule_proposal_link(@edition, "app-link--right") %>
-      <% end %>
     <% elsif @edition.withdrawn? %>
       <%= undo_withdraw_button(@edition) %>
     <% elsif @edition.scheduled? %>


### PR DESCRIPTION
https://trello.com/c/uC28c63Y/949-tie-up-scheduling-loose-ends

This should behave similarly to the lack of any 'Publish' action in this
scenario, with the slight downside that a user won't be able to propose
a schedule in this (hopefully unlikely) scenario.