### PR TITLE
Assertions

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -11,6 +11,18 @@ class ApplicationController < ActionController::Base
 
   add_flash_types :alert_with_description, :alert_with_items, :confirmation, :tried_to_publish, :tried_to_preview
 
+  rescue_from EditionAssertions::StateError do |e|
+    Rails.logger.warn(e.message)
+
+    if rendering_context == "modal"
+      render nothing: true, status: :bad_request
+    elsif e.edition.first? && e.edition.discarded?
+      redirect_to documents_path
+    else
+      redirect_to document_path(e.edition.document)
+    end
+  end
+
   def rendering_context
     request.headers["Content-Publisher-Rendering-Context"] || "application"
   end

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -2,6 +2,7 @@
 
 class ApplicationController < ActionController::Base
   include GDS::SSO::ControllerMethods
+  include EditionAssertions
 
   helper_method :rendering_context
 

--- a/app/controllers/backdate_controller.rb
+++ b/app/controllers/backdate_controller.rb
@@ -3,6 +3,8 @@
 class BackdateController < ApplicationController
   def edit
     @edition = Edition.find_current(document: params[:document])
+    assert_edition_state(@edition, &:editable?)
+    assert_edition_state(@edition, &:first?)
   end
 
   def update
@@ -27,7 +29,6 @@ class BackdateController < ApplicationController
   def destroy
     result = Backdate::DestroyInteractor.call(params: params, user: current_user)
     edition = result.edition
-
     redirect_to document_path(edition.document)
   end
 end

--- a/app/controllers/contacts_controller.rb
+++ b/app/controllers/contacts_controller.rb
@@ -3,6 +3,7 @@
 class ContactsController < ApplicationController
   def search
     @edition = Edition.find_current(document: params[:document])
+    assert_edition_state(@edition, &:editable?)
     @contacts_by_organisation = ContactsService.new.all_by_organisation
   rescue GdsApi::BaseError => e
     GovukError.notify(e)

--- a/app/controllers/documents_controller.rb
+++ b/app/controllers/documents_controller.rb
@@ -15,6 +15,7 @@ class DocumentsController < ApplicationController
 
   def edit
     @edition = Edition.find_current(document: params[:document])
+    assert_edition_state(@edition, &:editable?)
     @revision = @edition.revision
   end
 
@@ -24,11 +25,13 @@ class DocumentsController < ApplicationController
 
   def confirm_delete_draft
     edition = Edition.find_current(document: params[:document])
+    assert_edition_state(edition, &:editable?)
     redirect_to document_path(edition.document), confirmation: "documents/show/delete_draft"
   end
 
   def destroy
     result = Documents::DestroyInteractor.call(params: params, user: current_user)
+
     if result.api_error
       redirect_to document_path(params[:document]),
                   alert_with_description: t("documents.show.flashes.delete_draft_error")

--- a/app/controllers/editions_controller.rb
+++ b/app/controllers/editions_controller.rb
@@ -2,13 +2,7 @@
 
 class EditionsController < ApplicationController
   def create
-    result = Editions::CreateInteractor.call(params: params, user: current_user)
-    if result.draft_current_edition
-      # FIXME: this shouldn't be an exception but we've not worked out the
-      # right response - maybe bad request or a redirect with flash?
-      raise "Can't create a new edition when the current edition is a draft"
-    else
-      redirect_to edit_document_path(params[:document])
-    end
+    Editions::CreateInteractor.call(params: params, user: current_user)
+    redirect_to edit_document_path(params[:document])
   end
 end

--- a/app/controllers/file_attachments_controller.rb
+++ b/app/controllers/file_attachments_controller.rb
@@ -5,11 +5,14 @@ class FileAttachmentsController < ApplicationController
 
   def index
     @edition = Edition.find_current(document: params[:document])
+    assert_edition_state(@edition, &:editable?)
     render layout: rendering_context
   end
 
   def show
     @edition = Edition.find_current(document: params[:document])
+    assert_edition_state(@edition, &:editable?)
+
     @attachment = @edition.file_attachment_revisions
       .find_by!(file_attachment_id: params[:file_attachment_id])
 
@@ -67,6 +70,8 @@ class FileAttachmentsController < ApplicationController
 
   def edit
     @edition = Edition.find_current(document: params[:document])
+    assert_edition_state(@edition, &:editable?)
+
     @attachment = @edition.file_attachment_revisions
       .find_by!(file_attachment_id: params[:file_attachment_id])
 
@@ -74,8 +79,7 @@ class FileAttachmentsController < ApplicationController
   end
 
   def update
-    result = FileAttachments::UpdateInteractor.call(params: params,
-                                                    user: current_user)
+    result = FileAttachments::UpdateInteractor.call(params: params, user: current_user)
     edition = result.edition
     attachment_revision = result.file_attachment_revision
     issues = result.issues

--- a/app/controllers/images_controller.rb
+++ b/app/controllers/images_controller.rb
@@ -3,6 +3,7 @@
 class ImagesController < ApplicationController
   def index
     @edition = Edition.find_current(document: params[:document])
