### PR TITLE
Fix withdraw guidance

### DIFF
--- a/README.md
+++ b/README.md
@@ -90,7 +90,7 @@ app.
 To enable these permissions in a development environment run:
 
 ```
-bundle exec rake developer_permissions
+bundle exec rake development_permissions
 ```
 
 To enable them for your GOV.UK account add them to your account in

--- a/app/assets/stylesheets/components/_markdown-guidance.scss
+++ b/app/assets/stylesheets/components/_markdown-guidance.scss
@@ -53,4 +53,5 @@
   padding: 10px;
   background-color: govuk-colour("grey-3");
   white-space: pre-line;
+  word-break: break-word;
 }

--- a/app/controllers/withdraw_controller.rb
+++ b/app/controllers/withdraw_controller.rb
@@ -24,7 +24,7 @@ class WithdrawController < ApplicationController
       # right response - maybe bad request or a redirect with flash?
       raise "Can't withdraw an edition without managing editor permissions"
     elsif issues
-      flash["requirements"] = { "items" => issues.items }
+      flash.now["requirements"] = { "items" => issues.items }
 
       render :new,
              assigns: { edition: edition,

--- a/app/views/withdraw/new.html.erb
+++ b/app/views/withdraw/new.html.erb
@@ -7,9 +7,11 @@
   </div>
 </div>
 
-<div class="govuk-grid-row">
-  <div class="govuk-grid-column-two-thirds">
-    <%= form_tag withdraw_path(@edition.document), data: { gtm: "confirm-withdraw" } do %>
+<%= form_tag withdraw_path(@edition.document),
+             class: "app-c-contextual-guidance__form",
+             data: { gtm: "confirm-withdraw" } do %>
+  <div class="govuk-grid-row">
+    <div class="govuk-grid-column-two-thirds">
       <%= render "govuk_publishing_components/components/textarea", {
         label: {
           text: t("withdraw.new.public_explanation.title"),
@@ -24,33 +26,34 @@
           "contextual_guidance": "withdrawal-public-explanation-guidance",
         }
       } %>
+    </div>
 
-      <% if @edition.withdrawn? %>
-        <%= render "govuk_publishing_components/components/button", {
-          text: "Update explanation", margin_bottom: true
-        } %>
-      <% else %>
-        <%= render "govuk_publishing_components/components/button", {
-          text: "Withdraw document", margin_bottom: true
-        } %>
+    <div class="govuk-grid-column-one-third">
+      <%= render "components/contextual_guidance", {
+        id: "withdrawal-public-explanation-guidance",
+        title: t("withdraw.new.public_explanation.guidance_title"),
+      } do %>
+        <p>Explain to users why the page has been withdrawn. You can link to alternative content with markdown.</p>
+        <pre class="app-c-markdown-guidance__code-snippet">
+          [linktext](https://www.gov.uk/example)
+        </pre>
       <% end %>
+    </div>
+  </div>
 
-      <p class="govuk-body">
-        <%= link_to "Cancel", document_path(@edition.document),
-                    class: "govuk-link govuk-link--no-visited-state",
-                    data: { gtm: "cancel-withdraw" } %>
-      </p>
-    <% end %>
-  </div>
-  <div class="govuk-grid-column-one-third">
-    <%= render "components/contextual_guidance", {
-      id: "withdrawal-public-explanation-guidance",
-      title: t("withdraw.new.public_explanation.guidance_title"),
-    } do %>
-      <p>Explain to users why the page has been withdrawn. You can link to alternative content with markdown.</p>
-      <pre class="app-c-markdown-guidance__code-snippet">
-        [linktext](https://www.gov.uk/example)
-      </pre>
-    <% end %>
-  </div>
-</div>
+  <% if @edition.withdrawn? %>
+    <%= render "govuk_publishing_components/components/button", {
+      text: "Update explanation", margin_bottom: true
+    } %>
+  <% else %>
+    <%= render "govuk_publishing_components/components/button", {
+      text: "Withdraw document", margin_bottom: true
+    } %>
+  <% end %>
+
+  <p class="govuk-body">
+    <%= link_to "Cancel", document_path(@edition.document),
+                class: "govuk-link govuk-link--no-visited-state",
+                data: { gtm: "cancel-withdraw" } %>
+  </p>
+<% end %>


### PR DESCRIPTION
This fixes a few issues with the withdraw feature:

   - Requirements issues should not be persistent flashes
   - The guidance should be confined to the central page
   - The README should correctly say how to enable the feature