### PR TITLE
Access limit hints

### DIFF
--- a/app/assets/stylesheets/utilities/_overwrites.scss
+++ b/app/assets/stylesheets/utilities/_overwrites.scss
@@ -81,3 +81,9 @@
     word-wrap: break-word;
   }
 }
+
+.govuk-hint {
+  .govuk-list {
+    color: $govuk-secondary-text-colour;
+  }
+}

--- a/app/controllers/access_limit_controller.rb
+++ b/app/controllers/access_limit_controller.rb
@@ -1,6 +1,11 @@
 # frozen_string_literal: true
 
 class AccessLimitController < ApplicationController
+  rescue_from GdsApi::BaseError do |e|
+    GovukError.notify(e)
+    render "#{action_name}_api_down", status: :service_unavailable
+  end
+
   def edit
     @edition = Edition.find_current(document: params[:document])
     assert_edition_access(@edition, current_user)

--- a/app/views/access_limit/edit.html.erb
+++ b/app/views/access_limit/edit.html.erb
@@ -6,11 +6,12 @@
 
 <% if @edition.primary_publishing_organisation_id %>
   <% primary_org_id = @edition.primary_publishing_organisation_id %>
-  <% primary_org = service.by_content_id(primary_org_id)["internal_name"] %>
+  <% primary_org = service.by_content_id(primary_org_id)&.fetch("internal_name") %>
 <% end %>
 
 <% supporting_orgs = @edition.organisations
-  .map { |org_id| service.by_content_id(org_id)["internal_name"] } %>
+  .map { |org_id| service.by_content_id(org_id)&.fetch("internal_name") }
+  .compact %>
 
 <% tagged_orgs = ([primary_org] + supporting_orgs).compact %>
 

--- a/app/views/access_limit/edit.html.erb
+++ b/app/views/access_limit/edit.html.erb
@@ -2,6 +2,26 @@
 <% content_for :browser_title, t("access_limit.edit.browser_title") %>
 <% content_for :back_link, render_back_link(href: document_path(@edition.document)) %>
 
+<% service = LinkablesService.new("organisation") %>
+
+<% if @edition.primary_publishing_organisation_id %>
+  <% primary_org_id = @edition.primary_publishing_organisation_id %>
+  <% primary_org = service.by_content_id(primary_org_id)["internal_name"] %>
+<% end %>
+
+<% supporting_orgs = @edition.organisations
+  .map { |org_id| service.by_content_id(org_id)["internal_name"] } %>
+
+<% tagged_orgs = ([primary_org] + supporting_orgs).compact %>
+
+<% tagged_orgs_ul = capture do %>
+  <ul class="govuk-list">
+    <% tagged_orgs.each do |org| %>
+      <%= tag.li org %>
+    <% end %>
+  </ul>
+<% end %>
+
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
     <div class="govuk-body" %>
@@ -32,7 +52,8 @@
             data_attributes: {
               gtm: "choose-access-limit",
               "gtm-value": t("access_limit.edit.type.primary_organisation")
-            }
+            },
+            hint_text: primary_org
           },
           {
             value: "tagged_organisations",
@@ -41,7 +62,8 @@
             data_attributes: {
               gtm: "choose-access-limit",
               "gtm-value": t("access_limit.edit.type.tagged_organisations")
-            }
+            },
+            hint_text: tagged_orgs.any? && tagged_orgs_ul
           }
         ]
       } %>

--- a/app/views/access_limit/edit_api_down.html.erb
+++ b/app/views/access_limit/edit_api_down.html.erb
@@ -1,0 +1,6 @@
+<% content_for :back_link, render_back_link(href: document_path(@edition.document)) %>
+<% content_for :title, t("access_limit.edit.title", title: @edition.title_or_fallback) %>
+
+<p class="govuk-body">
+  <%= t("access_limit.edit.api_down") %>
+</p>

--- a/app/views/documents/forbidden.html.erb
+++ b/app/views/documents/forbidden.html.erb
@@ -4,7 +4,11 @@
   <%= t("documents.forbidden.description") %>
 </div>
 
-<% primary_org = LinkablesService.new("organisation")
- .by_content_id(@edition.primary_publishing_organisation_id) %>
+<div class="govuk-body">
+  <% begin %>
+   <% primary_org = LinkablesService.new("organisation")
+     .by_content_id(@edition.primary_publishing_organisation_id) %>
 
-<%= t("documents.forbidden.owner", primary_org: primary_org["internal_name"]) %>
+   <%= t("documents.forbidden.owner", primary_org: primary_org["internal_name"]) %>
+  <% rescue GdsApi::BaseError; end %>
+</div>

--- a/app/views/documents/forbidden.html.erb
+++ b/app/views/documents/forbidden.html.erb
@@ -6,9 +6,12 @@
 
 <div class="govuk-body">
   <% begin %>
