### PR TITLE
Only send filter events that have values

### DIFF
--- a/app/views/documents/index/_filters.html.erb
+++ b/app/views/documents/index/_filters.html.erb
@@ -9,7 +9,7 @@
     type: "search",
     data: {
       gtm: "input-title-or-url",
-      "gtm-visibility-tracking": true,
+      "gtm-visibility-tracking": params[:title_or_url].present?,
       "gtm-value": params[:title_or_url],
     }
   } %>
@@ -35,7 +35,7 @@
       class: "govuk-select",
       data: {
         gtm: "select-organisation",
-        "gtm-visibility-tracking": true,
+        "gtm-visibility-tracking": params[:organisation].present?,
         "gtm-value": params[:organisation]
       }
     %>
@@ -71,7 +71,7 @@
       class: "govuk-select",
       data: {
         gtm: "select-status",
-        "gtm-visibility-tracking": true,
+        "gtm-visibility-tracking": params[:status].present?,
         "gtm-value": params[:status],
       }
     %>
@@ -96,7 +96,7 @@
       class: "govuk-select",
       data: {
         gtm: "select-document-type",
-        "gtm-visibility-tracking": true,
+        "gtm-visibility-tracking": params[:document_type].present?,
         "gtm-value": params[:document_type]
       }
     %>


### PR DESCRIPTION
https://trello.com/c/B9rVHJTh/876-audit-and-fix-gtm-ga-issues

Previously we dispatched visibility events for all filters on the index
page, but then applied a selector in GTM to only really trigger if the
'data-gtm-action' attribute was set. As we start to use this attribute
for other elements, it's become normal to fire visibility events without
an associated 'action' e.g. for guidance. This pushes the special case
behaviour for these four elements into the codebase, using a question
method to determine if each has a 'value' and thus if we want to track.