### PR TITLE
Log the error a scheduled publishing fails on

### DIFF
--- a/app/jobs/scheduled_publishing_job.rb
+++ b/app/jobs/scheduled_publishing_job.rb
@@ -2,7 +2,8 @@
 
 class ScheduledPublishingJob < ApplicationJob
   # retry at 3s, 18s, 83s, 258s, 627s
-  retry_on(StandardError, wait: :exponentially_longer, attempts: 5) do |job|
+  retry_on(StandardError, wait: :exponentially_longer, attempts: 5) do |job, error|
+    GovukError.notify(error)
     ScheduledPublishingFailedService.new.call(job.arguments.first)
   end
 


### PR DESCRIPTION
Trello: https://trello.com/c/Bdccoiqd/735-notify-users-that-scheduled-content-has-failed-to-publish

The retry_on block will prevent exceptions working their way up the
stack. This means that errors are not reported to sentry by default.

This calls `GovukError.notify` to notify sentry for the reason the scheduling
failed. This will allow us to determine whether we need to fix code or handle
the exception. If the failure is due to an intermittent error (such as
timeout) this wouldn't make it to Sentry as they are filtered out in
govuk_test config.