### PR TITLE
Bump gds-sso to 14.1.1

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -108,7 +108,7 @@ GEM
       plek (>= 1.9.0)
       rack-cache
       rest-client (~> 2.0)
-    gds-sso (14.1.0)
+    gds-sso (14.1.1)
       multi_json (~> 1.0)
       oauth2 (~> 1.0)
       omniauth (~> 1.2)


### PR DESCRIPTION
This release fixes an error `NameError
uninitialized constant GDS::SSO::VERSION` (https://github.com/alphagov/gds-sso/commit/59e9fd42a0b49a50893ad26eaeb76657efeed245)