### PR TITLE
Move schedule timeline entries into interactors

### DIFF
--- a/app/interactors/schedule/create_interactor.rb
+++ b/app/interactors/schedule/create_interactor.rb
@@ -12,6 +12,7 @@ class Schedule::CreateInteractor < ApplicationInteractor
       find_and_lock_edition
       check_for_issues
       schedule_to_publish
+      create_timeline_entry
     end
   end
 
@@ -43,5 +44,13 @@ private
   def schedule_to_publish
     reviewed = params[:review_status] == "reviewed"
     ScheduleService.new(edition).schedule(user: user, reviewed: reviewed)
+  end
+
+  def create_timeline_entry
+    TimelineEntry.create_for_status_change(
+      entry_type: :scheduled,
+      status: edition.status,
+      details: edition.status.details,
+    )
   end
 end

--- a/app/interactors/schedule/update_interactor.rb
+++ b/app/interactors/schedule/update_interactor.rb
@@ -15,6 +15,7 @@ class Schedule::UpdateInteractor < ApplicationInteractor
       parse_publish_time
       check_for_issues
       reschedule_to_publish
+      create_timeline_entry
     end
   end
 
@@ -42,6 +43,14 @@ private
     context.fail! if publish_time == scheduling.publish_time
 
     ScheduleService.new(edition).reschedule(publish_time: publish_time, user: user)
+  end
+
+  def create_timeline_entry
+    TimelineEntry.create_for_status_change(
+      entry_type: :schedule_updated,
+      status: edition.status,
+      details: edition.status.details,
+    )
   end
 
   def schedule_params

--- a/app/services/schedule_service.rb
+++ b/app/services/schedule_service.rb
@@ -13,8 +13,6 @@ class ScheduleService
                                 publish_time: edition.proposed_publish_time)
 
     update_edition(scheduling, user)
-    create_timeline_entry(:scheduled, scheduling)
-
     create_publish_intent
     schedule_to_publish(scheduling)
   end
@@ -28,8 +26,6 @@ class ScheduleService
     new_scheduling = previous_scheduling.dup.tap { |s| s.publish_time = publish_time }
 
     update_edition(new_scheduling, user)
-    create_timeline_entry(:schedule_updated, new_scheduling)
-
     update_publish_intent
     schedule_to_publish(new_scheduling)
   end
@@ -43,14 +39,6 @@ private
     edition.assign_revision(updater.next_revision, user)
            .assign_status(:scheduled, user, status_details: scheduling)
            .save!
-  end
-
-  def create_timeline_entry(entry_type, scheduling)
-    TimelineEntry.create_for_status_change(
-      entry_type: entry_type,
-      status: edition.status,
-      details: scheduling,
-    )
   end
 
   def create_publish_intent

--- a/spec/features/scheduling/scheduled_publishing_spec.rb
+++ b/spec/features/scheduling/scheduled_publishing_spec.rb
@@ -50,11 +50,13 @@ RSpec.feature "Scheduled publishing" do
 
   def then_i_see_the_edition_is_scheduled
     expect(page).to have_content(I18n.t!("schedule.scheduled.title"))
-
     visit document_path(@edition.document)
-    expect(page).to have_content(I18n.t!("user_facing_states.scheduled.name"))
-    expect(page).to have_content(I18n.t!("documents.history.entry_types.scheduled"))
 
+    within(".app-timeline-entry") do
+      expect(page).to have_content(I18n.t!("documents.history.entry_types.scheduled"))
+    end
+
+    expect(page).to have_content(I18n.t!("user_facing_states.scheduled.name"))
     expect(page).to have_content("Scheduled to publish at 9:00am on 22 June 2019")
   end
 

--- a/spec/services/schedule_service_spec.rb
+++ b/spec/services/schedule_service_spec.rb
@@ -33,11 +33,6 @@ RSpec.describe ScheduleService do
       expect(edition.reload.proposed_publish_time).to be_nil
     end
 
-    it "creates a timeline entry" do
-      ScheduleService.new(edition).schedule(reviewed: true)
-      expect(edition.timeline_entries.first.entry_type).to eq("scheduled")
-    end
-
     it "creates a publishing intent" do
       request = stub_publishing_api_put_intent(edition.base_path, '"payload"')
       ScheduleService.new(edition).schedule(reviewed: true)
@@ -88,11 +83,6 @@ RSpec.describe ScheduleService do
       expect(new_scheduling.publish_time).to eq new_publish_time
       expect(new_scheduling.slice(:reviewed, :pre_scheduled_status))
         .to eql old_scheduling.slice(:reviewed, :pre_scheduled_status)
-    end
-
-    it "creates another timeline entry" do
-      ScheduleService.new(edition).reschedule(publish_time: new_publish_time)
-      expect(edition.timeline_entries.last.entry_type).to eq "schedule_updated"
     end
 
     it "updates the existing publishing intent" do


### PR DESCRIPTION
https://trello.com/c/P3z1xFBW/968-investigate-methods-to-prevent-access-to-document-based-on-access-limit-and-state

This makes scheduling consistent with other actions, noting that the
creation of timeline entries is not inherently part of the scheduling of
an edition.