### PR TITLE
Default to all access if user subverts form

### DIFF
--- a/app/interactors/access_limit/update_interactor.rb
+++ b/app/interactors/access_limit/update_interactor.rb
@@ -1,6 +1,8 @@
 # frozen_string_literal: true
 
 class AccessLimit::UpdateInteractor < ApplicationInteractor
+  LIMIT_TYPES = AccessLimit.limit_types.keys
+
   delegate :params,
            :user,
            :edition,
@@ -24,12 +26,12 @@ private
   def update_edition
     limit_type = params.require(:limit_type)
 
-    if limit_type == "none"
+    if LIMIT_TYPES.include?(limit_type)
+      context.fail! if edition.access_limit&.limit_type == limit_type
+      edition.assign_access_limit(limit_type, user).save!
+    else
       context.fail! if edition.access_limit.nil?
       edition.remove_access_limit(user).save!
-    else
-      context.fail! if edition.access_limit&.limit_type == params[:limit_type]
-      edition.assign_access_limit(limit_type, user).save!
     end
   end
 


### PR DESCRIPTION
https://trello.com/c/dlw2oE4O/987-create-a-form-so-users-can-limit-access-to-a-draft

Previously we raised an ArgumentError if the user managed to submit the
access limit form without a selection, or with an incorrect limt_type
value. This iterates the approach to be more comparable with e.g. the
PublishInteractor, so that we remove any access limit by default.