+    assert_edition_state(@edition, &:editable?)
     render layout: rendering_context
   end
 
@@ -28,6 +29,7 @@ class ImagesController < ApplicationController
 
   def crop
     @edition = Edition.find_current(document: params[:document])
+    assert_edition_state(@edition, &:editable?)
     @image_revision = @edition.image_revisions.find_by!(image_id: params[:image_id])
     render layout: rendering_context
   end
@@ -42,6 +44,7 @@ class ImagesController < ApplicationController
 
   def edit
     @edition = Edition.find_current(document: params[:document])
+    assert_edition_state(@edition, &:editable?)
     @image_revision = @edition.image_revisions.find_by!(image_id: params[:image_id])
     render layout: rendering_context
   end
@@ -92,6 +95,7 @@ class ImagesController < ApplicationController
 
   def download
     edition = Edition.find_current(document: params[:document])
+    assert_edition_state(edition, &:editable?)
     image_revision = edition.image_revisions.find_by!(image_id: params[:image_id])
     variant = image_revision.crop_variant("960x640!").processed
 

--- a/app/controllers/preview_controller.rb
+++ b/app/controllers/preview_controller.rb
@@ -17,5 +17,6 @@ class PreviewController < ApplicationController
 
   def show
     @edition = Edition.find_current(document: params[:document])
+    assert_edition_state(@edition, assertion: "not live") { !@edition.live? }
   end
 end

--- a/app/controllers/publish_controller.rb
+++ b/app/controllers/publish_controller.rb
@@ -3,6 +3,7 @@
 class PublishController < ApplicationController
   def confirmation
     @edition = Edition.find_current(document: params[:document])
+    assert_edition_state(@edition, &:editable?)
 
     issues = Requirements::EditionChecker.new(@edition)
                                          .pre_publish_issues(rescue_api_errors: false)

--- a/app/controllers/remove_controller.rb
+++ b/app/controllers/remove_controller.rb
@@ -3,5 +3,9 @@
 class RemoveController < ApplicationController
   def remove
     @edition = Edition.find_current(document: params[:document])
+
+    assert_edition_state(@edition, assertion: "is published") do
+      @edition.published? || @edition.published_but_needs_2i?
+    end
   end
 end

--- a/app/controllers/review_controller.rb
+++ b/app/controllers/review_controller.rb
@@ -17,13 +17,7 @@ class ReviewController < ApplicationController
   end
 
   def approve
-    result = Review::ApproveInteractor.call(params: params, user: current_user)
-
-    if result.wrong_status
-      # FIXME: this shouldn't be an exception but we've not worked out the
-      # right response - maybe bad request or a redirect with flash?
-      raise "Can't approve a document that doesn't need 2i"
-    end
+    Review::ApproveInteractor.call(params: params, user: current_user)
 
     redirect_to document_path(params[:document]),
                 notice: t("documents.show.flashes.approved")

--- a/app/controllers/schedule_controller.rb
+++ b/app/controllers/schedule_controller.rb
@@ -14,6 +14,7 @@ class ScheduleController < ApplicationController
 
   def edit
     @edition = Edition.find_current(document: params[:document])
+    assert_edition_state(@edition, &:scheduled?)
   end
 
   def update
@@ -72,5 +73,6 @@ class ScheduleController < ApplicationController
 
   def scheduled
     @edition = Edition.find_current(document: params[:document])
+    assert_edition_state(@edition, &:scheduled?)
   end
 end

--- a/app/controllers/schedule_proposal_controller.rb
+++ b/app/controllers/schedule_proposal_controller.rb
@@ -29,11 +29,11 @@ class ScheduleProposalController < ApplicationController
   def destroy
     result = ScheduleProposal::DestroyInteractor.call(params: params, user: current_user)
     edition = result.edition
-
     redirect_to document_path(edition.document)
   end
 
   def edit
     @edition = Edition.find_current(document: params[:document])
+    assert_edition_state(@edition, &:editable?)
   end
 end

--- a/app/controllers/tags_controller.rb
+++ b/app/controllers/tags_controller.rb
@@ -8,6 +8,7 @@ class TagsController < ApplicationController
 
   def edit
     @edition = Edition.find_current(document: params[:document])
+    assert_edition_state(@edition, &:editable?)
     @revision = @edition.revision
   end
 

--- a/app/controllers/topics_controller.rb
+++ b/app/controllers/topics_controller.rb
@@ -8,6 +8,7 @@ class TopicsController < ApplicationController
 
   def edit
     @edition = Edition.find_current(document: params[:document])
+    assert_edition_state(@edition, &:editable?)
     @version = @edition.document_topics.version
     @topics = @edition.topics
   end

--- a/app/controllers/unwithdraw_controller.rb
+++ b/app/controllers/unwithdraw_controller.rb
@@ -3,6 +3,7 @@
 class UnwithdrawController < ApplicationController
   def confirm
     @edition = Edition.find_current(document: params[:document])
