### PR TITLE
Add exception for user accessing schedule/new in wrong state

### DIFF
--- a/app/interactors/schedule/new_interactor.rb
+++ b/app/interactors/schedule/new_interactor.rb
@@ -17,6 +17,10 @@ class Schedule::NewInteractor
 
   def find_edition
     context.edition = Edition.find_current(document: params[:document])
+
+    unless edition.editable? && edition.proposed_publish_time.present?
+      raise "Can't schedule an edition which isn't schedulable"
+    end
   end
 
   def check_for_publish_issues


### PR DESCRIPTION
This is in response to the error we saw in sentry [1] where we saw an
error trying to run a greater than operator on a nil object. This
exception allows aborting this interactor when we are in the wrong
state.

This exception will still result in an error to the user but this is at
least something we don't need to debug which is the current case of the
nil comparison.

[1]: https://sentry.io/organizations/govuk/issues/1088840269/?project=202208&referrer=slack