### PR TITLE
Clear the set backdate if content has not been published

### DIFF
--- a/app/controllers/backdate_controller.rb
+++ b/app/controllers/backdate_controller.rb
@@ -23,4 +23,15 @@ class BackdateController < ApplicationController
       redirect_to document_path(edition.document)
     end
   end
+
+  def destroy
+    result = Backdate::DestroyInteractor.call(params: params, user: current_user)
+
+    if result.api_error
+      redirect_to document_path(params[:document]),
+                  alert_with_description: t("documents.show.flashes.backdate_error")
+    else
+      redirect_to document_path(params[:document])
+    end
+  end
 end

--- a/app/interactors/backdate/destroy_interactor.rb
+++ b/app/interactors/backdate/destroy_interactor.rb
@@ -1,0 +1,36 @@
+# frozen_string_literal: true
+
+class Backdate::DestroyInteractor
+  include Interactor
+
+  delegate :params, :edition, :user, to: :context
+
+  def call
+    Edition.transaction do
+      find_and_lock_edition
+      update_edition
+      create_timeline_entry
+    end
+  end
+
+private
+
+  def find_and_lock_edition
+    context.edition = Edition.lock.find_current(document: params[:document])
+  end
+
+  def update_edition
+    updater = Versioning::RevisionUpdater.new(edition.revision, user)
+    updater.assign(backdated_to: nil)
+
+    edition.assign_revision(updater.next_revision, user)
+           .save!
+  end
+
+  def create_timeline_entry
+    TimelineEntry.create_for_status_change(
+      entry_type: :backdate_deleted,
+      status: edition.status,
+    )
+  end
+end

--- a/app/models/timeline_entry.rb
+++ b/app/models/timeline_entry.rb
@@ -52,7 +52,8 @@ class TimelineEntry < ApplicationRecord
                      file_attachment_uploaded: "file_attachment_uploaded",
                      file_attachment_deleted: "file_attachment_deleted",
                      file_attachment_updated: "file_attachment_updated",
-                     backdated: "backdated" }
+                     backdated: "backdated",
+                     backdate_deleted: "backdate_deleted" }
 
   def self.create_for_status_change(entry_type:,
                                     status:,

--- a/app/views/backdate/edit.html.erb
+++ b/app/views/backdate/edit.html.erb
@@ -45,5 +45,13 @@
         margin_bottom: true
       } %>
     <% end %>
+    
+    <% if @edition.backdated_to %>
+      <%= form_tag backdate_path(@edition.document),
+          method: :delete,
+          data: { gtm: "clear-backdate" } do %>
+        <button class="govuk-link app-link--button govuk-link--no-visited-state">Clear backdate</button>
+      <% end %>
+    <% end %>
   </div>
 </div>

--- a/app/views/documents/show/_history_tab.html.erb
+++ b/app/views/documents/show/_history_tab.html.erb
@@ -33,6 +33,10 @@
           <%= t "documents.history.entry_content.backdated", date: date %>
         <% end %>
 
+        <% if entry.backdate_deleted? %>
+          <%= t "documents.history.entry_content.backdate_deleted", date: date %>
+        <% end %>
+
         <% if entry.removed? && entry.details %>
           <% removal = entry.details %>
           <% if removal.explanatory_note.present? %>

--- a/config/locales/en/documents/history.yml
+++ b/config/locales/en/documents/history.yml
@@ -33,5 +33,7 @@ en:
         file_attachment_uploaded: "Attachment uploaded"
         file_attachment_updated: "Attachment updated"
         backdated: "Backdated document"
+        backdate_deleted: "Backdate deleted"
       entry_content:
         backdated: "First published date backdated to %{date}"
+        backdate_deleted: "Document backdate removed"

--- a/config/locales/en/documents/show.yml
+++ b/config/locales/en/documents/show.yml
@@ -97,3 +97,6 @@ en:
         unschedule_error:
           title: Something has gone wrong
           description_govspeak: Something went wrong when stopping the scheduling of this document. Please try again or [raise a support request](https://support.publishing.service.gov.uk/technical_fault_report/new).
+        backdate_error:
+          title: Something has gone wrong
+          description_govspeak: Something went wrong when changing the backdate of this document. Please try again or [raise a support request](https://support.publishing.service.gov.uk/technical_fault_report/new).

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -74,6 +74,7 @@ Rails.application.routes.draw do
 
     get "/backdate" => "backdate#edit", as: :backdate
     post "/backdate" => "backdate#update"
+    delete "/backdate" => "backdate#destroy", as: :destroy_backdate
 
     post "/editions" => "editions#create", as: :create_edition
 


### PR DESCRIPTION
Trello Card: https://trello.com/c/TBs5E8vv/919-clear-the-set-backdate-if-content-has-not-been-published

To allow the user to remove a backdate that has been applied to some content,
this commit does the following:

- Creates a Destroy Interactor class and associated route for the Backdate, tied into
the controller, to allow clean removal of the backdate value from the Edition.
The backdate is now set to Nil when prompted.

- Adds a user action on the Edit Backdate page to allow the backdate to be removed
if there is one set. This action is not present if no date has been set.

- Adds an entry in the history tab for when a backdate is removed. Wording to be
confirmed. Along these lines, fixed a bug wherein we were referring to the backdate
from the Edition directly rather than an appropriate Revision. Fix will make more
calls to the database but prevents a Nil error when we nullify the backdate value.

- Adds an error for if the user hits an issue when editing the backdate, similar to
scheduling.