### PR TITLE
Fail interactors when an updater hasn't changed

### DIFF
--- a/app/interactors/backdate/update_interactor.rb
+++ b/app/interactors/backdate/update_interactor.rb
@@ -37,6 +37,8 @@ private
   def update_edition
     updater = Versioning::RevisionUpdater.new(edition.revision, user)
     updater.assign(backdated_to: date)
+    context.fail! unless updater.changed?
+
     edition.assign_revision(updater.next_revision, user).save!
   end
 

--- a/app/interactors/file_attachments/create_interactor.rb
+++ b/app/interactors/file_attachments/create_interactor.rb
@@ -49,6 +49,8 @@ private
   def update_edition
     updater = Versioning::RevisionUpdater.new(edition.revision, user)
     updater.add_file_attachment(attachment_revision)
+    context.fail! unless updater.changed?
+
     edition.assign_revision(updater.next_revision, user).save!
   end
 

--- a/app/interactors/file_attachments/destroy_interactor.rb
+++ b/app/interactors/file_attachments/destroy_interactor.rb
@@ -30,6 +30,8 @@ private
 
     updater = Versioning::RevisionUpdater.new(edition.revision, user)
     updater.remove_file_attachment(attachment_revision)
+    context.fail! unless updater.changed?
+
     edition.assign_revision(updater.next_revision, user).save!
   end
 

--- a/app/interactors/images/destroy_interactor.rb
+++ b/app/interactors/images/destroy_interactor.rb
@@ -28,6 +28,8 @@ private
     context.image_revision = edition.image_revisions.find_by!(image_id: params[:image_id])
     updater = Versioning::RevisionUpdater.new(edition.revision, user)
     updater.remove_image(image_revision)
+    context.fail! unless updater.changed?
+
     edition.assign_revision(updater.next_revision, user).save!
     context.removed_lead_image = updater.removed_lead_image?
   end

--- a/app/interactors/lead_image/remove_interactor.rb
+++ b/app/interactors/lead_image/remove_interactor.rb
@@ -36,6 +36,8 @@ private
   def remove_lead_image
     updater = Versioning::RevisionUpdater.new(edition.revision, user)
     updater.assign(lead_image_revision: nil)
+    context.fail! unless updater.changed?
+
     edition.assign_revision(updater.next_revision, user).save!
   end
 


### PR DESCRIPTION
This will ensure additional actions, such as creating a timeline entry, don't
happen if an edition hasn't actually changed.