### PR TITLE
Move edition methods into other classes

### DIFF
--- a/app/interactors/editions/create_interactor.rb
+++ b/app/interactors/editions/create_interactor.rb
@@ -5,16 +5,16 @@ class Editions::CreateInteractor < ApplicationInteractor
            :user,
            :live_edition,
            :next_edition,
-           :draft_current_edition,
            :discarded_edition,
+           :next_revision,
            to: :context
 
   def call
     Edition.transaction do
       find_and_lock_live_edition
+      create_next_revision
       create_next_edition
       create_timeline_entry
-      update_preview
     end
   end
 
@@ -25,8 +25,18 @@ private
     context.live_edition = edition
 
     assert_edition_state(edition, assertion: "can create new edition") do
-      edition.published? || edition.published_but_needs_2i? || edition.removed?
+      edition.live || edition.discarded?
     end
+  end
+
+  def create_next_revision
+    updater = Versioning::RevisionUpdater.new(live_edition.revision, user)
+
+    updater.assign(change_note: "",
+                   update_type: "major",
+                   proposed_publish_time: nil)
+
+    context.next_revision = updater.next_revision
   end
 
   def create_next_edition
@@ -37,8 +47,13 @@ private
       number: live_edition.number + 1,
     )
 
-    discarded_edition.resume_discarded(live_edition, user) if discarded_edition
-    context.next_edition = discarded_edition || Edition.create_next_edition(live_edition, user)
+    context.next_edition = discarded_edition ||
+      Edition.new(document: live_edition.document,
+                  number: live_edition.document.next_edition_number,
+                  created_by: user)
+
+    next_edition.assign_as_edit(user, current: true, revision: next_revision)
+    next_edition.assign_status(:draft, user).save!
   end
 
   def create_timeline_entry
@@ -49,9 +64,5 @@ private
       TimelineEntry.create_for_status_change(entry_type: :new_edition,
                                              status: next_edition.status)
     end
-  end
-
-  def update_preview
-    PreviewService.new(live_edition).try_create_preview
   end
 end

--- a/app/models/edition.rb
+++ b/app/models/edition.rb
@@ -150,24 +150,6 @@ class Edition < ApplicationRecord
     assign_as_edit(user, revision: revision)
   end
 
-  def assign_access_limit(limit_type, user)
-    raise "cannot access limit a live edition" if live?
-
-    access_limit = AccessLimit.new(created_by: user,
-                                   edition: self,
-                                   revision_at_creation: revision,
-                                   limit_type: limit_type)
-
-
-    assign_as_edit(user, access_limit: access_limit)
-  end
-
-  def remove_access_limit(user)
-    raise "no access limit to remove" unless access_limit
-
-    assign_as_edit(user, access_limit: nil)
-  end
-
   def editors
     user_ids = statuses.pluck(:created_by_id) + revisions.pluck(:created_by_id)
     User.where(id: user_ids.uniq)

--- a/app/services/publish_service.rb
+++ b/app/services/publish_service.rb
@@ -41,7 +41,7 @@ private
 
   def set_new_live_edition(user, with_review)
     status = with_review ? :published : :published_but_needs_2i
-    edition.remove_access_limit(user) if edition.access_limit
+    edition.assign_as_edit(user, access_limit: nil)
     edition.assign_status(status, user)
     edition.live = true
     edition.save!

--- a/spec/interactors/editions/create_interactor_spec.rb
+++ b/spec/interactors/editions/create_interactor_spec.rb
@@ -1,0 +1,83 @@
+# frozen_string_literal: true
+
+RSpec.describe Editions::CreateInteractor do
+  describe ".call" do
+    let(:user) { create :user }
+
+    it "resets the edition metadata" do
+      edition = create(:edition,
+                       :published,
+                       change_note: "note",
+                       proposed_publish_time: Time.current,
+                       update_type: :minor)
+
+      params = { document: edition.document.to_param }
+
+      next_edition = Editions::CreateInteractor
+        .call(params: params, user: user)
+        .next_edition
+
+      expect(next_edition.update_type).to eq "major"
+      expect(next_edition.change_note).to be_empty
+      expect(next_edition.proposed_publish_time).to be_nil
+      expect(next_edition).to be_draft
+      expect(next_edition).to be_current
+    end
+
+    context "when the edition was discarded" do
+      let(:live_edition) { create(:edition, :published) }
+      let(:params) { { document: live_edition.document.to_param } }
+
+      let!(:edition) do
+        create(:edition,
+               state: "discarded",
+               current: false,
+               document: live_edition.document)
+      end
+
+      it "resumes the edition" do
+        next_edition = Editions::CreateInteractor
+          .call(params: params, user: user)
+          .next_edition
+
+        expect(next_edition.number).to eq edition.number
+        expect(next_edition).to eq edition.reload
+      end
+
+      it "creates a timeline entry" do
+        next_edition = Editions::CreateInteractor
+          .call(params: params, user: user)
+          .next_edition
+
+        entry = TimelineEntry.last
+        expect(entry.entry_type).to eq "draft_reset"
+        expect(entry.status).to eq next_edition.status
+      end
+    end
+
+    context "when the edition was published" do
+      let(:edition) { create(:edition, :published, number: 2) }
+      let(:params) { { document: edition.document.to_param } }
+
+      it "creates a new edition" do
+        next_edition = Editions::CreateInteractor
+          .call(params: params, user: user)
+          .next_edition
+
+        expect(next_edition).to_not eq edition.reload
+        expect(next_edition.number).to eq 3
+        expect(next_edition.created_by).to eq user
+      end
+
+      it "creates a timeline entry" do
+        next_edition = Editions::CreateInteractor
+          .call(params: params, user: user)
+          .next_edition
+
+        entry = TimelineEntry.last
+        expect(entry.entry_type).to eq "new_edition"
+        expect(entry.status).to eq next_edition.status
+      end
+    end
+  end
+end

