### PR TITLE
Fix tracking attributes on email links

### DIFF
--- a/app/views/publish_mailer/publish_email.text.erb
+++ b/app/views/publish_mailer/publish_email.text.erb
@@ -31,4 +31,7 @@
 <% end -%>
 
 <%= t("publish_mailer.publish_email.edit_in_app") %>
-<%= document_url(@edition.document, utm_content: "publish-email-link") %>
+[<%= document_url(@edition.document) %>](<%= document_url(@edition.document,
+                                                          utm_source: "publish-email",
+                                                          utm_medium: "email",
+                                                          utm_campaign: "govuk-publishing") %>)

--- a/app/views/scheduled_publish_mailer/failure_email.text.erb
+++ b/app/views/scheduled_publish_mailer/failure_email.text.erb
@@ -7,7 +7,10 @@
 <%= t("scheduled_publish_mailer.failure_email.try_again") %>
 
 <%= t("scheduled_publish_mailer.failure_email.edit_in_app") %>
-<%= document_url(@edition.document, utm_content: "failed-publish-email-link") %>
+[<%= document_url(@edition.document) %>](<%= document_url(@edition.document,
+                                                          utm_source: "failed-publish-email",
+                                                          utm_medium: "email",
+                                                          utm_campaign: "govuk-publishing") %>)
 
 <%= t("scheduled_publish_mailer.failure_email.raise_ticket") %>
 

--- a/app/views/scheduled_publish_mailer/success_email.text.erb
+++ b/app/views/scheduled_publish_mailer/success_email.text.erb
@@ -34,4 +34,7 @@
 <% end -%>
 
 <%= t("scheduled_publish_mailer.success_email.edit_in_app") %>
-<%= document_url(@edition.document, utm_content: "scheduled-publish-email-link") %>
+[<%= document_url(@edition.document) %>](<%= document_url(@edition.document,
+                                                          utm_source: "scheduled-publish-email",
+                                                          utm_medium: "email",
+                                                          utm_campaign: "govuk-publishing") %>)


### PR DESCRIPTION
https://trello.com/c/fjVo0aK9/877-analytics-for-scheduling

Previously we only used the utm_content query param on the in-app links
we send out in emails, which is not sufficient for tracking the use of
these links in GA. This replaces utm_content with three params:

   - utm_source: this is what we put in utm_content previously
   - utm_medium: always 'email'
   - utm_campaign: always 'govuk-publishing'

The last param is optional, but potentially useful to distinguish other
links to our app that populate the other two parameters, which would
pollute our analytics. Since the text of the link is now quite long,
this replaces the original text with a markdown link approach to
completely hide the query params, although they will still be shown in
the text variant of the email.