### PR TITLE
Fix video woes

### DIFF
--- a/app/assets/javascripts/modal/modal-workflow.js
+++ b/app/assets/javascripts/modal/modal-workflow.js
@@ -6,6 +6,9 @@ function ModalWorkflow ($modal, actionCallback) {
 
   this.$multiSectionViewer = this.$modal
     .querySelector('[data-module="multi-section-viewer"]')
+
+  this.renderSuccess = this.renderSuccess.bind(this)
+  this.renderError = this.renderError.bind(this)
 }
 
 ModalWorkflow.prototype.initComponents = function () {
@@ -34,8 +37,8 @@ ModalWorkflow.prototype.overrideActions = function (actions) {
 
 ModalWorkflow.prototype.render = function (response) {
   response
-    .then(this.renderSuccess.bind(this))
-    .catch(this.renderError.bind(this))
+    .then(this.renderSuccess)
+    .catch(this.renderError)
 }
 
 ModalWorkflow.prototype.renderError = function (result) {

--- a/app/assets/javascripts/modules/inline-image-modal.js
+++ b/app/assets/javascripts/modules/inline-image-modal.js
@@ -63,7 +63,7 @@ InlineImageModal.prototype.actionCallback = function (item) {
             this.editor.insertBlock(item.dataset.modalData)
           }
         }.bind(this))
-        .catch(this.workflow.renderError.bind(this))
+        .catch(this.workflow.renderError)
     }
   }
 

--- a/app/assets/javascripts/modules/video-embed-modal.js
+++ b/app/assets/javascripts/modules/video-embed-modal.js
@@ -38,7 +38,7 @@ VideoEmbedModal.prototype.actionCallback = function (item) {
             this.editor.insertBlock(result.body)
           }
         }.bind(this))
-        .catch(this.workflow.renderError.bind(this))
+        .catch(this.workflow.renderError)
     }
   }
 

--- a/app/services/requirements/video_embed_checker.rb
+++ b/app/services/requirements/video_embed_checker.rb
@@ -29,6 +29,8 @@ module Requirements
 
       uri.host.to_s.end_with?(YOUTUBE_HOST) &&
         uri.path == "/watch" && uri.query.to_s.match(/v=/)
+    rescue URI::InvalidURIError
+      false
     end
   end
 end

--- a/spec/services/requirements/video_embed_checker_spec.rb
+++ b/spec/services/requirements/video_embed_checker_spec.rb
@@ -34,6 +34,12 @@ RSpec.describe Requirements::VideoEmbedChecker do
       expect(form_message).to eq(I18n.t!("requirements.video_embed_url.blank.form_message"))
     end
 
+    it "returns an issue for an invalid URI" do
+      issues = Requirements::VideoEmbedChecker.new.pre_embed_issues(url: "http: youtube com")
+      form_message = issues.items_for(:video_embed_url).first[:text]
+      expect(form_message).to eq(I18n.t!("requirements.video_embed_url.non_youtube.form_message"))
+    end
+
     it "returns an issue for non-YouTube URLs" do
       issues = Requirements::VideoEmbedChecker.new.pre_embed_issues(url: "http://vimeo.com")
       form_message = issues.items_for(:video_embed_url).first[:text]


### PR DESCRIPTION
A couple of issues were caught with video embeds in the scenario testing round yesterday:

- an invalid URI caused the video embed requirements checker to exception
- an error response wasn't being handled by the modals.

It does look like we have a testing black spot with regards to the modal flows. 