### PR TITLE
Show a warning on the tags page for access limited editions

### DIFF
--- a/app/views/tags/edit.html.erb
+++ b/app/views/tags/edit.html.erb
@@ -12,6 +12,12 @@
                  },
                  class: "app-c-contextual-guidance__form" do %>
       <% @edition.document_type.tags.each do |tag_field| %>
+        <% if @edition.access_limit.present? && tag_field.id == "primary_publishing_organisation" %>
+          <%= render "govuk_publishing_components/components/warning_text", {
+            text: t("tags.edit.organisation_warning"),
+          } %>
+        <% end %>
+
         <div id="<%= tag_field.id %>">
           <%= render "tags/tags/#{tag_field.type}_input",
             tag_field: tag_field,

--- a/config/locales/en/tags/edit.yml
+++ b/config/locales/en/tags/edit.yml
@@ -4,3 +4,4 @@ en:
       title: "Tags for ‘%{title}’"
       description: Add tags which describe what the content is about. Content will appear in lists on GOV.UK based on each tag.
       api_down: This content can't be edited right now. We're having trouble getting the data we need for you to make changes on this page.
+      organisation_warning: Access to this document is restricted. Adding or removing organisation tags will change who can access it.

--- a/spec/features/editing_tags/edit_tags_access_limited_spec.rb
+++ b/spec/features/editing_tags/edit_tags_access_limited_spec.rb
@@ -1,0 +1,35 @@
+# frozen_string_literal: true
+
+RSpec.feature "Edit tags of access limited edition" do
+  scenario do
+    given_there_is_an_access_limited_edition
+    when_i_visit_the_edit_tags_page
+    then_i_see_a_warning_against_editing_organisations
+  end
+
+  def given_there_is_an_access_limited_edition
+    primary_org = current_user.organisation_content_id
+
+    organisation_field = build(:tag_field,
+                               type: "single_tag",
+                               id: "primary_publishing_organisation")
+
+    stub_publishing_api_has_linkables(
+      [{ "content_id" => primary_org, "internal_name" => "Organisation" }],
+      document_type: organisation_field.document_type,
+    )
+    document_type = build(:document_type, tags: [organisation_field])
+    @edition = create(:edition,
+                      :access_limited,
+                      document_type_id: document_type.id,
+                      created_by: current_user)
+  end
+
+  def when_i_visit_the_edit_tags_page
+    visit tags_path(@edition.document)
+  end
+
+  def then_i_see_a_warning_against_editing_organisations
+    expect(page).to have_content(I18n.t!("tags.edit.organisation_warning"))
+  end
+end


### PR DESCRIPTION
Trello: https://trello.com/c/RUUozLeb/1006-warn-users-before-changing-organisations-on-an-access-limited-edition

This adds a warning for when an edition is access limited that users may experience undesirable consequences if they change an organisation.

It looks like this:

![Screen Shot 2019-07-24 at 16 24 40](https://user-images.githubusercontent.com/282717/61806423-8768d080-ae2f-11e9-85b8-41a8a1aafe6b.png)

Few areas where I had to make some decisions:

- I assumed it was to be placed above the field rather than the intro text, this would lead well into having this warning be part of the view for primary_publishing_organisation field when we move forward with formats;
- the copy doesn't cater for the different types of access limit, but I don't think that's a big problem;
- the copy doc specified inset or warning component, I picked warning since we were doing a warning;
- feature testing this is a bit tricky as it's the side effect of a different feature, I considered adding this as steps onto the "Set access limit" feature but that's already rather long so thought it was better standalone.