### PR TITLE
Add array-like methods to CheckerIssues

### DIFF
--- a/app/services/requirements/backdate_checker.rb
+++ b/app/services/requirements/backdate_checker.rb
@@ -9,7 +9,7 @@ module Requirements
     end
 
     def pre_submit_issues
-      issues = []
+      issues = CheckerIssues.new
 
       if in_the_future?
         issues << Issue.new(:backdate_date, :in_the_future)
@@ -20,7 +20,7 @@ module Requirements
         issues << Issue.new(:backdate_date, :too_long_ago, date: date)
       end
 
-      CheckerIssues.new(issues)
+      issues
     end
 
   private

--- a/app/services/requirements/checker_issues.rb
+++ b/app/services/requirements/checker_issues.rb
@@ -4,11 +4,15 @@ module Requirements
   class CheckerIssues
     include Enumerable
 
+    delegate :each, :<<, :empty?, to: :issues
     attr_reader :issues
-    delegate :each, to: :issues
 
-    def initialize(issues)
+    def initialize(issues = [])
       @issues = issues
+    end
+
+    def +(other)
+      CheckerIssues.new(issues + other.issues)
     end
 
     def items(params = {})

--- a/app/services/requirements/content_checker.rb
+++ b/app/services/requirements/content_checker.rb
@@ -13,7 +13,7 @@ module Requirements
     end
 
     def pre_preview_issues
-      issues = []
+      issues = CheckerIssues.new
 
       if revision.title.blank?
         issues << Issue.new(:title, :blank)
@@ -43,11 +43,11 @@ module Requirements
         end
       end
 
-      CheckerIssues.new(issues)
+      issues
     end
 
     def pre_publish_issues
-      issues = []
+      issues = CheckerIssues.new
 
       if revision.summary.blank?
         issues << Issue.new(:summary, :blank)
@@ -59,11 +59,13 @@ module Requirements
         end
       end
 
-      if edition.document.live_edition && revision.update_type == "major" && revision.change_note.blank?
+      if edition.document.live_edition &&
+          revision.update_type == "major" &&
+          revision.change_note.blank?
         issues << Issue.new(:change_note, :blank)
       end
 
-      CheckerIssues.new(issues)
+      issues
     end
   end
 end

--- a/app/services/requirements/edit_page_checker.rb
+++ b/app/services/requirements/edit_page_checker.rb
@@ -10,10 +10,10 @@ module Requirements
     end
 
     def pre_preview_issues
-      issues = []
-      issues += PathChecker.new(edition, revision).pre_preview_issues.to_a
-      issues += ContentChecker.new(edition, revision).pre_preview_issues.to_a
-      CheckerIssues.new(issues)
+      issues = CheckerIssues.new
+      issues += PathChecker.new(edition, revision).pre_preview_issues
+      issues += ContentChecker.new(edition, revision).pre_preview_issues
+      issues
     end
   end
 end

--- a/app/services/requirements/edition_checker.rb
+++ b/app/services/requirements/edition_checker.rb
@@ -10,24 +10,22 @@ module Requirements
     end
 
     def pre_preview_issues
-      issues = []
+      issues = CheckerIssues.new
 
       revision.image_revisions.each do |image|
-        issues += ImageRevisionChecker.new(image).pre_preview_issues.to_a
+        issues += ImageRevisionChecker.new(image).pre_preview_issues
       end
 
-      issues += ContentChecker.new(edition, revision).pre_preview_issues.to_a
-
-      CheckerIssues.new(issues)
+      issues += ContentChecker.new(edition, revision).pre_preview_issues
+      issues
     end
 
     def pre_publish_issues(params = {})
-      issues = []
-      issues += ContentChecker.new(edition, revision).pre_publish_issues.to_a
-      issues += TopicChecker.new(edition.document).pre_publish_issues(params).to_a
-      issues += TagChecker.new(edition, revision).pre_publish_issues.to_a
-
-      CheckerIssues.new(issues)
+      issues = CheckerIssues.new
+      issues += ContentChecker.new(edition, revision).pre_publish_issues
+      issues += TopicChecker.new(edition.document).pre_publish_issues(params)
+      issues += TagChecker.new(edition, revision).pre_publish_issues
+      issues
     end
   end
 end

--- a/app/services/requirements/file_attachment_checker.rb
+++ b/app/services/requirements/file_attachment_checker.rb
@@ -36,17 +36,13 @@ module Requirements
     end
 
     def pre_upload_issues
