### PR TITLE
Initial model for Access Limit

### DIFF
--- a/app/models/access_limit.rb
+++ b/app/models/access_limit.rb
@@ -1,0 +1,19 @@
+# frozen_string_literal: true
+
+# Represents an access limit which applies to an edition that is not live
+#
+# This model is immutable
+class AccessLimit < ApplicationRecord
+  belongs_to :created_by, class_name: "User", optional: true
+
+  belongs_to :edition
+
+  belongs_to :revision_at_creation, class_name: "Revision"
+
+  enum limit_type: { primary_organisation: "primary_organisation",
+                     all_organisations: "all_organisations" }
+
+  def readonly?
+    !new_record?
+  end
+end

--- a/app/models/edition.rb
+++ b/app/models/edition.rb
@@ -38,6 +38,8 @@ class Edition < ApplicationRecord
 
   belongs_to :status
 
+  belongs_to :access_limit, optional: true
+
   has_many :timeline_entries
 
   has_and_belongs_to_many :revisions

--- a/app/models/edition.rb
+++ b/app/models/edition.rb
@@ -185,6 +185,31 @@ class Edition < ApplicationRecord
     self
   end
 
+  def assign_access_limit(limit_type, user)
+    raise "cannot access limit a live edition" if live?
+
+    access_limit = AccessLimit.new(created_by: user,
+                                   edition: self,
+                                   revision_at_creation: revision,
+                                   limit_type: limit_type)
+
+    assign_attributes(access_limit: access_limit,
+                      last_edited_by: user,
+                      last_edited_at: Time.current)
+
+    self
+  end
+
+  def remove_access_limit(user)
+    raise "no access limit to remove" unless access_limit
+
+    assign_attributes(access_limit: nil,
+                      last_edited_by: user,
+                      last_edited_at: Time.current)
+
+    self
+  end
+
   def editors
     user_ids = statuses.pluck(:created_by_id) + revisions.pluck(:created_by_id)
     User.where(id: user_ids.uniq)

--- a/app/services/publish_service.rb
+++ b/app/services/publish_service.rb
@@ -41,6 +41,7 @@ private
 
   def set_new_live_edition(user, with_review)
     status = with_review ? :published : :published_but_needs_2i
+    edition.remove_access_limit(user) if edition.access_limit
     edition.assign_status(status, user)
     edition.live = true
     edition.save!

--- a/db/migrate/20190626155821_create_access_limits.rb
+++ b/db/migrate/20190626155821_create_access_limits.rb
@@ -1,0 +1,34 @@
+# frozen_string_literal: true
+
+class CreateAccessLimits < ActiveRecord::Migration[5.2]
+  def change
+    create_table :access_limits do |t|
+      t.datetime :created_at
+
+      t.references :created_by,
+                   foreign_key: { to_table: :users,
+                                  on_delete: :restrict },
+                   index: false
+
+      t.references :edition,
+                   foreign_key: { to_table: :editions,
+                                  on_delete: :restrict },
+                   null: false,
+                   index: false
+
+      t.references :revision_at_creation,
+                   foreign_key: { to_table: :revisions,
+                                  on_delete: :restrict },
+                   null: false,
+                   index: false
+
+      t.string :limit_type, null: false
+    end
+
+    add_reference :editions,
+                  :access_limit,
+                  foreign_key: { on_delete: :restrict },
+                  null: true,
+                  index: true
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,10 +10,18 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2019_06_17_142340) do
+ActiveRecord::Schema.define(version: 2019_06_26_155821) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
+
+  create_table "access_limits", force: :cascade do |t|
+    t.datetime "created_at"
+    t.bigint "created_by_id"
+    t.bigint "edition_id", null: false
+    t.bigint "revision_at_creation_id", null: false
+    t.string "limit_type", null: false
+  end
 
   create_table "active_storage_attachments", force: :cascade do |t|
     t.string "name", null: false
@@ -70,6 +78,8 @@ ActiveRecord::Schema.define(version: 2019_06_17_142340) do
     t.bigint "status_id", null: false
     t.bigint "revision_id", null: false
     t.boolean "revision_synced", default: false, null: false
+    t.bigint "access_limit_id"
+    t.index ["access_limit_id"], name: "index_editions_on_access_limit_id"
     t.index ["created_by_id"], name: "index_editions_on_created_by_id"
     t.index ["document_id", "current"], name: "index_editions_on_document_id_and_current", unique: true, where: "(current = true)"
     t.index ["document_id", "live"], name: "index_editions_on_document_id_and_live", unique: true, where: "(live = true)"
@@ -318,8 +328,12 @@ ActiveRecord::Schema.define(version: 2019_06_17_142340) do
     t.datetime "withdrawn_at", null: false
   end
 
+  add_foreign_key "access_limits", "editions", on_delete: :restrict
+  add_foreign_key "access_limits", "revisions", column: "revision_at_creation_id", on_delete: :restrict
+  add_foreign_key "access_limits", "users", column: "created_by_id", on_delete: :restrict
   add_foreign_key "content_revisions", "users", column: "created_by_id", on_delete: :restrict
   add_foreign_key "documents", "users", column: "created_by_id", on_delete: :restrict
+  add_foreign_key "editions", "access_limits", on_delete: :restrict
   add_foreign_key "editions", "documents", on_delete: :restrict
   add_foreign_key "editions", "revisions", on_delete: :restrict
   add_foreign_key "editions", "statuses", on_delete: :restrict

