### PR TITLE
Track visibility of the 'forbidden' page

### DIFF
--- a/app/views/documents/forbidden.html.erb
+++ b/app/views/documents/forbidden.html.erb
@@ -1,6 +1,6 @@
 <% content_for :title, t("documents.forbidden.title") %>
 
-<div class="govuk-body">
+<div class="govuk-body" data-gtm="access-limit-forbidden" data-gtm-visibility-tracking="true">
   <%= t("documents.forbidden.description") %>
 </div>
 


### PR DESCRIPTION
https://trello.com/c/Mb7uReAC/995-analytics-for-access-limiting

    This adds visibility tracking for the global 'forbidden' page. Since
    the title is the only analytics-visible indicator for this page (the URL
    doesn't change and no events occur on it), we should have a deliberate
    indicator that the user is not able to access an edition.