+    assert_edition_state(@edition, &:withdrawn?)
 
     if current_user.has_permission?(User::MANAGING_EDITOR_PERMISSION)
       redirect_to document_path(@edition.document), confirmation: "unwithdraw/confirm"

--- a/app/controllers/withdraw_controller.rb
+++ b/app/controllers/withdraw_controller.rb
@@ -3,8 +3,11 @@
 class WithdrawController < ApplicationController
   def new
     @edition = Edition.find_current(document: params[:document])
-    @public_explanation =
-      @edition.withdrawn? ? @edition.status.details.public_explanation : nil
+    @public_explanation = @edition.withdrawn? ? @edition.status.details.public_explanation : nil
+
+    assert_edition_state(@edition, assertion: "is published or withdrawn") do
+      @edition.published? || @edition.published_but_needs_2i? || @edition.withdrawn?
+    end
 
     if current_user.has_permission?(User::MANAGING_EDITOR_PERMISSION)
       render :new

--- a/app/interactors/application_interactor.rb
+++ b/app/interactors/application_interactor.rb
@@ -1,0 +1,5 @@
+# frozen_string_literal: true
+
+class ApplicationInteractor
+  include Interactor
+end

--- a/app/interactors/application_interactor.rb
+++ b/app/interactors/application_interactor.rb
@@ -2,4 +2,5 @@
 
 class ApplicationInteractor
   include Interactor
+  include EditionAssertions
 end

--- a/app/interactors/backdate/destroy_interactor.rb
+++ b/app/interactors/backdate/destroy_interactor.rb
@@ -1,9 +1,10 @@
 # frozen_string_literal: true
 
-class Backdate::DestroyInteractor
-  include Interactor
-
-  delegate :params, :edition, :user, to: :context
+class Backdate::DestroyInteractor < ApplicationInteractor
+  delegate :params,
+           :edition,
+           :user,
+           to: :context
 
   def call
     Edition.transaction do

--- a/app/interactors/backdate/destroy_interactor.rb
+++ b/app/interactors/backdate/destroy_interactor.rb
@@ -19,12 +19,8 @@ private
 
   def find_and_lock_edition
     context.edition = Edition.lock.find_current(document: params[:document])
-
-    unless edition.editable? && edition.first?
-      # FIXME: this shouldn't be an exception but we've not worked out the
-      # right response - maybe bad request or a redirect with flash?
-      raise "Only editable backdated first editions can have their backdated date cleared."
-    end
+    assert_edition_state(edition, &:editable?)
+    assert_edition_state(edition, &:first?)
   end
 
   def update_edition

--- a/app/interactors/backdate/update_interactor.rb
+++ b/app/interactors/backdate/update_interactor.rb
@@ -1,7 +1,6 @@
 # frozen_string_literal: true
 
-class Backdate::UpdateInteractor
-  include Interactor
+class Backdate::UpdateInteractor < ApplicationInteractor
   delegate :params,
            :user,
            :edition,

--- a/app/interactors/backdate/update_interactor.rb
+++ b/app/interactors/backdate/update_interactor.rb
@@ -25,12 +25,8 @@ private
 
   def find_and_lock_edition
     context.edition = Edition.lock.find_current(document: params[:document])
-
-    unless edition.first? && edition.editable?
-      # FIXME: this shouldn't be an exception but we've not worked out the
-      # right response - maybe bad request or a redirect with flash?
-      raise "Only editable first editions can be backdated."
-    end
+    assert_edition_state(edition, &:first?)
+    assert_edition_state(edition, &:editable?)
   end
 
   def update_edition

--- a/app/interactors/contacts/insert_interactor.rb
+++ b/app/interactors/contacts/insert_interactor.rb
@@ -1,7 +1,6 @@
 # frozen_string_literal: true
 
-class Contacts::InsertInteractor
-  include Interactor
+class Contacts::InsertInteractor < ApplicationInteractor
   delegate :params,
            :user,
            :edition,

--- a/app/interactors/contacts/insert_interactor.rb
+++ b/app/interactors/contacts/insert_interactor.rb
@@ -22,6 +22,7 @@ private
 
   def find_and_lock_edition
     context.edition = Edition.lock.find_current(document: params[:document])
+    assert_edition_state(edition, &:editable?)
   end
 
   def check_for_submission

--- a/app/interactors/documents/destroy_interactor.rb
+++ b/app/interactors/documents/destroy_interactor.rb
@@ -1,7 +1,6 @@
 # frozen_string_literal: true
 
-class Documents::DestroyInteractor
-  include Interactor
+class Documents::DestroyInteractor < ApplicationInteractor
   delegate :params,
            :user,
            :edition,

--- a/app/interactors/documents/update_interactor.rb
+++ b/app/interactors/documents/update_interactor.rb
@@ -23,6 +23,7 @@ private
 
   def find_and_lock_edition
     context.edition = Edition.lock.find_current(document: params[:document])
+    assert_edition_state(edition, &:editable?)
   end
 
   def update_revision

--- a/app/interactors/documents/update_interactor.rb
+++ b/app/interactors/documents/update_interactor.rb
@@ -1,7 +1,6 @@
 # frozen_string_literal: true
 
