### PR TITLE
Make PutContent request after backdating content

### DIFF
--- a/app/interactors/backdate/update_interactor.rb
+++ b/app/interactors/backdate/update_interactor.rb
@@ -17,6 +17,8 @@ class Backdate::UpdateInteractor
 
       update_edition
       create_timeline_entry
+
+      update_preview
     end
   end
 
@@ -63,5 +65,9 @@ private
       edition: edition,
       created_by: user,
     )
+  end
+
+  def update_preview
+    PreviewService.new(edition).try_create_preview
   end
 end

--- a/spec/features/workflow/backdate_spec.rb
+++ b/spec/features/workflow/backdate_spec.rb
@@ -48,6 +48,7 @@ RSpec.feature "Backdate content" do
   end
 
   def and_i_click_save
+    @request = stub_publishing_api_put_content(@edition.content_id, {})
     click_on "Save"
   end
 
@@ -55,6 +56,7 @@ RSpec.feature "Backdate content" do
     expect(page).to have_content("1 January 2019")
     expect(page).to have_content(I18n.t!("documents.history.entry_types.backdated",
                                          date: "01 January 2019"))
+    expect(@request).to have_been_requested
   end
 
   def given_there_is_a_document_with_a_second_edition


### PR DESCRIPTION
For https://trello.com/c/CnWIubp8/955-publishing-api-to-use-publicupdatedat-for-change-note-times

In order for the Publishing API to be made aware that content has been
backdated, we need to make a PutContent request.