### PR TITLE
Add check for user's organisation to set access limit

### DIFF
--- a/app/services/requirements/access_limit_checker.rb
+++ b/app/services/requirements/access_limit_checker.rb
@@ -13,6 +13,11 @@ module Requirements
       issues = CheckerIssues.new
       return issues if edition.access_limit.nil?
 
+      if user.organisation_content_id.blank?
+        issues << Issue.new(:access_limit, :user_has_no_org)
+        return issues
+      end
+
       if edition.primary_publishing_organisation_id.blank?
         issues << Issue.new(:access_limit, :no_primary_org)
         return issues

--- a/config/locales/en/requirements.yml
+++ b/config/locales/en/requirements.yml
@@ -133,6 +133,9 @@ en:
       non_youtube:
         form_message: Enter a valid YouTube web address
     access_limit:
+      user_has_no_org:
+        form_message: |
+          Associate your Signon account with an organisation or you will not be able to limit access to this document. Please ask your managing editor to raise a support request.
       no_primary_org:
         form_message: Select a primary organisation before you can limit access
       not_in_orgs:

--- a/spec/services/requirements/access_limit_checker_spec.rb
+++ b/spec/services/requirements/access_limit_checker_spec.rb
@@ -34,5 +34,16 @@ RSpec.describe Requirements::AccessLimitChecker do
         expect(issues).to be_empty
       end
     end
+
+    context "when user has no organisation associated with account" do
+      let(:user) { build(:user, organisation_content_id: nil) }
+
+      it "returns an issue when the user is not in the orgs" do
+        edition = build(:edition, :access_limited, created_by: user)
+        issues = Requirements::AccessLimitChecker.new(edition, user).pre_update_issues
+        form_message = issues.items_for(:access_limit).first[:text]
+        expect(form_message).to eq(I18n.t!("requirements.access_limit.user_has_no_org.form_message"))
+      end
+    end
   end
 end


### PR DESCRIPTION
This adds a requirement that a user has an organisation associated with their account to set access limits. This is to prevent a user locking themselves out of content.