### PR TITLE
Prefix scss variables and lint

### DIFF
--- a/app/assets/stylesheets/components/_image-cropper.scss
+++ b/app/assets/stylesheets/components/_image-cropper.scss
@@ -1,5 +1,6 @@
 @import url(asset-path("cropperjs/dist/cropper.min.css"));
-$cropper-point-size: 20px;
+
+$app-cropper-point-size: 20px;
 
 .app-c-image-cropper {
   @include govuk-font($size: 19);
@@ -17,49 +18,49 @@ $cropper-point-size: 20px;
   }
 
   .cropper-point {
-    width: $cropper-point-size;
-    height: $cropper-point-size;
+    width: $app-cropper-point-size;
+    height: $app-cropper-point-size;
     opacity: 1;
   }
 
   .cropper-point.point-n {
-    top: -$cropper-point-size / 2;
-    margin-left: -$cropper-point-size / 2;
+    top: -$app-cropper-point-size / 2;
+    margin-left: -$app-cropper-point-size / 2;
   }
 
   .cropper-point.point-ne {
-    top: -$cropper-point-size / 2;
-    right: -$cropper-point-size / 2;
+    top: -$app-cropper-point-size / 2;
+    right: -$app-cropper-point-size / 2;
   }
 
   .cropper-point.point-e {
-    right: -$cropper-point-size / 2;
-    margin-top: -$cropper-point-size / 2;
+    right: -$app-cropper-point-size / 2;
+    margin-top: -$app-cropper-point-size / 2;
   }
 
   .cropper-point.point-se {
-    right: -$cropper-point-size / 2;
-    bottom: -$cropper-point-size / 2;
+    right: -$app-cropper-point-size / 2;
+    bottom: -$app-cropper-point-size / 2;
   }
 
   .cropper-point.point-s {
-    bottom: -$cropper-point-size / 2;
-    margin-left: -$cropper-point-size / 2;
+    bottom: -$app-cropper-point-size / 2;
+    margin-left: -$app-cropper-point-size / 2;
   }
 
   .cropper-point.point-sw {
-    bottom: -$cropper-point-size / 2;
-    left: -$cropper-point-size / 2;
+    bottom: -$app-cropper-point-size / 2;
+    left: -$app-cropper-point-size / 2;
   }
 
   .cropper-point.point-w {
-    left: -$cropper-point-size / 2;
-    margin-top: -$cropper-point-size / 2;
+    left: -$app-cropper-point-size / 2;
+    margin-top: -$app-cropper-point-size / 2;
   }
 
   .cropper-point.point-nw {
-    top: -$cropper-point-size / 2;
-    left: -$cropper-point-size / 2;
+    top: -$app-cropper-point-size / 2;
+    left: -$app-cropper-point-size / 2;
   }
 }
 

