### PR TITLE
Clear the set backdate if content has not been published

### DIFF
--- a/app/controllers/backdate_controller.rb
+++ b/app/controllers/backdate_controller.rb
@@ -23,4 +23,11 @@ class BackdateController < ApplicationController
       redirect_to document_path(edition.document)
     end
   end
+
+  def destroy
+    result = Backdate::DestroyInteractor.call(params: params, user: current_user)
+    edition = result.edition
+
+    redirect_to document_path(edition.document)
+  end
 end

--- a/app/interactors/backdate/destroy_interactor.rb
+++ b/app/interactors/backdate/destroy_interactor.rb
@@ -9,6 +9,7 @@ class Backdate::DestroyInteractor
     Edition.transaction do
       find_and_lock_edition
       update_edition
+      create_timeline_entry
       update_preview
     end
   end
@@ -31,6 +32,15 @@ private
     context.fail! unless updater.changed?
 
     edition.assign_revision(updater.next_revision, user).save!
+  end
+
+  def create_timeline_entry
+    TimelineEntry.create_for_revision(
+      entry_type: :backdate_cleared,
+      revision: edition.revision,
+      edition: edition,
+      created_by: user,
+    )
   end
 
   def update_preview

--- a/app/interactors/backdate/destroy_interactor.rb
+++ b/app/interactors/backdate/destroy_interactor.rb
@@ -1,0 +1,39 @@
+# frozen_string_literal: true
+
+class Backdate::DestroyInteractor
+  include Interactor
+
+  delegate :params, :edition, :user, to: :context
+
+  def call
+    Edition.transaction do
+      find_and_lock_edition
+      update_edition
+      update_preview
+    end
+  end
+
+private
+
+  def find_and_lock_edition
+    context.edition = Edition.lock.find_current(document: params[:document])
+
+    unless edition.editable? && edition.first?
+      # FIXME: this shouldn't be an exception but we've not worked out the
+      # right response - maybe bad request or a redirect with flash?
+      raise "Only editable backdated first editions can have their backdated date cleared."
+    end
+  end
+
+  def update_edition
+    updater = Versioning::RevisionUpdater.new(edition.revision, user)
+    updater.assign(backdated_to: nil)
+    context.fail! unless updater.changed?
+
+    edition.assign_revision(updater.next_revision, user).save!
+  end
+
+  def update_preview
+    PreviewService.new(edition).try_create_preview
+  end
+end

--- a/app/models/timeline_entry.rb
+++ b/app/models/timeline_entry.rb
@@ -52,7 +52,8 @@ class TimelineEntry < ApplicationRecord
                      file_attachment_uploaded: "file_attachment_uploaded",
                      file_attachment_deleted: "file_attachment_deleted",
                      file_attachment_updated: "file_attachment_updated",
-                     backdated: "backdated" }
+                     backdated: "backdated",
+                     backdate_cleared: "backdate_cleared" }
 
   def self.create_for_status_change(entry_type:,
                                     status:,

--- a/app/views/backdate/edit.html.erb
+++ b/app/views/backdate/edit.html.erb
@@ -45,5 +45,13 @@
         margin_bottom: true
       } %>
     <% end %>
+
+    <% if @edition.backdated_to %>
+      <%= form_tag backdate_path(@edition.document),
+          method: :delete,
+          data: { gtm: "clear-backdate" } do %>
+        <button class="govuk-link app-link--button govuk-link--no-visited-state">Clear backdate</button>
+      <% end %>
+    <% end %>
   </div>
 </div>

--- a/app/views/documents/show/_history_tab.html.erb
+++ b/app/views/documents/show/_history_tab.html.erb
@@ -29,7 +29,7 @@
         <% end %>
 
         <% if entry.backdated? %>
-          <% date = format_date(entry.edition.backdated_to) %>
+          <% date = format_date(entry.revision.backdated_to) %>
           <%= t "documents.history.entry_content.backdated", date: date %>
         <% end %>
 

--- a/config/locales/en/documents/history.yml
+++ b/config/locales/en/documents/history.yml
@@ -33,5 +33,6 @@ en:
         file_attachment_uploaded: "Attachment uploaded"
         file_attachment_updated: "Attachment updated"
         backdated: "Backdated document"
