### PR TITLE
Try to create preview when editing access limits

### DIFF
--- a/app/interactors/access_limit/update_interactor.rb
+++ b/app/interactors/access_limit/update_interactor.rb
@@ -15,6 +15,7 @@ class AccessLimit::UpdateInteractor < ApplicationInteractor
       check_for_issues
       update_edition
       create_timeline_entry
+      update_preview
     end
   end
 
@@ -62,5 +63,9 @@ private
       edition: edition,
       details: edition.access_limit,
     )
+  end
+
+  def update_preview
+    PreviewService.new(edition).try_create_preview
   end
 end

--- a/app/services/preview_asset_service/payload.rb
+++ b/app/services/preview_asset_service/payload.rb
@@ -24,6 +24,6 @@ private
   end
 
   def access_limited
-    edition.access_limit&.organisation_ids
+    edition.access_limit_organisation_ids
   end
 end

--- a/app/services/publishing_api_payload.rb
+++ b/app/services/publishing_api_payload.rb
@@ -28,10 +28,11 @@ class PublishingApiPayload
       ],
       "links" => links,
       "access_limited" => {
+        "organisations" => edition.access_limit_organisation_ids,
         "auth_bypass_ids" => [
           PreviewAuthBypassService.new(edition).auth_bypass_id,
         ],
-      },
+      }.compact,
     }
     payload["change_note"] = edition.change_note if edition.major?
 

--- a/spec/features/editing_content_settings/edit_access_limit_requirements_spec.rb
+++ b/spec/features/editing_content_settings/edit_access_limit_requirements_spec.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-RSpec.feature "Set access limit with requirements issues" do
+RSpec.feature "Edit access limit with requirements issues" do
   scenario do
     given_there_is_an_edition_in_another_org
     when_i_try_to_set_an_access_limit

--- a/spec/features/editing_content_settings/edit_access_limit_spec.rb
+++ b/spec/features/editing_content_settings/edit_access_limit_spec.rb
@@ -11,18 +11,24 @@ RSpec.feature "Edit access limit" do
   end
 
   def given_there_is_an_access_limited_edition
-    @supporting_org = SecureRandom.uuid
+    supporting_org = SecureRandom.uuid
     primary_org = current_user.organisation_content_id
 
     stub_publishing_api_has_linkables(
-      [{ "content_id" => primary_org, "internal_name" => "Primary org" }],
+      [{ "content_id" => primary_org, "internal_name" => "Primary org" },
+       { "content_id" => supporting_org, "internal_name" => "Supporting org" }],
       document_type: "organisation",
     )
 
-    @edition = create(:edition,
-                      :access_limited,
-                      limit_type: :tagged_organisations,
-                      created_by: current_user)
+    @edition = create(
+      :edition,
+      :access_limited,
+      limit_type: :tagged_organisations,
+      tags: {
+        primary_publishing_organisation: [primary_org],
+        organisations: [supporting_org],
+      },
+    )
   end
 
   def when_i_visit_the_summary_page
@@ -36,9 +42,15 @@ RSpec.feature "Edit access limit" do
   def then_i_see_the_current_access_limit
     radio_text = I18n.t!("access_limit.edit.type.tagged_organisations")
     expect(find_field(radio_text)).to be_checked
+
+    within ".govuk-radios" do
+      expect(page).to have_content("Primary org", count: 2)
+      expect(page).to have_content("Supporting org")
+    end
   end
 
   def when_i_edit_the_access_limit_type
+    stub_any_publishing_api_put_content
     choose(I18n.t!("access_limit.edit.type.primary_organisation"))
     click_on "Save"
   end

--- a/spec/services/preview_asset_service/payload_spec.rb
+++ b/spec/services/preview_asset_service/payload_spec.rb
@@ -23,7 +23,7 @@ RSpec.describe PreviewAssetService::Payload do
     context "when the edition is access limited" do
       it "returns a payload with the permitted org ids" do
         edition = build :edition, :access_limited
-        allow(edition.access_limit).to receive(:organisation_ids) { "ids" }
+        allow(edition).to receive(:access_limit_organisation_ids) { "ids" }
         payload = PreviewAssetService::Payload.new(edition).for_update
         expect(payload[:access_limited_organisation_ids]).to eq "ids"
       end
@@ -47,7 +47,7 @@ RSpec.describe PreviewAssetService::Payload do
     context "when the edition is access limited" do
       it "returns a payload with the permitted org ids" do
         edition = build :edition, :access_limited
-        allow(edition.access_limit).to receive(:organisation_ids) { "ids" }
+        allow(edition).to receive(:access_limit_organisation_ids) { "ids" }
         payload = PreviewAssetService::Payload.new(edition).for_upload(asset)
         expect(payload[:access_limited_organisation_ids]).to eq "ids"
       end

--- a/spec/services/publishing_api_payload_spec.rb
+++ b/spec/services/publishing_api_payload_spec.rb
@@ -49,6 +49,20 @@ RSpec.describe PublishingApiPayload do
       expect(payload).not_to include("first_published_at")
     end
 
+    it "specifies an auth bypass ID for anonymous previews" do
+      edition = build(:edition)
+      allow_any_instance_of(PreviewAuthBypassService).to receive(:auth_bypass_id) { "id" }
+      payload = PublishingApiPayload.new(edition).payload
+      expect(payload["access_limited"]).to eq("auth_bypass_ids" => %w[id])
+    end
+
+    it "specifies organistions when the edition is access limited" do
+      edition = build(:edition, :access_limited)
+      allow(edition).to receive(:access_limit_organisation_ids) { %w[org-id] }
+      payload = PublishingApiPayload.new(edition).payload
+      expect(payload["access_limited"]["organisations"]).to eq %w[org-id]
+    end
+
     it "includes primary_publishing_organisation in organisations links" do
       organisation = build(:tag_field, type: "single_tag", id: "primary_publishing_organisation")
       document_type = build(:document_type, tags: [organisation])


### PR DESCRIPTION
https://trello.com/c/jvJZCHPG/989-present-access-limited-documents-to-publishing-api-and-asset-manager

This extends the existing feature to do API calls with the necessary
access limit metadata. In order to better distinguish between the the
different tests for access limits (the form vs. the behaviour), this
also renames the previous 'set_access_limit_spec' to 'enforce_'.