### PR TITLE
Rename action to value

### DIFF
--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -34,7 +34,7 @@ module ApplicationHelper
       issue_item.merge(
         data_attributes: {
           "gtm" => "requirements-issue",
-          "gtm-action" => issue_item[:text],
+          "gtm-value" => issue_item[:text],
           "gtm-visibility-tracking" => true,
         },
       )

--- a/app/views/components/_markdown_guidance.html.erb
+++ b/app/views/components/_markdown_guidance.html.erb
@@ -4,7 +4,7 @@
         data_attributes: { gtm: "markdown-guidance-details" },
         margin_bottom: 0
   } do %>
-    <div data-gtm="acronyms-guidance" data-gtm-action="Acronyms" data-gtm-visibility-tracking="true">
+    <div data-gtm="acronyms-guidance" data-gtm-value="Acronyms" data-gtm-visibility-tracking="true">
       <p>Definitions for acronyms that will appear if the user hovers the mouse over it.</p>
       <p>Add each definition in its own paragraph at the end of the body copy.</p>
       <pre class="app-c-markdown-guidance__code-snippet">
@@ -18,7 +18,7 @@
         data_attributes: { gtm: "markdown-guidance-details" },
         margin_bottom: 0
   } do %>
-    <div data-gtm="address-guidance" data-gtm-action="Addresses" data-gtm-visibility-tracking="true">
+    <div data-gtm="address-guidance" data-gtm-value="Addresses" data-gtm-visibility-tracking="true">
       <p>Use the Insert menu to look up and add a saved Contact address.</p>
       <p>Or you can add $A before and after an address to inset it.</p>
       <pre class="app-c-markdown-guidance__code-snippet">
@@ -35,7 +35,7 @@
         data_attributes: { gtm: "markdown-guidance-details" },
         margin_bottom: 0
   } do %>
-    <div data-gtm="call-to-action-guidance" data-gtm-action="Call to action" data-gtm-visibility-tracking="true">
+    <div data-gtm="call-to-action-guidance" data-gtm-value="Call to action" data-gtm-visibility-tracking="true">
       <p>Add $CTA before and after a paragraph to highlight an action for the user.</p>
       <pre class="app-c-markdown-guidance__code-snippet">
       $CTA
@@ -50,7 +50,7 @@
         data_attributes: { gtm: "markdown-guidance-details" },
         margin_bottom: 0
   } do %>
-    <div data-gtm="email-link-guidance" data-gtm-action="Email links" data-gtm-visibility-tracking="true">
+    <div data-gtm="email-link-guidance" data-gtm-value="Email links" data-gtm-visibility-tracking="true">
       <p>Select an email address and use the Link button to make a Mailto link.</p>
       <p>Or you can add < and > before and after an email address.</p>
       <pre class="app-c-markdown-guidance__code-snippet">
@@ -64,7 +64,7 @@
         data_attributes: { gtm: "markdown-guidance-details" },
         margin_bottom: 0
   } do %>
-    <div data-gtm="tables-guidance" data-gtm-action="Tables" data-gtm-visibility-tracking="true">
+    <div data-gtm="tables-guidance" data-gtm-value="Tables" data-gtm-visibility-tracking="true">
       <p>Add | to separate data into columns and put each row on a new line.</p>
       <pre class="app-c-markdown-guidance__code-snippet">
       Name | Colour | Number
@@ -88,7 +88,7 @@
         data_attributes: { gtm: "markdown-guidance-details" },
         margin_bottom: 0
   } do %>
-    <div data-gtm="bar-charts-guidance" data-gtm-action="Bar charts" data-gtm-visibility-tracking="true">
+    <div data-gtm="bar-charts-guidance" data-gtm-value="Bar charts" data-gtm-visibility-tracking="true">
       <p>Add {barchart} at the end of numeric tables to display a simple bar chart.</p>
       <pre class="app-c-markdown-guidance__code-snippet">
       Name | Number | Number

--- a/app/views/documents/index/_filters.html.erb
+++ b/app/views/documents/index/_filters.html.erb
@@ -10,7 +10,7 @@
     data: {
       gtm: "input-title-or-url",
       "gtm-visibility-tracking": true,
-      "gtm-action": params[:title_or_url],
+      "gtm-value": params[:title_or_url],
     }
   } %>
 
@@ -36,7 +36,7 @@
       data: {
         gtm: "select-organisation",
         "gtm-visibility-tracking": true,
-        "gtm-action": params[:organisation]
+        "gtm-value": params[:organisation]
       }
     %>
   </div>
@@ -72,7 +72,7 @@
       data: {
         gtm: "select-status",
         "gtm-visibility-tracking": true,
-        "gtm-action": params[:status],
+        "gtm-value": params[:status],
       }
     %>
   </div>
@@ -97,7 +97,7 @@
       data: {
         gtm: "select-document-type",
         "gtm-visibility-tracking": true,
-        "gtm-action": params[:document_type]
+        "gtm-value": params[:document_type]
       }
     %>
   </div>