+        backdate_cleared: "Backdate cleared"
       entry_content:
         backdated: "First published date backdated to %{date}"

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -74,6 +74,7 @@ Rails.application.routes.draw do
 
     get "/backdate" => "backdate#edit", as: :backdate
     post "/backdate" => "backdate#update"
+    delete "/backdate" => "backdate#destroy"
 
     post "/editions" => "editions#create", as: :create_edition
 

--- a/spec/factories/edition_factory.rb
+++ b/spec/factories/edition_factory.rb
@@ -54,6 +54,7 @@ FactoryBot.define do
           update_type: evaluator.update_type,
           change_note: evaluator.change_note,
           proposed_publish_time: evaluator.proposed_publish_time,
+          backdated_to: evaluator.backdated_to,
           lead_image_revision: evaluator.lead_image_revision,
           image_revisions: image_revisions,
           file_attachment_revisions: evaluator.file_attachment_revisions,

--- a/spec/features/workflow/clear_backdate_spec.rb
+++ b/spec/features/workflow/clear_backdate_spec.rb
@@ -1,0 +1,41 @@
+# frozen_string_literal: true
+
+RSpec.feature "Clear backdate" do
+  scenario do
+    given_there_is_an_editable_backdated_edition
+    when_i_visit_the_summary_page
+    i_can_see_the_date_the_content_has_been_backdated_to
+    when_i_click_to_edit_the_backdate
+    and_i_click_clear_backdate
+    then_i_see_the_content_is_no_longer_backdated
+  end
+
+  def given_there_is_an_editable_backdated_edition
+    @backdated_to = Time.current.yesterday
+    @edition = create(:edition, backdated_to: @backdated_to)
+  end
+
+  def when_i_visit_the_summary_page
+    visit document_path(@edition.document)
+  end
+
+  def i_can_see_the_date_the_content_has_been_backdated_to
+    backdate_title = I18n.t("documents.show.content_settings.backdate.title")
+    date = @backdated_to.strftime("%-d %B %Y")
+    expect(page).to have_content("#{backdate_title} #{date}")
+  end
+
+  def when_i_click_to_edit_the_backdate
+    click_on "Edit Backdate"
+  end
+
+  def and_i_click_clear_backdate
+    @request = stub_publishing_api_put_content(@edition.content_id, {})
+    click_on "Clear backdate"
+  end
+
+  def then_i_see_the_content_is_no_longer_backdated
+    expect(@request).to have_been_requested
+    expect(page).not_to have_content(@backdated_to.strftime("%-d %B %Y"))
+  end
+end

--- a/spec/features/workflow/clear_backdate_spec.rb
+++ b/spec/features/workflow/clear_backdate_spec.rb
@@ -36,6 +36,10 @@ RSpec.feature "Clear backdate" do
 
   def then_i_see_the_content_is_no_longer_backdated
     expect(@request).to have_been_requested
+
     expect(page).not_to have_content(@backdated_to.strftime("%-d %B %Y"))
+    expect(page).to have_content(
+      I18n.t!("documents.history.entry_types.backdate_cleared"),
+    )
   end
 end


### PR DESCRIPTION
For https://trello.com/c/TBs5E8vv/919-clear-the-set-backdate-if-content-has-not-been-published

This allows users to clear a set backdate.  We also fix a bug where we used the edition's `backdate_to`
value instead of the `backdated_to` value associated with a revision, which caused nil errors and incorrect dates to appear in timeline entries.

### Existing backdate
> <img width="668" alt="backdate_1" src="https://user-images.githubusercontent.com/13434452/60183456-470d3700-981e-11e9-89a1-61b68437d13d.png">

### Clear backdate link
> <img width="677" alt="backdate_2" src="https://user-images.githubusercontent.com/13434452/60183469-4c6a8180-981e-11e9-81bc-ec227162328c.png">

### Backdate no longer set after clearing
> <img width="663" alt="backdate_3" src="https://user-images.githubusercontent.com/13434452/60183488-53918f80-981e-11e9-891b-70d09cb5ad4c.png">

### Timeline entry created when a backdate is cleared
> <img width="490" alt="backdate_4" src="https://user-images.githubusercontent.com/13434452/60183531-63a96f00-981e-11e9-996d-30c6da667aff.png">

