### PR TITLE
Add page preview script to hide the cookie banner in iframes

### DIFF
--- a/app/assets/javascripts/application.js
+++ b/app/assets/javascripts/application.js
@@ -16,11 +16,12 @@
 //= require whatwg-fetch/dist/fetch.umd.js
 
 //= require components/autocomplete.js
-//= require components/toolbar-dropdown.js
 //= require components/image-cropper.js
 //= require components/input-length-suggester.js
 //= require components/markdown-editor.js
 //= require components/multi-section-viewer.js
+//= require components/page-preview.js
+//= require components/toolbar-dropdown.js
 //= require components/url-preview.js
 //= require miller-columns-element/dist/index.umd.js
 

--- a/app/assets/javascripts/components/page-preview.js
+++ b/app/assets/javascripts/components/page-preview.js
@@ -1,0 +1,30 @@
+window.GOVUK = window.GOVUK || {}
+window.GOVUK.Modules = window.GOVUK.Modules || {};
+
+(function (Modules) {
+  function PagePreview () { }
+
+  PagePreview.prototype.start = function ($module) {
+    this.$module = $module[0]
+
+    this.mobileIframe = this.$module.querySelector('.app-c-preview__mobile-iframe')
+    this.desktopIframe = this.$module.querySelector('.app-c-preview__desktop-iframe')
+
+    this.mobileIframe.onload = function () {
+      this.sendMessage(this.mobileIframe, {'hideCookieBanner': 'true'})
+    }.bind(this)
+
+    this.desktopIframe.onload = function () {
+      this.sendMessage(this.desktopIframe, {'hideCookieBanner': 'true'})
+    }.bind(this)
+  }
+
+  PagePreview.prototype.sendMessage = function (iframe, dataObject) {
+    if (iframe && iframe.contentWindow) {
+      var data = JSON.stringify(dataObject)
+      iframe.contentWindow.postMessage(data, window.location.origin)
+    }
+  }
+
+  Modules.PagePreview = PagePreview
+})(window.GOVUK.Modules)

--- a/app/assets/javascripts/components/page-preview.js
+++ b/app/assets/javascripts/components/page-preview.js
@@ -9,20 +9,21 @@ window.GOVUK.Modules = window.GOVUK.Modules || {};
 
     this.mobileIframe = this.$module.querySelector('.app-c-preview__mobile-iframe')
     this.desktopIframe = this.$module.querySelector('.app-c-preview__desktop-iframe')
+    this.iframeOriginUrl = this.$module.dataset.iframeOriginUrl
 
     this.mobileIframe.onload = function () {
-      this.sendMessage(this.mobileIframe, {'hideCookieBanner': 'true'})
+      this.sendMessage(this.mobileIframe, {'hideCookieBanner': 'true'}, this.iframeOriginUrl)
     }.bind(this)
 
     this.desktopIframe.onload = function () {
-      this.sendMessage(this.desktopIframe, {'hideCookieBanner': 'true'})
+      this.sendMessage(this.desktopIframe, {'hideCookieBanner': 'true'}, this.iframeOriginUrl)
     }.bind(this)
   }
 
