### PR TITLE
Improve contextual guidance on small screens

### DIFF
--- a/app/assets/stylesheets/components/_contextual-guidance.scss
+++ b/app/assets/stylesheets/components/_contextual-guidance.scss
@@ -14,9 +14,10 @@
 
   @include govuk-font(19);
 
-  @include govuk-responsive-margin(6, "bottom");
+  margin-bottom: govuk-spacing(7);
 
   @include govuk-media-query($from: tablet) {
+    margin-bottom: govuk-spacing(7);
     padding-top: govuk-spacing(6);
   }
 }

--- a/app/assets/stylesheets/components/_contextual-guidance.scss
+++ b/app/assets/stylesheets/components/_contextual-guidance.scss
@@ -33,7 +33,14 @@
 }
 
 .app-c-contextual-guidance {
-  padding-top: govuk-spacing(5);
-  border-top: 5px solid $govuk-focus-colour;
+  padding-left: govuk-spacing(3);
+  border-left: 4px solid $govuk-focus-colour;
   background: govuk-colour("white");
+
+  @include govuk-media-query($from: tablet) {
+    padding-top: govuk-spacing(5);
+    padding-left: 0;
+    border-top: 5px solid $govuk-focus-colour;
+    border-left: 0;
+  }
 }

--- a/app/assets/stylesheets/components/_input-length-suggester.scss
+++ b/app/assets/stylesheets/components/_input-length-suggester.scss
@@ -3,5 +3,5 @@
 }
 
 .app-c-input-length-suggester__hidden {
-  visibility: hidden;
+  display: none;
 }

--- a/app/assets/stylesheets/components/_url-preview.scss
+++ b/app/assets/stylesheets/components/_url-preview.scss
@@ -2,6 +2,10 @@
   @include govuk-font(19);
 
   @include govuk-responsive-margin(6, "bottom");
+
+  .govuk-inset-text {
+    margin-top: 0;
+  }
 }
 
 .app-c-url-preview__title {

--- a/app/views/components/docs/contextual_guidance.yml
+++ b/app/views/components/docs/contextual_guidance.yml
@@ -1,5 +1,16 @@
 name: Contextual guidance
 description: Provides a container with additional information when focusing an input field (e.g. input, textarea)
+body: |
+  This component is build to be used with a focusable elements that refers to it.
+
+  The contextual guidance must have an id. The input must refer the contextual guidance using a `data-contextual-guidance`
+  attribute (e.g. `<input data-contextual-guidance="my-contextual-guidance-id">`).
+
+  On tablet and desktop, the guidance container is set to float on the page and prevent other elements from moving around (e.g. pushing next fields down the page).
+
+  To use this component in a form built using a grid layout, an `app-c-contextual-guidance__form` class needs to be added to the wrapping `<form>` element.
+  When used like this the last guidance won't overflow in order to prevent it from overlapping with the footer.
+
 part_of_admin_layout: true
 accessibility_criteria: |
   The component must:
@@ -13,17 +24,19 @@ examples:
   default:
     description: Reveals a contextul guidance on the side overflowing the container
     embed: |
-      <div class="govuk-grid-row">
-        <div class="govuk-grid-column-two-thirds">
-          <div class="govuk-form-group">
-            <label for="title" class="govuk-label govuk-label--s">Title</label>
-            <input class="govuk-input" id="title" data-contextual-guidance="news-title-guidance" placeholder="Focus to reveal">
+      <form class="app-c-contextual-guidance__form">
+        <div class="govuk-grid-row">
+          <div class="govuk-grid-column-two-thirds">
+            <div class="govuk-form-group">
+              <label for="title" class="govuk-label govuk-label--s">Title</label>
+              <input class="govuk-input" id="title" data-contextual-guidance="news-title-guidance" placeholder="Focus to reveal">
+            </div>
+          </div>
+          <div class="govuk-grid-column-one-third">
+            <%= component %>
           </div>
         </div>
-        <div class="govuk-grid-column-one-third">
-          <%= component %>
-        </div>
-      </div>
+      </form>
     data:
       title: Writing a news title
       id: news-title-guidance

--- a/app/views/documents/edit.html.erb
+++ b/app/views/documents/edit.html.erb
@@ -39,15 +39,6 @@
           message: "Title should be under 65 characters. Current length: {count}",
         } %>
       <% end %>
-
-      <%= render "components/url_preview", {
-        title: t("documents.edit.url_preview.available"),
-        default_message: t("documents.edit.url_preview.no_title"),
-        error_message: t("documents.edit.url_preview.error"),
-        website_root: Plek.new.website_root,
-        base_path: @revision.base_path
-      } do %>
-      <% end %>
     </div>
 
     <% if @edition.document_type.guidance_for("title") %>
@@ -60,6 +51,18 @@
         <% end %>
       </div>
     <% end %>
+  </div>
+
+  <div class="govuk-grid-row">
+    <div class="govuk-grid-column-two-thirds">
+      <%= render "components/url_preview", {
+        title: t("documents.edit.url_preview.available"),
+        default_message: t("documents.edit.url_preview.no_title"),
+        error_message: t("documents.edit.url_preview.error"),
+        website_root: Plek.new.website_root,
+        base_path: @revision.base_path
+      } %>
+    </div>
   </div>
 
   <div class="govuk-grid-row">


### PR DESCRIPTION
This PR updates the contextual guidance component and document edit page after a design iteration to improve the user interface on small screens or when using magnifying tools.

Changes:
- Set highlight border on the left for mobile views b13d318
- Increase margin-bottom for the guidance container for mobile views cbf4e43
- Hide the input length suggester container when no message is presented d03ee7a
- Add documentation to contextual guidance and update the example 534029b
- Update edit page to place the url preview section in a new row 51b1050
- Remove inset text top margin when used in the url preview component f295751

## Review app preview
[Preview contextual guidance component](https://content-publisher-revi-pr-1253.herokuapp.com/component-guide/contextual_guidance)
[Preview the component in edit document page](https://content-publisher-revi-pr-1253.herokuapp.com/documents/4571577e-63f9-4879-b36b-3b257b33be24:en/edit)

## Static examples previews (before and after)
### Title field
![contextual-guidance-title](https://user-images.githubusercontent.com/788096/61304448-172fce80-a7e1-11e9-8e25-e92e559f7783.jpg)

### Summary field
![imgonline-com-ua-twotoone-0QOopfX0Jk9Q](https://user-images.githubusercontent.com/788096/61304472-21ea6380-a7e1-11e9-827c-fd8d4afa6f96.jpg)


[Trello card](https://trello.com/c/OHO5MB3o)