### PR TITLE
Access limit everywhere

### DIFF
--- a/app/controllers/access_limit_controller.rb
+++ b/app/controllers/access_limit_controller.rb
@@ -3,6 +3,7 @@
 class AccessLimitController < ApplicationController
   def edit
     @edition = Edition.find_current(document: params[:document])
+    assert_edition_access(@edition, current_user)
   end
 
   def update

--- a/app/controllers/backdate_controller.rb
+++ b/app/controllers/backdate_controller.rb
@@ -5,6 +5,7 @@ class BackdateController < ApplicationController
     @edition = Edition.find_current(document: params[:document])
     assert_edition_state(@edition, &:editable?)
     assert_edition_state(@edition, &:first?)
+    assert_edition_access(@edition, current_user)
   end
 
   def update

--- a/app/controllers/contacts_controller.rb
+++ b/app/controllers/contacts_controller.rb
@@ -4,6 +4,7 @@ class ContactsController < ApplicationController
   def search
     @edition = Edition.find_current(document: params[:document])
     assert_edition_state(@edition, &:editable?)
+    assert_edition_access(@edition, current_user)
     @contacts_by_organisation = ContactsService.new.all_by_organisation
   rescue GdsApi::BaseError => e
     GovukError.notify(e)

--- a/app/controllers/documents_controller.rb
+++ b/app/controllers/documents_controller.rb
@@ -28,6 +28,7 @@ class DocumentsController < ApplicationController
   def confirm_delete_draft
     edition = Edition.find_current(document: params[:document])
     assert_edition_state(edition, &:editable?)
+    assert_edition_access(edition, current_user)
     redirect_to document_path(edition.document), confirmation: "documents/show/delete_draft"
   end
 
@@ -63,6 +64,7 @@ class DocumentsController < ApplicationController
 
   def generate_path
     edition = Edition.find_current(document: params[:document])
+    assert_edition_access(edition, current_user)
     base_path = PathGeneratorService.new.path(edition.document, params[:title])
     render plain: base_path
   end

--- a/app/controllers/file_attachments_controller.rb
+++ b/app/controllers/file_attachments_controller.rb
@@ -6,12 +6,14 @@ class FileAttachmentsController < ApplicationController
   def index
     @edition = Edition.find_current(document: params[:document])
     assert_edition_state(@edition, &:editable?)
+    assert_edition_access(@edition, current_user)
     render layout: rendering_context
   end
 
   def show
     @edition = Edition.find_current(document: params[:document])
     assert_edition_state(@edition, &:editable?)
+    assert_edition_access(@edition, current_user)
 
     @attachment = @edition.file_attachment_revisions
       .find_by!(file_attachment_id: params[:file_attachment_id])
@@ -20,7 +22,7 @@ class FileAttachmentsController < ApplicationController
   end
 
   def preview