-class Documents::UpdateInteractor
-  include Interactor
+class Documents::UpdateInteractor < ApplicationInteractor
   delegate :params,
            :user,
            :edition,

--- a/app/interactors/editions/create_interactor.rb
+++ b/app/interactors/editions/create_interactor.rb
@@ -22,9 +22,11 @@ private
 
   def find_and_lock_live_edition
     edition = Edition.lock.find_current(document: params[:document])
-    context.fail!(draft_current_edition: true) unless edition.live?
-
     context.live_edition = edition
+
+    assert_edition_state(edition, assertion: "can create new edition") do
+      edition.published? || edition.published_but_needs_2i? || edition.removed?
+    end
   end
 
   def create_next_edition

--- a/app/interactors/editions/create_interactor.rb
+++ b/app/interactors/editions/create_interactor.rb
@@ -1,7 +1,6 @@
 # frozen_string_literal: true
 
-class Editions::CreateInteractor
-  include Interactor
+class Editions::CreateInteractor < ApplicationInteractor
   delegate :params,
            :user,
            :live_edition,

--- a/app/interactors/file_attachments/create_interactor.rb
+++ b/app/interactors/file_attachments/create_interactor.rb
@@ -1,8 +1,6 @@
 # frozen_string_literal: true
 
-class FileAttachments::CreateInteractor
-  include Interactor
-
+class FileAttachments::CreateInteractor < ApplicationInteractor
   delegate :params,
            :user,
            :edition,

--- a/app/interactors/file_attachments/create_interactor.rb
+++ b/app/interactors/file_attachments/create_interactor.rb
@@ -21,14 +21,15 @@ class FileAttachments::CreateInteractor < ApplicationInteractor
 
 private
 
+  def find_and_lock_edition
+    context.edition = Edition.lock.find_current(document: params[:document])
+    assert_edition_state(edition, &:editable?)
+  end
+
   def check_for_issues
     issues = Requirements::FileAttachmentChecker.new(file: params[:file], title: params[:title])
                                                 .pre_upload_issues
     context.fail!(issues: issues) if issues.any?
-  end
-
-  def find_and_lock_edition
-    context.edition = Edition.lock.find_current(document: params[:document])
   end
 
   def upload_attachment

--- a/app/interactors/file_attachments/destroy_interactor.rb
+++ b/app/interactors/file_attachments/destroy_interactor.rb
@@ -20,6 +20,7 @@ private
 
   def find_and_lock_edition
     context.edition = Edition.lock.find_current(document: params[:document])
+    assert_edition_state(edition, &:editable?)
   end
 
   def find_and_remove_attachment

--- a/app/interactors/file_attachments/destroy_interactor.rb
+++ b/app/interactors/file_attachments/destroy_interactor.rb
@@ -1,8 +1,6 @@
 # frozen_string_literal: true
 
-class FileAttachments::DestroyInteractor
-  include Interactor
-
+class FileAttachments::DestroyInteractor < ApplicationInteractor
   delegate :params,
            :user,
            :edition,

--- a/app/interactors/file_attachments/preview_interactor.rb
+++ b/app/interactors/file_attachments/preview_interactor.rb
@@ -19,6 +19,7 @@ private
 
   def find_and_lock_edition
     context.edition = Edition.lock.find_current(document: params[:document])
+    assert_edition_state(edition, &:editable?)
   end
 
   def find_attachment

--- a/app/interactors/file_attachments/preview_interactor.rb
+++ b/app/interactors/file_attachments/preview_interactor.rb
@@ -1,8 +1,6 @@
 # frozen_string_literal: true
 
-class FileAttachments::PreviewInteractor
-  include Interactor
-
+class FileAttachments::PreviewInteractor < ApplicationInteractor
   delegate :params,
            :edition,
            :attachment_revision,

--- a/app/interactors/file_attachments/update_interactor.rb
+++ b/app/interactors/file_attachments/update_interactor.rb
@@ -25,6 +25,7 @@ private
 
   def find_and_lock_edition
     context.edition = Edition.lock.find_current(document: params[:document])
+    assert_edition_state(edition, &:editable?)
   end
 
   def find_file_attachment

--- a/app/interactors/file_attachments/update_interactor.rb
+++ b/app/interactors/file_attachments/update_interactor.rb
@@ -1,8 +1,6 @@
 # frozen_string_literal: true
 
-class FileAttachments::UpdateInteractor
-  include Interactor
-
+class FileAttachments::UpdateInteractor < ApplicationInteractor
   delegate :params,
            :user,
            :edition,

--- a/app/interactors/images/create_interactor.rb
+++ b/app/interactors/images/create_interactor.rb
@@ -1,7 +1,6 @@
 # frozen_string_literal: true
 
-class Images::CreateInteractor
-  include Interactor
+class Images::CreateInteractor < ApplicationInteractor
   delegate :params,
            :user,
            :edition,

--- a/app/interactors/images/create_interactor.rb
+++ b/app/interactors/images/create_interactor.rb
@@ -21,6 +21,7 @@ private
 
   def find_and_lock_edition
     context.edition = Edition.lock.find_current(document: params[:document])
