### PR TITLE
Remove duplicated copy on scheduled page

### DIFF
--- a/app/views/schedule/scheduled.html.erb
+++ b/app/views/schedule/scheduled.html.erb
@@ -1,5 +1,5 @@
 <% content_for :back_link, render_back_link(text: "Return to dashboard", href: document_path(@edition.document)) %>
-<% content_for :title, t("schedule.scheduled.title") %>
+<% content_for :browser_title, t("schedule.scheduled.title") %>
 
 <% scheduling = @edition.status.details %>
 <% time = format_time(scheduling.publish_time) %>


### PR DESCRIPTION
For https://trello.com/c/j7pcf6Nm/960-copy-review-for-scheduling

The same copy was appearing in the title and panel on the scheduled page, so we remove the title to
avoid duplication.

### Before
![scheduled_before](https://user-images.githubusercontent.com/13434452/60170513-7745dd00-9800-11e9-9c6a-949dd4ed1ba1.png)

### After
<img width="1017" alt="Screen Shot 2019-06-26 at 10 45 08" src="https://user-images.githubusercontent.com/13434452/60170400-4665a800-9800-11e9-9925-505e62deed8d.png">
