### PR TITLE
More consistent app-side__action padding

### DIFF
--- a/app/assets/stylesheets/objects/_side.scss
+++ b/app/assets/stylesheets/objects/_side.scss
@@ -7,15 +7,17 @@
 }
 
 .app-side__actions {
-  @include govuk-responsive-margin(3, "bottom");
-
   .govuk-button {
     width: 100%;
     margin-bottom: govuk-spacing(3);
   }
 
-  .govuk-link {
-    margin-bottom: govuk-spacing(3);
+  > .govuk-button:last-child {
+    margin-bottom: 0;
+  }
+
+  > .app-side__form:last-child .govuk-button {
+    margin-bottom: 0;
   }
 
   .govuk-section-break {

--- a/app/helpers/actions_helper.rb
+++ b/app/helpers/actions_helper.rb
@@ -2,7 +2,9 @@
 
 module ActionsHelper
   def create_edition_button(edition, secondary: false)
-    form_tag create_edition_path(edition.document), data: { gtm: "create-new-edition" } do
+    form_tag create_edition_path(edition.document),
+             class: "app-side__form",
+             data: { gtm: "create-new-edition" } do
       render "govuk_publishing_components/components/button",
              text: "Create new edition",
              data_attributes: { gtm: "create-edition" },
@@ -81,19 +83,25 @@ module ActionsHelper
   end
 
   def create_preview_button(edition)
-    form_tag create_preview_path(edition.document), data: { gtm: "preview" } do
+    form_tag create_preview_path(edition.document),
+             class: "app-side__form",
+             data: { gtm: "preview" } do
       render "govuk_publishing_components/components/button", text: "Preview"
     end
   end
 
   def approve_button(edition)
-    form_tag approve_document_path(edition.document), data: { gtm: "approve" } do
+    form_tag approve_document_path(edition.document),
+             class: "app-side__form",
+             data: { gtm: "approve" } do
       render "govuk_publishing_components/components/button", text: "Approve"
     end
   end
 
   def submit_for_2i_button(edition)
-    form_tag submit_document_for_2i_path(edition.document), data: { gtm: "submit-for-2i" } do
+    form_tag submit_document_for_2i_path(edition.document),
+             class: "app-side__form",
+             data: { gtm: "submit-for-2i" } do
       render "govuk_publishing_components/components/button", text: "Submit for 2i review"
     end
   end


### PR DESCRIPTION
Trello: https://trello.com/c/uC28c63Y/949-tie-up-scheduling-loose-ends

This removes a persistent margin-bottom from app-side__actions box,
which doesn't seem to have a particular use and makes the padding on
this box bottom heavy.

To consistently make the padding even we need to remove the margins from
buttons when they are the last item in the actions. This can be
complicated because the buttons could be embedded in forms, which makes
the usage of :last-child tricky.

There is also a margin removed on .govuk-link elements which isn't
needed since it only has an effect when this is floated.

@alex-ju this all got a bit hairier than I'd have liked. You'll have to let me know if
I've made any CSS sins.

## Before:
<img width="979" alt="Screen Shot 2019-06-21 at 15 31 25" src="https://user-images.githubusercontent.com/282717/59934978-b1039600-9444-11e9-9701-2961440b1153.png">
<img width="974" alt="Screen Shot 2019-06-21 at 15 31 18" src="https://user-images.githubusercontent.com/282717/59934979-b19c2c80-9444-11e9-964c-e5636984c973.png">
<img width="973" alt="Screen Shot 2019-06-21 at 15 31 12" src="https://user-images.githubusercontent.com/282717/59934980-b19c2c80-9444-11e9-980e-5317ed2b5722.png">
<img width="977" alt="Screen Shot 2019-06-21 at 15 31 07" src="https://user-images.githubusercontent.com/282717/59934981-b19c2c80-9444-11e9-92da-93a3ca1ca366.png">
<img width="983" alt="Screen Shot 2019-06-21 at 15 31 01" src="https://user-images.githubusercontent.com/282717/59934982-b19c2c80-9444-11e9-912e-c7a474b15daa.png">

## After:

<img width="979" alt="Screen Shot 2019-06-21 at 16 21 49" src="https://user-images.githubusercontent.com/282717/59935020-c082df00-9444-11e9-9315-612d85310900.png">
<img width="982" alt="Screen Shot 2019-06-21 at 16 21 44" src="https://user-images.githubusercontent.com/282717/59935021-c11b7580-9444-11e9-8133-8097cfce7db9.png">
<img width="973" alt="Screen Shot 2019-06-21 at 16 21 36" src="https://user-images.githubusercontent.com/282717/59935022-c11b7580-9444-11e9-8a53-78019fd0e9a4.png">
<img width="985" alt="Screen Shot 2019-06-21 at 16 21 31" src="https://user-images.githubusercontent.com/282717/59935024-c11b7580-9444-11e9-9a4b-64b7f4370608.png">
<img width="989" alt="Screen Shot 2019-06-21 at 16 21 25" src="https://user-images.githubusercontent.com/282717/59935025-c1b40c00-9444-11e9-9fc9-ac0cde5b30e3.png">