--- a/app/assets/stylesheets/components/_inset-prompt.scss
+++ b/app/assets/stylesheets/components/_inset-prompt.scss
@@ -1,24 +1,21 @@
-$govuk-notice-border-color: govuk-colour("grey-1");
-$govuk-notice-background-color: govuk-colour("grey-4");
-
 .app-c-inset-prompt {
   @include govuk-text-colour;
   @include govuk-responsive-padding(4);
   @include govuk-responsive-margin(6, "bottom");
   @include govuk-focusable;
 
-  border-left: $govuk-border-width-mobile solid $govuk-notice-border-color;
+  border-left: $govuk-border-width-mobile solid govuk-colour("grey-1");
 
   @include govuk-media-query($from: tablet) {
-    border-left: $govuk-border-width solid $govuk-notice-border-color;
+    border-left: $govuk-border-width solid govuk-colour("grey-1");
   }
 
-  background-color: $govuk-notice-background-color;
+  background-color: govuk-colour("grey-4");
 }
 
 .app-c-inset-prompt--error {
-  background-color: govuk-tint($govuk-error-colour, 90%);
   border-color: $govuk-error-colour;
+  background-color: govuk-tint($govuk-error-colour, 90%);
 }
 
 .app-c-inset-prompt__title {

--- a/app/assets/stylesheets/components/_markdown-editor.scss
+++ b/app/assets/stylesheets/components/_markdown-editor.scss
@@ -1,8 +1,8 @@
-$toolbar-button-size: 50px;
+$app-toolbar-button-size: 50px;
 
 .app-c-markdown-editor {
   .govuk-textarea {
-    border-top: none;
+    border-top: 0;
     resize: vertical;
 
     &:focus {
@@ -44,8 +44,8 @@ $toolbar-button-size: 50px;
   cursor: pointer;
 
   &:focus {
-    outline-offset: -$govuk-focus-width;
     border-color: transparent;
+    outline-offset: -$govuk-focus-width;
     background-color: transparent;
   }
 }
@@ -76,8 +76,8 @@ $toolbar-button-size: 50px;
   color: $govuk-text-colour;
 
   .govuk-textarea {
-    overflow: scroll;
     padding: govuk-spacing(6);
+    overflow: scroll;
     background-color: govuk-colour("grey-4");
   }
 
@@ -101,35 +101,35 @@ $toolbar-button-size: 50px;
 .app-c-markdown-editor__toolbar-button {
   @include govuk-focusable-fill;
   display: inline-block;
+  width: $app-toolbar-button-size;
+  height: $app-toolbar-button-size;
   background: none;
-  width: $toolbar-button-size;
-  height: $toolbar-button-size;
 
   &:focus {
     outline-offset: -$govuk-focus-width;
   }
 
   &:hover {
-    cursor: pointer;
     background-color: govuk-colour("grey-3");
+    cursor: pointer;
   }
 }
 
 .app-c-markdown-editor__toolbar-icon {
   display: inline-block;
-  fill: currentColor;
   background: inherit;
+  fill: currentColor;
   pointer-events: none;
 }
 
 .app-c-markdown-editor__toolbar-button--text {
   @include govuk-font($size: 16, $weight: bold);
-  border: none;
-  border-left: 4px solid govuk-colour('white');
   width: auto;
-  vertical-align: top;
-  background: transparent;
   padding: govuk-spacing(3);
+  border: 0;
+  border-left: 4px solid govuk-colour("white");
+  background: transparent;
+  vertical-align: top;
 }
 
 .app-c-markdown-editor__toolbar-button--end {

--- a/app/assets/stylesheets/components/_markdown-guidance.scss
+++ b/app/assets/stylesheets/components/_markdown-guidance.scss
@@ -50,7 +50,7 @@
 }
 
 .app-c-markdown-guidance__code-snippet {
-  white-space: pre-line;
-  background-color: govuk-colour('grey-3');
   padding: 10px;
+  background-color: govuk-colour("grey-3");
+  white-space: pre-line;
 }

--- a/app/assets/stylesheets/components/_page-preview.scss
+++ b/app/assets/stylesheets/components/_page-preview.scss
@@ -1,10 +1,10 @@
-$google-link-colour: #1a0dab;
-$google-url-colour: #006621;
-$google-description-colour: #545454;
-$mobile-frame-width: 320px;
-$mobile-frame-height: 585px;
-$mobile-border-width: 17px;
-$mobile-border-bottom-width: 68px;
+$app-google-link-colour: #1a0dab;
+$app-google-url-colour: #006621;
+$app-google-description-colour: #545454;
+$app-mobile-frame-width: 320px;
+$app-mobile-frame-height: 585px;
+$app-mobile-border-width: 17px;
+$app-mobile-border-bottom-width: 68px;
 
 .app-c-preview {
   .govuk-tabs__list {
@@ -25,18 +25,18 @@ $mobile-border-bottom-width: 68px;
 
   @include govuk-media-query($from: tablet) {
     display: block;
-    width: $mobile-frame-width + 2 * $mobile-border-width;
-    height: $mobile-frame-height + $mobile-border-width + $mobile-border-bottom-width;
+    width: $app-mobile-frame-width + 2 * $app-mobile-border-width;
+    height: $app-mobile-frame-height + $app-mobile-border-width + $app-mobile-border-bottom-width;
     background-image: image-url("components/preview-mobile.svg");
     background-repeat: no-repeat;
   }
 }
 
 .app-c-preview__mobile-iframe {
-  width: $mobile-frame-width;
-  height: $mobile-frame-height;
-  margin: $mobile-border-width;
-  margin-bottom: $mobile-border-bottom-width;
+  width: $app-mobile-frame-width;
+  height: $app-mobile-frame-height;
+  margin: $app-mobile-border-width;
+  margin-bottom: $app-mobile-border-bottom-width;
   border: 0;
 }
 
@@ -58,14 +58,14 @@ $mobile-border-bottom-width: 68px;
 }
 
 .app-c-preview__google-title {
-  color: $google-link-colour;
+  color: $app-google-link-colour;
   font-family: arial, sans-serif;
   font-size: 18px;
   text-decoration: none;
 }
 
 .app-c-preview__google-url {
-  color: $google-url-colour;
+  color: $app-google-url-colour;
   font-family: arial, sans-serif;
   font-size: 14px;
   font-weight: 400;
@@ -73,7 +73,7 @@ $mobile-border-bottom-width: 68px;
 }
 
 .app-c-preview__google-description {
-  color: $google-description-colour;
+  color: $app-google-description-colour;
   font-family: arial, sans-serif;
   font-size: 13px;
   line-height: 1.4;

--- a/app/assets/stylesheets/components/_side-navigation.scss
+++ b/app/assets/stylesheets/components/_side-navigation.scss
@@ -8,7 +8,7 @@
   .app-c-side-navigation__list-item {
     @include govuk-font(16);
     padding: govuk-spacing(2) 0;
-    border-bottom: 1px solid govuk-colour('grey-3');
+    border-bottom: 1px solid govuk-colour("grey-3");
 
     .govuk-link {
       font-size: inherit;
@@ -19,7 +19,7 @@
   .app-c-side-navigation__list-item--current {
     .govuk-link {
       @include govuk-font($size: 16, $weight: bold);
-      color: govuk-colour('black');
+      color: govuk-colour("black");
     }
   }
 

--- a/app/assets/stylesheets/components/_summary.scss
+++ b/app/assets/stylesheets/components/_summary.scss
@@ -12,7 +12,7 @@
   }
 
   &:nth-last-of-type(1) {
-    border-bottom: none;
+    border-bottom: 0;
   }
 }
 

--- a/app/assets/stylesheets/components/_toolbar-dropdown.scss
+++ b/app/assets/stylesheets/components/_toolbar-dropdown.scss
@@ -1,28 +1,28 @@
-$dropdown-arrow-size: 12px;
-$dropdown-arrow-spacing: $dropdown-arrow-size / 2;
+$app-dropdown-arrow-size: 12px;
+$app-dropdown-arrow-spacing: $app-dropdown-arrow-size / 2;
 
 .app-c-toolbar-dropdown {
   display: inline-block;
-  min-width: 120px;
   position: relative;
-  text-align: left;
+  min-width: 120px;
   background: inherit;
+  text-align: left;
 }
 
 .app-c-toolbar-dropdown--end {
   float: right;
-  border-left: 4px solid govuk-colour('white');
+  border-left: 4px solid govuk-colour("white");
 }
 
 .app-c-toolbar-dropdown__title {
   @include govuk-font($size: 16, $weight: bold);
   @include govuk-focusable;
-  background: inherit;
-  border: 0;
-  cursor: pointer;
-  user-select: none;
   display: block;
   padding: govuk-spacing(3);
+  border: 0;
+  background: inherit;
+  cursor: pointer;
+  user-select: none;
 
   &:hover {
     background-color: govuk-colour("grey-3");
@@ -33,11 +33,11 @@ $dropdown-arrow-spacing: $dropdown-arrow-size / 2;
   }
 
   &::after {
+    content: "";
     position: relative;
     top: 4px;
-    content: "";
     float: right;
-    @include govuk-shape-arrow($direction: down, $base: $dropdown-arrow-size, $display: inline-block);
+    @include govuk-shape-arrow($direction: down, $base: $app-dropdown-arrow-size, $display: inline-block);
   }
 
   &::-webkit-details-marker {
@@ -47,14 +47,14 @@ $dropdown-arrow-spacing: $dropdown-arrow-size / 2;
 
 .app-c-toolbar-dropdown__container {
   position: absolute;
-  width: 100%;
   z-index: 100;
+  width: 100%;
 }
 
 .app-c-toolbar-dropdown__list {
-  list-style: none;
   margin: 0;
   padding: 0;
+  list-style: none;
 }
 
 .app-c-toolbar-dropdown__list-item {
@@ -66,14 +66,13 @@ $dropdown-arrow-spacing: $dropdown-arrow-size / 2;
   @include govuk-font($size: 16);
   @include govuk-focusable;
 
-  appearance: none;
-  -webkit-appearance: none;
-
-  background: govuk-colour("grey-4");
-  color: $govuk-text-colour;
-  padding: govuk-spacing(3);
-  text-decoration: none;
   display: block;
+  padding: govuk-spacing(3);
+  color: $govuk-text-colour;
+  background: govuk-colour("grey-4");
+  text-decoration: none;
+  -webkit-appearance: none;
+  appearance: none;
 
   &:hover {
     background-color: govuk-colour("grey-3");
@@ -84,25 +83,24 @@ $dropdown-arrow-spacing: $dropdown-arrow-size / 2;
   }
 
   &::-moz-focus-inner {
-    border: 0;
     padding: 0;
+    border: 0;
   }
 }
 
 .app-c-toolbar-dropdown__button {
   @include govuk-font($size: 16);
   @include govuk-focusable;
-  appearance: none;
-  -webkit-appearance: none;
-
-  background: govuk-colour("grey-4");
-  color: $govuk-text-colour;
-  border: 0;
-  cursor: pointer;
   display: block;
-  padding: govuk-spacing(3);
-  text-align: inherit;
   width: 100%;
+  padding: govuk-spacing(3);
+  border: 0;
+  color: $govuk-text-colour;
+  background: govuk-colour("grey-4");
+  text-align: inherit;
+  cursor: pointer;
+  -webkit-appearance: none;
+  appearance: none;
 
   &:hover {
     background-color: govuk-colour("grey-3");
@@ -113,7 +111,7 @@ $dropdown-arrow-spacing: $dropdown-arrow-size / 2;
   }
 
   &::-moz-focus-inner {
-    border: 0;
     padding: 0;
+    border: 0;
   }
 }

--- a/app/assets/stylesheets/core/_link.scss
+++ b/app/assets/stylesheets/core/_link.scss
@@ -18,8 +18,8 @@
 }
 
 .app-link--inline {
-  padding: govuk-spacing(3) 0;
   display: inline-block;
+  padding: govuk-spacing(3) 0;
 
   @include govuk-media-query($from: tablet) {
     padding: 8px govuk-spacing(3);


### PR DESCRIPTION
A quick clean-up in our SCSS files. Prefixing app-level SCSS variables consistently - helps figuring out where that variable/mixin is defined (`govuk-` for govuk-frontend, `gem-` for govuk_publishing_components and `app-` for app-level code) and lint using [govuk_publishing_components sass-lint rules](https://github.com/alphagov/govuk_publishing_components/blob/master/.sass-lint.yml).