+    assert_edition_state(edition, &:editable?)
   end
 
   def check_for_issues

--- a/app/interactors/images/destroy_interactor.rb
+++ b/app/interactors/images/destroy_interactor.rb
@@ -1,7 +1,6 @@
 # frozen_string_literal: true
 
-class Images::DestroyInteractor
-  include Interactor
+class Images::DestroyInteractor < ApplicationInteractor
   delegate :params,
            :user,
            :edition,

--- a/app/interactors/images/destroy_interactor.rb
+++ b/app/interactors/images/destroy_interactor.rb
@@ -21,6 +21,7 @@ private
 
   def find_and_lock_edition
     context.edition = Edition.lock.find_current(document: params[:document])
+    assert_edition_state(edition, &:editable?)
   end
 
   def find_and_remove_image

--- a/app/interactors/images/update_crop_interactor.rb
+++ b/app/interactors/images/update_crop_interactor.rb
@@ -1,7 +1,6 @@
 # frozen_string_literal: true
 
-class Images::UpdateCropInteractor
-  include Interactor
+class Images::UpdateCropInteractor < ApplicationInteractor
   delegate :params,
            :user,
            :edition,

--- a/app/interactors/images/update_crop_interactor.rb
+++ b/app/interactors/images/update_crop_interactor.rb
@@ -23,6 +23,7 @@ private
 
   def find_and_lock_edition
     context.edition = Edition.lock.find_current(document: params[:document])
+    assert_edition_state(edition, &:editable?)
   end
 
   def find_and_update_image

--- a/app/interactors/images/update_interactor.rb
+++ b/app/interactors/images/update_interactor.rb
@@ -1,8 +1,6 @@
 # frozen_string_literal: true
 
-class Images::UpdateInteractor
-  include Interactor
-
+class Images::UpdateInteractor < ApplicationInteractor
   delegate :params,
            :user,
            :edition,

--- a/app/interactors/images/update_interactor.rb
+++ b/app/interactors/images/update_interactor.rb
@@ -27,6 +27,7 @@ private
 
   def find_and_lock_edition
     context.edition = Edition.lock.find_current(document: params[:document])
+    assert_edition_state(edition, &:editable?)
   end
 
   def find_and_update_image

--- a/app/interactors/internal_notes/create_interactor.rb
+++ b/app/interactors/internal_notes/create_interactor.rb
@@ -1,8 +1,6 @@
 # frozen_string_literal: true
 
-class InternalNotes::CreateInteractor
-  include Interactor
-
+class InternalNotes::CreateInteractor < ApplicationInteractor
   delegate :params,
            :user,
            :edition,

--- a/app/interactors/lead_image/choose_interactor.rb
+++ b/app/interactors/lead_image/choose_interactor.rb
@@ -1,7 +1,6 @@
 # frozen_string_literal: true
 
-class LeadImage::ChooseInteractor
-  include Interactor
+class LeadImage::ChooseInteractor < ApplicationInteractor
   delegate :params,
            :user,
            :edition,

--- a/app/interactors/lead_image/choose_interactor.rb
+++ b/app/interactors/lead_image/choose_interactor.rb
@@ -23,6 +23,7 @@ private
 
   def find_and_lock_edition
     context.edition = Edition.lock.find_current(document: params[:document])
+    assert_edition_state(edition, &:editable?)
   end
 
   def find_image_revision

--- a/app/interactors/lead_image/remove_interactor.rb
+++ b/app/interactors/lead_image/remove_interactor.rb
@@ -24,6 +24,7 @@ private
 
   def find_and_lock_edition
     context.edition = Edition.lock.find_current(document: params[:document])
+    assert_edition_state(edition, &:editable?)
   end
 
   def check_lead_image

--- a/app/interactors/lead_image/remove_interactor.rb
+++ b/app/interactors/lead_image/remove_interactor.rb
@@ -1,8 +1,6 @@
 # frozen_string_literal: true
 
-class LeadImage::RemoveInteractor
-  include Interactor
-
+class LeadImage::RemoveInteractor < ApplicationInteractor
   delegate :params,
            :user,
            :edition,

--- a/app/interactors/new_document/choose_supertype_interactor.rb
+++ b/app/interactors/new_document/choose_supertype_interactor.rb
@@ -1,8 +1,6 @@
 # frozen_string_literal: true
 
-class NewDocument::ChooseSupertypeInteractor
-  include Interactor
-
+class NewDocument::ChooseSupertypeInteractor < ApplicationInteractor
   delegate :user,
            :params,
            :supertype,

--- a/app/interactors/new_document/create_interactor.rb
+++ b/app/interactors/new_document/create_interactor.rb
@@ -1,8 +1,6 @@
 # frozen_string_literal: true
 
-class NewDocument::CreateInteractor
-  include Interactor
-
+class NewDocument::CreateInteractor < ApplicationInteractor
   delegate :params,
            :user,
            :document_type,

