### PR TITLE
Stop user locking themselves out

### DIFF
--- a/app/controllers/access_limit_controller.rb
+++ b/app/controllers/access_limit_controller.rb
@@ -13,6 +13,16 @@ class AccessLimitController < ApplicationController
 
   def update
     result = AccessLimit::UpdateInteractor.call(params: params, user: current_user)
-    redirect_to document_path(result.edition.document)
+    issues, edition = result.to_h.values_at(:issues, :edition)
+
+    if issues
+      flash.now["requirements"] = { "items" => issues.items }
+
+      render :edit,
+             assigns: { edition: edition, issues: issues },
+             status: :unprocessable_entity
+    else
+      redirect_to document_path(edition.document)
+    end
   end
 end

--- a/app/services/requirements/access_limit_checker.rb
+++ b/app/services/requirements/access_limit_checker.rb
@@ -1,0 +1,49 @@
+# frozen_string_literal: true
+
+module Requirements
+  class AccessLimitChecker
+    attr_reader :edition, :user
+
+    def initialize(edition, user)
+      @edition = edition
+      @user = user
+    end
+
+    def pre_update_issues
+      issues = []
+
+      if edition.access_limit.nil?
+        return CheckerIssues.new([])
+      end
+
+      if edition.primary_publishing_organisation_id.blank?
+        issues << Issue.new(:access_limit, :no_primary_org)
+        return CheckerIssues.new(issues)
+      end
+
+      if edition.access_limit.primary_organisation? &&
+          user_is_not_in_primary_org?
+        issues << Issue.new(:access_limit, :not_in_orgs)
+      end
+
+      if edition.access_limit.tagged_organisations? &&
+          user_is_not_in_any_org?
+        issues << Issue.new(:access_limit, :not_in_orgs)
+      end
+
+      CheckerIssues.new(issues)
+    end
+
+  private
+
+    def user_is_not_in_primary_org?
+      edition.primary_publishing_organisation_id !=
+        user.organisation_content_id
+    end
+
+    def user_is_not_in_any_org?
+      user_is_not_in_primary_org? &&
+        edition.organisations.exclude?(user.organisation_content_id)
+    end
+  end
+end