-      issues = title_issues + file_issues
-
-      CheckerIssues.new(issues)
+      title_issues + file_issues
     end
 
     def pre_update_issues
-      issues = []
-      issues += title_issues if title_issues.any?
-      issues += file_issues if file.present? && file_issues.any?
-
-      CheckerIssues.new(issues)
+      issues = title_issues
+      issues += file_issues if file.present?
+      issues
     end
 
   private
@@ -75,7 +71,7 @@ module Requirements
     end
 
     def title_issues
-      issues = []
+      issues = CheckerIssues.new
 
       if title.blank?
         issues << Issue.new(:file_attachment_title, :blank)
@@ -91,7 +87,7 @@ module Requirements
     end
 
     def file_issues
-      issues = []
+      issues = CheckerIssues.new
 
       unless file
         issues << Issue.new(:file_attachment_upload, :no_file)

--- a/app/services/requirements/image_revision_checker.rb
+++ b/app/services/requirements/image_revision_checker.rb
@@ -13,7 +13,7 @@ module Requirements
     end
 
     def pre_preview_metadata_issues
-      issues = []
+      issues = CheckerIssues.new
 
       if image_revision.alt_text.blank?
         issues << Issue.new(:alt_text,
@@ -46,7 +46,7 @@ module Requirements
                             image_revision: image_revision)
       end
 
-      CheckerIssues.new(issues)
+      issues
     end
 
     def pre_preview_issues

--- a/app/services/requirements/image_upload_checker.rb
+++ b/app/services/requirements/image_upload_checker.rb
@@ -16,7 +16,7 @@ module Requirements
     end
 
     def issues
-      issues = []
+      issues = CheckerIssues.new
 
       unless file
         issues << Issue.new(:image_upload, :no_file)
@@ -41,7 +41,7 @@ module Requirements
         issues << Issue.new(:image_upload, :too_small, width: Image::WIDTH, height: Image::HEIGHT)
       end
 
-      CheckerIssues.new(issues)
+      issues
     end
 
   private

--- a/app/services/requirements/path_checker.rb
+++ b/app/services/requirements/path_checker.rb
@@ -10,7 +10,7 @@ module Requirements
     end
 
     def pre_preview_issues
-      issues = []
+      issues = CheckerIssues.new
 
       begin
         if edition.document_type.check_path_conflict && base_path_conflict?
@@ -20,7 +20,7 @@ module Requirements
         GovukError.notify(e)
       end
 
-      CheckerIssues.new(issues)
+      issues
     end
 
   private

--- a/app/services/requirements/publish_time_checker.rb
+++ b/app/services/requirements/publish_time_checker.rb
@@ -14,7 +14,7 @@ module Requirements
     end
 
     def issues
