### PR TITLE
SQL script to remove access limited content

### DIFF
--- a/db/migrate/20190717170541_allow_edition_deletion.rb
+++ b/db/migrate/20190717170541_allow_edition_deletion.rb
@@ -1,0 +1,67 @@
+# frozen_string_literal: true
+
+class AllowEditionDeletion < ActiveRecord::Migration[5.2]
+  def up
+    remove_foreign_key :access_limits, :editions
+    add_foreign_key :access_limits,
+                    :editions,
+                    on_delete: :cascade
+
+    remove_foreign_key :editions_revisions, :editions
+    add_foreign_key :editions_revisions,
+                    :editions,
+                    on_delete: :cascade
+
+    remove_foreign_key :statuses, :editions
+    add_foreign_key :statuses,
+                    :editions,
+                    on_delete: :cascade
+
+    remove_foreign_key :revisions_statuses, :statuses
+    add_foreign_key :revisions_statuses,
+                    :statuses,
+                    on_delete: :cascade
+
+    remove_foreign_key :internal_notes, :editions
+    add_foreign_key :internal_notes,
+                    :editions,
+                    on_delete: :cascade
+
+    remove_foreign_key :timeline_entries, :editions
+    add_foreign_key :timeline_entries,
+                    :editions,
+                    on_delete: :cascade
+  end
+
+  def down
+    remove_foreign_key :access_limits, :editions
+    add_foreign_key :access_limits,
+                    :editions,
+                    on_delete: :restrict
+
+    remove_foreign_key :editions_revisions, :editions
+    add_foreign_key :editions_revisions,
+                    :editions,
+                    on_delete: :restrict
+
+    remove_foreign_key :statuses, :editions
+    add_foreign_key :statuses,
+                    :editions,
+                    on_delete: :restrict
+
+    remove_foreign_key :revisions_statuses, :statuses
+    add_foreign_key :revisions_statuses,
+                    :statuses,
+                    on_delete: :restrict
+
+    remove_foreign_key :internal_notes, :editions
+    add_foreign_key :internal_notes,
+                    :editions,
+                    on_delete: :restrict
+
+    remove_foreign_key :timeline_entries, :editions
+    add_foreign_key :timeline_entries,
+                    :editions,
+                    on_delete: :restrict
+  end
+end

--- a/db/migrate/20190717203348_allow_revision_deletion.rb
+++ b/db/migrate/20190717203348_allow_revision_deletion.rb
@@ -1,0 +1,75 @@
+# frozen_string_literal: true
+
+class AllowRevisionDeletion < ActiveRecord::Migration[5.2]
+  def up
+    remove_foreign_key :revisions_image_revisions, :revisions
+    add_foreign_key :revisions_image_revisions,
+                    :revisions,
+                    on_delete: :cascade
+
+    remove_foreign_key :image_assets, :image_blob_revisions
+    add_foreign_key :image_assets,
+                    :image_blob_revisions,
+                    column: :blob_revision_id,
+                    on_delete: :cascade
+
+    remove_foreign_key :image_assets, :image_assets
+    add_foreign_key :image_assets,
+                    :image_assets,
+                    column: :superseded_by_id,
+                    on_delete: :nullify
+
+    remove_foreign_key :revisions_file_attachment_revisions, :revisions
+    add_foreign_key :revisions_file_attachment_revisions,
+                    :revisions,
+                    on_delete: :cascade
+
+    remove_foreign_key :file_attachment_assets, :file_attachment_blob_revisions
+    add_foreign_key :file_attachment_assets,
+                    :file_attachment_blob_revisions,
+                    column: :blob_revision_id,
+                    on_delete: :cascade
+
+    remove_foreign_key :file_attachment_assets, :file_attachment_assets
+    add_foreign_key :file_attachment_assets,
+                    :file_attachment_assets,
+                    column: :superseded_by_id,
+                    on_delete: :nullify
+  end
+
+  def down
+    remove_foreign_key :revisions_image_revisions, :revisions
+    add_foreign_key :revisions_image_revisions,
+                    :revisions,
+                    on_delete: :restrict
+
+    remove_foreign_key :image_assets, :image_blob_revisions
+    add_foreign_key :image_assets,
+                    :image_blob_revisions,
+                    column: :blob_revision_id,
+                    on_delete: :restrict
+
+    remove_foreign_key :image_assets, :image_assets
+    add_foreign_key :image_assets,
+                    :image_assets,
+                    column: :superseded_by_id,
+                    on_delete: :restrict
+
+    remove_foreign_key :revisions_file_attachment_revisions, :revisions
+    add_foreign_key :revisions_file_attachment_revisions,
+                    :revisions,
+                    on_delete: :restrict
+
+    remove_foreign_key :file_attachment_assets, :file_attachment_blob_revisions
+    add_foreign_key :file_attachment_assets,
+                    :file_attachment_blob_revisions,
+                    column: :blob_revision_id,
+                    on_delete: :restrict
+
+    remove_foreign_key :file_attachment_assets, :file_attachment_assets
+    add_foreign_key :file_attachment_assets,
+                    :file_attachment_assets,
+                    column: :superseded_by_id,
+                    on_delete: :restrict
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2019_06_26_155821) do
+ActiveRecord::Schema.define(version: 2019_07_17_170541) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -328,7 +328,7 @@ ActiveRecord::Schema.define(version: 2019_06_26_155821) do
     t.datetime "withdrawn_at", null: false
   end
 