--- a/app/views/access_limit/edit.html.erb
+++ b/app/views/access_limit/edit.html.erb
@@ -36,6 +36,7 @@
     <%= form_tag access_limit_path(@edition.document), data: { gtm: "confirm-access-limit" } do %>
       <%= render "govuk_publishing_components/components/radio", {
         name: "limit_type",
+        error_items: @issues&.items_for(:access_limit),
         items: [
           {
             value: "none",

--- a/config/locales/en/requirements.yml
+++ b/config/locales/en/requirements.yml
@@ -132,3 +132,8 @@ en:
         form_message: Enter a web address
       non_youtube:
         form_message: Enter a valid YouTube web address
+    access_limit:
+      no_primary_org:
+        form_message: Select a primary organisation before you can limit access
+      not_in_orgs:
+        form_message: Select an access option that includes the organisation your account is a member of so that you will still have access

--- a/spec/features/editing_content_settings/set_access_limit_requirements_spec.rb
+++ b/spec/features/editing_content_settings/set_access_limit_requirements_spec.rb
@@ -1,0 +1,23 @@
+# frozen_string_literal: true
+
+RSpec.feature "Set access limit with requirements issues" do
+  scenario do
+    given_there_is_an_edition_with_no_orgs
+    when_i_try_to_set_an_access_limit
+    then_i_see_an_error_to_fix_the_issue
+  end
+
+  def given_there_is_an_edition_with_no_orgs
+    @edition = create(:edition)
+  end
+
+  def when_i_try_to_set_an_access_limit
+    visit access_limit_path(@edition.document)
+    choose(I18n.t!("access_limit.edit.type.primary_organisation"))
+    click_on "Save"
+  end
+
+  def then_i_see_an_error_to_fix_the_issue
+    expect(page).to have_content(I18n.t!("requirements.access_limit.no_primary_org.form_message"))
+  end
+end

--- a/spec/services/requirements/access_limit_checker_spec.rb
+++ b/spec/services/requirements/access_limit_checker_spec.rb
@@ -1,0 +1,90 @@
+# frozen_string_literal: true
+
+RSpec.describe Requirements::AccessLimitChecker do
+  describe "#pre_update_issues" do
+    let(:user) { build :user, organisation_content_id: "my-org" }
+
+    it "returns no issues when there is no access limit" do
+      edition = build(:edition)
+      issues = Requirements::AccessLimitChecker.new(edition, user).pre_update_issues
+      expect(issues.items).to be_empty
+    end
+
+    it "returns an issue when the edition has no primary org" do
+      edition = build(:edition, :access_limited)
+      issues = Requirements::AccessLimitChecker.new(edition, user).pre_update_issues
+
+      form_message = issues.items_for(:access_limit).first[:text]
+      expect(form_message).to eq(I18n.t!("requirements.access_limit.no_primary_org.form_message"))
+    end
+
+    context "the access limit is for the primary org" do
+      it "returns an issue when the user is not in the org" do
+        edition = build(:edition,
+                        :access_limited,
+                        limit_type: :primary_organisation,
+                        tags: {
+                          primary_publishing_organisation: %w[another-org],
+                        })
+
+        issues = Requirements::AccessLimitChecker.new(edition, user).pre_update_issues
+        form_message = issues.items_for(:access_limit).first[:text]
+        expect(form_message).to eq(I18n.t!("requirements.access_limit.not_in_orgs.form_message"))
+      end
+
+      it "returns no issues when the user is in the org" do
+        edition = build(:edition,
+                        :access_limited,
+                        limit_type: :primary_organisation,
+                        tags: {
+                          primary_publishing_organisation: %w[my-org],
+                        })
+
+        issues = Requirements::AccessLimitChecker.new(edition, user).pre_update_issues
+        expect(issues.items).to be_empty
+      end
+    end
+
+    context "the access limit is for tagged orgs" do
+      it "returns an issue when the user is not in any of the orgs" do
+        edition = build(:edition,
+                        :access_limited,
+                        limit_type: :tagged_organisations,
+                        tags: {
+                          primary_publishing_organisation: %w[another-org],
+                          organisations: %w[supporting-org],
+                        })
+
+        issues = Requirements::AccessLimitChecker.new(edition, user).pre_update_issues
+        form_message = issues.items_for(:access_limit).first[:text]
+        expect(form_message).to eq(I18n.t!("requirements.access_limit.not_in_orgs.form_message"))
+      end
+
+      it "returns no issues when the user is in a supporting org" do
+        edition = build(:edition,
+                        :access_limited,
+                        limit_type: :tagged_organisations,
+                        tags: {
+                          primary_publishing_organisation: %w[another-org],
+                          organisations: %w[my-org],
+                        })
+
+        issues = Requirements::AccessLimitChecker.new(edition, user).pre_update_issues
+        expect(issues.items).to be_empty
+      end
+
+      it "returns no issues when the user is in the primary org" do
+        edition = build(:edition,
+                        :access_limited,
+                        limit_type: :tagged_organisations,
+                        tags: {
+                          primary_publishing_organisation: %w[my-org],
+                          organisations: %w[supporting-org],
+                        })
+
+        issues = Requirements::AccessLimitChecker.new(edition, user).pre_update_issues
+        expect(issues.items).to be_empty
+      end
+    end
+  end
+end


### PR DESCRIPTION
https://trello.com/c/dlw2oE4O/987-create-a-form-so-users-can-limit-access-to-a-draft

This adds a requirements checker to ensure a user cannot set an access
limit that would lock them out of an edition.

<img width="1060" alt="Screen Shot 2019-07-24 at 17 40 44" src="https://user-images.githubusercontent.com/9029009/61813456-a53d3200-ae3d-11e9-8e30-8065ee94f61a.png">
