### PR TITLE
Access limit orgs

### DIFF
--- a/app/models/access_limit.rb
+++ b/app/models/access_limit.rb
@@ -19,6 +19,7 @@ class AccessLimit < ApplicationRecord
 
   def organisation_ids
     orgs = [edition.primary_publishing_organisation_id]
-    primary_organisation? ? orgs : orgs + edition.organisations
+    orgs += edition.supporting_organisation_ids if tagged_organisations?
+    orgs
   end
 end

--- a/app/models/access_limit.rb
+++ b/app/models/access_limit.rb
@@ -16,4 +16,9 @@ class AccessLimit < ApplicationRecord
   def readonly?
     !new_record?
   end
+
+  def organisation_ids
+    orgs = [edition.primary_publishing_organisation_id]
+    primary_organisation? ? orgs : orgs + edition.organisations
+  end
 end

--- a/app/models/edition.rb
+++ b/app/models/edition.rb
@@ -71,7 +71,7 @@ class Edition < ApplicationRecord
            :file_attachment_revisions,
            :assets,
            :primary_publishing_organisation_id,
-           :organisations,
+           :supporting_organisation_ids,
            :backdated_to,
            to: :revision
 

--- a/app/models/revision.rb
+++ b/app/models/revision.rb
@@ -59,7 +59,7 @@ class Revision < ApplicationRecord
 
   delegate :tags,
            :primary_publishing_organisation_id,
-           :organisations,
+           :supporting_organisation_ids,
            to: :tags_revision
 
   def self.create_initial(document, user = nil, tags = {})

--- a/app/models/tags_revision.rb
+++ b/app/models/tags_revision.rb
@@ -15,7 +15,7 @@ class TagsRevision < ApplicationRecord
     tags["primary_publishing_organisation"].to_a.first
   end
 
-  def organisations
+  def supporting_organisation_ids
     tags["organisations"].to_a
   end
 end

--- a/app/services/edition_assertions.rb
+++ b/app/services/edition_assertions.rb
@@ -33,14 +33,9 @@ module EditionAssertions
   def assert_edition_access(edition, user)
     return unless edition.access_limit
 
-    org_id = user.organisation_content_id
-    access_limit = edition.access_limit
+    return if edition.access_limit.organisation_ids
+      .include?(user.organisation_content_id)
 
-    return if org_id == edition.primary_publishing_organisation_id
-
-    return if access_limit.tagged_organisations? &&
-      edition.organisations.include?(org_id)
-
-    raise AccessError.new(edition, access_limit.limit_type)
+    raise AccessError.new(edition, edition.access_limit.limit_type)
   end
 end

--- a/app/services/requirements/access_limit_checker.rb
+++ b/app/services/requirements/access_limit_checker.rb
@@ -18,13 +18,7 @@ module Requirements
         return issues
       end
 
-      if edition.access_limit.primary_organisation? &&
-          user_is_not_in_primary_org?
-        issues << Issue.new(:access_limit, :not_in_orgs)
-      end
-
-      if edition.access_limit.tagged_organisations? &&
-          user_is_not_in_any_org?
+      if user_is_not_in_access_limit_orgs?
         issues << Issue.new(:access_limit, :not_in_orgs)
       end
 
@@ -33,14 +27,9 @@ module Requirements
 
   private
 
-    def user_is_not_in_primary_org?
-      edition.primary_publishing_organisation_id !=
-        user.organisation_content_id
-    end
-
-    def user_is_not_in_any_org?
-      user_is_not_in_primary_org? &&
-        edition.organisations.exclude?(user.organisation_content_id)
+    def user_is_not_in_access_limit_orgs?
+      edition.access_limit.organisation_ids
+        .exclude?(user.organisation_content_id)
     end
   end
 end

--- a/app/views/access_limit/edit.html.erb
+++ b/app/views/access_limit/edit.html.erb
@@ -9,7 +9,7 @@
   <% primary_org = service.by_content_id(primary_org_id)&.fetch("internal_name") %>
 <% end %>
 
-<% supporting_orgs = @edition.organisations
+<% supporting_orgs = @edition.supporting_organisation_ids
   .map { |org_id| service.by_content_id(org_id)&.fetch("internal_name") }
   .compact %>
 

