### PR TITLE
Check that event.target has a dataset property

### DIFF
--- a/app/assets/javascripts/modules/gtm-copy-paste-listener.js
+++ b/app/assets/javascripts/modules/gtm-copy-paste-listener.js
@@ -4,7 +4,7 @@ GtmCopyPasteListener.handleCopyPaste = function (prefix) {
   return function (event) {
     var element = event.target
 
-    if (!element) {
+    if (!element || !element.dataset) {
       return
     }
 


### PR DESCRIPTION
We've seen errors come into sentry where the event target property does
not have a dataset value [1]

Alex and I have set together and tried to replicate this problem and
have not managed to do so. All we can conclude is that there are scenarios
where the event.target property can potentially not point to a HTML
element.

As this event handler runs globally it feels for any copy or paste event
it feels prudent to put protection against it so that we prevent this
error from occurring.

[1]: https://sentry.io/organizations/govuk/issues/1088753936/?project=202208&referrer=slack