-  add_foreign_key "access_limits", "editions", on_delete: :restrict
+  add_foreign_key "access_limits", "editions", on_delete: :cascade
   add_foreign_key "access_limits", "revisions", column: "revision_at_creation_id", on_delete: :restrict
   add_foreign_key "access_limits", "users", column: "created_by_id", on_delete: :restrict
   add_foreign_key "content_revisions", "users", column: "created_by_id", on_delete: :restrict
@@ -339,7 +339,7 @@ ActiveRecord::Schema.define(version: 2019_06_26_155821) do
   add_foreign_key "editions", "statuses", on_delete: :restrict
   add_foreign_key "editions", "users", column: "created_by_id", on_delete: :restrict
   add_foreign_key "editions", "users", column: "last_edited_by_id", on_delete: :restrict
-  add_foreign_key "editions_revisions", "editions", on_delete: :restrict
+  add_foreign_key "editions_revisions", "editions", on_delete: :cascade
   add_foreign_key "editions_revisions", "revisions", on_delete: :restrict
   add_foreign_key "file_attachment_assets", "file_attachment_assets", column: "superseded_by_id", on_delete: :restrict
   add_foreign_key "file_attachment_assets", "file_attachment_blob_revisions", column: "blob_revision_id", on_delete: :restrict
@@ -361,7 +361,7 @@ ActiveRecord::Schema.define(version: 2019_06_26_155821) do
   add_foreign_key "image_revisions", "images", on_delete: :restrict
   add_foreign_key "image_revisions", "users", column: "created_by_id", on_delete: :restrict
   add_foreign_key "images", "users", column: "created_by_id", on_delete: :restrict
-  add_foreign_key "internal_notes", "editions", on_delete: :restrict
+  add_foreign_key "internal_notes", "editions", on_delete: :cascade
   add_foreign_key "internal_notes", "users", column: "created_by_id", on_delete: :restrict
   add_foreign_key "metadata_revisions", "users", column: "created_by_id", on_delete: :restrict
   add_foreign_key "revisions", "content_revisions", on_delete: :restrict
@@ -376,14 +376,14 @@ ActiveRecord::Schema.define(version: 2019_06_26_155821) do
   add_foreign_key "revisions_image_revisions", "image_revisions", on_delete: :restrict
   add_foreign_key "revisions_image_revisions", "revisions", on_delete: :restrict
   add_foreign_key "revisions_statuses", "revisions", on_delete: :restrict
-  add_foreign_key "revisions_statuses", "statuses", on_delete: :restrict
+  add_foreign_key "revisions_statuses", "statuses", on_delete: :cascade
   add_foreign_key "schedulings", "statuses", column: "pre_scheduled_status_id", on_delete: :restrict
-  add_foreign_key "statuses", "editions", on_delete: :restrict
+  add_foreign_key "statuses", "editions", on_delete: :cascade
   add_foreign_key "statuses", "revisions", column: "revision_at_creation_id", on_delete: :restrict
   add_foreign_key "statuses", "users", column: "created_by_id", on_delete: :restrict
   add_foreign_key "tags_revisions", "users", column: "created_by_id", on_delete: :restrict
   add_foreign_key "timeline_entries", "documents", on_delete: :restrict
