### PR TITLE
Filter editions to respect access limiting

### DIFF
--- a/app/controllers/documents_controller.rb
+++ b/app/controllers/documents_controller.rb
@@ -7,7 +7,7 @@ class DocumentsController < ApplicationController
       return
     end
 
-    filter = EditionFilter.new(filter_params)
+    filter = EditionFilter.new(current_user, filter_params)
     @editions = filter.editions
     @filter_params = filter.filter_params
     @sort = filter.sort

--- a/spec/services/edition_filter_spec.rb
+++ b/spec/services/edition_filter_spec.rb
@@ -1,18 +1,20 @@
 # frozen_string_literal: true
 
 RSpec.describe EditionFilter do
+  let(:user) { build :user, organisation_content_id: "org-id" }
+
   describe "#editions" do
     it "orders the editions by edition last_edited_at" do
       edition1 = create(:edition, last_edited_at: 1.minute.ago)
       edition2 = create(:edition, last_edited_at: 2.minutes.ago)
 
-      editions = EditionFilter.new(sort: "last_updated").editions
+      editions = EditionFilter.new(user, sort: "last_updated").editions
       expect(editions).to eq([edition2, edition1])
 
-      editions = EditionFilter.new(sort: "-last_updated").editions
+      editions = EditionFilter.new(user, sort: "-last_updated").editions
       expect(editions).to eq([edition1, edition2])
 
-      editions = EditionFilter.new(sort: "default -last_updated").editions
+      editions = EditionFilter.new(user, sort: "default -last_updated").editions
       expect(editions).to eq([edition1, edition2])
     end
 
@@ -20,16 +22,16 @@ RSpec.describe EditionFilter do
       edition1 = create(:edition, title: "First", base_path: "/doc_1")
       edition2 = create(:edition, title: "Second", base_path: "/doc_2")
 
-      editions = EditionFilter.new(filters: { title_or_url: " " }).editions
+      editions = EditionFilter.new(user, filters: { title_or_url: " " }).editions
       expect(editions).to match_array([edition1, edition2])
 
-      editions = EditionFilter.new(filters: { title_or_url: "Fir" }).editions
+      editions = EditionFilter.new(user, filters: { title_or_url: "Fir" }).editions
       expect(editions).to eq([edition1])
 
-      editions = EditionFilter.new(filters: { title_or_url: "_1" }).editions
+      editions = EditionFilter.new(user, filters: { title_or_url: "_1" }).editions
       expect(editions).to eq([edition1])
 
-      editions = EditionFilter.new(filters: { title_or_url: "%" }).editions
+      editions = EditionFilter.new(user, filters: { title_or_url: "%" }).editions
       expect(editions).to be_empty
     end
 
@@ -37,10 +39,10 @@ RSpec.describe EditionFilter do
       edition1 = create(:edition, document_type_id: "type_1")
       edition2 = create(:edition, document_type_id: "type_2")
 
-      editions = EditionFilter.new(filters: { document_type: " " }).editions
+      editions = EditionFilter.new(user, filters: { document_type: " " }).editions
       expect(editions).to match_array([edition1, edition2])
 
-      editions = EditionFilter.new(filters: { document_type: "type_1" }).editions
+      editions = EditionFilter.new(user, filters: { document_type: "type_1" }).editions
       expect(editions).to eq([edition1])
     end
 
@@ -48,13 +50,13 @@ RSpec.describe EditionFilter do
       edition1 = create(:edition, state: "draft")
       edition2 = create(:edition, state: "submitted_for_review")
 
-      editions = EditionFilter.new(filters: { status: " " }).editions
+      editions = EditionFilter.new(user, filters: { status: " " }).editions
       expect(editions).to match_array([edition1, edition2])
 
-      editions = EditionFilter.new(filters: { status: "non-existant" }).editions
+      editions = EditionFilter.new(user, filters: { status: "non-existant" }).editions
       expect(editions).to be_empty
 
-      editions = EditionFilter.new(filters: { status: "draft" }).editions
+      editions = EditionFilter.new(user, filters: { status: "draft" }).editions
       expect(editions).to eq([edition1])
     end
 
@@ -62,10 +64,10 @@ RSpec.describe EditionFilter do
       edition1 = create(:edition, state: "published")
       edition2 = create(:edition, state: "published_but_needs_2i")
 
-      editions = EditionFilter.new(filters: { status: "published" }).editions
+      editions = EditionFilter.new(user, filters: { status: "published" }).editions
       expect(editions).to match_array([edition1, edition2])
 
-      editions = EditionFilter.new(filters: { status: "published_but_needs_2i" }).editions
+      editions = EditionFilter.new(user, filters: { status: "published_but_needs_2i" }).editions
       expect(editions).to eq([edition2])
     end
 
@@ -74,17 +76,17 @@ RSpec.describe EditionFilter do
       edition2 = create(:edition, tags: { organisations: %w[org1] })
       edition3 = create(:edition, tags: { organisations: %w[org11] })
 