--- a/spec/interactors/editions/create_interactor_spec.rb
+++ b/spec/interactors/editions/create_interactor_spec.rb
@@ -6,7 +6,7 @@ RSpec.describe Editions::CreateInteractor do
 
     it "resets the edition metadata" do
       edition = create(:edition,
-                       :published,
+                       live: true,
                        change_note: "note",
                        proposed_publish_time: Time.current,
                        update_type: :minor)
@@ -55,8 +55,8 @@ RSpec.describe Editions::CreateInteractor do
       end
     end
 
-    context "when the edition was published" do
-      let(:edition) { create(:edition, :published, number: 2) }
+    context "when the edition is live" do
+      let(:edition) { create(:edition, live: true, number: 2) }
       let(:params) { { document: edition.document.to_param } }
 
       it "creates a new edition" do

--- a/spec/models/edition_spec.rb
+++ b/spec/models/edition_spec.rb
@@ -53,59 +53,21 @@ RSpec.describe Edition do
     end
   end
 
-  describe ".create_next_edition" do
+  describe "#assign_as_edit" do
+    let(:edition) { build(:edition) }
     let(:user) { build(:user) }
 
-    it "creates a draft edition with next edition number" do
-      preceding = create(:edition, number: 5, current: false)
-
-      edition = Edition.create_next_edition(preceding, user)
-
-      expect(edition).to be_a(Edition)
-      expect(edition).to be_draft
-      expect(edition.number).to be 6
+    it "assigns the given attributes" do
+      edition.assign_as_edit(user, number: 2)
+      expect(edition.number).to eq 2
     end
 
-    it "resets the change note, update type and proposed publish time" do
-      preceding = create(:edition,
-                         change_note: "Changes",
-                         update_type: :minor,
-                         current: false,
-                         proposed_publish_time: Time.zone.now)
-
-      edition = Edition.create_next_edition(preceding, user)
-
-      expect(edition.change_note).to be_empty
-      expect(edition.update_type).to eq("major")
-      expect(edition.proposed_publish_time).to be_nil
-    end
-  end
-
-  describe "#resume_discarded" do
-    let(:live_edition) { create(:edition, :published, current: false) }
-    let(:user) { build(:user) }
-
-    it "sets the edition to be a draft" do
-      edition = create(:edition,
-                       state: :discarded,
-                       document: live_edition.document)
-
-      edition.resume_discarded(live_edition, user)
-
-      expect(edition).to be_draft
-    end
-
-    it "resets the change note and update type" do
-      edition = create(:edition,
-                       state: :discarded,
-                       document: live_edition.document,
-                       change_note: "Changes",
-                       update_type: :minor)
-
-      edition.resume_discarded(live_edition, user)
-
-      expect(edition.change_note).to be_empty
-      expect(edition.update_type).to eq("major")
+    it "updates the edition metadata" do
+      freeze_time do
+        edition.assign_as_edit(user, {})
+        expect(edition.last_edited_by).to eq user
+        expect(edition.last_edited_at).to eq Time.current
+      end
     end
   end
 

--- a/spec/models/edition_spec.rb
+++ b/spec/models/edition_spec.rb
@@ -159,51 +159,6 @@ RSpec.describe Edition do
     end
   end
 
-  describe "#assign_access_limit" do
-    it "assigns an access limit" do
-      edition = build(:edition)
-      user = build(:user)
-
-      edition.assign_access_limit(:tagged_organisations, user)
-
-      expect(edition.access_limit).to be_tagged_organisations
-      expect(edition.access_limit.created_by).to eq(user)
-      expect(edition.access_limit.revision_at_creation).to eq(edition.revision)
-    end
-
-    it "updates the edition last edited information" do
-      edition = build(:edition)
-      user = build(:user)
-
-      travel_to(Time.current) do
-        expect { edition.assign_access_limit(:tagged_organisations, user) }
-          .to change { edition.last_edited_by }.to(user)
-          .and change { edition.last_edited_at }.to(Time.current)
-      end
-    end
-  end
-
-  describe "#remove_access_limit" do
-    it "removes an access limit" do
-      edition = build(:edition, :access_limited)
-
-      expect { edition.remove_access_limit(build(:user)) }
-        .to change { edition.access_limit }
-        .to(nil)
-    end
-
-    it "updates the edition last edited information" do
-      edition = build(:edition, :access_limited)
-      user = build(:user)
-
-      travel_to(Time.current) do
-        expect { edition.remove_access_limit(user) }
-          .to change { edition.last_edited_by }.to(user)
-          .and change { edition.last_edited_at }.to(Time.current)
-      end
-    end
-  end
-
   describe "#access_limit_organisation_ids" do
     context "when there is no access limit" do
       it "returns nil" do


### PR DESCRIPTION
https://trello.com/c/P3z1xFBW/968-investigate-methods-to-prevent-access-to-document-based-on-access-limit-and-state

This moves a few of the methods in the Edition class to the (mostly) single points where they are used, making space to add another method in https://github.com/alphagov/content-publisher/pull/1297. Please see the commits for more details.