### PR TITLE
Fix 2i link tracking to use standard attributes

### DIFF
--- a/app/views/documents/show/_submitted_for_review.html.erb
+++ b/app/views/documents/show/_submitted_for_review.html.erb
@@ -1,7 +1,10 @@
 <% copy_to_clipboard = render(
   "govuk_publishing_components/components/copy_to_clipboard",
     label: t("documents.show.flashes.submitted_for_review.label"),
-    copyable_content: document_url(@edition.document, utm_content: "2i-link"),
+    copyable_content: document_url(@edition.document,
+                                   utm_source: "2i-link",
+                                   utm_medium: "anonymous",
+                                   utm_campaign: "govuk-publishing"),
     button_text: "Copy link",
     button_data_attributes: {
       gtm: "copy-url-for-2i-approval"

--- a/app/views/publish/published.html.erb
+++ b/app/views/publish/published.html.erb
@@ -24,7 +24,10 @@
 
       <%= render "govuk_publishing_components/components/copy_to_clipboard",
         label: t("publish.published.published_without_review.send_label"),
-        copyable_content: document_url(@edition.document, utm_content: "2i-link"),
+        copyable_content: document_url(@edition.document,
+                                       utm_source: "2i-link",
+                                       utm_medium: "anonymous",
+                                       utm_campaign: "govuk-publishing"),
         button_text: "Copy link",
         button_data_attributes: {
           gtm: "copy-published-content-link"


### PR DESCRIPTION
https://trello.com/c/B9rVHJTh/876-audit-and-fix-gtm-ga-issues

Previously we just used the 'utm_content' attribute, which isn't
sufficient to support tracking in GA. This swaps out the old attribute
for a new set that's consistent with the way we do this for email links.