--- a/app/views/documents/show/_proposed_scheduling_notice.html.erb
+++ b/app/views/documents/show/_proposed_scheduling_notice.html.erb
@@ -22,7 +22,7 @@
     margin_bottom: 4,
     data_attributes: {
       gtm: "pre-schedule-issues",
-      "gtm-action": issues.items(style: "summary").first[:text],
+      "gtm-value": issues.items(style: "summary").first[:text],
       "gtm-visibility-tracking": true
     }
   } %>

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -69,7 +69,7 @@
           message: flash["alert_with_description"].fetch("title"),
           data_attributes: {
             gtm: "alert-with-description",
-            "gtm-action" => flash["alert_with_description"]["title"],
+            "gtm-value" => flash["alert_with_description"]["title"],
             "gtm-visibility-tracking" => true
           },
           description: capture do

--- a/app/views/new_document/choose_document_type.html.erb
+++ b/app/views/new_document/choose_document_type.html.erb
@@ -14,7 +14,7 @@
             hint_text: document_type.description,
             data_attributes: {
               gtm: "choose-document-type",
-              "gtm-action": document_type.label,
+              "gtm-value": document_type.label,
             },
             conditional: document_type.hint ? tag.div(govspeak_to_html(document_type.hint_govspeak), class: "govuk-body") : nil,
             bold: true,

--- a/app/views/new_document/choose_supertype.html.erb
+++ b/app/views/new_document/choose_supertype.html.erb
@@ -18,7 +18,7 @@
             bold: true,
             data_attributes: {
               gtm: "choose-supertype",
-              "gtm-action": supertype.label,
+              "gtm-value": supertype.label,
             },
             conditional: supertype.hint ? tag.p(supertype.hint, class: "govuk-body") : nil,
           }

--- a/app/views/publish/confirmation.html.erb
+++ b/app/views/publish/confirmation.html.erb
@@ -13,7 +13,7 @@
             text: t("publish.confirmation.has_been_reviewed"),
             data_attributes: {
               gtm: "choose-publish-review-status",
-              "gtm-action": t("publish.confirmation.has_been_reviewed"),
+              "gtm-value": t("publish.confirmation.has_been_reviewed"),
             },
           },
           {
@@ -21,7 +21,7 @@
             text: t("publish.confirmation.should_be_reviewed"),
             data_attributes: {
               gtm: "choose-publish-review-status",
-              "gtm-action": t("publish.confirmation.should_be_reviewed"),
+              "gtm-value": t("publish.confirmation.should_be_reviewed"),
             },
           },
         ]

--- a/app/views/schedule/edit.html.erb
+++ b/app/views/schedule/edit.html.erb
@@ -3,7 +3,7 @@
 
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
-    <%= form_tag edit_schedule_path(@edition.document), data: { gtm: "confirm-proposed-schedule" } do %>
+    <%= form_tag edit_schedule_path(@edition.document), data: { gtm: "confirm-edit-schedule" } do %>
       <%= hidden_field_tag(:wizard, params[:wizard]) %>
 
       <% scheduling = @edition.status.details %>

--- a/app/views/schedule/new.html.erb
+++ b/app/views/schedule/new.html.erb
@@ -23,7 +23,7 @@
             text: t("schedule.new.review_status.reviewed"),
             data_attributes: {
               gtm: "choose-schedule-publish-review-status",
-              "gtm-action": t("schedule.new.review_status.reviewed")
+              "gtm-value": t("schedule.new.review_status.reviewed")
             }
           },
           {
@@ -31,7 +31,7 @@
             text: t("schedule.new.review_status.not_reviewed"),
             data_attributes: {
               gtm: "choose-schedule-publish-review-status",
-              "gtm-action": t("schedule.new.review_status.not_reviewed")
+              "gtm-value": t("schedule.new.review_status.not_reviewed")
             }
           },
         ]

--- a/app/views/schedule_proposal/edit.html.erb
+++ b/app/views/schedule_proposal/edit.html.erb
@@ -23,7 +23,7 @@
               checked: params.dig(:schedule, :action) == "save",
               data_attributes: {
                 gtm: "schedule-action",
-                "gtm-action": t("schedule_proposal.edit.actions.save")
+                "gtm-value": t("schedule_proposal.edit.actions.save")
               }
             },
             {
@@ -32,7 +32,7 @@
               checked: params.dig(:schedule, :action) == "schedule",
               data_attributes: {
                 gtm: "schedule-action",
-                "gtm-action": t("schedule_proposal.edit.actions.schedule")
+                "gtm-value": t("schedule_proposal.edit.actions.schedule")
               }
             },
           ]


### PR DESCRIPTION
https://trello.com/c/fjVo0aK9/877-analytics-for-scheduling

This renames the 'gtm-action' attribute to 'gtm-value' so it makes more sense, irrespective of the weird way we're using it in GTM ;-).