### PR TITLE
Improve summary page

### DIFF
--- a/app/assets/stylesheets/components/_contextual-guidance.scss
+++ b/app/assets/stylesheets/components/_contextual-guidance.scss
@@ -1,9 +1,4 @@
 .app-c-contextual-guidance__form {
-  .govuk-grid-column-one-third,
-  .govuk-grid-column-two-thirds {
-    position: relative;
-  }
-
   .govuk-grid-row:last-of-type .app-c-contextual-guidance__wrapper {
     position: relative;
   }
@@ -28,7 +23,7 @@
 
     @include govuk-media-query($from: tablet) {
       position: absolute;
-      margin-right: govuk-spacing(3);
+      width: calc(100% - #{govuk-spacing(6)});
     }
   }
 }

--- a/app/assets/stylesheets/objects/_grid.scss
+++ b/app/assets/stylesheets/objects/_grid.scss
@@ -1,4 +1,4 @@
-.app-grid-column--end {
+.app-grid-column--align-right {
   text-align: right;
 }
 

--- a/app/assets/stylesheets/objects/_grid.scss
+++ b/app/assets/stylesheets/objects/_grid.scss
@@ -1,3 +1,7 @@
 .app-grid-column--end {
   text-align: right;
 }
+
+.app-grid-column--float-right {
+  float: right;
+}

--- a/app/assets/stylesheets/objects/_history.scss
+++ b/app/assets/stylesheets/objects/_history.scss
@@ -1,9 +1,3 @@
-.app-timeline-heading {
-  @include govuk-media-query($from: tablet) {
-    @include govuk-visually-hidden;
-  }
-}
-
 .app-timeline-entry__dateline {
   color: $govuk-secondary-text-colour;
 }

--- a/app/assets/stylesheets/objects/_side.scss
+++ b/app/assets/stylesheets/objects/_side.scss
@@ -1,3 +1,10 @@
+.app-side__wrapper {
+  @include govuk-media-query($from: tablet) {
+    position: absolute;
+    width: calc(100% - #{govuk-spacing(6)});
+  }
+}
+
 .app-side {
   @include govuk-responsive-margin(6, "bottom");
   @include govuk-clearfix;

--- a/app/assets/stylesheets/utilities/_overwrites.scss
+++ b/app/assets/stylesheets/utilities/_overwrites.scss
@@ -92,3 +92,11 @@
 .govuk-grid-column-two-thirds {
   position: relative;
 }
+
+.govuk-tabs {
+  .govuk-heading-l {
+    @include govuk-media-query($from: tablet) {
+      @include govuk-visually-hidden;
+    }
+  }
+}

--- a/app/assets/stylesheets/utilities/_overwrites.scss
+++ b/app/assets/stylesheets/utilities/_overwrites.scss
@@ -87,3 +87,8 @@
     color: $govuk-secondary-text-colour;
   }
 }
+
+.govuk-grid-column-one-third,
+.govuk-grid-column-two-thirds {
+  position: relative;
+}

--- a/app/views/components/_inset_prompt.html.erb
+++ b/app/views/components/_inset_prompt.html.erb
@@ -10,7 +10,7 @@
 %>
 
 <%= tag.div class: root_classes, id: id, data: data_attributes do %>
-  <%= tag.h2 title, class: "app-c-inset-prompt__title" %>
+  <%= tag.h3 title, class: "app-c-inset-prompt__title" %>
 
   <%= tag.div class: "app-c-inset-prompt__body" do %>
     <%= description if description %>

--- a/app/views/components/_summary.html.erb
+++ b/app/views/components/_summary.html.erb
@@ -8,7 +8,7 @@
 
 <%= tag.div class: "app-c-summary", id: id do %>
   <% if title %>
-    <%= tag.h2 title, class: "govuk-heading-m" %>
+    <%= tag.h3 title, class: "govuk-heading-m" %>
     <% if edit.any? %>
       <%= link_to edit.fetch(:href),
                   class: "app-c-summary__edit-section-link",

--- a/app/views/documents/show.html.erb
+++ b/app/views/documents/show.html.erb
@@ -8,12 +8,14 @@
     {
       id: "edit-document",
       label: t("documents.show.tabs.summary"),
+      title: t("documents.show.tabs.summary"),
       content: render("documents/show/summary_tab"),
       tab_data_attributes: { gtm: "summary-tab" }
     },
     {
       id: "document-history",
       label: t("documents.show.tabs.history"),
+      title: t("documents.show.tabs.history"),
       content: render("documents/show/history_tab"),
       tab_data_attributes: { gtm: "history-tab" }
     }

--- a/app/views/documents/show/_summary_tab.html.erb
+++ b/app/views/documents/show/_summary_tab.html.erb
@@ -13,7 +13,30 @@
     <% if @edition.failed_to_publish? %>
       <%= render "documents/show/failed_to_publish_notice" %>
     <% end %>
+  </div>
 
+  <div class="govuk-grid-column-one-third app-grid-column--float-right">
+    <aside class="app-side__wrapper">
+      <% if @edition.scheduled? %>
+        <%= render "documents/show/scheduled_notice" %>
+      <% end %>
+
+      <% if @edition.editable? && @edition.proposed_publish_time %>
+        <%= render "documents/show/proposed_scheduling_notice" %>
+      <% end %>
+
+      <%= render "documents/show/actions" %>
+      <%= render "documents/show/document_metadata" %>
+
+      <% if current_user.has_permission?(User::DEBUG_PERMISSION) %>
+        <%= render "documents/show/debug" %>
+      <% end %>
+    </aside>
+  </div>
+</div>
+
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-two-thirds">
     <%= render "documents/show/contents" %>
 
     <% if @edition.document_type.images %>
@@ -28,23 +51,6 @@
 
     <% if @edition.editable? %>
       <%= render "documents/show/content_settings" %>
-    <% end %>
-  </div>
-
-  <div class="govuk-grid-column-one-third">
-    <% if @edition.scheduled? %>
-      <%= render "documents/show/scheduled_notice" %>
-    <% end %>
-
-    <% if @edition.editable? && @edition.proposed_publish_time %>
-      <%= render "documents/show/proposed_scheduling_notice" %>
-    <% end %>
-
-    <%= render "documents/show/actions" %>
-    <%= render "documents/show/document_metadata" %>
-
-    <% if current_user.has_permission?(User::DEBUG_PERMISSION) %>
-      <%= render "documents/show/debug" %>
     <% end %>
   </div>
 </div>

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -101,7 +101,7 @@
           <span class="govuk-caption-l"><%= yield(:context) %></span>
           <h1 class="govuk-heading-l"><%= yield(:title) %></h1>
         </div>
-        <div class="govuk-grid-column-one-third app-grid-column--end">
+        <div class="govuk-grid-column-one-third app-grid-column--align-right">
           <%= yield(:title_side) %>
         </div>
       </div>


### PR DESCRIPTION
This PR update the document summary page layout so that on small screens (or when increasing the size) publisher are able to interact with it without scrolling too much.

- Refactor summary tab layout to move actions between flash messages/requirements and document summary. The tab order is so updated and the mobile layout will preserve the above mentioned order.
- After the code introduced by the above work:
  - bring the `app-grid-column` modifiers in line to make it more clear which does what.
  - align contextual guidance wrapper with side wrapper
- Add headings to tab sections on mobile
- After the code introduced by the above work:
  - Remove relict class `app-timeline-heading` as it's not used anymore
  - Restructure heading levels for summary page

### New headings landmarks structure

```
H1: Document title
├─ H2: Document summary
│   ├─ H3: Requirements heading
│   ├─ H3: Content
│   ├─ H3: Lead image
│   ├─ H3: Topics
│   ├─ H3: Tags
│   └─ H3: Content settings
└─ H2: Document history
    └─ H3: 1st edition
        ├─ H4: Document updated
        └─ H4: First created
```

### Visual changes

(left `master`, right: `improve-summary-page`)

![imgonline-com-ua-twotoone-MVrkcDQusbyDYu](https://user-images.githubusercontent.com/788096/61726711-01368680-ad6a-11e9-8ee6-66d60946d985.jpg)

[Trello card](https://trello.com/c/95Mdb8FV)