-      editions = EditionFilter.new(filters: { organisation: " " }).editions
+      editions = EditionFilter.new(user, filters: { organisation: " " }).editions
       expect(editions).to match_array([edition1, edition2, edition3])
 
-      editions = EditionFilter.new(filters: { organisation: "org1" }).editions
+      editions = EditionFilter.new(user, filters: { organisation: "org1" }).editions
       expect(editions).to match_array([edition1, edition2])
     end
 
     it "ignores other kinds of filter" do
       edition1 = create(:edition)
 
-      editions = EditionFilter.new(filters: { invalid: "filter" }).editions
+      editions = EditionFilter.new(user, filters: { invalid: "filter" }).editions
       expect(editions).to eq([edition1])
     end
 
@@ -92,32 +94,100 @@ RSpec.describe EditionFilter do
       edition1 = create(:edition, last_edited_at: 1.minute.ago)
       edition2 = create(:edition, last_edited_at: 2.minutes.ago)
 
-      editions = EditionFilter.new(page: 1, per_page: 1).editions
+      editions = EditionFilter.new(user, page: 1, per_page: 1).editions
       expect(editions).to eq([edition1])
 
-      editions = EditionFilter.new(page: 2, per_page: 1).editions
+      editions = EditionFilter.new(user, page: 2, per_page: 1).editions
       expect(editions).to eq([edition2])
+    end
+
+    context "when the edition is access limited to the primary org" do
+      let!(:edition) do
+        create(:edition,
+               :access_limited,
+               limit_type: :primary_organisation,
+               tags: {
+                 primary_publishing_organisation: [user.organisation_content_id],
+                 organisations: %w[supporting-org],
+              })
+      end
+
+      it "includes the edition if the user is in its primary org" do
+        editions = EditionFilter.new(user).editions
+        expect(editions).to eq([edition])
+      end
+
+      it "excludes the edition if the user is in a supporting org" do
+        supporting_user = build(:user, organisation_content_id: "supporting-org")
+        editions = EditionFilter.new(supporting_user).editions
+        expect(editions).to be_empty
+      end
+
+      it "excludes the edition if the user is in a some other org" do
+        user = build(:user, organisation_content_id: "other-org")
+        editions = EditionFilter.new(user).editions
+        expect(editions).to be_empty
+      end
+
+      it "excludes the edition if the user has no org" do
+        editions = EditionFilter.new(build(:user)).editions
+        expect(editions).to be_empty
+      end
+    end
+
+    context "when the edition is access limited to tagged orgs" do
+      let!(:edition) do
+        create(:edition,
+               :access_limited,
+               limit_type: :tagged_organisations,
+               tags: {
+                 primary_publishing_organisation: [user.organisation_content_id],
+                 organisations: %w[supporting-org],
+              })
+      end
+
+      it "includes the edition if the user is in its primary org" do
+        editions = EditionFilter.new(user).editions
+        expect(editions).to eq([edition])
+      end
+
+      it "includes the edition if the user is in a supporting org" do
+        supporting_user = build(:user, organisation_content_id: "supporting-org")
+        editions = EditionFilter.new(supporting_user).editions
+        expect(editions).to eq([edition])
+      end
+
+      it "excludes the edition if the user is in a some other org" do
+        user = build(:user, organisation_content_id: "other-org")
+        editions = EditionFilter.new(user).editions
+        expect(editions).to be_empty
+      end
+
+      it "excludes the edition if the user has no org" do
+        editions = EditionFilter.new(build(:user)).editions
+        expect(editions).to be_empty
+      end
     end
   end
 
   describe "#filter_params" do
     it "returns the params used to filter" do
-      params = EditionFilter.new(filters: { title_or_url: "title" }).filter_params
+      params = EditionFilter.new(user, filters: { title_or_url: "title" }).filter_params
       expect(params).to eq(title_or_url: "title")
     end
 
     it "maintains empty params" do
-      params = EditionFilter.new(filters: { organisation: "" }).filter_params
+      params = EditionFilter.new(user, filters: { organisation: "" }).filter_params
       expect(params).to eq(organisation: "")
     end
 
     it "includes sort and page if they are different to default" do
-      params = EditionFilter.new(sort: "last_updated", page: 5).filter_params
+      params = EditionFilter.new(user, sort: "last_updated", page: 5).filter_params
       expect(params).to eq(sort: "last_updated", page: 5)
     end
 
     it "rejects page parameters less than 1" do
-      params = EditionFilter.new(page: 0).filter_params
+      params = EditionFilter.new(user, page: 0).filter_params
       expect(params).to eq({})
     end
   end


### PR DESCRIPTION
https://trello.com/c/OJwGOdvd/988-dont-show-access-limited-documents-in-index-page-when-user-is-not-part-of-a-relevant-organisation

This adds an additional filtering step to the EditionFilter that scopes
the query to only include access limited editions the user can access.