--- a/spec/features/editing_content_settings/set_access_limit_requirements_spec.rb
+++ b/spec/features/editing_content_settings/set_access_limit_requirements_spec.rb
@@ -2,13 +2,16 @@
 
 RSpec.feature "Set access limit with requirements issues" do
   scenario do
-    given_there_is_an_edition_with_no_orgs
+    given_there_is_an_edition_in_another_org
     when_i_try_to_set_an_access_limit
     then_i_see_an_error_to_fix_the_issue
   end
 
-  def given_there_is_an_edition_with_no_orgs
-    @edition = create(:edition)
+  def given_there_is_an_edition_in_another_org
+    @edition = create(:edition,
+                      tags: {
+                        primary_publishing_organisation: %w[another-org],
+                      })
   end
 
   def when_i_try_to_set_an_access_limit
@@ -18,6 +21,6 @@ RSpec.feature "Set access limit with requirements issues" do
   end
 
   def then_i_see_an_error_to_fix_the_issue
-    expect(page).to have_content(I18n.t!("requirements.access_limit.no_primary_org.form_message"))
+    expect(page).to have_content(I18n.t!("requirements.access_limit.not_in_orgs.form_message"))
   end
 end

--- a/spec/models/access_limit_spec.rb
+++ b/spec/models/access_limit_spec.rb
@@ -1,0 +1,39 @@
+# frozen_string_literal: true
+
+RSpec.describe AccessLimit do
+  describe "#organisation_ids" do
+    context "when the limit is to primary orgs" do
+      let(:edition) do
+        build(:edition,
+              :access_limited,
+              limit_type: :primary_organisation,
+              tags: {
+                primary_publishing_organisation: %w[primary-org],
+                organisations: %w[supporting-org],
+              })
+      end
+
+      it "returns just the primary org id" do
+        ids = edition.access_limit.organisation_ids
+        expect(ids).to eq(%w[primary-org])
+      end
+    end
+
+    context "when the limit is to tagged orgs" do
+      let(:edition) do
+        build(:edition,
+              :access_limited,
+              limit_type: :tagged_organisations,
+              tags: {
+                primary_publishing_organisation: %w[primary-org],
+                organisations: %w[supporting-org],
+              })
+      end
+
+      it "returns the primary and supporting orgs" do
+        ids = edition.access_limit.organisation_ids
+        expect(ids).to match_array(%w[primary-org supporting-org])
+      end
+    end
+  end
+end

--- a/spec/services/edition_assertions_spec.rb
+++ b/spec/services/edition_assertions_spec.rb
@@ -29,54 +29,18 @@ RSpec.describe EditionAssertions do
       expect { assert_edition_access(edition, user) }.to_not raise_error
     end
 
-    context "when access is limited to the primary org" do
-      let(:edition) do
-        build :edition, :access_limited, limit_type: :primary_organisation, created_by: user
-      end
+    context "when the edition is access limited to some orgs" do
+      let(:edition) { build(:edition, :access_limited) }
 
-      it "does nothing when the user is in the primary org" do
+      it "does nothing when the user is in the orgs" do
+        allow(edition.access_limit).to receive(:organisation_ids) { %w[primary-org-id] }
         expect { assert_edition_access(edition, user) }.to_not raise_error
       end
 
-      it "raises an error when the user is in a supporting org" do
-        supporting_user = build :user, organisation_content_id: "supporting-org-id"
+      it "raises an error when the user is not in the orgs" do
+        allow(edition.access_limit).to receive(:organisation_ids) { %w[another-org-id] }
 
-        expect { assert_edition_access(edition, supporting_user) }
-          .to raise_error(EditionAssertions::AccessError)
-      end
-
-      it "raises an error when the user is in another org" do
-        another_user = build :user, organisation_content_id: "another-org"
-
-        expect { assert_edition_access(edition, another_user) }
-          .to raise_error(EditionAssertions::AccessError)
-      end
-    end
-
-    context "when access is limited to tagged orgs" do
-      let(:edition) do
-        build :edition,
-              :access_limited,
-              limit_type: :tagged_organisations,
-              tags: {
-                primary_publishing_organisation: %w[primary-org-id],
-                organisations: %w[primary-org-id supporting-org-id],
-              }
-      end
-
-      it "does nothing when the user is in the primary org" do
-        expect { assert_edition_access(edition, user) }.to_not raise_error
-      end
-
-      it "does nothing when the user is in a supporting org" do
-        supporting_user = build :user, organisation_content_id: "supporting-org-id"
-        expect { assert_edition_access(edition, supporting_user) }.to_not raise_error
-      end
-
-      it "raises an error when the user is in another org" do
-        another_user = build :user, organisation_content_id: "another-org"
-
-        expect { assert_edition_access(edition, another_user) }
+        expect { assert_edition_access(edition, user) }
           .to raise_error(EditionAssertions::AccessError)
       end
     end