-      issues = []
+      issues = CheckerIssues.new
 
       if publish_time > MAX_PUBLISH_DELAY.from_now
         issues << Issue.new(:schedule_date,
@@ -33,7 +33,7 @@ module Requirements
         issues << Issue.new(field, :in_the_past)
       end
 
-      CheckerIssues.new(issues)
+      issues
     end
   end
 end

--- a/app/services/requirements/tag_checker.rb
+++ b/app/services/requirements/tag_checker.rb
@@ -10,14 +10,15 @@ module Requirements
     end
 
     def pre_publish_issues
-      issues = []
+      issues = CheckerIssues.new
+
       if edition.document_type.tags.map(&:id).include?("primary_publishing_organisation")
         if revision.primary_publishing_organisation_id.blank?
           issues << Issue.new(:primary_publishing_organisation, :blank)
         end
       end
 
-      CheckerIssues.new(issues)
+      issues
     end
   end
 end

--- a/app/services/requirements/topic_checker.rb
+++ b/app/services/requirements/topic_checker.rb
@@ -9,7 +9,7 @@ module Requirements
     end
 
     def pre_publish_issues(rescue_api_errors: true)
-      issues = []
+      issues = CheckerIssues.new
 
       begin
         if document.document_type.topics && document.topics.none?
@@ -20,7 +20,7 @@ module Requirements
         raise unless rescue_api_errors
       end
 
-      CheckerIssues.new(issues)
+      issues
     end
   end
 end

--- a/app/services/requirements/video_embed_checker.rb
+++ b/app/services/requirements/video_embed_checker.rb
@@ -6,7 +6,7 @@ module Requirements
     YOUTU_HOST = "youtu.be"
 
     def pre_embed_issues(title: nil, url: nil)
-      issues = []
+      issues = CheckerIssues.new
 
       if title.blank?
         issues << Issue.new(:video_embed_title, :blank)
@@ -18,7 +18,7 @@ module Requirements
         issues << Issue.new(:video_embed_url, :non_youtube)
       end
 
-      CheckerIssues.new(issues)
+      issues
     end
 
   private

--- a/app/services/requirements/withdrawal_checker.rb
+++ b/app/services/requirements/withdrawal_checker.rb
@@ -10,7 +10,7 @@ module Requirements
     end
 
     def pre_withdrawal_issues
-      issues = []
+      issues = CheckerIssues.new
 
       if public_explanation.blank?
         issues << Issue.new(:public_explanation, :blank)
@@ -20,7 +20,7 @@ module Requirements
         issues << Issue.new(:public_explanation, :invalid_govspeak)
       end
 
-      CheckerIssues.new(issues)
+      issues
     end
   end
 end

--- a/spec/services/requirements/backdate_checker_spec.rb
+++ b/spec/services/requirements/backdate_checker_spec.rb
@@ -6,7 +6,7 @@ RSpec.describe Requirements::BackdateChecker do
       date = Time.current.change(day: 1, month: 1, year: 2019)
       issues = Requirements::BackdateChecker.new(date).pre_submit_issues
 
-      expect(issues.items).to be_empty
+      expect(issues).to be_empty
     end
 
     it "returns an issue if the date is in the future" do

--- a/spec/services/requirements/content_checker_spec.rb
+++ b/spec/services/requirements/content_checker_spec.rb
@@ -5,7 +5,7 @@ RSpec.describe Requirements::ContentChecker do
     it "returns no issues if there are none" do
       edition = build :edition
       issues = Requirements::ContentChecker.new(edition).pre_preview_issues
-      expect(issues.items).to be_empty
+      expect(issues).to be_empty
     end
 
     it "returns an issue if there is no title" do
@@ -96,7 +96,7 @@ RSpec.describe Requirements::ContentChecker do
     it "returns no issues if there are none" do
       edition = build :edition, :publishable
       issues = Requirements::ContentChecker.new(edition).pre_publish_issues
-      expect(issues.items).to be_empty
+      expect(issues).to be_empty
     end
 
     it "returns an issue if the summary is blank" do

--- a/spec/services/requirements/file_attachment_checker_spec.rb
+++ b/spec/services/requirements/file_attachment_checker_spec.rb
@@ -7,7 +7,7 @@ RSpec.describe Requirements::FileAttachmentChecker do
 
       issues = Requirements::FileAttachmentChecker.new(file: file, title: "Cool title")
                                                   .pre_upload_issues
-      expect(issues.items).to be_empty
+      expect(issues).to be_empty
     end
 
     it "returns no upload issues for a text file when it has no extension" do
@@ -87,7 +87,7 @@ RSpec.describe Requirements::FileAttachmentChecker do
 
       issues = Requirements::FileAttachmentChecker.new(file: file, title: "Cool title")
                                                   .pre_update_issues
-      expect(issues.items).to be_empty
+      expect(issues).to be_empty
     end
 
     it "returns title issues when only the title is provided" do

--- a/spec/services/requirements/image_revision_checker_spec.rb
+++ b/spec/services/requirements/image_revision_checker_spec.rb
@@ -5,7 +5,7 @@ RSpec.describe Requirements::ImageRevisionChecker do
     it "returns no issues if there are none" do
       image_revision = build :image_revision, alt_text: "something"
       issues = Requirements::ImageRevisionChecker.new(image_revision).pre_preview_issues
-      expect(issues.items).to be_empty
+      expect(issues).to be_empty
     end
 
     it "returns an issue if there is no alt text" do

--- a/spec/services/requirements/image_upload_checker_spec.rb
+++ b/spec/services/requirements/image_upload_checker_spec.rb
@@ -5,7 +5,7 @@ RSpec.describe Requirements::ImageUploadChecker do
     it "returns no issues if there are none" do
       file = fixture_file_upload("files/960x640.jpg", "image/jpeg")
       issues = Requirements::ImageUploadChecker.new(file).issues
-      expect(issues.items).to be_empty
+      expect(issues).to be_empty
     end
 
     it "returns an issue when no image is specified" do

--- a/spec/services/requirements/path_checker_spec.rb
+++ b/spec/services/requirements/path_checker_spec.rb
@@ -7,7 +7,7 @@ RSpec.describe Requirements::PathChecker do
         document_type = build :document_type
         edition = build :edition, document_type_id: document_type.id
         issues = Requirements::PathChecker.new(edition).pre_preview_issues
-        expect(issues.items).to be_empty
+        expect(issues).to be_empty
       end
     end
 
@@ -17,7 +17,7 @@ RSpec.describe Requirements::PathChecker do
         edition = build :edition, document_type_id: document_type.id
         stub_publishing_api_has_lookups(edition.base_path => nil)
         issues = Requirements::PathChecker.new(edition).pre_preview_issues
-        expect(issues.items).to be_empty
+        expect(issues).to be_empty
       end
 
       it "returns no issues if the document owns the path" do
@@ -25,7 +25,7 @@ RSpec.describe Requirements::PathChecker do
         edition = build :edition, document_type_id: document_type.id
         stub_publishing_api_has_lookups(edition.base_path => edition.content_id)
         issues = Requirements::PathChecker.new(edition).pre_preview_issues
-        expect(issues.items).to be_empty
+        expect(issues).to be_empty
       end
 
       it "returns an issue if the base_path conflicts" do
@@ -48,11 +48,11 @@ RSpec.describe Requirements::PathChecker do
         stub_publishing_api_has_lookups(edition.base_path => nil,
                                    revision.base_path => SecureRandom.uuid)
         issues = Requirements::PathChecker.new(edition).pre_preview_issues
-        expect(issues.items).to be_empty
+        expect(issues).to be_empty
 
         issues = Requirements::PathChecker.new(edition, revision)
                                                      .pre_preview_issues
-        expect(issues.items).not_to be_empty
+        expect(issues).not_to be_empty
       end
     end
 

--- a/spec/services/requirements/publish_time_checker_spec.rb
+++ b/spec/services/requirements/publish_time_checker_spec.rb
@@ -6,7 +6,7 @@ RSpec.describe Requirements::PublishTimeChecker do
   describe "#issues" do
     it "returns no issues if there are none" do
       issues = Requirements::PublishTimeChecker.new(1.day.from_now).issues
-      expect(issues.items).to be_empty
+      expect(issues).to be_empty
     end
 
     it "returns a date issue if the date is in the past" do

--- a/spec/services/requirements/topic_checker_spec.rb
+++ b/spec/services/requirements/topic_checker_spec.rb
@@ -7,7 +7,7 @@ RSpec.describe Requirements::TopicChecker do
     it "returns no issues if there are none" do
       edition = build :edition, :publishable
       issues = Requirements::TopicChecker.new(edition.document).pre_publish_issues
-      expect(issues.items).to be_empty
+      expect(issues).to be_empty
     end
 
     context "when the Publishing API is available" do

--- a/spec/services/requirements/video_embed_checker_spec.rb
+++ b/spec/services/requirements/video_embed_checker_spec.rb
@@ -7,13 +7,13 @@ RSpec.describe Requirements::VideoEmbedChecker do
         title: "A title", url: "https://www.youtube.com/watch?v=hY7m5jjJ9mM",
       )
 
-      expect(issues.items).to be_empty
+      expect(issues).to be_empty
 
       issues = Requirements::VideoEmbedChecker.new.pre_embed_issues(
         title: "A title", url: "https://youtu.be/FdeioVndUhs",
       )
 
-      expect(issues.items).to be_empty
+      expect(issues).to be_empty
     end
 
     it "returns an issue when the title is blank" do

--- a/spec/services/requirements/withdrawal_checker_spec.rb
+++ b/spec/services/requirements/withdrawal_checker_spec.rb
@@ -6,7 +6,7 @@ RSpec.describe Requirements::WithdrawalChecker do
       public_explanation = SecureRandom.alphanumeric
       issues = Requirements::WithdrawalChecker.new(public_explanation, build(:edition))
                                               .pre_withdrawal_issues
-      expect(issues.items).to be_empty
+      expect(issues).to be_empty
     end
 
     it "returns an issue if there is no public explanation" do


### PR DESCRIPTION
This makes the CheckerIssues behave more like an array, so that we can
always work with this class instead of going backwards and forwards
between arrays in order to emulate '<<', '+=' and 'empty?'.