### PR TITLE
Move bits of withdraw service into interactor

### DIFF
--- a/spec/features/workflow/edit_withdrawal_spec.rb
+++ b/spec/features/workflow/edit_withdrawal_spec.rb
@@ -43,8 +43,6 @@ RSpec.feature "Edit a withdrawal" do
 
   def then_i_can_see_the_updated_explanation
     expect(page).to have_content(@new_explanation)
-
-    click_on "Document history"
     expect(page).to have_content(I18n.t!("documents.history.entry_types.withdrawn_updated"))
   end
 end

--- a/spec/features/workflow/withdraw_publishing_api_down_spec.rb
+++ b/spec/features/workflow/withdraw_publishing_api_down_spec.rb
@@ -4,10 +4,9 @@ RSpec.feature "Withdraw a document when Publishing API is down" do
   scenario do
     given_there_is_a_published_edition
     and_i_am_a_managing_editor
-    when_i_visit_the_withdraw_document_page
     and_the_publishing_api_is_down
-    when_i_fill_in_the_public_explanation
-    and_click_on_withdraw_document
+    when_i_visit_the_summary_page
+    and_i_try_to_withdraw_an_edition
     then_i_see_a_withdrawal_error_message
     and_the_document_has_not_been_withdrawn
   end
@@ -16,23 +15,21 @@ RSpec.feature "Withdraw a document when Publishing API is down" do
     @edition = create(:edition, :published)
   end
 
-  def and_i_am_a_managing_editor
-    login_as(create(:user, :managing_editor))
-  end
-
-  def when_i_visit_the_withdraw_document_page
-    visit withdraw_path(@edition.document)
-  end
-
   def and_the_publishing_api_is_down
     publishing_api_isnt_available
   end
 
-  def when_i_fill_in_the_public_explanation
-    fill_in "public_explanation", with: "An explanation"
+  def and_i_am_a_managing_editor
+    login_as(create(:user, :managing_editor))
   end
 
-  def and_click_on_withdraw_document
+  def when_i_visit_the_summary_page
+    visit document_path(@edition.document)
+  end
+
+  def and_i_try_to_withdraw_an_edition
+    click_on "Withdraw"
+    fill_in "public_explanation", with: "An explanation"
     click_on "Withdraw document"
   end
 
@@ -41,7 +38,7 @@ RSpec.feature "Withdraw a document when Publishing API is down" do
   end
 
   def and_the_document_has_not_been_withdrawn
-    @edition.reload
-    expect(@edition.state).not_to eq("withdrawn")
+    visit document_path(@edition.document)
+    expect(page).to have_content(I18n.t!("user_facing_states.published.name"))
   end
 end

--- a/spec/features/workflow/withdraw_spec.rb
+++ b/spec/features/workflow/withdraw_spec.rb
@@ -6,9 +6,8 @@ RSpec.feature "Withdraw a document" do
     and_i_am_a_managing_editor
     when_i_visit_the_summary_page
     and_i_click_on_withdraw
-    then_i_see_that_i_can_withdraw_the_document
-    when_i_fill_in_the_public_explanation
-    and_click_on_withdraw_document
+    and_i_fill_in_the_explanation
+    and_i_confirm_the_withdrawal
     then_i_see_the_document_has_been_withdrawn
   end
 
@@ -28,17 +27,12 @@ RSpec.feature "Withdraw a document" do
     click_on "Withdraw"
   end
 
-  def then_i_see_that_i_can_withdraw_the_document
-    expect(page).to have_content "Withdraw '#{@edition.title}'"
-  end
-
-  def when_i_fill_in_the_public_explanation
+  def and_i_fill_in_the_explanation
     @explanation = "An explanation using [markdown](https://www.gov.uk)"
     fill_in "public_explanation", with: @explanation
-    expect(page).to have_content(I18n.t!("withdraw.new.public_explanation.guidance_title"))
   end
 
-  def and_click_on_withdraw_document
+  def and_i_confirm_the_withdrawal
     converted_explanation = GovspeakDocument.new(@explanation, @edition).payload_html
     body = { type: "withdrawal", explanation: converted_explanation, locale: @edition.locale }
     stub_publishing_api_unpublish(@edition.content_id, body: body)
@@ -54,6 +48,7 @@ RSpec.feature "Withdraw a document" do
     expect(page).to have_content(I18n.t!("documents.show.withdrawn.title",
                                          document_type: document_type,
                                          withdrawn_date: withdrawal.created_at.strftime("%-d %B %Y")))
+
     expect(page).to have_content(@explanation)
     expect(page).to have_content(I18n.t!("documents.show.metadata.withdrawn_by") + ": #{status.created_by.name}")
   end


### PR DESCRIPTION
Previously the WithdrawService managed the TimelineEntry for a withdraw
action, as well as change detection when editing a withdrawal; both of
these are standard tasks for an interactor. This moves both of these
responsibilities out of the service and into the associated interactor.