--- a/app/interactors/preview/create_interactor.rb
+++ b/app/interactors/preview/create_interactor.rb
@@ -1,8 +1,6 @@
 # frozen_string_literal: true
 
-class Preview::CreateInteractor
-  include Interactor
-
+class Preview::CreateInteractor < ApplicationInteractor
   delegate :params,
            :user,
            :edition,

--- a/app/interactors/preview/create_interactor.rb
+++ b/app/interactors/preview/create_interactor.rb
@@ -20,6 +20,7 @@ private
 
   def find_and_lock_edition
     context.edition = Edition.lock.find_current(document: params[:document])
+    assert_edition_state(edition, &:editable?)
   end
 
   def check_for_issues

--- a/app/interactors/publish/publish_interactor.rb
+++ b/app/interactors/publish/publish_interactor.rb
@@ -24,13 +24,10 @@ private
 
   def find_and_lock_edition
     context.edition = Edition.lock.find_current(document: params[:document])
+    assert_edition_state(edition, &:editable?)
 
-    unless edition.editable?
-      raise "Can't publish an edition which isn't editable"
-    end
-
-    if Requirements::EditionChecker.new(edition).pre_publish_issues(rescue_api_errors: false).any?
-      raise "Can't publish an edition with requirements issues"
+    assert_edition_state(edition, assertion: "has no requirements issues") do
+      Requirements::EditionChecker.new(edition).pre_publish_issues(rescue_api_errors: false).none?
     end
   end
 
@@ -40,6 +37,7 @@ private
     issues = Requirements::CheckerIssues.new([
       Requirements::Issue.new(:review_status, :not_selected),
     ])
+
     context.fail!(issues: issues)
   end
 

--- a/app/interactors/publish/publish_interactor.rb
+++ b/app/interactors/publish/publish_interactor.rb
@@ -1,8 +1,6 @@
 # frozen_string_literal: true
 
-class Publish::PublishInteractor
-  include Interactor
-
+class Publish::PublishInteractor < ApplicationInteractor
   delegate :params,
            :user,
            :edition,

--- a/app/interactors/review/approve_interactor.rb
+++ b/app/interactors/review/approve_interactor.rb
@@ -1,8 +1,6 @@
 # frozen_string_literal: true
 
-class Review::ApproveInteractor
-  include Interactor
-
+class Review::ApproveInteractor < ApplicationInteractor
   delegate :params,
            :user,
            :edition,

--- a/app/interactors/review/approve_interactor.rb
+++ b/app/interactors/review/approve_interactor.rb
@@ -10,8 +10,6 @@ class Review::ApproveInteractor < ApplicationInteractor
   def call
     Edition.transaction do
       find_and_lock_edition
-      check_status
-
       approve_edition
       create_timeline_entry
     end
@@ -21,10 +19,7 @@ private
 
   def find_and_lock_edition
     context.edition = Edition.lock.find_current(document: params[:document])
-  end
-
-  def check_status
-    context.fail!(wrong_status: true) unless edition.published_but_needs_2i?
+    assert_edition_state(edition, &:published_but_needs_2i?)
   end
 
   def approve_edition

--- a/app/interactors/review/submit_for2i_interactor.rb
+++ b/app/interactors/review/submit_for2i_interactor.rb
@@ -22,6 +22,7 @@ private
 
   def find_and_lock_edition
     context.edition = Edition.lock.find_current(document: params[:document])
+    assert_edition_state(edition, &:draft?)
   end
 
   def check_for_issues

--- a/app/interactors/review/submit_for2i_interactor.rb
+++ b/app/interactors/review/submit_for2i_interactor.rb
@@ -1,8 +1,6 @@
 # frozen_string_literal: true
 
-class Review::SubmitFor2iInteractor
-  include Interactor
-
+class Review::SubmitFor2iInteractor < ApplicationInteractor
   delegate :params,
            :user,
            :edition,

--- a/app/interactors/schedule/create_interactor.rb
+++ b/app/interactors/schedule/create_interactor.rb
@@ -1,8 +1,6 @@
 # frozen_string_literal: true
 
-class Schedule::CreateInteractor
-  include Interactor
-
+class Schedule::CreateInteractor < ApplicationInteractor
   delegate :params,
            :user,
            :edition,

--- a/app/interactors/schedule/create_interactor.rb
+++ b/app/interactors/schedule/create_interactor.rb
@@ -19,13 +19,14 @@ private
 
   def find_and_lock_edition
     context.edition = Edition.lock.find_current(document: params[:document])
+    assert_edition_state(edition, &:editable?)
 
-    unless edition.editable? && edition.proposed_publish_time.present?
-      raise "Can't schedule an edition which isn't schedulable"
+    assert_edition_state(edition, assertion: "has proposed publish time") do
+      edition.proposed_publish_time.present?
     end
 
-    if Requirements::EditionChecker.new(edition).pre_publish_issues(rescue_api_errors: false).any?
-      raise "Can't schedule an edition with requirements issues"
+    assert_edition_state(edition, assertion: "has no requirements issues") do
+      Requirements::EditionChecker.new(edition).pre_publish_issues(rescue_api_errors: false).none?
     end
   end
 

