### PR TITLE
Return suggestions when querying a mix of result and hint

### DIFF
--- a/app/assets/javascripts/components/autocomplete.js
+++ b/app/assets/javascripts/components/autocomplete.js
@@ -52,9 +52,23 @@ window.GOVUK.Modules = window.GOVUK.Modules || {};
         })
         syncResults(query
           ? results.filter(function (result) {
-            var valueContains = result.text.toLowerCase().indexOf(query.toLowerCase()) !== -1
-            var hintContains = result.hint.toLowerCase().indexOf(query.toLowerCase()) !== -1
-            return valueContains || hintContains
+            var queryLowerCase = query.toLowerCase()
+            var resultTextLowerCase = result.text.toLowerCase()
+            var resultHintLowerCase = result.hint.toLowerCase()
+            var resultLowerCase = resultTextLowerCase + ' ' + resultHintLowerCase
+            var resultWords = resultLowerCase.split(' ')
+            var resultIncludesWord = false
+
+            var valueContains = resultTextLowerCase.indexOf(queryLowerCase) !== -1
+            var hintContains = resultHintLowerCase.indexOf(queryLowerCase) !== -1
+
+            resultWords.forEach(function (resultWord) {
+              if (resultWord && queryLowerCase.includes(resultWord)) {
+                resultIncludesWord = true
+              }
+            })
+
+            return valueContains || hintContains || resultIncludesWord
           }) : []
         )
       },

--- a/app/assets/javascripts/components/autocomplete.js
+++ b/app/assets/javascripts/components/autocomplete.js
@@ -52,23 +52,16 @@ window.GOVUK.Modules = window.GOVUK.Modules || {};
         })
         syncResults(query
           ? results.filter(function (result) {
-            var queryLowerCase = query.toLowerCase()
+            var queryLowerCase = query.toLowerCase().trim()
             var resultTextLowerCase = result.text.toLowerCase()
             var resultHintLowerCase = result.hint.toLowerCase()
-            var resultLowerCase = resultTextLowerCase + ' ' + resultHintLowerCase
-            var resultWords = resultLowerCase.split(' ')
-            var resultIncludesWord = false
+            var textAndHintLowerCase = resultTextLowerCase + ' ' + resultHintLowerCase
+            var hintAndTextLowerCase = resultHintLowerCase + ' ' + resultTextLowerCase
 
-            var valueContains = resultTextLowerCase.indexOf(queryLowerCase) !== -1
-            var hintContains = resultHintLowerCase.indexOf(queryLowerCase) !== -1
+            var textAndHintContains = textAndHintLowerCase.indexOf(queryLowerCase) !== -1
+            var hintAndTextContains = hintAndTextLowerCase.indexOf(queryLowerCase) !== -1
 
-            resultWords.forEach(function (resultWord) {
-              if (resultWord && queryLowerCase.includes(resultWord)) {
-                resultIncludesWord = true
-              }
-            })
-
-            return valueContains || hintContains || resultIncludesWord
+            return textAndHintContains || hintAndTextContains
           }) : []
         )
       },


### PR DESCRIPTION
Update the `syncResults` function of the `AutoCompleteWithHintOnOptions` to return suggestions when a mix of text and hint terms is used in the query string.

[Trello card](https://trello.com/c/vPEvzSY9)