### PR TITLE
Trigger search topic event on autocomplete for search topics

### DIFF
--- a/app/assets/javascripts/application.js
+++ b/app/assets/javascripts/application.js
@@ -29,6 +29,7 @@
 //= require modal/modal-workflow.js
 
 //= require modules/gtm-copy-paste-listener.js
+//= require modules/gtm-topics-listener.js
 //= require modules/inline-attachment-modal.js
 //= require modules/inline-image-modal.js
 //= require modules/video-embed-modal.js

--- a/app/assets/javascripts/components/autocomplete.js
+++ b/app/assets/javascripts/components/autocomplete.js
@@ -127,6 +127,7 @@ window.GOVUK.Modules = window.GOVUK.Modules || {};
 
   Autocomplete.prototype.initAutoCompleteSearchTopics = function () {
     var $input = this.$module.querySelector('input')
+    var $module = this.$module
     var millerColumns = document.querySelector('miller-columns')
     var topics = millerColumns.taxonomy.flattenedTopics
 
@@ -182,6 +183,7 @@ window.GOVUK.Modules = window.GOVUK.Modules || {};
       },
       onConfirm: function (result) {
         if (result && !result.topic.selected && !result.topic.selectedChildren.length) {
+          Autocomplete.prototype.triggerEvent($module, 'search-topic', result.topic)
           millerColumns.taxonomy.topicClicked(result.topic)
         }
       }
@@ -192,6 +194,20 @@ window.GOVUK.Modules = window.GOVUK.Modules || {};
 
   Autocomplete.prototype.dropdownArrow = function (config) {
     return '<svg class="' + config.className + '" style="top: 8px;" viewBox="0 0 512 512" ><path d="M256,298.3L256,298.3L256,298.3l174.2-167.2c4.3-4.2,11.4-4.1,15.8,0.2l30.6,29.9c4.4,4.3,4.5,11.3,0.2,15.5L264.1,380.9  c-2.2,2.2-5.2,3.2-8.1,3c-3,0.1-5.9-0.9-8.1-3L35.2,176.7c-4.3-4.2-4.2-11.2,0.2-15.5L66,131.3c4.4-4.3,11.5-4.4,15.8-0.2L256,298.3  z"/></svg>'
+  }
+
+  Autocomplete.prototype.triggerEvent = function (element, eventName, detail) {
+    var params = {bubbles: true, cancelable: true, detail: detail || null}
+    var event
+
+    if (typeof window.CustomEvent === 'function') {
+      event = new window.CustomEvent(eventName, params)
+    } else {
+      event = document.createEvent('CustomEvent')
+      event.initCustomEvent(eventName, params.bubbles, params.cancelable, params.detail)
+    }
+
+    element.dispatchEvent(event)
   }
 
   Modules.Autocomplete = Autocomplete

--- a/app/assets/javascripts/modules/gtm-topics-listener.js
+++ b/app/assets/javascripts/modules/gtm-topics-listener.js
@@ -1,0 +1,22 @@
+var GtmTopicsListener = {}
+
+GtmTopicsListener.handleTopicClick = function (dataGtm) {
+  return function (event) {
+    var element = event.target
+    var topic = event.detail
+
+    if (!element || !topic.topicNames) {
+      return
+    }
+
+    var topicName = topic.topicNames.join(' > ')
+
+    window.dataLayer.push({
+      event: 'Click',
+      dataGtm: dataGtm,
+      dataGtmValue: topicName
+    })
+  }
+}
+
+window.addEventListener('search-topic', GtmTopicsListener.handleTopicClick('select-topic-from-search-results'))

--- a/spec/javascripts/modules/gtm-search-topic-listener-spec.js
+++ b/spec/javascripts/modules/gtm-search-topic-listener-spec.js
@@ -1,0 +1,24 @@
+/* eslint-env jasmine */
+
+describe('Gtm search topic listener', function () {
+  'use strict'
+
+  beforeEach(function () {
+    window.dataLayer = []
+  })
+
+  it('should push to the dataLayer', function () {
+    document.dispatchEvent(new window.CustomEvent('search-topic', {
+      bubbles: true,
+      detail: {
+        topicNames: ['Business and industry', 'Business regulation']
+      }
+    }))
+
+    expect(window.dataLayer).toContain({
+      event: 'Click',
+      dataGtm: 'select-topic-from-search-results',
+      dataGtmValue: 'Business and industry > Business regulation'
+    })
+  })
+})


### PR DESCRIPTION
Trigger an event when searching for topics using the autocomplete component, so it can be tracked with analytics. It uses a `triggerEvent` function which acts as a polyfill for browsers that don't support CustomEvents..

It can be used/tested as shown in the example below:

```js
var autocomplete = document.querySelector('[data-autocomplete-type="topics"]')

autocomplete.addEventListener('search-topic', function(e){
  console.log(e.detail.topicNames.join(' > '))
})
```

[Trello card](https://trello.com/c/tAXP6pf1)