### PR TITLE
Allow GDS users to override access limits

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -40,11 +40,9 @@ class ApplicationController < ActionController::Base
       .includes(:access_limit, revision: [:tags_revision])
       .find_current(document: document_param)
 
-    return unless edition
-      .access_limit_organisation_ids
-      &.exclude?(current_user.organisation_content_id)
-
-    render "documents/forbidden", status: :forbidden,
-      assigns: { edition: edition }
+    unless current_user.can_access?(edition)
+      render "documents/forbidden", status: :forbidden,
+        assigns: { edition: edition }
+    end
   end
 end

--- a/app/models/edition.rb
+++ b/app/models/edition.rb
@@ -156,7 +156,7 @@ class Edition < ApplicationRecord
   end
 
   def access_limit_organisation_ids
-    return unless access_limit
+    raise "no access limit" unless access_limit
 
     orgs = [primary_publishing_organisation_id]
     orgs += supporting_organisation_ids if access_limit.tagged_organisations?

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -7,4 +7,16 @@ class User < ApplicationRecord
   PRE_RELEASE_FEATURES_PERMISSION = "pre_release_features"
   DEBUG_PERMISSION = "debug"
   MANAGING_EDITOR_PERMISSION = "managing_editor"
+  ACCESS_LIMIT_OVERRIDE_PERMISSION = "access_limit_override"
+
+  def can_access?(edition)
+    return true unless edition.access_limit
+
+    return true if has_permission?(
+      ACCESS_LIMIT_OVERRIDE_PERMISSION,
+    )
+
+    edition.access_limit_organisation_ids
+      .include?(organisation_content_id)
+  end
 end

--- a/app/services/edition_filter.rb
+++ b/app/services/edition_filter.rb
@@ -45,6 +45,10 @@ private
   end
 
   def access_limited_scope(scope)
+    return scope if user.has_permission?(
+      User::ACCESS_LIMIT_OVERRIDE_PERMISSION,
+    )
+
     scope.where(
       "access_limit_id IS NULL" + " OR " +
       "(

--- a/spec/models/edition_spec.rb
+++ b/spec/models/edition_spec.rb
@@ -160,13 +160,6 @@ RSpec.describe Edition do
   end
 
   describe "#access_limit_organisation_ids" do
-    context "when there is no access limit" do
-      it "returns nil" do
-        edition = build :edition
-        expect(edition.access_limit_organisation_ids).to be_nil
-      end
-    end
-
     context "when the limit is to primary orgs" do
       let(:edition) do
         build(:edition,

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -1,0 +1,42 @@
+# frozen_string_literal: true
+
+RSpec.describe User do
+  describe "#can_access?" do
+    context "when the user has an override permission" do
+      it "returns true" do
+        user = build(:user, permissions: [
+          User::ACCESS_LIMIT_OVERRIDE_PERMISSION,
+        ])
+
+        edition = build(:edition)
+        expect(user.can_access?(edition)).to be_truthy
+      end
+    end
+
+    context "when the edition is access limited" do
+      let(:edition) { build(:edition, :access_limited) }
+
+      before do
+        allow(edition).to receive(:access_limit_organisation_ids) { %w[org-id] }
+      end
+
+      it "returns true if the user is in the specified orgs" do
+        user = build(:user, organisation_content_id: "org-id")
+        expect(user.can_access?(edition)).to be_truthy
+      end
+
+      it "returns false if the user is not in the orgs" do
+        user = build(:user, organisation_content_id: "another-org-id")
+        expect(user.can_access?(edition)).to be_falsey
+      end
+    end
+
+    context "when the edition is not access limited" do
+      it "returns true" do
+        edition = build(:edition)
+        user = build(:user)
+        expect(user.can_access?(edition)).to be_truthy
+      end
+    end
+  end
+end

--- a/spec/services/edition_filter_spec.rb
+++ b/spec/services/edition_filter_spec.rb
@@ -168,6 +168,19 @@ RSpec.describe EditionFilter do
         expect(editions).to be_empty
       end
     end
+
+    context "when the user has an access override permission" do
+      it "includes the edition" do
+        edition = create(:edition, :access_limited)
+
+        gds_user = build(:user, permissions: [
+          User::ACCESS_LIMIT_OVERRIDE_PERMISSION,
+        ])
+
+        editions = EditionFilter.new(gds_user).editions
+        expect(editions).to eq([edition])
+      end
+    end
   end
 
   describe "#filter_params" do


### PR DESCRIPTION
https://trello.com/c/nRJAyOex/983-access-limiting

This adds a new permission that overrides the normal 'foridden' and
filtering behaviours for access limited editions, so that users are
still able to provide support with requests associated with these
editions, which they would otherwise be unable to find/view/edit.

While some existing apps use more role-like permissions, such as 'GDS
Admin', the permission here is specific to its functionality, as well as
which users it should be applied to. This helps avoids confusion about
the behaviour and applicability of permissions that are actually roles.

Previously it was only possible to test this behaviour at the feature
level, which would be complex due to the three variables - permission,
limit type, organisations - involved. This extracts the conditional
into a new User#can_access? method in order to fully test the code.