### PR TITLE
Send public_updated_at to Publishing API

### DIFF
--- a/app/services/publishing_api_payload.rb
+++ b/app/services/publishing_api_payload.rb
@@ -34,7 +34,12 @@ class PublishingApiPayload
       },
     }
     payload["change_note"] = edition.change_note if edition.major?
-    payload["first_published_at"] = edition.backdated_to if edition.backdated_to
+
+    if edition.backdated_to.present?
+      payload["first_published_at"] = edition.backdated_to
+      payload["public_updated_at"] = edition.backdated_to if edition.first?
+    end
+
     payload
   end
 

--- a/spec/services/publishing_api_payload_spec.rb
+++ b/spec/services/publishing_api_payload_spec.rb
@@ -174,5 +174,14 @@ RSpec.describe PublishingApiPayload do
 
       expect(payload).to match a_hash_including("first_published_at" => date)
     end
+
+    it "include public_updated_at if the edition has backdated_to and is a first edition" do
+      date = Time.current.yesterday
+      revision = build(:revision, backdated_to: date)
+      edition = create(:edition, revision: revision, number: 1)
+      payload = PublishingApiPayload.new(edition).payload
+
+      expect(payload).to match a_hash_including("public_updated_at" => date)
+    end
   end
 end


### PR DESCRIPTION
For https://trello.com/c/x6ImOUSP/918-create-a-form-so-user-can-save-the-backdate-for-their-content

We send `public_updated_at` to the Publishing API when a user backdates content. This only applies to the first edition as users currently can only backdate first editions.