-  add_foreign_key "timeline_entries", "editions", on_delete: :restrict
+  add_foreign_key "timeline_entries", "editions", on_delete: :cascade
   add_foreign_key "timeline_entries", "revisions", on_delete: :restrict
   add_foreign_key "timeline_entries", "statuses", on_delete: :restrict
   add_foreign_key "timeline_entries", "users", column: "created_by_id", on_delete: :restrict

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2019_07_17_170541) do
+ActiveRecord::Schema.define(version: 2019_07_17_203348) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -341,8 +341,8 @@ ActiveRecord::Schema.define(version: 2019_07_17_170541) do
   add_foreign_key "editions", "users", column: "last_edited_by_id", on_delete: :restrict
   add_foreign_key "editions_revisions", "editions", on_delete: :cascade
   add_foreign_key "editions_revisions", "revisions", on_delete: :restrict
-  add_foreign_key "file_attachment_assets", "file_attachment_assets", column: "superseded_by_id", on_delete: :restrict
-  add_foreign_key "file_attachment_assets", "file_attachment_blob_revisions", column: "blob_revision_id", on_delete: :restrict
+  add_foreign_key "file_attachment_assets", "file_attachment_assets", column: "superseded_by_id", on_delete: :nullify
+  add_foreign_key "file_attachment_assets", "file_attachment_blob_revisions", column: "blob_revision_id", on_delete: :cascade
   add_foreign_key "file_attachment_blob_revisions", "active_storage_blobs", column: "blob_id", on_delete: :restrict
   add_foreign_key "file_attachment_blob_revisions", "users", column: "created_by_id", on_delete: :restrict
   add_foreign_key "file_attachment_metadata_revisions", "users", column: "created_by_id", on_delete: :restrict
@@ -351,8 +351,8 @@ ActiveRecord::Schema.define(version: 2019_07_17_170541) do
   add_foreign_key "file_attachment_revisions", "file_attachments", on_delete: :restrict
   add_foreign_key "file_attachment_revisions", "users", column: "created_by_id", on_delete: :restrict
   add_foreign_key "file_attachments", "users", column: "created_by_id", on_delete: :restrict
-  add_foreign_key "image_assets", "image_assets", column: "superseded_by_id", on_delete: :restrict
-  add_foreign_key "image_assets", "image_blob_revisions", column: "blob_revision_id", on_delete: :restrict
+  add_foreign_key "image_assets", "image_assets", column: "superseded_by_id", on_delete: :nullify
+  add_foreign_key "image_assets", "image_blob_revisions", column: "blob_revision_id", on_delete: :cascade
   add_foreign_key "image_blob_revisions", "active_storage_blobs", column: "blob_id", on_delete: :restrict
   add_foreign_key "image_blob_revisions", "users", column: "created_by_id", on_delete: :restrict
   add_foreign_key "image_metadata_revisions", "users", column: "created_by_id", on_delete: :restrict
@@ -372,9 +372,9 @@ ActiveRecord::Schema.define(version: 2019_07_17_170541) do
   add_foreign_key "revisions", "tags_revisions", on_delete: :restrict
   add_foreign_key "revisions", "users", column: "created_by_id", on_delete: :restrict
   add_foreign_key "revisions_file_attachment_revisions", "file_attachment_revisions", on_delete: :restrict
-  add_foreign_key "revisions_file_attachment_revisions", "revisions", on_delete: :restrict
+  add_foreign_key "revisions_file_attachment_revisions", "revisions", on_delete: :cascade
   add_foreign_key "revisions_image_revisions", "image_revisions", on_delete: :restrict
-  add_foreign_key "revisions_image_revisions", "revisions", on_delete: :restrict
+  add_foreign_key "revisions_image_revisions", "revisions", on_delete: :cascade
   add_foreign_key "revisions_statuses", "revisions", on_delete: :restrict
   add_foreign_key "revisions_statuses", "statuses", on_delete: :cascade
   add_foreign_key "schedulings", "statuses", column: "pre_scheduled_status_id", on_delete: :restrict

