### PR TITLE
Update paste-html-to-govspeak to 0.2.3

### DIFF
--- a/package.json
+++ b/package.json
@@ -27,7 +27,7 @@
     "es5-polyfill": "^0.0.6",
     "markdown-toolbar-element": "^0.2.0",
     "miller-columns-element": "^1.0.0",
-    "paste-html-to-govspeak": "^0.2.2",
+    "paste-html-to-govspeak": "^0.2.3",
     "raven-js": "^3.27.0",
     "url-polyfill": "^1.1.3",
     "whatwg-fetch": "^3.0.0"

--- a/yarn.lock
+++ b/yarn.lock
@@ -971,9 +971,10 @@ parse-json@^4.0.0:
     error-ex "^1.3.1"
     json-parse-better-errors "^1.0.1"
 
-paste-html-to-govspeak@^0.2.2:
-  version "0.2.2"
-  resolved "https://registry.yarnpkg.com/paste-html-to-govspeak/-/paste-html-to-govspeak-0.2.2.tgz#7966cf10dca3cae82770f35c79f66b6aaf07ecb2"
+paste-html-to-govspeak@^0.2.3:
+  version "0.2.3"
+  resolved "https://registry.yarnpkg.com/paste-html-to-govspeak/-/paste-html-to-govspeak-0.2.3.tgz#15d91a9e542c20e405f33b86d57cad2a3128aa8b"
+  integrity sha512-lqxYqF1FrP8z5Me61Gouc998falswzDrLsehya4n+MXEIwoQoFpHa+wHNnxVFkTBC77JIDLtr2xJjLxsKkP+wg==
 
 path-exists@^3.0.0:
   version "3.0.0"


### PR DESCRIPTION
Update paste-html-to-govspeak to 0.2.3 which [fixes two IE11 issues](https://github.com/alphagov/paste-html-to-govspeak/blob/master/CHANGELOG.md#023).

Trello cards:
https://trello.com/c/MOMnfctt
https://trello.com/c/YUzyMrrn