--- a/app/interactors/schedule/destroy_interactor.rb
+++ b/app/interactors/schedule/destroy_interactor.rb
@@ -1,9 +1,10 @@
 # frozen_string_literal: true
 
-class Schedule::DestroyInteractor
-  include Interactor
-
-  delegate :params, :edition, :user, to: :context
+class Schedule::DestroyInteractor < ApplicationInteractor
+  delegate :params,
+           :edition,
+           :user,
+           to: :context
 
   def call
     Edition.transaction do

--- a/app/interactors/schedule/destroy_interactor.rb
+++ b/app/interactors/schedule/destroy_interactor.rb
@@ -19,10 +19,7 @@ private
 
   def find_and_lock_edition
     context.edition = Edition.lock.find_current(document: params[:document])
-
-    unless edition.scheduled?
-      raise "Cannot unschedule an edition that is not scheduled"
-    end
+    assert_edition_state(edition, &:scheduled?)
   end
 
   def update_edition

--- a/app/interactors/schedule/new_interactor.rb
+++ b/app/interactors/schedule/new_interactor.rb
@@ -1,8 +1,6 @@
 # frozen_string_literal: true
 
-class Schedule::NewInteractor
-  include Interactor
-
+class Schedule::NewInteractor < ApplicationInteractor
   delegate :params,
            :edition,
            :publish_issues,

--- a/app/interactors/schedule/new_interactor.rb
+++ b/app/interactors/schedule/new_interactor.rb
@@ -15,9 +15,10 @@ class Schedule::NewInteractor < ApplicationInteractor
 
   def find_edition
     context.edition = Edition.find_current(document: params[:document])
+    assert_edition_state(edition, &:editable?)
 
-    unless edition.editable? && edition.proposed_publish_time.present?
-      raise "Can't schedule an edition which isn't schedulable"
+    assert_edition_state(edition, assertion: "has proposed publish time") do
+      edition.proposed_publish_time.present?
     end
   end
 

--- a/app/interactors/schedule/update_interactor.rb
+++ b/app/interactors/schedule/update_interactor.rb
@@ -1,8 +1,6 @@
 # frozen_string_literal: true
 
-class Schedule::UpdateInteractor
-  include Interactor
-
+class Schedule::UpdateInteractor < ApplicationInteractor
   delegate :params,
            :user,
            :edition,

--- a/app/interactors/schedule/update_interactor.rb
+++ b/app/interactors/schedule/update_interactor.rb
@@ -22,10 +22,7 @@ private
 
   def find_and_lock_edition
     context.edition = Edition.lock.find_current(document: params[:document])
-
-    unless edition.scheduled?
-      raise "Can't reschedule an edition which isn't scheduled"
-    end
+    assert_edition_state(edition, &:scheduled?)
   end
 
   def parse_publish_time

--- a/app/interactors/schedule_proposal/destroy_interactor.rb
+++ b/app/interactors/schedule_proposal/destroy_interactor.rb
@@ -1,7 +1,6 @@
 # frozen_string_literal: true
 
-class ScheduleProposal::DestroyInteractor
-  include Interactor
+class ScheduleProposal::DestroyInteractor < ApplicationInteractor
   delegate :params,
            :edition,
            :user,

--- a/app/interactors/schedule_proposal/destroy_interactor.rb
+++ b/app/interactors/schedule_proposal/destroy_interactor.rb
@@ -17,10 +17,7 @@ private
 
   def find_and_lock_edition
     context.edition = Edition.lock.find_current(document: params[:document])
-
-    unless edition.editable?
-      raise "Cannot modify an edition that is not editable"
-    end
+    assert_edition_state(edition, &:editable?)
   end
 
   def clear_proposed_time

--- a/app/interactors/schedule_proposal/update_interactor.rb
+++ b/app/interactors/schedule_proposal/update_interactor.rb
@@ -22,10 +22,7 @@ private
 
   def find_and_lock_edition
     context.edition = Edition.lock.find_current(document: params[:document])
-
-    unless edition.editable?
-      raise "Can't set a schedule date/time unless edition is editable"
-    end
+    assert_edition_state(edition, &:editable?)
   end
 
   def parse_publish_time

--- a/app/interactors/schedule_proposal/update_interactor.rb
+++ b/app/interactors/schedule_proposal/update_interactor.rb
@@ -1,7 +1,6 @@
 # frozen_string_literal: true
 
-class ScheduleProposal::UpdateInteractor
-  include Interactor
+class ScheduleProposal::UpdateInteractor < ApplicationInteractor
   delegate :params,
            :edition,
            :revision,

--- a/app/interactors/tags/update_interactor.rb
+++ b/app/interactors/tags/update_interactor.rb
@@ -1,8 +1,6 @@
 # frozen_string_literal: true
 
-class Tags::UpdateInteractor
-  include Interactor
-
+class Tags::UpdateInteractor < ApplicationInteractor
   delegate :params,
            :user,
            :edition,

