### PR TITLE
Improve confirmation pages

### DIFF
--- a/app/assets/stylesheets/components/_url-preview.scss
+++ b/app/assets/stylesheets/components/_url-preview.scss
@@ -9,6 +9,10 @@
   margin: 0;
 }
 
+.app-c-url-preview__url {
+  word-wrap: break-word;
+}
+
 .app-c-url-preview__default-message,
 .app-c-url-preview__error-message,
 .app-c-url-preview__url {

--- a/app/assets/stylesheets/utilities/_overwrites.scss
+++ b/app/assets/stylesheets/utilities/_overwrites.scss
@@ -76,4 +76,8 @@
       margin-bottom: 0;
     }
   }
+
+  .govuk-link {
+    word-wrap: break-word;
+  }
 }

--- a/app/views/publish/published.html.erb
+++ b/app/views/publish/published.html.erb
@@ -6,6 +6,11 @@
 
 <% content_for :browser_title, t("publish.published.title") %>
 <% public_url = edition_public_url(@edition) %>
+<% published_edition_link = render("govuk_publishing_components/components/inset_text", {
+    text: link_to(strip_scheme_from_url(public_url), public_url,
+                  class: "govuk-link govuk-link--no-visited-state",
+                  data: { gtm: "view-published-edition" })
+}) %>
 
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
@@ -17,11 +22,7 @@
 
       <%= render_govspeak(t("publish.published.published_without_review.body_govspeak", title: @edition.title)) %>
 
-      <%= render "govuk_publishing_components/components/inset_text", {
-        text: link_to(strip_scheme_from_url(public_url), public_url,
-                      class: "govuk-link govuk-link--no-visited-state",
-                      data: { gtm: "view-published-edition" })
-      } %>
+      <%= published_edition_link %>
 
       <%= render_govspeak(t("publish.published.published_without_review.what_to_do_govspeak")) %>
 
@@ -47,11 +48,7 @@
 
       <%= render_govspeak(t("publish.published.reviewed.body_govspeak", title: @edition.title)) %>
 
-      <%= render "govuk_publishing_components/components/inset_text", {
-        text: link_to(strip_scheme_from_url(public_url), public_url,
-                      class: "govuk-link govuk-link--no-visited-state",
-                      data: { gtm: "view-published-edition" })
-      } %>
+      <%= published_edition_link %>
     <% end %>
   </div>
 </div>

--- a/app/views/publish/published.html.erb
+++ b/app/views/publish/published.html.erb
@@ -5,24 +5,25 @@
 <% end %>
 
 <% content_for :browser_title, t("publish.published.title") %>
+<% public_url = edition_public_url(@edition) %>
 
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
-    <% public_url = edition_public_url(@edition) %>
 
     <% if @edition.status.published_but_needs_2i? %>
       <%= render "govuk_publishing_components/components/panel", {
         title: t("publish.published.published_without_review.title")
       } %>
 
-      <%= render "govuk_publishing_components/components/govspeak" do %>
-        <%= govspeak_to_html t("publish.published.published_without_review.body_govspeak", title: @edition.title) %>
-        <%= link_to(strip_scheme_from_url(public_url), public_url,
-                    class: "govuk-link govuk-link--no-visited-state",
-                    data: { gtm: "view-published-edition" }) %>
+      <%= render_govspeak(t("publish.published.published_without_review.body_govspeak", title: @edition.title)) %>
 
-        <%= govspeak_to_html t("publish.published.published_without_review.what_to_do_govspeak") %>
-      <% end %>
+      <%= render "govuk_publishing_components/components/inset_text", {
+        text: link_to(strip_scheme_from_url(public_url), public_url,
+                      class: "govuk-link govuk-link--no-visited-state",
+                      data: { gtm: "view-published-edition" })
+      } %>
+
+      <%= render_govspeak(t("publish.published.published_without_review.what_to_do_govspeak")) %>
 
       <%= render "govuk_publishing_components/components/copy_to_clipboard",
         label: t("publish.published.published_without_review.send_label"),
@@ -44,13 +45,13 @@
         title: t("publish.published.reviewed.title")
       } %>
 
-      <%= render "govuk_publishing_components/components/govspeak" do %>
-        <%= govspeak_to_html t("publish.published.reviewed.body_govspeak", title: @edition.title) %>
+      <%= render_govspeak(t("publish.published.reviewed.body_govspeak", title: @edition.title)) %>
 
-        <%= link_to(strip_scheme_from_url(public_url), public_url,
-                    class: "govuk-link govuk-link--no-visited-state",
-                    data: { gtm: "view-published-edition" }) %>
-      <% end %>
+      <%= render "govuk_publishing_components/components/inset_text", {
+        text: link_to(strip_scheme_from_url(public_url), public_url,
+                      class: "govuk-link govuk-link--no-visited-state",
+                      data: { gtm: "view-published-edition" })
+      } %>
     <% end %>
   </div>
 </div>

--- a/app/views/schedule/scheduled.html.erb
+++ b/app/views/schedule/scheduled.html.erb
@@ -12,12 +12,12 @@
       title: t("schedule.scheduled.title")
     } %>
 
-    <%= render "govuk_publishing_components/components/govspeak" do %>
-      <%= govspeak_to_html t("schedule.scheduled.body_govspeak", title: @edition.title, time: time, date: date) %>
-    <% end %>
+    <%= render_govspeak(t("schedule.scheduled.body_govspeak", title: @edition.title, time: time, date: date)) %>
 
     <%= render "govuk_publishing_components/components/inset_text", {
-      text: strip_scheme_from_url(public_url)
+      text: link_to(strip_scheme_from_url(public_url), public_url,
+      class: "govuk-link govuk-link--no-visited-state",
+      data: { gtm: "view-scheduled-edition" })
     } %>
   </div>
 </div>


### PR DESCRIPTION
This PR updates the confirmation pages (for scheduled and published workflows) to render markup consistently and use inset text and links for URLs. It also breaks words in URLs for both links within inset-text components and for URLs in the url-preview component. This prevents long URLs from overflowing the containers (which is currently creating issues on mobile devices).

### Dekstop
#### Confirmation for published
![confirmation-published](https://user-images.githubusercontent.com/788096/61387473-203aa180-a8ae-11e9-879e-8a0edf573e9b.jpg)

#### Confirmation for scheduled
![confirmation-scheduled](https://user-images.githubusercontent.com/788096/61387507-2b8dcd00-a8ae-11e9-8efd-8a04da15fb36.jpg)


### Mobile (similar results for scheduled and published)
![confirmation-published-mobile](https://user-images.githubusercontent.com/788096/61387570-4b24f580-a8ae-11e9-97af-998355f158c7.jpg)

[Trello card](https://trello.com/c/X9vsbFTC)