-   <% primary_org = LinkablesService.new("organisation")
-     .by_content_id(@edition.primary_publishing_organisation_id) %>
+    <% primary_org = LinkablesService.new("organisation")
+      .by_content_id(@edition.primary_publishing_organisation_id) %>
 
-   <%= t("documents.forbidden.owner", primary_org: primary_org["internal_name"]) %>
+    <% if primary_org %>
+      <%= t("documents.forbidden.owner",
+            primary_org: primary_org.fetch("internal_name")) %>
+    <% end %>
   <% rescue GdsApi::BaseError; end %>
 </div>

--- a/app/views/documents/forbidden.html.erb
+++ b/app/views/documents/forbidden.html.erb
@@ -3,3 +3,8 @@
 <div class="govuk-body">
   <%= t("documents.forbidden.description") %>
 </div>
+
+<% primary_org = LinkablesService.new("organisation")
+ .by_content_id(@edition.primary_publishing_organisation_id) %>
+
+<%= t("documents.forbidden.owner", primary_org: primary_org["internal_name"]) %>

--- a/app/views/documents/tags/_multi_tag.html.erb
+++ b/app/views/documents/tags/_multi_tag.html.erb
@@ -1,7 +1,7 @@
 <% if values.any? %>
   <ul class="govuk-list">
     <% values.each do |value| %>
-      <li><%= value["internal_name"] %></li>
+      <li><%= value&.fetch("internal_name") %></li>
     <% end %>
   </ul>
 <% else %>

--- a/app/views/documents/tags/_single_tag.html.erb
+++ b/app/views/documents/tags/_single_tag.html.erb
@@ -1,5 +1,5 @@
 <% if values.first %>
-  <%= values.first["internal_name"] %>
+  <%= values.first&.fetch("internal_name") %>
 <% else %>
   <%= t("documents.show.tags.none") %>
 <% end %>

--- a/config/locales/en/access_limit/edit.yml
+++ b/config/locales/en/access_limit/edit.yml
@@ -3,6 +3,7 @@ en:
     edit:
       browser_title: Access limit content
       title: Who can access this document
+      api_down: This content can't be edited right now. We're having trouble getting the data we need for you to make changes on this page.
       description: You can limit who is able to find and edit this document before it is published. Select an option that includes the organisation associated with your account.
       no_access_limit: All publishers have access
       type:

--- a/config/locales/en/documents/forbidden.yml
+++ b/config/locales/en/documents/forbidden.yml
@@ -3,3 +3,4 @@ en:
     forbidden:
       title: Forbidden
       description: You do not have permission to access this page.
+      owner: This page is owned by %{primary_org}.

--- a/spec/features/editing_content_settings/edit_access_limit_publishing_api_down_spec.rb
+++ b/spec/features/editing_content_settings/edit_access_limit_publishing_api_down_spec.rb
@@ -1,0 +1,49 @@
+# frozen_string_literal: true
+
+RSpec.feature "Edit access limit when the Publishing API is down" do
+  background do
+    given_there_is_an_access_limited_edition
+    and_the_publishing_api_is_down
+  end
+
+  scenario "user has access" do
+    when_i_visit_the_summary_page
+    and_i_go_to_edit_the_access_limit
+    then_i_see_an_error_message
+  end
+
+  scenario "user does not have access" do
+    given_i_am_a_user_in_some_other_org
+    when_i_visit_the_summary_page
+    then_i_see_i_cannot_edit_the_edition
+  end
+
+  def given_there_is_an_access_limited_edition
+    @edition = create(:edition, :access_limited, created_by: current_user)
+  end
+
+  def and_the_publishing_api_is_down
+    publishing_api_isnt_available
+  end
+
+  def given_i_am_a_user_in_some_other_org
+    other_org_user = create(:user, organisation_content_id: "other-org")
+    login_as(other_org_user)
+  end
+
+  def when_i_visit_the_summary_page
+    visit document_path(@edition.document)
+  end
+
+  def and_i_go_to_edit_the_access_limit
+    click_on "Edit Access limiting"
+  end
+
+  def then_i_see_an_error_message
+    expect(page).to have_content(I18n.t!("access_limit.edit.api_down"))
+  end
+
+  def then_i_see_i_cannot_edit_the_edition
+    expect(page).to have_content(I18n.t!("documents.forbidden.description"))
+  end
+end

--- a/spec/features/editing_content_settings/edit_access_limit_spec.rb
+++ b/spec/features/editing_content_settings/edit_access_limit_spec.rb
@@ -11,7 +11,18 @@ RSpec.feature "Edit access limit" do
   end
 
   def given_there_is_an_access_limited_edition
