### PR TITLE
Remove broken/unwanted image upload link

### DIFF
--- a/app/views/documents/show/_lead_image.html.erb
+++ b/app/views/documents/show/_lead_image.html.erb
@@ -22,13 +22,7 @@
     } %>
   <% end %>
 <% else %>
-  <% capture do %>
-    <%= t("documents.show.lead_image.no_lead_image") %>
-    <% link_to t("documents.show.lead_image.upload_image"),
-               images_path(@edition.document),
-               class: "govuk-link",
-               data: { gtm: "upload-lead-image" } %>
-  <% end %>
+  <% t("documents.show.lead_image.no_lead_image") %>
 <% end %>
 
 <%= render "components/summary", {

--- a/config/locales/en/documents/show.yml
+++ b/config/locales/en/documents/show.yml
@@ -31,7 +31,6 @@ en:
       lead_image:
         title: Lead image
         no_lead_image: No image selected. The default image for your department will be used.
-        upload_image: Upload an image
         alt_text: Alt text
         caption: Caption
         credit: Credit


### PR DESCRIPTION
Previously we had code to render a link to upload an image directly from
the summary, which would act the same as clicking 'Change'. Now that the
'Change' link is renamed to 'Edit', we don't believe the additional link
is necessary. It's also been broken for ages. This removes it!