--- a/db/scrub_access_limited.sql
+++ b/db/scrub_access_limited.sql
@@ -1,0 +1,24 @@
+-- This script is to be executed by https://github.com/alphagov/env-sync-and-backup
+-- (private repo) as part of the data sync from production to integration.
+-- It is used to remove any access limited content from Content Publisher at
+-- the point of copying to integration.
+-- It is kept in this repo to be tested with the application, whenever changes
+-- are made it should be re-copied to the env-sync-and-backup repository.
+
+-- Remove current status of any access limited editions
+UPDATE editions
+SET current = false
+WHERE access_limit_id IS NOT NULL;
+
+-- Set the live editions to current for any docs with an access limited draft
+UPDATE editions
+SET current = true
+WHERE live = true
+AND document_id IN (
+  SELECT document_id
+  FROM editions
+  WHERE access_limit_id IS NOT NULL
+);
+
+-- Delete any access limited editions
+DELETE FROM editions WHERE access_limit_id IS NOT NULL;

--- a/db/scrub_access_limited.sql
+++ b/db/scrub_access_limited.sql
@@ -22,3 +22,74 @@ AND document_id IN (
 
 -- Delete any access limited editions
 DELETE FROM editions WHERE access_limit_id IS NOT NULL;
+
+-- Delete orphaned revisions
+DELETE FROM revisions WHERE NOT EXISTS (
+  SELECT 1
+  FROM editions_revisions
+  WHERE editions_revisions.revision_id = revisions.id
+);
+
+DELETE FROM content_revisions WHERE NOT EXISTS (
+  SELECT 1
+  FROM revisions
+  WHERE revisions.content_revision_id = content_revisions.id
+);
+
+DELETE FROM tags_revisions WHERE NOT EXISTS (
+  SELECT 1
+  FROM revisions
+  WHERE revisions.tags_revision_id = tags_revisions.id
+);
+
+DELETE FROM metadata_revisions WHERE NOT EXISTS (
+  SELECT 1
+  FROM revisions
+  WHERE revisions.metadata_revision_id = metadata_revisions.id
+);
+
+DELETE FROM image_revisions WHERE NOT EXISTS (
+  SELECT 1
+  FROM revisions_image_revisions
+  WHERE revisions_image_revisions.image_revision_id = image_revisions.id
+);
+
+DELETE FROM image_blob_revisions WHERE NOT EXISTS (
+  SELECT 1
+  FROM image_revisions
+  WHERE image_revisions.blob_revision_id = image_blob_revisions.id
+);
+
+DELETE FROM image_metadata_revisions WHERE NOT EXISTS (
+  SELECT 1
+  FROM image_revisions
+  WHERE image_revisions.metadata_revision_id = image_metadata_revisions.id
+);
+
+DELETE FROM file_attachment_revisions WHERE NOT EXISTS (
+  SELECT 1
+  FROM revisions_file_attachment_revisions
+  WHERE revisions_file_attachment_revisions.file_attachment_revision_id = file_attachment_revisions.id
+);
+
+DELETE FROM file_attachment_blob_revisions WHERE NOT EXISTS (
+  SELECT 1
+  FROM file_attachment_revisions
+  WHERE file_attachment_revisions.blob_revision_id = file_attachment_blob_revisions.id
+);
+
+DELETE FROM file_attachment_metadata_revisions WHERE NOT EXISTS (
+  SELECT 1
+  FROM file_attachment_revisions
+  WHERE file_attachment_revisions.metadata_revision_id = file_attachment_metadata_revisions.id
+);
+
+DELETE FROM active_storage_blobs WHERE NOT EXISTS (
+  SELECT 1
+  FROM image_blob_revisions
+  WHERE image_blob_revisions.blob_id = active_storage_blobs.id
+) AND NOT EXISTS (
+  SELECT 1
+  FROM file_attachment_blob_revisions
+  WHERE file_attachment_blob_revisions.blob_id = active_storage_blobs.id
+)

--- a/spec/db/scrub_access_limited_spec.rb
+++ b/spec/db/scrub_access_limited_spec.rb
@@ -1,0 +1,59 @@
+# frozen_string_literal: true
+
+RSpec.describe "Scrub Access Limited SQL Script" do
+  def execute_sql
+    sql = File.read(Rails.root.join("db", "scrub_access_limited.sql"))
+    ActiveRecord::Base.connection.execute(sql)
+  end
+
+  let(:document) { create(:document) }
+
+  it "replaces an access limited draft with the live one" do
+    current_edition = create(:edition, :access_limited, document: document)
+    live_edition = create(:edition,
+                          :published,
+                          current: false,
+                          document: current_edition.document)
+
+    expect(document.reload.current_edition).to eq(current_edition)
+
+    execute_sql
+
+    expect(document.reload.current_edition).to eq(live_edition)
+    expect { current_edition.reload }.to raise_error(ActiveRecord::RecordNotFound)
+  end
+
+  it "leaves no editions for a document with only an active limited draft" do
+    create(:edition, :access_limited, document: document)
+
+    expect { execute_sql }
+      .to change { document.editions.count }
+      .to(0)
+  end
+
+  it "doesn't affect editions that aren't access limited" do
+    create(:edition, document: document)
+
+    expect { execute_sql }
+      .not_to change { document.editions.count }
+      .from(1)
+  end
+
+  it "removes associated internal notes" do
+    edition = create(:edition, :access_limited)
+    internal_note = create(:internal_note, edition: edition)
+
+    execute_sql
+
+    expect { internal_note.reload }.to raise_error(ActiveRecord::RecordNotFound)
+  end
+
+  it "removes associated timeline entries" do
+    edition = create(:edition, :access_limited)
+    timeline_entry = create(:timeline_entry, edition: edition)
+
+    execute_sql
+
+    expect { timeline_entry.reload }.to raise_error(ActiveRecord::RecordNotFound)
+  end
+end


### PR DESCRIPTION
Trello: https://trello.com/c/X8hmEQKk/990-data-syncing-access-limited-content-to-integration

This introduces a SQL script, tests for that script and database migrations that allow for content to be removed as part of the [production to integration data sync](https://docs.publishing.service.gov.uk/manual/alerts/data-sync.html). The SQL file should be copied to https://github.com/alphagov/env-sync-and-backup/tree/master/sanitising-sql, it is included here so that it can be tested as part of any database schema changes.

The approach used here is very similar to [Email Alert API](https://github.com/alphagov/email-alert-api/blob/2d8c09117cd8bea1c696940283ccc64ec2be6e14/lib/data_hygiene/anonymise_email_addresses.sql) with the following differences:

- SQL file is put in `./db` for Content Publisher rather than `./lib/data_hygiene`, lib didn't seem an intuitive place for an SQL file and I'm not sure how this relates to data hygiene;
- SQL comments are used instead of Ruby ones, not really sure why that decision was made in Email Alert API.

Testing on my local machines I can see it successfully removes records:

Before

```
content_publisher_development# SELECT schemaname,relname,n_live_tup
  FROM pg_stat_user_tables
  ORDER BY n_live_tup DESC;
┌────────────┬─────────────────────────────────────┬────────────┐
│ schemaname │               relname               │ n_live_tup │
├────────────┼─────────────────────────────────────┼────────────┤
│ public     │ revisions_statuses                  │       3122 │
│ public     │ timeline_entries                    │       2796 │
│ public     │ revisions                           │       2400 │
│ public     │ editions_revisions                  │       2400 │
│ public     │ revisions_image_revisions           │       1836 │
│ public     │ content_revisions                   │       1428 │
│ public     │ statuses                            │       1166 │
```

After

```
content_publisher_development# SELECT schemaname,relname,n_live_tup
  FROM pg_stat_user_tables
  ORDER BY n_live_tup DESC;
┌────────────┬─────────────────────────────────────┬────────────┐
│ schemaname │               relname               │ n_live_tup │
├────────────┼─────────────────────────────────────┼────────────┤
│ public     │ revisions_statuses                  │       3117 │
│ public     │ timeline_entries                    │       2788 │
│ public     │ revisions                           │       2395 │
│ public     │ editions_revisions                  │       2395 │
│ public     │ revisions_image_revisions           │       1833 │
│ public     │ content_revisions                   │       1426 │
│ public     │ statuses                            │       1163 │
```

This SQL runs very fast as our database size is small, I'm not really sure how well the queries that check for orphans will scale though. 

I'll plan to follow this up with an ADR that updates our deletion strategy to reflect this use case.