--- a/spec/services/requirements/access_limit_checker_spec.rb
+++ b/spec/services/requirements/access_limit_checker_spec.rb
@@ -18,70 +18,18 @@ RSpec.describe Requirements::AccessLimitChecker do
       expect(form_message).to eq(I18n.t!("requirements.access_limit.no_primary_org.form_message"))
     end
 
-    context "the access limit is for the primary org" do
-      it "returns an issue when the user is not in the org" do
-        edition = build(:edition,
-                        :access_limited,
-                        limit_type: :primary_organisation,
-                        tags: {
-                          primary_publishing_organisation: %w[another-org],
-                        })
+    context "when edition is access limited to some orgs" do
+      let(:edition) { build(:edition, :access_limited, created_by: user) }
 
+      it "returns an issue when the user is not in the orgs" do
+        allow(edition.access_limit).to receive(:organisation_ids) { %w[another-org] }
         issues = Requirements::AccessLimitChecker.new(edition, user).pre_update_issues
         form_message = issues.items_for(:access_limit).first[:text]
         expect(form_message).to eq(I18n.t!("requirements.access_limit.not_in_orgs.form_message"))
       end
 
-      it "returns no issues when the user is in the org" do
-        edition = build(:edition,
-                        :access_limited,
-                        limit_type: :primary_organisation,
-                        tags: {
-                          primary_publishing_organisation: %w[my-org],
-                        })
-
-        issues = Requirements::AccessLimitChecker.new(edition, user).pre_update_issues
-        expect(issues).to be_empty
-      end
-    end
-
-    context "the access limit is for tagged orgs" do
-      it "returns an issue when the user is not in any of the orgs" do
-        edition = build(:edition,
-                        :access_limited,
-                        limit_type: :tagged_organisations,
-                        tags: {
-                          primary_publishing_organisation: %w[another-org],
-                          organisations: %w[supporting-org],
-                        })
-
-        issues = Requirements::AccessLimitChecker.new(edition, user).pre_update_issues
-        form_message = issues.items_for(:access_limit).first[:text]
-        expect(form_message).to eq(I18n.t!("requirements.access_limit.not_in_orgs.form_message"))
-      end
-
-      it "returns no issues when the user is in a supporting org" do
-        edition = build(:edition,
-                        :access_limited,
-                        limit_type: :tagged_organisations,
-                        tags: {
-                          primary_publishing_organisation: %w[another-org],
-                          organisations: %w[my-org],
-                        })
-
-        issues = Requirements::AccessLimitChecker.new(edition, user).pre_update_issues
-        expect(issues).to be_empty
-      end
-
-      it "returns no issues when the user is in the primary org" do
-        edition = build(:edition,
-                        :access_limited,
-                        limit_type: :tagged_organisations,
-                        tags: {
-                          primary_publishing_organisation: %w[my-org],
-                          organisations: %w[supporting-org],
-                        })
-
+      it "returns no issues when the user is in the orgs" do
+        allow(edition.access_limit).to receive(:organisation_ids) { %w[my-org] }
         issues = Requirements::AccessLimitChecker.new(edition, user).pre_update_issues
         expect(issues).to be_empty
       end


### PR DESCRIPTION
https://trello.com/c/jvJZCHPG/989-present-access-limited-documents-to-publishing-api-and-asset-manager

This moves some of the access limit code into the model to remove the existing duplication and in anticipation of its re-use as part of the future payloads for the Publishing API and for assets.

This also renames the `TagsRevision#organisation` method to `supporting_organisation_ids`, to make it less ambiguous and more consistent with `primary_publishing_organisation_id`.