### PR TITLE
Allow users to remove a set access limit

### DIFF
--- a/app/models/timeline_entry.rb
+++ b/app/models/timeline_entry.rb
@@ -55,7 +55,8 @@ class TimelineEntry < ApplicationRecord
                      backdated: "backdated",
                      backdate_cleared: "backdate_cleared",
                      access_limit_created: "access_limit_created",
-                     access_limit_updated: "access_limit_updated" }
+                     access_limit_updated: "access_limit_updated",
+                     access_limit_removed: "access_limit_removed" }
 
   def self.create_for_status_change(entry_type:,
                                     status:,

--- a/app/views/access_limit/edit.html.erb
+++ b/app/views/access_limit/edit.html.erb
@@ -17,6 +17,15 @@
         name: "limit_type",
         items: [
           {
+            value: "none",
+            text: t("access_limit.edit.no_access_limit"),
+            checked: @edition.access_limit.nil?,
+            data_attributes: {
+              gtm: "choose-access-limit",
+              "gtm-value": t("access_limit.edit.no_access_limit")
+            }
+          },
+          {
             value: "primary_organisation",
             text: t("access_limit.edit.type.primary_organisation"),
             checked: @edition.access_limit&.primary_organisation?,

--- a/config/locales/en/access_limit/edit.yml
+++ b/config/locales/en/access_limit/edit.yml
@@ -4,6 +4,7 @@ en:
       browser_title: Access limit content
       title: Who can access this document
       description: You can limit who is able to find and edit this document before it is published. Select an option that includes the organisation associated with your account.
+      no_access_limit: All publishers have access
       type:
         primary_organisation: Only publishers in the primary organisation have access
         all_organisations: Only publishers in tagged organistions have access

--- a/config/locales/en/documents/history.yml
+++ b/config/locales/en/documents/history.yml
@@ -36,5 +36,6 @@ en:
         backdate_cleared: "Backdate cleared"
         access_limit_created: "Access limit created"
         access_limit_updated: "Access limit updated"
+        access_limit_removed: "Access limit removed"
       entry_content:
         backdated: "First published date backdated to %{date}"

--- a/spec/features/editing_content_settings/remove_access_limit_spec.rb
+++ b/spec/features/editing_content_settings/remove_access_limit_spec.rb
@@ -1,0 +1,47 @@
+# frozen_string_literal: true
+
+RSpec.feature "Remove access limit" do
+  scenario do
+    given_there_is_an_access_limited_edition
+    and_there_is_a_user_in_some_other_org
+    when_i_visit_the_summary_page
+    and_i_go_to_edit_the_access_limit
+    and_i_remove_the_access_limit
+    then_i_see_the_access_limit_is_removed
+    and_the_other_user_can_edit_the_edition
+  end
+
+  def given_there_is_an_access_limited_edition
+    @edition = create(:edition, :access_limited, created_by: current_user)
+  end
+
+  def and_there_is_a_user_in_some_other_org
+    @other_org_user = create(:user,
+                             permissions: [User::PRE_RELEASE_FEATURES_PERMISSION],
+                             organisation_content_id: SecureRandom.uuid)
+  end
+
+  def when_i_visit_the_summary_page
+    visit document_path(@edition.document)
+  end
+
+  def and_i_go_to_edit_the_access_limit
+    click_on "Edit Access limit"
+  end
+
+  def and_i_remove_the_access_limit
+    choose I18n.t!("access_limit.edit.no_access_limit")
+    click_on "Save"
+  end
+
+  def then_i_see_the_access_limit_is_removed
+    expect(page).to have_content(I18n.t!("documents.show.content_settings.access_limit.no_access_limit"))
+    expect(page).to have_content(I18n.t!("documents.history.entry_types.access_limit_removed"))
+  end
+
+  def and_the_other_user_can_edit_the_edition
+    login_as(@other_org_user)
+    visit document_path(@edition.document)
+    expect(page).to have_content("Edit Access limiting")
+  end
+end


### PR DESCRIPTION
https://trello.com/c/dlw2oE4O/987-create-a-form-so-users-can-limit-access-to-a-draft