### PR TITLE
Rename all_organisations -> tagged_organisations

### DIFF
--- a/app/models/access_limit.rb
+++ b/app/models/access_limit.rb
@@ -11,7 +11,7 @@ class AccessLimit < ApplicationRecord
   belongs_to :revision_at_creation, class_name: "Revision"
 
   enum limit_type: { primary_organisation: "primary_organisation",
-                     all_organisations: "all_organisations" }
+                     tagged_organisations: "tagged_organisations" }
 
   def readonly?
     !new_record?

--- a/app/services/edition_assertions.rb
+++ b/app/services/edition_assertions.rb
@@ -38,7 +38,7 @@ module EditionAssertions
 
     return if org_id == edition.primary_publishing_organisation_id
 
-    return if access_limit.all_organisations? &&
+    return if access_limit.tagged_organisations? &&
       edition.organisations.include?(org_id)
 
     raise AccessError.new(edition, access_limit.limit_type)

--- a/app/views/access_limit/edit.html.erb
+++ b/app/views/access_limit/edit.html.erb
@@ -35,12 +35,12 @@
             }
           },
           {
-            value: "all_organisations",
-            text: t("access_limit.edit.type.all_organisations"),
-            checked: @edition.access_limit&.all_organisations?,
+            value: "tagged_organisations",
+            text: t("access_limit.edit.type.tagged_organisations"),
+            checked: @edition.access_limit&.tagged_organisations?,
             data_attributes: {
               gtm: "choose-access-limit",
-              "gtm-value": t("access_limit.edit.type.all_organisations")
+              "gtm-value": t("access_limit.edit.type.tagged_organisations")
             }
           }
         ]

--- a/config/locales/en/access_limit/edit.yml
+++ b/config/locales/en/access_limit/edit.yml
@@ -7,4 +7,4 @@ en:
       no_access_limit: All publishers have access
       type:
         primary_organisation: Only publishers in the primary organisation have access
-        all_organisations: Only publishers in tagged organistions have access
+        tagged_organisations: Only publishers in tagged organistions have access

--- a/config/locales/en/documents/show.yml
+++ b/config/locales/en/documents/show.yml
@@ -42,7 +42,7 @@ en:
           title: Access limiting
           no_access_limit: None
           type:
-            all_organisations: Only publishers in tagged organistions have access
+            tagged_organisations: Only publishers in tagged organistions have access
             primary_organisation: Only publishers in the primary organisation have access
       metadata:
         status: Status

--- a/spec/factories/edition_factory.rb
+++ b/spec/factories/edition_factory.rb
@@ -164,7 +164,7 @@ FactoryBot.define do
 
     trait :access_limited do
       transient do
-        limit_type { :all_organisations }
+        limit_type { :tagged_organisations }
       end
 
       after(:build) do |edition, evaluator|

--- a/spec/features/editing_content_settings/edit_access_limit_spec.rb
+++ b/spec/features/editing_content_settings/edit_access_limit_spec.rb
@@ -23,7 +23,7 @@ RSpec.feature "Edit access limit" do
   end
 
   def then_i_see_the_current_access_limit
-    radio_text = I18n.t!("access_limit.edit.type.all_organisations")
+    radio_text = I18n.t!("access_limit.edit.type.tagged_organisations")
     expect(find_field(radio_text)).to be_checked
   end
 

--- a/spec/features/editing_content_settings/set_access_limit_spec.rb
+++ b/spec/features/editing_content_settings/set_access_limit_spec.rb
@@ -20,8 +20,8 @@ RSpec.feature "Set access limit" do
   scenario "all organisations" do
     when_i_visit_the_summary_page
     and_i_edit_the_access_limit
-    and_i_limit_to_all_organisations
-    then_i_see_all_orgs_have_access
+    and_i_limit_to_tagged_organisations
+    then_i_see_tagged_orgs_have_access
     and_i_can_still_edit_the_edition
     and_the_supporting_user_can_also
     and_someone_in_another_org_cannot
@@ -62,8 +62,8 @@ RSpec.feature "Set access limit" do
     click_on "Save"
   end
 
-  def and_i_limit_to_all_organisations
-    choose I18n.t!("access_limit.edit.type.all_organisations")
+  def and_i_limit_to_tagged_organisations
+    choose I18n.t!("access_limit.edit.type.tagged_organisations")
     click_on "Save"
   end
 
@@ -72,8 +72,8 @@ RSpec.feature "Set access limit" do
     expect(page).to have_content(I18n.t!("documents.history.entry_types.access_limit_created"))
   end
 
-  def then_i_see_all_orgs_have_access
-    expect(page).to have_content(I18n.t!("documents.show.content_settings.access_limit.type.all_organisations"))
+  def then_i_see_tagged_orgs_have_access
+    expect(page).to have_content(I18n.t!("documents.show.content_settings.access_limit.type.tagged_organisations"))
     expect(page).to have_content(I18n.t!("documents.history.entry_types.access_limit_created"))
   end
 

--- a/spec/models/edition_spec.rb
+++ b/spec/models/edition_spec.rb
@@ -202,9 +202,9 @@ RSpec.describe Edition do
       edition = build(:edition)
       user = build(:user)
 
-      edition.assign_access_limit(:all_organisations, user)
+      edition.assign_access_limit(:tagged_organisations, user)
 
-      expect(edition.access_limit).to be_all_organisations
+      expect(edition.access_limit).to be_tagged_organisations
       expect(edition.access_limit.created_by).to eq(user)
       expect(edition.access_limit.revision_at_creation).to eq(edition.revision)
     end
@@ -214,7 +214,7 @@ RSpec.describe Edition do
       user = build(:user)
 
       travel_to(Time.current) do
-        expect { edition.assign_access_limit(:all_organisations, user) }
+        expect { edition.assign_access_limit(:tagged_organisations, user) }
           .to change { edition.last_edited_by }.to(user)
           .and change { edition.last_edited_at }.to(Time.current)
       end

--- a/spec/services/edition_assertions_spec.rb
+++ b/spec/services/edition_assertions_spec.rb
@@ -38,6 +38,13 @@ RSpec.describe EditionAssertions do
         expect { assert_edition_access(edition, user) }.to_not raise_error
       end
 
+      it "raises an error when the user is in a supporting org" do
+        supporting_user = build :user, organisation_content_id: "supporting-org-id"
+
+        expect { assert_edition_access(edition, supporting_user) }
+          .to raise_error(EditionAssertions::AccessError)
+      end
+
       it "raises an error when the user is in another org" do
         another_user = build :user, organisation_content_id: "another-org"
 
@@ -46,11 +53,11 @@ RSpec.describe EditionAssertions do
       end
     end
 
-    context "when access is limited to supporting orgs" do
+    context "when access is limited to tagged orgs" do
       let(:edition) do
         build :edition,
               :access_limited,
-              limit_type: :all_organisations,
+              limit_type: :tagged_organisations,
               tags: {
                 primary_publishing_organisation: %w[primary-org-id],
                 organisations: %w[primary-org-id supporting-org-id],


### PR DESCRIPTION
https://trello.com/c/dlw2oE4O/987-create-a-form-so-users-can-limit-access-to-a-draft

Previously we used 'all_organisations' to refer to an access limited
edition where users in the primary and any supporting orgs had access,
which was a little confusing due to the use of 'all'. This renames it to
'tagged_organisations', based on the copy we show to the user.