-    result = FileAttachments::PreviewInteractor.call(params: params)
+    result = FileAttachments::PreviewInteractor.call(params: params, user: current_user)
     attachment_revision, edition, can_preview, api_error = result.to_h.values_at(:attachment_revision,
                                                                                  :edition,
                                                                                  :can_preview,

--- a/app/controllers/govspeak_preview_controller.rb
+++ b/app/controllers/govspeak_preview_controller.rb
@@ -5,6 +5,7 @@ class GovspeakPreviewController < ApplicationController
 
   def to_html
     edition = Edition.find_current(document: params[:document])
+    assert_edition_access(edition, current_user)
     govspeak_html = GovspeakDocument.new(params[:govspeak], edition).in_app_html
     render partial: "govuk_publishing_components/components/govspeak",
            locals: { content: govspeak_html.html_safe } # rubocop:disable Rails/OutputSafety

--- a/app/controllers/images_controller.rb
+++ b/app/controllers/images_controller.rb
@@ -4,6 +4,7 @@ class ImagesController < ApplicationController
   def index
     @edition = Edition.find_current(document: params[:document])
     assert_edition_state(@edition, &:editable?)
+    assert_edition_access(@edition, current_user)
     render layout: rendering_context
   end
 

--- a/app/controllers/schedule_controller.rb
+++ b/app/controllers/schedule_controller.rb
@@ -2,7 +2,7 @@
 
 class ScheduleController < ApplicationController
   def new
-    result = Schedule::NewInteractor.call(params: params)
+    result = Schedule::NewInteractor.call(params: params, user: current_user)
     @edition = result.edition
 
     if result.publish_issues
@@ -15,6 +15,7 @@ class ScheduleController < ApplicationController
   def edit
     @edition = Edition.find_current(document: params[:document])
     assert_edition_state(@edition, &:scheduled?)
+    assert_edition_access(@edition, current_user)
   end
 
   def update
@@ -74,5 +75,6 @@ class ScheduleController < ApplicationController
   def scheduled
     @edition = Edition.find_current(document: params[:document])
     assert_edition_state(@edition, &:scheduled?)
+    assert_edition_access(@edition, current_user)
   end
 end

--- a/app/controllers/schedule_proposal_controller.rb
+++ b/app/controllers/schedule_proposal_controller.rb
@@ -35,5 +35,6 @@ class ScheduleProposalController < ApplicationController
   def edit
     @edition = Edition.find_current(document: params[:document])
     assert_edition_state(@edition, &:editable?)
+    assert_edition_access(@edition, current_user)
   end
 end

--- a/app/controllers/tags_controller.rb
+++ b/app/controllers/tags_controller.rb
@@ -9,6 +9,7 @@ class TagsController < ApplicationController
   def edit
     @edition = Edition.find_current(document: params[:document])
     assert_edition_state(@edition, &:editable?)
+    assert_edition_access(@edition, current_user)
     @revision = @edition.revision
   end
 

--- a/app/controllers/topics_controller.rb
+++ b/app/controllers/topics_controller.rb
@@ -9,6 +9,7 @@ class TopicsController < ApplicationController
   def edit
     @edition = Edition.find_current(document: params[:document])
     assert_edition_state(@edition, &:editable?)
+    assert_edition_access(@edition, current_user)
     @version = @edition.document_topics.version
     @topics = @edition.topics
   end

--- a/app/interactors/backdate/update_interactor.rb
+++ b/app/interactors/backdate/update_interactor.rb
@@ -27,6 +27,7 @@ private
     context.edition = Edition.lock.find_current(document: params[:document])
     assert_edition_state(edition, &:first?)
     assert_edition_state(edition, &:editable?)
+    assert_edition_access(edition, user)
   end
 
   def update_edition

--- a/app/interactors/contacts/insert_interactor.rb
+++ b/app/interactors/contacts/insert_interactor.rb
@@ -23,6 +23,7 @@ private
   def find_and_lock_edition
     context.edition = Edition.lock.find_current(document: params[:document])
     assert_edition_state(edition, &:editable?)
+    assert_edition_access(edition, user)
   end
 
   def check_for_submission

--- a/app/interactors/documents/destroy_interactor.rb
+++ b/app/interactors/documents/destroy_interactor.rb
@@ -19,6 +19,8 @@ private
 
   def find_and_lock_edition
     context.edition = Edition.lock.find_current(document: params[:document])
+    assert_edition_state(edition, &:editable?)
+    assert_edition_access(edition, user)
   end
 
   def discard_draft

--- a/app/interactors/documents/update_interactor.rb
+++ b/app/interactors/documents/update_interactor.rb
@@ -24,6 +24,7 @@ private
   def find_and_lock_edition
     context.edition = Edition.lock.find_current(document: params[:document])
     assert_edition_state(edition, &:editable?)
+    assert_edition_access(edition, user)
   end
 
   def update_revision

--- a/app/interactors/file_attachments/preview_interactor.rb
+++ b/app/interactors/file_attachments/preview_interactor.rb
@@ -2,6 +2,7 @@
 
 class FileAttachments::PreviewInteractor < ApplicationInteractor
   delegate :params,
+           :user,
            :edition,
            :attachment_revision,
            :asset,
@@ -20,6 +21,7 @@ private
   def find_and_lock_edition
     context.edition = Edition.lock.find_current(document: params[:document])
     assert_edition_state(edition, &:editable?)
+    assert_edition_access(edition, user)
   end
 
   def find_attachment

--- a/app/interactors/images/create_interactor.rb
+++ b/app/interactors/images/create_interactor.rb
@@ -22,6 +22,7 @@ private
   def find_and_lock_edition
     context.edition = Edition.lock.find_current(document: params[:document])
     assert_edition_state(edition, &:editable?)
+    assert_edition_access(edition, user)
   end
 
   def check_for_issues

--- a/app/interactors/lead_image/choose_interactor.rb
+++ b/app/interactors/lead_image/choose_interactor.rb
@@ -24,6 +24,7 @@ private
   def find_and_lock_edition
     context.edition = Edition.lock.find_current(document: params[:document])
     assert_edition_state(edition, &:editable?)
+    assert_edition_access(edition, user)
   end
 
   def find_image_revision

--- a/app/interactors/lead_image/remove_interactor.rb
+++ b/app/interactors/lead_image/remove_interactor.rb
@@ -25,6 +25,7 @@ private
   def find_and_lock_edition
     context.edition = Edition.lock.find_current(document: params[:document])
     assert_edition_state(edition, &:editable?)
+    assert_edition_access(edition, user)
   end
 
   def check_lead_image

--- a/app/interactors/preview/create_interactor.rb
+++ b/app/interactors/preview/create_interactor.rb
@@ -21,6 +21,7 @@ private
   def find_and_lock_edition
     context.edition = Edition.lock.find_current(document: params[:document])
     assert_edition_state(edition, &:editable?)
+    assert_edition_access(edition, user)
   end
 
   def check_for_issues

--- a/app/interactors/publish/confirmation_interactor.rb
+++ b/app/interactors/publish/confirmation_interactor.rb
@@ -20,6 +20,7 @@ private
   def find_and_lock_edition
     context.edition = Edition.find_current(document: params[:document])
     assert_edition_state(edition, &:editable?)
+    assert_edition_access(edition, user)
   end
 
   def check_for_issues

--- a/app/interactors/publish/publish_interactor.rb
+++ b/app/interactors/publish/publish_interactor.rb
@@ -25,6 +25,7 @@ private
   def find_and_lock_edition
     context.edition = Edition.lock.find_current(document: params[:document])
     assert_edition_state(edition, &:editable?)
+    assert_edition_access(edition, user)
 
     assert_edition_state(edition, assertion: "has no requirements issues") do
       Requirements::EditionChecker.new(edition).pre_publish_issues(rescue_api_errors: false).none?

--- a/app/interactors/review/approve_interactor.rb
+++ b/app/interactors/review/approve_interactor.rb
@@ -20,6 +20,7 @@ private
   def find_and_lock_edition
     context.edition = Edition.lock.find_current(document: params[:document])
     assert_edition_state(edition, &:published_but_needs_2i?)
+    assert_edition_access(edition, user)
   end
 
   def approve_edition

--- a/app/interactors/review/submit_for2i_interactor.rb
+++ b/app/interactors/review/submit_for2i_interactor.rb
@@ -23,6 +23,7 @@ private
   def find_and_lock_edition
     context.edition = Edition.lock.find_current(document: params[:document])
     assert_edition_state(edition, &:draft?)
+    assert_edition_access(edition, user)
   end
 
   def check_for_issues

--- a/app/interactors/schedule/create_interactor.rb
+++ b/app/interactors/schedule/create_interactor.rb
@@ -21,6 +21,7 @@ private
   def find_and_lock_edition
     context.edition = Edition.lock.find_current(document: params[:document])
     assert_edition_state(edition, &:editable?)
+    assert_edition_access(edition, user)
 
     assert_edition_state(edition, assertion: "has proposed publish time") do
       edition.proposed_publish_time.present?

--- a/app/interactors/schedule/destroy_interactor.rb
+++ b/app/interactors/schedule/destroy_interactor.rb
@@ -20,6 +20,7 @@ private
   def find_and_lock_edition
     context.edition = Edition.lock.find_current(document: params[:document])
     assert_edition_state(edition, &:scheduled?)
+    assert_edition_access(edition, user)
   end
 
   def update_edition

--- a/app/interactors/schedule/new_interactor.rb
+++ b/app/interactors/schedule/new_interactor.rb
@@ -2,6 +2,7 @@
 
 class Schedule::NewInteractor < ApplicationInteractor
   delegate :params,
+           :user,
            :edition,
            :publish_issues,
            :schedule_issues,
@@ -16,6 +17,7 @@ class Schedule::NewInteractor < ApplicationInteractor
   def find_edition
     context.edition = Edition.find_current(document: params[:document])
     assert_edition_state(edition, &:editable?)
+    assert_edition_access(edition, user)
 
     assert_edition_state(edition, assertion: "has proposed publish time") do
       edition.proposed_publish_time.present?

--- a/app/interactors/schedule/update_interactor.rb
+++ b/app/interactors/schedule/update_interactor.rb
@@ -24,6 +24,7 @@ private
   def find_and_lock_edition
     context.edition = Edition.lock.find_current(document: params[:document])
     assert_edition_state(edition, &:scheduled?)
+    assert_edition_access(edition, user)
   end
 
   def parse_publish_time

--- a/app/interactors/schedule_proposal/update_interactor.rb
+++ b/app/interactors/schedule_proposal/update_interactor.rb
@@ -23,6 +23,7 @@ private
   def find_and_lock_edition
     context.edition = Edition.lock.find_current(document: params[:document])
     assert_edition_state(edition, &:editable?)
+    assert_edition_access(edition, user)
   end
 
   def parse_publish_time

--- a/app/interactors/tags/update_interactor.rb
+++ b/app/interactors/tags/update_interactor.rb
@@ -26,6 +26,7 @@ private
   def find_and_lock_edition
     context.edition = Edition.lock.find_current(document: params[:document])
     assert_edition_state(edition, &:editable?)
+    assert_edition_access(edition, user)
   end
 
   def update_revision

--- a/app/interactors/topics/update_interactor.rb
+++ b/app/interactors/topics/update_interactor.rb
@@ -18,6 +18,7 @@ private
   def find_document
     edition = Edition.find_current(document: params[:document])
     assert_edition_state(edition, &:editable?)
+    assert_edition_access(edition, user)
     context.document = edition.document
   end
 


### PR DESCRIPTION
https://trello.com/c/P3z1xFBW/968-investigate-methods-to-prevent-access-to-document-based-on-access-limit-and-state

    This adds assertions for access limited editions in all places where
    (part of) the edition is exposed but the edition is not yet public. One
    exception to this is the 'debug' view, which has a developer-specific
    permission associated with it, which we will treat as an override.