-    @edition = create(:edition, :access_limited, created_by: current_user)
+    @supporting_org = SecureRandom.uuid
+    primary_org = current_user.organisation_content_id
+
+    stub_publishing_api_has_linkables(
+      [{ "content_id" => primary_org, "internal_name" => "Primary org" }],
+      document_type: "organisation",
+    )
+
+    @edition = create(:edition,
+                      :access_limited,
+                      limit_type: :tagged_organisations,
+                      created_by: current_user)
   end
 
   def when_i_visit_the_summary_page

--- a/spec/features/editing_content_settings/remove_access_limit_spec.rb
+++ b/spec/features/editing_content_settings/remove_access_limit_spec.rb
@@ -13,6 +13,12 @@ RSpec.feature "Remove access limit" do
 
   def given_there_is_an_access_limited_edition
     @edition = create(:edition, :access_limited, created_by: current_user)
+    primary_org = current_user.organisation_content_id
+
+    stub_publishing_api_has_linkables(
+      [{ "content_id" => primary_org, "internal_name" => "Primary org" }],
+      document_type: "organisation",
+    )
   end
 
   def and_there_is_a_user_in_some_other_org

--- a/spec/features/editing_content_settings/set_access_limit_spec.rb
+++ b/spec/features/editing_content_settings/set_access_limit_spec.rb
@@ -93,6 +93,7 @@ RSpec.feature "Set access limit" do
   end
 
   def and_i_can_still_edit_the_edition
+    visit document_path(@edition.document)
     expect(page).to have_content("Edit Access limiting")
     visit edit_document_path(@edition.document)
     expect(page).to have_content(I18n.t!("documents.edit.title", title: @edition.title_or_fallback))
@@ -100,25 +101,25 @@ RSpec.feature "Set access limit" do
 
   def and_the_supporting_user_can_also
     login_as(@supporting_org_user)
-    visit document_path(@edition.document)
-    expect(page).to have_content("Edit Access limiting")
-    visit edit_document_path(@edition.document)
-    expect(page).to have_content(I18n.t!("documents.edit.title", title: @edition.title_or_fallback))
+    and_i_can_still_edit_the_edition
   end
 
   def and_the_supporting_user_cannot
     login_as(@supporting_org_user)
-    visit document_path(@edition.document)
-    expect(page).to have_content("You do not have permission to access this page.")
-    visit edit_document_path(@edition.document)
-    expect(page).to have_content("You do not have permission to access this page.")
+    i_cannot_edit_the_edition
   end
 
   def and_someone_in_another_org_cannot
     login_as(@other_org_user)
+    i_cannot_edit_the_edition
+  end
+
+  def i_cannot_edit_the_edition
     visit document_path(@edition.document)
-    expect(page).to have_content("You do not have permission to access this page.")
+    expect(page).to have_content(I18n.t!("documents.forbidden.description"))
+    expect(page).to have_content(I18n.t!("documents.forbidden.owner", primary_org: "Primary org"))
     visit edit_document_path(@edition.document)
-    expect(page).to have_content("You do not have permission to access this page.")
+    expect(page).to have_content(I18n.t!("documents.forbidden.description"))
+    expect(page).to have_content(I18n.t!("documents.forbidden.owner", primary_org: "Primary org"))
   end
 end

--- a/spec/features/editing_content_settings/set_access_limit_spec.rb
+++ b/spec/features/editing_content_settings/set_access_limit_spec.rb
@@ -31,9 +31,15 @@ RSpec.feature "Set access limit" do
     @supporting_org = SecureRandom.uuid
     primary_org = current_user.organisation_content_id
 
+    stub_publishing_api_has_linkables(
+      [{ "content_id" => primary_org, "internal_name" => "Primary org" },
+       { "content_id" => @supporting_org, "internal_name" => "Supporting org" }],
+      document_type: "organisation",
+    )
+
     @edition = create(:edition, tags: {
       primary_publishing_organisation: [primary_org],
-      organisations: [primary_org, @supporting_org],
+      organisations: [@supporting_org],
     })
   end
 
@@ -58,11 +64,20 @@ RSpec.feature "Set access limit" do
   end
 
   def and_i_limit_to_my_organisation
+    within ".govuk-radios" do
+      expect(page).to have_content("Primary org")
+    end
+
     choose I18n.t!("access_limit.edit.type.primary_organisation")
     click_on "Save"
   end
 
   def and_i_limit_to_tagged_organisations
+    within ".govuk-radios" do
+      expect(page).to have_content("Primary org", count: 2)
+      expect(page).to have_content("Supporting org")
+    end
+
     choose I18n.t!("access_limit.edit.type.tagged_organisations")
     click_on "Save"
   end


### PR DESCRIPTION
https://trello.com/c/dlw2oE4O/987-create-a-form-so-users-can-limit-access-to-a-draft

This adds organisation 'hints' when the user is editing the access limit for an edition, and when they see a 'forbidden' page, so they can follow-up with the owner org.