### PR TITLE
Backdate Update Interactor fails if edition unchanged

### DIFF
--- a/app/interactors/backdate/update_interactor.rb
+++ b/app/interactors/backdate/update_interactor.rb
@@ -38,6 +38,8 @@ private
     updater = Versioning::RevisionUpdater.new(edition.revision, user)
     updater.assign(backdated_to: date)
     edition.assign_revision(updater.next_revision, user).save!
+
+    context.fail! unless updater.changed?
   end
 
   def backdate_params


### PR DESCRIPTION
This will ensure additional actions, such as creating a timeline entry, don't
happen if an edition hasn't actually changed.