### PR TITLE
Remove editable/access assertions for topics

### DIFF
--- a/app/controllers/topics_controller.rb
+++ b/app/controllers/topics_controller.rb
@@ -8,7 +8,6 @@ class TopicsController < ApplicationController
 
   def edit
     @edition = Edition.find_current(document: params[:document])
-    assert_edition_state(@edition, &:editable?)
     assert_edition_access(@edition, current_user)
     @version = @edition.document_topics.version
     @topics = @edition.topics

--- a/app/interactors/topics/update_interactor.rb
+++ b/app/interactors/topics/update_interactor.rb
@@ -17,7 +17,6 @@ private
 
   def find_document
     edition = Edition.find_current(document: params[:document])
-    assert_edition_state(edition, &:editable?)
     assert_edition_access(edition, user)
     context.document = edition.document
   end


### PR DESCRIPTION
Previously we required the edition to be editable for a user to
edit/update topics, but this wasn't consistent with our 'always
editable' approach in the UI. However, we should keep the access
limiting assertion as this page reveals the title of the edition.