-  PagePreview.prototype.sendMessage = function (iframe, dataObject) {
-    if (iframe && iframe.contentWindow) {
+  PagePreview.prototype.sendMessage = function (iframe, dataObject, originUrl) {
+    if (iframe && iframe.contentWindow && originUrl) {
       var data = JSON.stringify(dataObject)
-      iframe.contentWindow.postMessage(data, window.location.origin)
+      iframe.contentWindow.postMessage(data, originUrl)
     }
   }
 

--- a/app/assets/stylesheets/components/_page-preview.scss
+++ b/app/assets/stylesheets/components/_page-preview.scss
@@ -40,7 +40,7 @@ $app-mobile-border-bottom-width: 68px;
   border: 0;
 }
 
-.app-c-preview__desktop-preview {
+.app-c-preview__desktop-iframe {
   display: block;
   width: 100%;
   height: 1000px;

--- a/app/helpers/external_url_helper.rb
+++ b/app/helpers/external_url_helper.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-module EditionUrlHelper
+module ExternalUrlHelper
   def edition_public_url(edition)
     return unless edition.base_path
 
@@ -10,9 +10,12 @@ module EditionUrlHelper
   def edition_preview_url(edition)
     return unless edition.base_path
 
-    host = Plek.new.external_url_for("draft-origin")
     service = PreviewAuthBypassService.new(edition.document)
     params = { token: service.preview_token }.to_query
-    host + edition.base_path + "?" + params
+    draft_host_url + edition.base_path + "?" + params
+  end
+
+  def draft_host_url
+    Plek.new.external_url_for("draft-origin")
   end
 end

--- a/app/mailers/publish_mailer.rb
+++ b/app/mailers/publish_mailer.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 class PublishMailer < ApplicationMailer
-  helper :date_time, :edition_url
+  helper :date_time, :external_url
 
   self.delivery_job = EmailDeliveryJob
 

--- a/app/mailers/scheduled_publish_mailer.rb
+++ b/app/mailers/scheduled_publish_mailer.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 class ScheduledPublishMailer < ApplicationMailer
-  helper :date_time, :edition_url
+  helper :date_time, :external_url
 
   self.delivery_job = EmailDeliveryJob
 

--- a/app/views/components/_page_preview.html.erb
+++ b/app/views/components/_page_preview.html.erb
@@ -21,7 +21,7 @@
   </div>
 </div>
 
-<div class="app-c-preview">
+<div class="app-c-preview" data-module="page-preview">
   <% mobile_preview = capture do %>
     <%= tag.div class: "app-c-preview__mobile" do %>
       <%= tag.iframe class: "app-c-preview__mobile-iframe", src: url, title: "Preview of the page on mobile" %>
@@ -29,7 +29,7 @@
   <% end %>
 
   <% desktop_and_tablet = capture do %>
-    <%= tag.iframe class: "app-c-preview__desktop-preview", src: url, title: "Preview of the page on desktop or tablet" %>
+    <%= tag.iframe class: "app-c-preview__desktop-iframe", src: url, title: "Preview of the page on desktop or tablet" %>
   <% end %>
 
   <% snippet_preview = capture do %>

--- a/app/views/components/_page_preview.html.erb
+++ b/app/views/components/_page_preview.html.erb
@@ -21,7 +21,7 @@
   </div>
 </div>
 
-<div class="app-c-preview" data-module="page-preview">
+<div class="app-c-preview" data-module="page-preview" data-iframe-origin-url="<%= draft_host_url %>">
   <% mobile_preview = capture do %>
     <%= tag.div class: "app-c-preview__mobile" do %>
       <%= tag.iframe class: "app-c-preview__mobile-iframe", src: url, title: "Preview of the page on mobile" %>

--- a/app/views/components/docs/page_preview.yml
+++ b/app/views/components/docs/page_preview.yml
@@ -8,7 +8,7 @@ accessibility_criteria: |
 examples:
   default:
     data:
-      title: "A carrot cake has been baked"
-      base_path: "/news/cake-baked"
-      description: A carrot cake was baked for the publishing workflow team's fika, the government announced today.
-      url: "https://www.gov.uk/browse"
+      title: Foreign Secretary heads to Brussels to discuss Iran
+      base_path: "/government/news/foreign-secretary-heads-to-brussels-to-discuss-iran"
+      description: Ahead of the Foreign Affairs Council in Brussels, Jeremy Hunt said he would be building on the leadership shown by the E3 to maintain the nuclear deal.
+      url: "https://draft-origin.publishing.service.gov.uk/government/news/foreign-secretary-heads-to-brussels-to-discuss-iran"

--- a/spec/helpers/external_url_helper_spec.rb
+++ b/spec/helpers/external_url_helper_spec.rb
@@ -1,13 +1,13 @@
 # frozen_string_literal: true
 
-RSpec.describe EditionUrlHelper, type: :helper do
+RSpec.describe ExternalUrlHelper, type: :helper do
   let(:edition) do
     build(:edition,
           base_path: "/foo",
           content_id: "d2547c42-8ed3-49f5-baeb-6112f98c2bf9")
   end
 
-  describe "#public_url" do
+  describe "#edition_public_url" do
     it "returns the URL" do
       url = edition_public_url(edition)
       expect(url).to eq("https://www.test.gov.uk/foo")
@@ -20,7 +20,7 @@ RSpec.describe EditionUrlHelper, type: :helper do
     end
   end
 
-  describe "#preview_url" do
+  describe "#edition_preview_url" do
     let(:preview_auth_bypass_service) do
       instance_double(PreviewAuthBypassService, preview_token: "secret")
     end
@@ -38,6 +38,13 @@ RSpec.describe EditionUrlHelper, type: :helper do
       edition = build(:edition, base_path: nil)
       url = edition_preview_url(edition)
       expect(url).to be_nil
+    end
+  end
+
+  describe "#draft_host_url" do
+    it "returns the URL" do
+      url = draft_host_url
+      expect(url).to eq("https://draft-origin.test.gov.uk")
     end
   end
 end

--- a/spec/javascripts/components/page-preview-spec.js
+++ b/spec/javascripts/components/page-preview-spec.js
@@ -6,13 +6,14 @@ describe('Page preview component', function () {
 
   var container
   var pagePreview
+  var draftUrl = 'https://draft-origin.publishing.service.gov.uk'
 
   beforeEach(function () {
     container = document.createElement('div')
     container.innerHTML =
-      '<div class="app-c-preview" data-module="page-preview">' +
-        '<iframe class="app-c-preview__mobile-iframe" src="http://localhost:3221/component-guide/cookie_banner/default/preview" title="Preview of the page on mobile"></iframe>' +
-        '<iframe class="app-c-preview__desktop-iframe" src="http://localhost:3221/component-guide/cookie_banner/default/preview" title="Preview of the page on desktop or tablet"></iframe>' +
+      '<div class="app-c-preview" data-module="page-preview"  data-iframe-origin-url="' + draftUrl + '">' +
+        '<iframe class="app-c-preview__mobile-iframe" src="' + draftUrl + '/government/news/foreign-secretary-heads-to-brussels-to-discuss-iran" title="Preview of the page on mobile"></iframe>' +
+        '<iframe class="app-c-preview__desktop-iframe" src="' + draftUrl + '/government/news/foreign-secretary-heads-to-brussels-to-discuss-iran" title="Preview of the page on mobile"></iframe>' +
       '</div>'
 
     document.body.appendChild(container)
@@ -29,7 +30,7 @@ describe('Page preview component', function () {
     var mobileIframe = container.querySelector('.app-c-preview__mobile-iframe')
     spyOn(mobileIframe.contentWindow, 'postMessage')
 
-    pagePreview.sendMessage(mobileIframe, {'hideCookieBanner': 'true'})
+    pagePreview.sendMessage(mobileIframe, {'hideCookieBanner': 'true'}, draftUrl)
 
     expect(mobileIframe.contentWindow.postMessage).toHaveBeenCalled()
   })

--- a/spec/javascripts/components/page-preview-spec.js
+++ b/spec/javascripts/components/page-preview-spec.js
@@ -1,0 +1,36 @@
+/* eslint-env jasmine, jquery */
+/* global GOVUK */
+
+describe('Page preview component', function () {
+  'use strict'
+
+  var container
+  var pagePreview
+
+  beforeEach(function () {
+    container = document.createElement('div')
+    container.innerHTML =
+      '<div class="app-c-preview" data-module="page-preview">' +
+        '<iframe class="app-c-preview__mobile-iframe" src="http://localhost:3221/component-guide/cookie_banner/default/preview" title="Preview of the page on mobile"></iframe>' +
+        '<iframe class="app-c-preview__desktop-iframe" src="http://localhost:3221/component-guide/cookie_banner/default/preview" title="Preview of the page on desktop or tablet"></iframe>' +
+      '</div>'
+
+    document.body.appendChild(container)
+    var element = document.querySelector('[data-module="page-preview"]')
+    pagePreview = new GOVUK.Modules.PagePreview()
+    pagePreview.start($(element))
+  })
+
+  afterEach(function () {
+    document.body.removeChild(container)
+  })
+
+  it('should send a message to the mobile iframe\'s source document to hide the cookie banner', function () {
+    var mobileIframe = container.querySelector('.app-c-preview__mobile-iframe')
+    spyOn(mobileIframe.contentWindow, 'postMessage')
+
+    pagePreview.sendMessage(mobileIframe, {'hideCookieBanner': 'true'})
+
+    expect(mobileIframe.contentWindow.postMessage).toHaveBeenCalled()
+  })
+})


### PR DESCRIPTION
This PR adds a script to the page preview component which send a message to the child document of an iframe to hide the cookie banner.

The message is a stringified Object `{'hideCookieBanner': 'true'}` with the indent to use a similar approach for other changes needed in the child document (e.g. making the links open in a new window)

## Events chain
→ `PagePreview.start`
→ `CookieBanner.start`
→ `CookieBanner.listenForCrossOriginMessages`
→ `PagePreview` iframe loads
→ `PagePreview.sendMessage`
→ `CookieBanner.receiveMessage`

## Dependencies
This PR is marked as draft as it should be merged after govuk_publishing_components is released with [an updated version of `CookieBanner` which captures messages](https://github.com/alphagov/govuk_publishing_components/pull/988).

## Tests
This behaviour was tested locally using an updated version of the cookie banner component.
Cross browser testing: Chrome, Edge, Firefox, IE8-11, Safari

## Preview
### Before
![localhost_3221_component-guide_page_preview_default_preview](https://user-images.githubusercontent.com/788096/61131781-0239ff00-a4b2-11e9-8a58-dec3f9602e19.png)
![localhost_3221_component-guide_page_preview_default_preview (1)](https://user-images.githubusercontent.com/788096/61131786-049c5900-a4b2-11e9-9a32-28d368568604.png)

### After
![localhost_3221_component-guide_page_preview_default_preview (2)](https://user-images.githubusercontent.com/788096/61131792-07974980-a4b2-11e9-87a9-71f470fe7982.png)
![localhost_3221_component-guide_page_preview_default_preview (3)](https://user-images.githubusercontent.com/788096/61131840-12ea7500-a4b2-11e9-9777-53ab8fb3d606.png)

[Trello card](https://trello.com/c/QXbQKBG3)