### PR TITLE
BH backdate release

### DIFF
--- a/app/views/documents/show/_summary_tab.html.erb
+++ b/app/views/documents/show/_summary_tab.html.erb
@@ -26,7 +26,7 @@
 
     <%= render "documents/show/tags" %>
 
-    <% if @edition.first? && @edition.editable? && current_user.has_permission?(User::PRE_RELEASE_FEATURES_PERMISSION) %>
+    <% if @edition.first? && @edition.editable? %>
       <%= render "documents/show/content_settings" %>
     <% end %>
   </div>

--- a/app/views/publisher_information/beta_capabilities.govspeak.md
+++ b/app/views/publisher_information/beta_capabilities.govspeak.md
@@ -13,7 +13,6 @@ It is possible to remove (unpublish) pages on request.
 
 Some features are not available yet:
 
-* backdating content
 * access limiting
 * translations
 

--- a/app/views/publisher_information/how_to_use_publisher.govspeak.md
+++ b/app/views/publisher_information/how_to_use_publisher.govspeak.md
@@ -101,6 +101,16 @@ Changes to topics are applied to a live page as soon as you save. If the content
 
 ---
 
+##Backdating
+
+If content has previously been available on another web page you must enter the date for when it was first published online. 
+
+The public First Published date will show the date the content was first made available rather than when it was first published in Content Publisher. This prevents old information being presented as new. 
+
+You can only backdate content before it is first published. Updates cannot be backdated.
+
+---
+
 ##How to update content
 
 You can search for existing content using the document search.

--- a/app/views/publisher_information/publisher_updates.govspeak.md
+++ b/app/views/publisher_information/publisher_updates.govspeak.md
@@ -1,3 +1,8 @@
+### Backdating <span class="govuk-caption-m">27 June 2019</span>
+You can now backdate on content if it has previously been available on another web page.
+
+The public First Published date will tell users when the information was first available rather than when the new page was published. It is important that old information is not presented as new.
+
 ### Scheduling <span class="govuk-caption-m">26 June 2019</span>
 You can now schedule content to automatically go live at a later date and time.
 


### PR DESCRIPTION
For https://trello.com/c/MciuKE6C/970-release-backdating

updates to 
What's New
What Content Publisher Can and Cannot do
How to use Content Publisher

Date may need updating.