--- a/app/interactors/tags/update_interactor.rb
+++ b/app/interactors/tags/update_interactor.rb
@@ -25,6 +25,7 @@ private
 
   def find_and_lock_edition
     context.edition = Edition.lock.find_current(document: params[:document])
+    assert_edition_state(edition, &:editable?)
   end
 
   def update_revision

--- a/app/interactors/topics/update_interactor.rb
+++ b/app/interactors/topics/update_interactor.rb
@@ -16,7 +16,9 @@ class Topics::UpdateInteractor < ApplicationInteractor
 private
 
   def find_document
-    context.document = Document.with_current_edition.find_by_param(params[:document])
+    edition = Edition.find_current(document: params[:document])
+    assert_edition_state(edition, &:editable?)
+    context.document = edition.document
   end
 
   def update_topics

--- a/app/interactors/topics/update_interactor.rb
+++ b/app/interactors/topics/update_interactor.rb
@@ -1,8 +1,6 @@
 # frozen_string_literal: true
 
-class Topics::UpdateInteractor
-  include Interactor
-
+class Topics::UpdateInteractor < ApplicationInteractor
   delegate :params,
            :user,
            :document,

--- a/app/interactors/unwithdraw/unwithdraw_interactor.rb
+++ b/app/interactors/unwithdraw/unwithdraw_interactor.rb
@@ -20,6 +20,7 @@ private
 
   def find_and_lock_edition
     context.edition = Edition.lock.find_current(document: params[:document])
+    assert_edition_state(edition, &:withdrawn?)
   end
 
   def update_edition

--- a/app/interactors/unwithdraw/unwithdraw_interactor.rb
+++ b/app/interactors/unwithdraw/unwithdraw_interactor.rb
@@ -1,9 +1,11 @@
 # frozen_string_literal: true
 
-class Unwithdraw::UnwithdrawInteractor
-  include Interactor
-
-  delegate :params, :user, :edition, :api_error, to: :context
+class Unwithdraw::UnwithdrawInteractor < ApplicationInteractor
+  delegate :params,
+           :user,
+           :edition,
+           :api_error,
+           to: :context
 
   def call
     Edition.transaction do

--- a/app/interactors/withdraw/create_interactor.rb
+++ b/app/interactors/withdraw/create_interactor.rb
@@ -1,8 +1,6 @@
 # frozen_string_literal: true
 
-class Withdraw::CreateInteractor
-  include Interactor
-
+class Withdraw::CreateInteractor < ApplicationInteractor
   delegate :params,
            :user,
            :edition,

--- a/app/interactors/withdraw/create_interactor.rb
+++ b/app/interactors/withdraw/create_interactor.rb
@@ -29,6 +29,10 @@ private
 
   def find_and_lock_edition
     context.edition = Edition.lock.find_current(document: params[:document])
+
+    assert_edition_state(@edition, assertion: "is published or withdrawn") do
+      edition.published? || edition.published_but_needs_2i? || edition.withdrawn?
+    end
   end
 
   def check_for_issues

--- a/app/services/edition_assertions.rb
+++ b/app/services/edition_assertions.rb
@@ -1,0 +1,30 @@
+# frozen_string_literal: true
+
+module EditionAssertions
+  class Error < StandardError
+    attr_reader :edition
+
+    def initialize(edition, assertion)
+      @edition = edition
+      super("Assertion failed: #{assertion}")
+    end
+  end
+
+  class StateError < Error
+    def initialize(edition, assertion)
+      super(edition, assertion || "meets state requirements")
+    end
+  end
+
+  def assert_edition_state(edition, options = {}, &block)
+    return if block.call(edition)
+
+    assertion = options[:assertion]
+    assertion ||= block.to_s if block.to_s =~ /&:/ # &:editable?
+    raise StateError.new(edition, assertion)
+  end
+
+  def assert_edition_access(_edition, _user)
+    raise "not implemented"
+  end
+end

--- a/spec/services/edition_assertions_spec.rb
+++ b/spec/services/edition_assertions_spec.rb
@@ -1,0 +1,23 @@
+# frozen_string_literal: true
+
+RSpec.describe EditionAssertions do
+  include EditionAssertions
+
+  describe "#assert_edition_state" do
+    let(:edition) { build :edition }
+
+    it "does nothing when the assertion block returns true" do
+      expect { assert_edition_state(edition) { true } }.to_not raise_error
+    end
+
+    it "throws an error when the assertion block is false" do
+      expect { assert_edition_state(edition) { false } }
+        .to raise_error(EditionAssertions::StateError)
+    end
+
+    it "can throw errors with custom messaging" do
+      expect { assert_edition_state(edition, assertion: "custom messaging") { false } }
+        .to raise_error(EditionAssertions::StateError, /custom messaging/)
+    end
+  end
+end


### PR DESCRIPTION
https://trello.com/c/P3z1xFBW/968-investigate-methods-to-prevent-access-to-document-based-on-access-limit-and-state

This replaces and supplements our previous ad-hoc 'raise' assertions with a new EditionAssertions module and a new redirect behaviour for when they happen. Please see the commits for more details.