### PR TITLE
Move controller raises to interactors

### DIFF
--- a/app/controllers/editions_controller.rb
+++ b/app/controllers/editions_controller.rb
@@ -2,13 +2,7 @@
 
 class EditionsController < ApplicationController
   def create
-    result = Editions::CreateInteractor.call(params: params, user: current_user)
-    if result.draft_current_edition
-      # FIXME: this shouldn't be an exception but we've not worked out the
-      # right response - maybe bad request or a redirect with flash?
-      raise "Can't create a new edition when the current edition is a draft"
-    else
-      redirect_to edit_document_path(params[:document])
-    end
+    Editions::CreateInteractor.call(params: params, user: current_user)
+    redirect_to edit_document_path(params[:document])
   end
 end

--- a/app/controllers/review_controller.rb
+++ b/app/controllers/review_controller.rb
@@ -17,13 +17,7 @@ class ReviewController < ApplicationController
   end
 
   def approve
-    result = Review::ApproveInteractor.call(params: params, user: current_user)
-
-    if result.wrong_status
-      # FIXME: this shouldn't be an exception but we've not worked out the
-      # right response - maybe bad request or a redirect with flash?
-      raise "Can't approve a document that doesn't need 2i"
-    end
+    Review::ApproveInteractor.call(params: params, user: current_user)
 
     redirect_to document_path(params[:document]),
                 notice: t("documents.show.flashes.approved")

--- a/app/controllers/withdraw_controller.rb
+++ b/app/controllers/withdraw_controller.rb
@@ -15,15 +15,9 @@ class WithdrawController < ApplicationController
 
   def create
     result = Withdraw::CreateInteractor.call(params: params, user: current_user)
-    edition, no_permission, issues, api_error = result.to_h.values_at(:edition,
-                                                                      :no_permission,
-                                                                      :issues,
-                                                                      :api_error)
-    if no_permission
-      # FIXME: this shouldn't be an exception but we've not worked out the
-      # right response - maybe bad request or a redirect with flash?
-      raise "Can't withdraw an edition without managing editor permissions"
-    elsif issues
+    edition, issues, api_error = result.to_h.values_at(:edition, :issues, :api_error)
+
+    if issues
       flash.now["requirements"] = { "items" => issues.items }
 
       render :new,

--- a/app/interactors/editions/create_interactor.rb
+++ b/app/interactors/editions/create_interactor.rb
@@ -23,7 +23,10 @@ private
 
   def find_and_lock_live_edition
     edition = Edition.lock.find_current(document: params[:document])
-    context.fail!(draft_current_edition: true) unless edition.live?
+
+    unless edition.live?
+      raise "Can't create a new edition when the current edition is a draft"
+    end
 
     context.live_edition = edition
   end

--- a/app/interactors/review/approve_interactor.rb
+++ b/app/interactors/review/approve_interactor.rb
@@ -12,8 +12,6 @@ class Review::ApproveInteractor
   def call
     Edition.transaction do
       find_and_lock_edition
-      check_status
-
       approve_edition
       create_timeline_entry
     end
@@ -23,10 +21,10 @@ private
 
   def find_and_lock_edition
     context.edition = Edition.lock.find_current(document: params[:document])
-  end
 
-  def check_status
-    context.fail!(wrong_status: true) unless edition.published_but_needs_2i?
+    unless edition.published_but_needs_2i?
+      raise "Can't approve a document that doesn't need 2i"
+    end
   end
 
   def approve_edition

--- a/app/interactors/withdraw/create_interactor.rb
+++ b/app/interactors/withdraw/create_interactor.rb
@@ -25,7 +25,7 @@ private
 
   def check_permission
     unless user.has_permission?(User::MANAGING_EDITOR_PERMISSION)
-      context.fail!(no_permission: true)
+      raise "Can't withdraw an edition without managing editor permissions"
     end
   end
 


### PR DESCRIPTION
https://trello.com/c/P3z1xFBW/968-investigate-methods-to-prevent-access-to-document-based-on-access-limit-and-state

Previously we had 3 sanity checks ('raise' statements) in our
controllers, whereas most are found our interactors. This moves
them into their associated interactors to be more consistent.