--- a/spec/factories/access_limit_factory.rb
+++ b/spec/factories/access_limit_factory.rb
@@ -1,0 +1,10 @@
+# frozen_string_literal: true
+
+FactoryBot.define do
+  factory :access_limit do
+    limit_type { :primary_organisation }
+    association :edition
+    association :revision_at_creation, factory: :revision
+    association :created_by, factory: :user
+  end
+end

--- a/spec/factories/edition_factory.rb
+++ b/spec/factories/edition_factory.rb
@@ -160,5 +160,21 @@ FactoryBot.define do
         )
       end
     end
+
+    trait :access_limited do
+      transient do
+        limit_type { :all_organisations }
+      end
+
+      after(:build) do |edition, evaluator|
+        edition.access_limit = evaluator.association(
+          :access_limit,
+          limit_type: evaluator.limit_type,
+          edition: edition,
+          created_by: edition.created_by,
+          revision_at_creation: edition.revision,
+        )
+      end
+    end
   end
 end

--- a/spec/models/edition_spec.rb
+++ b/spec/models/edition_spec.rb
@@ -207,4 +207,49 @@ RSpec.describe Edition do
       end
     end
   end
+
+  describe "#assign_access_limit" do
+    it "assigns an access limit" do
+      edition = build(:edition)
+      user = build(:user)
+
+      edition.assign_access_limit(:all_organisations, user)
+
+      expect(edition.access_limit).to be_all_organisations
+      expect(edition.access_limit.created_by).to eq(user)
+      expect(edition.access_limit.revision_at_creation).to eq(edition.revision)
+    end
+
+    it "updates the edition last edited information" do
+      edition = build(:edition)
+      user = build(:user)
+
+      travel_to(Time.current) do
+        expect { edition.assign_access_limit(:all_organisations, user) }
+          .to change { edition.last_edited_by }.to(user)
+          .and change { edition.last_edited_at }.to(Time.current)
+      end
+    end
+  end
+
+  describe "#remove_access_limit" do
+    it "removes an access limit" do
+      edition = build(:edition, :access_limited)
+
+      expect { edition.remove_access_limit(build(:user)) }
+        .to change { edition.access_limit }
+        .to(nil)
+    end
+
+    it "updates the edition last edited information" do
+      edition = build(:edition, :access_limited)
+      user = build(:user)
+
+      travel_to(Time.current) do
+        expect { edition.remove_access_limit(user) }
+          .to change { edition.last_edited_by }.to(user)
+          .and change { edition.last_edited_at }.to(Time.current)
+      end
+    end
+  end
 end

--- a/spec/services/publish_service_spec.rb
+++ b/spec/services/publish_service_spec.rb
@@ -52,4 +52,15 @@ RSpec.describe PublishService do
         .publish(user: create(:user), with_review: true)
     end
   end
+
+  context "when the edition is access limited" do
+    it "removes the access limit" do
+      edition = create(:edition, :access_limited)
+
+      PublishService.new(edition)
+                    .publish(user: create(:user), with_review: true)
+
+      expect(edition.access_limit).to be_nil
+    end
+  end
 end

--- a/spec/services/publish_service_spec.rb
+++ b/spec/services/publish_service_spec.rb
@@ -1,16 +1,16 @@
 # frozen_string_literal: true
 
 RSpec.describe PublishService do
+  before { stub_any_publishing_api_publish }
+
   describe "#publish" do
     context "when there is no live edition" do
       let(:edition) { create(:edition, :publishable) }
-      let!(:publish_request) do
-        stub_publishing_api_publish(edition.content_id,
-                                    update_type: nil,
-                                    locale: edition.locale)
-      end
 
       it "publishes the current_edition" do
+        publish_request = stub_publishing_api_publish(edition.content_id,
+                                                      update_type: nil,
+                                                      locale: edition.locale)
         PublishService.new(edition)
                       .publish(user: create(:user), with_review: true)
 
@@ -24,7 +24,6 @@ RSpec.describe PublishService do
         PublishService.new(edition)
                       .publish(user: create(:user), with_review: false)
 
-        expect(publish_request).to have_been_requested
         expect(edition).to be_published_but_needs_2i
       end
     end
@@ -34,9 +33,6 @@ RSpec.describe PublishService do
         document = create(:document, :with_current_and_live_editions)
         current_edition = document.current_edition
         live_edition = document.live_edition
-        stub_publishing_api_publish(document.content_id,
-                                    update_type: nil,
-                                    locale: document.locale)
 
         PublishService.new(current_edition)
                       .publish(user: create(:user), with_review: true)
@@ -49,9 +45,6 @@ RSpec.describe PublishService do
     it "calls the PublishAssetService" do
       document = create(:document, :with_current_and_live_editions)
       current_edition = document.current_edition
-      stub_publishing_api_publish(document.content_id,
-                                  update_type: nil,
-                                  locale: document.locale)
 
       expect_any_instance_of(PublishAssetService).to receive(:publish_assets)
 


### PR DESCRIPTION
Trello: https://trello.com/c/gdQrj56v/956-design-the-modelling-of-access-limiting

This creates a model for AccessLimit, sets up a method for assigning an access limit and removes an existing one at the point of publishing.

One thing I wrestled with a bit was the syntax for methods to add and remove access limits to an edition. I ended up going with a single method that can be used to add and remove:

```
edition.assign_access_limit(limit_type: :all_organisations, user: user) # to add
edition.assign_access_limit(limit_type: nil, user: user) # to remove
```

Another option could be `edition.remove_access_limit(user)` or `edition.assign_no_access_limit(user)`, I wasn't so keen on dropping the assign convention and felt `assign_no_access_limit` was a bit weird.

