### PR TITLE
DRY-up requirements specs with a new matcher

### DIFF
--- a/spec/lib/requirements/access_limit_checker_spec.rb
+++ b/spec/lib/requirements/access_limit_checker_spec.rb
@@ -13,9 +13,7 @@ RSpec.describe Requirements::AccessLimitChecker do
     it "returns an issue when the edition has no primary org" do
       edition = build(:edition, :access_limited)
       issues = Requirements::AccessLimitChecker.new(edition, user).pre_update_issues
-
-      form_message = issues.items_for(:access_limit).first[:text]
-      expect(form_message).to eq(I18n.t!("requirements.access_limit.no_primary_org.form_message"))
+      expect(issues).to have_issue(:access_limit, :no_primary_org)
     end
 
     context "when edition is access limited to some orgs" do
@@ -24,8 +22,7 @@ RSpec.describe Requirements::AccessLimitChecker do
       it "returns an issue when the user is not in the orgs" do
         allow(edition).to receive(:access_limit_organisation_ids) { %w[another-org] }
         issues = Requirements::AccessLimitChecker.new(edition, user).pre_update_issues
-        form_message = issues.items_for(:access_limit).first[:text]
-        expect(form_message).to eq(I18n.t!("requirements.access_limit.not_in_orgs.form_message"))
+        expect(issues).to have_issue(:access_limit, :not_in_orgs)
       end
 
       it "returns no issues when the user is in the orgs" do
@@ -41,8 +38,7 @@ RSpec.describe Requirements::AccessLimitChecker do
       it "returns an issue when the user is not in the orgs" do
         edition = build(:edition, :access_limited, created_by: user)
         issues = Requirements::AccessLimitChecker.new(edition, user).pre_update_issues
-        form_message = issues.items_for(:access_limit).first[:text]
-        expect(form_message).to eq(I18n.t!("requirements.access_limit.user_has_no_org.form_message"))
+        expect(issues).to have_issue(:access_limit, :user_has_no_org)
       end
     end
   end

--- a/spec/lib/requirements/backdate_checker_spec.rb
+++ b/spec/lib/requirements/backdate_checker_spec.rb
@@ -5,29 +5,22 @@ RSpec.describe Requirements::BackdateChecker do
     it "returns no issues if there are none" do
       date = Time.current.change(day: 1, month: 1, year: 2019)
       issues = Requirements::BackdateChecker.new(date).pre_submit_issues
-
       expect(issues).to be_empty
     end
 
     it "returns an issue if the date is in the future" do
       date = Time.current.change(day: 1, month: 1, year: 2020)
       issues = Requirements::BackdateChecker.new(date).pre_submit_issues
-      future_date_issue = I18n.t!("requirements.backdate_date.in_the_future.form_message")
-
-      expect(issues.items_for(:backdate_date))
-        .to include(a_hash_including(text: future_date_issue))
+      expect(issues).to have_issue(:backdate_date, :in_the_future)
     end
 
     it "returns an issue if the date is too long ago" do
       earliest_date = Requirements::BackdateChecker::EARLIEST_DATE
       issues = Requirements::BackdateChecker.new(earliest_date - 1).pre_submit_issues
-      distant_past_issue = I18n.t!(
-        "requirements.backdate_date.too_long_ago.form_message",
-        date: earliest_date.strftime("%-d %B %Y"),
-      )
 
-      expect(issues.items_for(:backdate_date))
-        .to include(a_hash_including(text: distant_past_issue))
+      expect(issues).to have_issue(:backdate_date,
+                                   :too_long_ago,
+                                   date: earliest_date.strftime("%-d %B %Y"))
     end
   end
 end

--- a/spec/lib/requirements/content_checker_spec.rb
+++ b/spec/lib/requirements/content_checker_spec.rb
@@ -11,68 +11,38 @@ RSpec.describe Requirements::ContentChecker do
     it "returns an issue if there is no title" do
       edition = build :edition
       revision = build :revision, title: nil
-      issues = Requirements::ContentChecker.new(edition, revision)
-                                           .pre_preview_issues
-
-      form_message = issues.items_for(:title).first[:text]
-      expect(form_message).to eq(I18n.t!("requirements.title.blank.form_message"))
-
-      summary_message = issues.items_for(:title, style: "summary").first[:text]
-      expect(summary_message).to eq(I18n.t!("requirements.title.blank.summary_message"))
+      issues = Requirements::ContentChecker.new(edition, revision).pre_preview_issues
+      expect(issues).to have_issue(:title, :blank, styles: %i[form summary])
     end
 
     it "returns an issue if the title is too long" do
-      max_length = Requirements::ContentChecker::TITLE_MAX_LENGTH
       edition = build :edition
+      max_length = Requirements::ContentChecker::TITLE_MAX_LENGTH
       revision = build :revision, title: "a" * (max_length + 1)
-      issues = Requirements::ContentChecker.new(edition, revision)
-                                           .pre_preview_issues
-
-      form_message = issues.items_for(:title).first[:text]
-      expect(form_message).to eq(I18n.t!("requirements.title.too_long.form_message", max_length: max_length))
-
-      summary_message = issues.items_for(:title, style: "summary").first[:text]
-      expect(summary_message).to eq(I18n.t!("requirements.title.too_long.summary_message", max_length: max_length))
+      issues = Requirements::ContentChecker.new(edition, revision).pre_preview_issues
+      expect(issues).to have_issue(:title, :too_long, styles: %i[form summary], max_length: max_length)
     end
 
     it "returns an issue if the title has newlines" do
       edition = build :edition
       revision = build :revision, title: "a\nb"
-      issues = Requirements::ContentChecker.new(edition, revision)
-                                           .pre_preview_issues
-
-      form_message = issues.items_for(:title).first[:text]
-      expect(form_message).to eq(I18n.t!("requirements.title.multiline.form_message"))
-
-      summary_message = issues.items_for(:title, style: "summary").first[:text]
-      expect(summary_message).to eq(I18n.t!("requirements.title.multiline.summary_message"))
+      issues = Requirements::ContentChecker.new(edition, revision).pre_preview_issues
+      expect(issues).to have_issue(:title, :multiline, styles: %i[form summary])
     end
 
     it "returns an issue if the summary is too long" do
-      max_length = Requirements::ContentChecker::SUMMARY_MAX_LENGTH
       edition = build :edition
+      max_length = Requirements::ContentChecker::SUMMARY_MAX_LENGTH
       revision = build :revision, summary: "a" * (max_length + 1)
-      issues = Requirements::ContentChecker.new(edition, revision)
-                                           .pre_preview_issues
-
-      form_message = issues.items_for(:summary).first[:text]
-      expect(form_message).to eq(I18n.t!("requirements.summary.too_long.form_message", max_length: max_length))
-
-      summary_message = issues.items_for(:summary, style: "summary").first[:text]
-      expect(summary_message).to eq(I18n.t!("requirements.summary.too_long.summary_message", max_length: max_length))
+      issues = Requirements::ContentChecker.new(edition, revision).pre_preview_issues
+      expect(issues).to have_issue(:summary, :too_long, styles: %i[form summary], max_length: max_length)
     end
 
     it "returns an issue if the summary has newlines" do
       edition = build :edition
       revision = build :revision, summary: "a\nb"
-      issues = Requirements::ContentChecker.new(edition, revision)
-                                           .pre_preview_issues
-
-      form_message = issues.items_for(:summary).first[:text]
-      expect(form_message).to eq(I18n.t!("requirements.summary.multiline.form_message"))
-
-      summary_message = issues.items_for(:summary, style: "summary").first[:text]
-      expect(summary_message).to eq(I18n.t!("requirements.summary.multiline.summary_message"))
+      issues = Requirements::ContentChecker.new(edition, revision).pre_preview_issues
+      expect(issues).to have_issue(:summary, :multiline, styles: %i[form summary])
     end
 
     it "returns an issue if the a govspeak field contains forbidden HTML" do
@@ -80,15 +50,8 @@ RSpec.describe Requirements::ContentChecker do
       document_type = build :document_type, contents: [body_field]
       edition = build :edition, document_type_id: document_type.id
       revision = build :revision, contents: { body: "<script>alert('hi')</script>" }
-
-      issues = Requirements::ContentChecker.new(edition, revision)
-                                           .pre_preview_issues
-
-      form_message = issues.items_for(:body).first[:text]
-      expect(form_message).to eq(I18n.t!("requirements.body.invalid_govspeak.form_message"))
-
-      summary_message = issues.items_for(:body, style: "summary").first[:text]
-      expect(summary_message).to eq(I18n.t!("requirements.body.invalid_govspeak.summary_message"))
+      issues = Requirements::ContentChecker.new(edition, revision).pre_preview_issues
+      expect(issues).to have_issue(:body, :invalid_govspeak, styles: %i[form summary])
     end
   end
 
@@ -102,39 +65,22 @@ RSpec.describe Requirements::ContentChecker do
     it "returns an issue if the summary is blank" do
       edition = build :edition
       revision = build :revision, summary: nil
-      issues = Requirements::ContentChecker.new(edition, revision)
-                                           .pre_publish_issues
-
-      form_message = issues.items_for(:summary).first[:text]
-      expect(form_message).to eq(I18n.t!("requirements.summary.blank.form_message"))
-
-      summary_message = issues.items_for(:summary, style: "summary").first[:text]
-      expect(summary_message).to eq(I18n.t!("requirements.summary.blank.summary_message"))
+      issues = Requirements::ContentChecker.new(edition, revision).pre_publish_issues
+      expect(issues).to have_issue(:summary, :blank, styles: %i[form summary])
     end
 
     it "returns an issue if a field is blank" do
       document_type = build :document_type, contents: [build(:field, id: "body")]
       edition = build :edition, document_type_id: document_type.id
       issues = Requirements::ContentChecker.new(edition).pre_publish_issues
-
-      form_message = issues.items_for(:body).first[:text]
-      expect(form_message).to eq(I18n.t!("requirements.body.blank.form_message"))
-
-      summary_message = issues.items_for(:body, style: "summary").first[:text]
-      expect(summary_message).to eq(I18n.t!("requirements.body.blank.summary_message"))
+      expect(issues).to have_issue(:body, :blank, styles: %i[form summary])
     end
 
     it "returns an issue if a major change note is blank" do
       document = build :document, :with_live_edition
       edition = build :edition, update_type: "major", change_note: nil, document: document
-
       issues = Requirements::ContentChecker.new(edition).pre_publish_issues
-
-      form_message = issues.items_for(:change_note).first[:text]
-      expect(form_message).to eq(I18n.t!("requirements.change_note.blank.form_message"))
-
-      summary_message = issues.items_for(:change_note, style: "summary").first[:text]
-      expect(summary_message).to eq(I18n.t!("requirements.change_note.blank.summary_message"))
+      expect(issues).to have_issue(:change_note, :blank, styles: %i[form summary])
     end
   end
 end

--- a/spec/lib/requirements/file_attachment_checker_spec.rb
+++ b/spec/lib/requirements/file_attachment_checker_spec.rb
@@ -4,103 +4,64 @@ RSpec.describe Requirements::FileAttachmentChecker do
   describe "#pre_upload_issues" do
     it "returns no issues if there are none" do
       file = fixture_file_upload("files/text-file.txt", "text/plain")
-
-      issues = Requirements::FileAttachmentChecker.new(file: file, title: "Cool title")
-                                                  .pre_upload_issues
+      issues = Requirements::FileAttachmentChecker.new(file: file, title: "Cool title").pre_upload_issues
       expect(issues).to be_empty
     end
 
     it "returns no upload issues for a text file when it has no extension" do
       file = fixture_file_upload("files/no_extension", "text/plain")
-      issues = Requirements::FileAttachmentChecker.new(file: file, title: nil)
-                                                  .pre_upload_issues
-
+      issues = Requirements::FileAttachmentChecker.new(file: file, title: nil).pre_upload_issues
       expect(issues.items_for(:file_attachment_upload)).to be_empty
     end
 
     it "returns no upload issues when a zip file contains supported file types" do
       file = fixture_file_upload("files/valid_zip.zip", "application/zip")
-      issues = Requirements::FileAttachmentChecker.new(file: file, title: nil)
-                                                  .pre_upload_issues
-
+      issues = Requirements::FileAttachmentChecker.new(file: file, title: nil).pre_upload_issues
       expect(issues.items_for(:file_attachment_upload)).to be_empty
     end
 
     it "returns an issue when there is no title" do
-      issues = Requirements::FileAttachmentChecker.new(file: nil, title: "")
-                                                  .pre_upload_issues
-      form_message = issues.items_for(:file_attachment_title).first[:text]
-      expect(form_message).to eq(
-        I18n.t!("requirements.file_attachment_title.blank.form_message"),
-      )
+      issues = Requirements::FileAttachmentChecker.new(file: nil, title: "").pre_upload_issues
+      expect(issues).to have_issue(:file_attachment_title, :blank)
     end
 
     it "returns an issue when the title is too long" do
       max_length = Requirements::FileAttachmentChecker::TITLE_MAX_LENGTH
       title = "z" * (max_length + 1)
-      issues = Requirements::FileAttachmentChecker.new(file: nil, title: title)
-                                                  .pre_upload_issues
-
-      form_message = issues.items_for(:file_attachment_title).first[:text]
-      expect(form_message).to eq(
-        I18n.t!("requirements.file_attachment_title.too_long.form_message",
-                max_length: max_length),
-      )
+      issues = Requirements::FileAttachmentChecker.new(file: nil, title: title).pre_upload_issues
+      expect(issues).to have_issue(:file_attachment_title, :too_long, max_length: max_length)
     end
 
     it "returns an issue when no file_attachment is specified" do
-      issues = Requirements::FileAttachmentChecker.new(file: nil, title: "Cool title")
-                                                  .pre_upload_issues
-
-      form_message = issues.items_for(:file_attachment_upload).first[:text]
-      expect(form_message).to eq(
-        I18n.t!("requirements.file_attachment_upload.no_file.form_message"),
-      )
+      issues = Requirements::FileAttachmentChecker.new(file: nil, title: "Cool title").pre_upload_issues
+      expect(issues).to have_issue(:file_attachment_upload, :no_file)
     end
 
     it "returns an issue when the file type is not supported" do
       file = fixture_file_upload("files/bad_file.rb", "application/x-ruby")
-      issues = Requirements::FileAttachmentChecker.new(file: file, title: "Cool title")
-                                                  .pre_upload_issues
-
-      form_message = issues.items_for(:file_attachment_upload).first[:text]
-      expect(form_message).to eq(
-        I18n.t!("requirements.file_attachment_upload.unsupported_type.form_message"),
-      )
+      issues = Requirements::FileAttachmentChecker.new(file: file, title: "Cool title").pre_upload_issues
+      expect(issues).to have_issue(:file_attachment_upload, :unsupported_type)
     end
 
     it "returns an issue when the zip file contains unsupported file types" do
       file = fixture_file_upload("files/unsupported_type_in_zip.zip", "application/zip")
-      issues = Requirements::FileAttachmentChecker.new(file: file, title: "Cool title")
-                                                  .pre_upload_issues
-
-      form_message = issues.items_for(:file_attachment_upload).first[:text]
-      expect(form_message).to eq(
-        I18n.t!("requirements.file_attachment_upload.zip_unsupported_type.form_message"),
-      )
+      issues = Requirements::FileAttachmentChecker.new(file: file, title: "Cool title").pre_upload_issues
+      expect(issues).to have_issue(:file_attachment_upload, :zip_unsupported_type)
     end
   end
 
   describe "#pre_update_issues" do
     it "returns no issues if there are none" do
       file = fixture_file_upload("files/text-file.txt", "text/plain")
-
-      issues = Requirements::FileAttachmentChecker.new(file: file, title: "Cool title")
-                                                  .pre_update_issues
+      issues = Requirements::FileAttachmentChecker.new(file: file, title: "Cool title").pre_update_issues
       expect(issues).to be_empty
     end
 
     it "returns title issues when only the title is provided" do
       max_length = Requirements::FileAttachmentChecker::TITLE_MAX_LENGTH
       title = "z" * (max_length + 1)
-      issues = Requirements::FileAttachmentChecker.new(title: title)
-                                                  .pre_update_issues
-
-      form_message = issues.items_for(:file_attachment_title).first[:text]
-      expect(form_message).to eq(
-        I18n.t!("requirements.file_attachment_title.too_long.form_message",
-                max_length: max_length),
-      )
+      issues = Requirements::FileAttachmentChecker.new(title: title).pre_update_issues
+      expect(issues).to have_issue(:file_attachment_title, :too_long, max_length: max_length)
       expect(issues.items_for(:file_attachment_upload)).to be_empty
     end
   end

--- a/spec/lib/requirements/image_revision_checker_spec.rb
+++ b/spec/lib/requirements/image_revision_checker_spec.rb
@@ -12,12 +12,11 @@ RSpec.describe Requirements::ImageRevisionChecker do
       image_revision = build :image_revision
       issues = Requirements::ImageRevisionChecker.new(image_revision).pre_preview_issues
 
-      form_message = issues.items_for(:alt_text).first[:text]
-      expect(form_message).to eq(I18n.t!("requirements.alt_text.blank.form_message"))
-
-      summary_message = issues.items_for(:alt_text, style: "summary").first[:text]
-      expect(summary_message)
-        .to eq(I18n.t!("requirements.alt_text.blank.summary_message", filename: image_revision.filename))
+      expect(issues).to have_issue(:alt_text,
+                                   :blank,
+                                   styles: %i[form summary],
+                                   filename: image_revision.filename,
+                                   image_revision: image_revision)
     end
 
     it "returns an issue if the alt text is too long" do
@@ -25,17 +24,12 @@ RSpec.describe Requirements::ImageRevisionChecker do
       image_revision = build :image_revision, alt_text: "a" * (max_length + 1)
       issues = Requirements::ImageRevisionChecker.new(image_revision).pre_preview_issues
 
-      form_message = issues.items_for(:alt_text).first[:text]
-      expect(form_message)
-        .to eq(I18n.t!("requirements.alt_text.too_long.form_message", max_length: max_length))
-
-      summary_message = issues.items_for(:alt_text, style: "summary").first[:text]
-      expect(summary_message)
-        .to eq(
-          I18n.t!("requirements.alt_text.too_long.summary_message",
-                  max_length: max_length,
-                  filename: image_revision.filename),
-        )
+      expect(issues).to have_issue(:alt_text,
+                                   :too_long,
+                                   styles: %i[form summary],
+                                   max_length: max_length,
+                                   filename: image_revision.filename,
+                                   image_revision: image_revision)
     end
 
     it "returns an issue if the caption is too long" do
@@ -43,17 +37,12 @@ RSpec.describe Requirements::ImageRevisionChecker do
       image_revision = build :image_revision, caption: "a" * (max_length + 1)
       issues = Requirements::ImageRevisionChecker.new(image_revision).pre_preview_issues
 
-      form_message = issues.items_for(:caption).first[:text]
-      expect(form_message)
-        .to eq(I18n.t!("requirements.caption.too_long.form_message", max_length: max_length))
-
-      summary_message = issues.items_for(:caption, style: "summary").first[:text]
-      expect(summary_message)
-        .to eq(
-          I18n.t!("requirements.caption.too_long.summary_message",
-                  max_length: max_length,
-                  filename: image_revision.filename),
-        )
+      expect(issues).to have_issue(:caption,
+                                   :too_long,
+                                   styles: %i[form summary],
+                                   max_length: max_length,
+                                   filename: image_revision.filename,
+                                   image_revision: image_revision)
     end
 
     it "returns an issue if the credit is too long" do
@@ -61,17 +50,12 @@ RSpec.describe Requirements::ImageRevisionChecker do
       image_revision = build :image_revision, credit: "a" * (max_length + 1)
       issues = Requirements::ImageRevisionChecker.new(image_revision).pre_preview_issues
 
-      form_message = issues.items_for(:credit).first[:text]
-      expect(form_message)
-        .to eq(I18n.t!("requirements.credit.too_long.form_message", max_length: max_length))
-
-      summary_message = issues.items_for(:credit, style: "summary").first[:text]
-      expect(summary_message)
-        .to eq(
-          I18n.t!("requirements.credit.too_long.summary_message",
-                  max_length: max_length,
-                  filename: image_revision.filename),
-        )
+      expect(issues).to have_issue(:credit,
+                                   :too_long,
+                                   styles: %i[form summary],
+                                   max_length: max_length,
+                                   filename: image_revision.filename,
+                                   image_revision: image_revision)
     end
   end
 end

--- a/spec/lib/requirements/image_upload_checker_spec.rb
+++ b/spec/lib/requirements/image_upload_checker_spec.rb
@@ -10,37 +10,32 @@ RSpec.describe Requirements::ImageUploadChecker do
 
     it "returns an issue when no image is specified" do
       issues = Requirements::ImageUploadChecker.new(nil).issues
-      form_message = issues.items_for(:image_upload).first[:text]
-      expect(form_message).to eq(I18n.t!("requirements.image_upload.no_file.form_message"))
+      expect(issues).to have_issue(:image_upload, :no_file)
     end
 
     it "returns an issue when an unsupported file type is provided" do
       file = fixture_file_upload("files/text-file.txt", "text/plain")
       issues = Requirements::ImageUploadChecker.new(file).issues
-      form_message = issues.items_for(:image_upload).first[:text]
-      expect(form_message).to eq(I18n.t!("requirements.image_upload.unsupported_type.form_message"))
+      expect(issues).to have_issue(:image_upload, :unsupported_type)
     end
 
     it "returns an issue when a file bigger than the max size is provided" do
       file = fixture_file_upload("files/960x640.jpg", "image/jpeg")
       allow(file).to receive(:size).and_return(30.megabytes)
       issues = Requirements::ImageUploadChecker.new(file).issues
-      form_message = issues.items_for(:image_upload).first[:text]
-      expect(form_message).to eq(I18n.t!("requirements.image_upload.too_big.form_message", max_size: "20 MB"))
+      expect(issues).to have_issue(:image_upload, :too_big, max_size: "20 MB")
     end
 
     it "returns an issue when a file smaller than the minimum dimensions is provided" do
       file = fixture_file_upload("files/100x100.jpg", "image/jpeg")
       issues = Requirements::ImageUploadChecker.new(file).issues
-      form_message = issues.items_for(:image_upload).first[:text]
-      expect(form_message).to eq(I18n.t!("requirements.image_upload.too_small.form_message", width: Image::WIDTH, height: Image::HEIGHT))
+      expect(issues).to have_issue(:image_upload, :too_small, width: Image::WIDTH, height: Image::HEIGHT)
     end
 
     it "returns an issues when a file with multiple frames is provided (animated gif)" do
       file = fixture_file_upload("files/animated-gif.gif", "image/gif")
       issues = Requirements::ImageUploadChecker.new(file).issues
-      form_message = issues.items_for(:image_upload).first[:text]
-      expect(form_message).to eq(I18n.t!("requirements.image_upload.animated_image.form_message"))
+      expect(issues).to have_issue(:image_upload, :animated_image)
     end
   end
 end

--- a/spec/lib/requirements/path_checker_spec.rb
+++ b/spec/lib/requirements/path_checker_spec.rb
@@ -33,25 +33,16 @@ RSpec.describe Requirements::PathChecker do
         edition = build :edition, document_type_id: document_type.id
         stub_publishing_api_has_lookups(edition.base_path => SecureRandom.uuid)
         issues = Requirements::PathChecker.new(edition).pre_preview_issues
-
-        form_message = issues.items_for(:title).first[:text]
-        expect(form_message).to eq(I18n.t!("requirements.title.conflict.form_message"))
-
-        summary_message = issues.items_for(:title, style: "summary").first[:text]
-        expect(summary_message).to eq(I18n.t!("requirements.title.conflict.summary_message"))
+        expect(issues).to have_issue(:title, :conflict, styles: %i[form summary])
       end
 
       it "can check a revision" do
         document_type = build :document_type, check_path_conflict: true
         edition = build :edition, document_type_id: document_type.id
         revision = build :revision
-        stub_publishing_api_has_lookups(edition.base_path => nil,
-                                   revision.base_path => SecureRandom.uuid)
-        issues = Requirements::PathChecker.new(edition).pre_preview_issues
-        expect(issues).to be_empty
 
-        issues = Requirements::PathChecker.new(edition, revision)
-                                                     .pre_preview_issues
+        stub_publishing_api_has_lookups(edition.base_path => nil, revision.base_path => SecureRandom.uuid)
+        issues = Requirements::PathChecker.new(edition, revision).pre_preview_issues
         expect(issues).not_to be_empty
       end
     end

--- a/spec/lib/requirements/publish_time_checker_spec.rb
+++ b/spec/lib/requirements/publish_time_checker_spec.rb
@@ -11,44 +11,31 @@ RSpec.describe Requirements::PublishTimeChecker do
 
     it "returns a date issue if the date is in the past" do
       issues = Requirements::PublishTimeChecker.new(1.day.ago).issues
-
-      form_message = issues.items_for(:schedule_date).first[:text]
-      expect(form_message).to eq(I18n.t!("requirements.schedule_date.in_the_past.form_message"))
-
-      summary_message = issues.items_for(:schedule_date, style: "summary").first[:text]
-      expect(summary_message).to eq(I18n.t!("requirements.schedule_date.in_the_past.summary_message"))
+      expect(issues).to have_issue(:schedule_date, :in_the_past, styles: %i[form summary])
     end
 
     it "returns a time issue if just the time is in the past" do
       travel_to(Time.zone.parse("2019-06-17 15:00")) do
         issues = Requirements::PublishTimeChecker.new(1.hour.ago).issues
-
-        form_message = issues.items_for(:schedule_time).first[:text]
-        expect(form_message).to eq(I18n.t!("requirements.schedule_time.in_the_past.form_message"))
-
-        summary_message = issues.items_for(:schedule_time, style: "summary").first[:text]
-        expect(summary_message).to eq(I18n.t!("requirements.schedule_time.in_the_past.summary_message"))
+        expect(issues).to have_issue(:schedule_time, :in_the_past, styles: %i[form summary])
       end
     end
 
     it "returns an issue if the time is too close to now" do
       issues = Requirements::PublishTimeChecker.new(5.minutes.from_now).issues
 
-      form_message = issues.items_for(:schedule_time).first[:text]
-      expect(form_message).to eq(I18n.t!("requirements.schedule_time.too_close_to_now.form_message",
-                                         time_period: "15 minutes"))
-
-      summary_message = issues.items_for(:schedule_time, style: "summary").first[:text]
-      expect(summary_message).to eq(I18n.t!("requirements.schedule_time.too_close_to_now.summary_message",
-                                            time_period: "15 minutes"))
+      expect(issues).to have_issue(:schedule_time,
+                                   :too_close_to_now,
+                                   styles: %i[form summary],
+                                   time_period: "15 minutes")
     end
 
     it "returns an issue if the date is too far into the future" do
       issues = Requirements::PublishTimeChecker.new(10.years.from_now).issues
 
-      form_message = issues.items_for(:schedule_date).first[:text]
-      expect(form_message).to eq(I18n.t!("requirements.schedule_date.too_far_in_future.form_message",
-                                         time_period: "14 months"))
+      expect(issues).to have_issue(:schedule_date,
+                                   :too_far_in_future,
+                                   time_period: "14 months")
     end
   end
 end

--- a/spec/lib/requirements/tag_checker_spec.rb
+++ b/spec/lib/requirements/tag_checker_spec.rb
@@ -21,21 +21,9 @@ RSpec.describe Requirements::TagChecker do
         edition = build(:edition, document_type_id: document_type.id)
         issues = Requirements::TagChecker.new(edition).pre_publish_issues
 
-        form_message = issues
-          .items_for(:primary_publishing_organisation)
-          .first[:text]
-
-        expect(form_message).to eq(
-          I18n.t!("requirements.primary_publishing_organisation.blank.form_message"),
-        )
-
-        summary_message = issues
-          .items_for(:primary_publishing_organisation, style: :summary)
-          .first[:text]
-
-        expect(summary_message).to eq(
-          I18n.t!("requirements.primary_publishing_organisation.blank.summary_message"),
-        )
+        expect(issues).to have_issue(:primary_publishing_organisation,
+                                     :blank,
+                                     styles: %i[form summary])
       end
 
       it "returns no issues when there is a primary org" do

--- a/spec/lib/requirements/topic_checker_spec.rb
+++ b/spec/lib/requirements/topic_checker_spec.rb
@@ -26,12 +26,7 @@ RSpec.describe Requirements::TopicChecker do
 
       it "returns an issue if there are no topics" do
         issues = Requirements::TopicChecker.new(document).pre_publish_issues
-
-        form_message = issues.items_for(:topics).first[:text]
-        expect(form_message).to eq(I18n.t!("requirements.topics.none.form_message"))
-
-        summary_message = issues.items_for(:topics, style: "summary").first[:text]
-        expect(summary_message).to eq(I18n.t!("requirements.topics.none.summary_message"))
+        expect(issues).to have_issue(:topics, :none, styles: %i[form summary])
       end
     end
 

--- a/spec/lib/requirements/video_embed_checker_spec.rb
+++ b/spec/lib/requirements/video_embed_checker_spec.rb
@@ -18,38 +18,32 @@ RSpec.describe Requirements::VideoEmbedChecker do
 
     it "returns an issue when the title is blank" do
       issues = Requirements::VideoEmbedChecker.new.pre_embed_issues
-      form_message = issues.items_for(:video_embed_title).first[:text]
-      expect(form_message).to eq(I18n.t!("requirements.video_embed_title.blank.form_message"))
+      expect(issues).to have_issue(:video_embed_title, :blank)
     end
 
     it "returns an issue for invalid URL hosts" do
       issues = Requirements::VideoEmbedChecker.new.pre_embed_issues(url: "/on-localhost")
-      form_message = issues.items_for(:video_embed_url).first[:text]
-      expect(form_message).to eq(I18n.t!("requirements.video_embed_url.non_youtube.form_message"))
+      expect(issues).to have_issue(:video_embed_url, :non_youtube)
     end
 
     it "returns an issue when the URL is blank" do
       issues = Requirements::VideoEmbedChecker.new.pre_embed_issues
-      form_message = issues.items_for(:video_embed_url).first[:text]
-      expect(form_message).to eq(I18n.t!("requirements.video_embed_url.blank.form_message"))
+      expect(issues).to have_issue(:video_embed_url, :blank)
     end
 
     it "returns an issue for an invalid URI" do
       issues = Requirements::VideoEmbedChecker.new.pre_embed_issues(url: "http: youtube com")
-      form_message = issues.items_for(:video_embed_url).first[:text]
-      expect(form_message).to eq(I18n.t!("requirements.video_embed_url.non_youtube.form_message"))
+      expect(issues).to have_issue(:video_embed_url, :non_youtube)
     end
 
     it "returns an issue for non-YouTube URLs" do
       issues = Requirements::VideoEmbedChecker.new.pre_embed_issues(url: "http://vimeo.com")
-      form_message = issues.items_for(:video_embed_url).first[:text]
-      expect(form_message).to eq(I18n.t!("requirements.video_embed_url.non_youtube.form_message"))
+      expect(issues).to have_issue(:video_embed_url, :non_youtube)
     end
 
     it "returns an issue for incomplete YouTube URLs" do
       issues = Requirements::VideoEmbedChecker.new.pre_embed_issues(url: "https://www.youtube.com/watch")
-      form_message = issues.items_for(:video_embed_url).first[:text]
-      expect(form_message).to eq(I18n.t!("requirements.video_embed_url.non_youtube.form_message"))
+      expect(issues).to have_issue(:video_embed_url, :non_youtube)
     end
   end
 end

--- a/spec/lib/requirements/withdrawal_checker_spec.rb
+++ b/spec/lib/requirements/withdrawal_checker_spec.rb
@@ -2,27 +2,23 @@
 
 RSpec.describe Requirements::WithdrawalChecker do
   describe "#pre_withdrawal_issues" do
+    let(:edition) { build(:edition) }
+
     it "returns no issues if there are none" do
-      public_explanation = SecureRandom.alphanumeric
-      issues = Requirements::WithdrawalChecker.new(public_explanation, build(:edition))
-                                              .pre_withdrawal_issues
+      explanation = SecureRandom.alphanumeric
+      issues = Requirements::WithdrawalChecker.new(explanation, edition).pre_withdrawal_issues
       expect(issues).to be_empty
     end
 
     it "returns an issue if there is no public explanation" do
-      issues = Requirements::WithdrawalChecker.new(nil, build(:edition))
-                                              .pre_withdrawal_issues
-
-      message = issues.items_for(:public_explanation).first[:text]
-      expect(message).to eq(I18n.t!("requirements.public_explanation.blank.form_message"))
+      issues = Requirements::WithdrawalChecker.new(nil, edition).pre_withdrawal_issues
+      expect(issues).to have_issue(:public_explanation, :blank)
     end
 
     it "returns an issue if there is invalid govspeak in the public explanation" do
-      issues = Requirements::WithdrawalChecker.new("<script>alert('123')</script>", build(:edition))
-                                              .pre_withdrawal_issues
-
-      message = issues.items_for(:public_explanation).first[:text]
-      expect(message).to eq(I18n.t!("requirements.public_explanation.invalid_govspeak.form_message"))
+      explanation = "<script>alert('123')</script>"
+      issues = Requirements::WithdrawalChecker.new(explanation, edition).pre_withdrawal_issues
+      expect(issues).to have_issue(:public_explanation, :invalid_govspeak)
     end
   end
 end

--- a/spec/support/requirements_helper.rb
+++ b/spec/support/requirements_helper.rb
@@ -1,0 +1,26 @@
+# frozen_string_literal: true
+
+RSpec::Matchers.define :have_issue do |field, key, context = {}|
+  context[:styles] ||= %i[form]
+
+  match do |issues|
+    issue = issues.find do |actual_issue|
+      actual_issue.field == field && actual_issue.issue_key == key &&
+        actual_issue.context == context.except(:styles)
+    end
+
+    # use the issue message to do a deep check (include context)
+    # this also means we cover all the translations being defined
+    issue && context[:styles].all? do |style|
+      expected = I18n.t!("requirements.#{field}.#{key}.#{style}_message",
+                         context.except(:styles).merge(force_raise: true))
+
+      issue.message(style: style) == expected
+    end
+  end
+
+  failure_message do |actual_issues|
+    issue = Requirements::Issue.new(field, key, context.except(:styles))
+    "expected #{actual_issues.inspect} to have issue #{issue.inspect}"
+  end
+end


### PR DESCRIPTION
https://trello.com/c/dlw2oE4O/987-create-a-form-so-users-can-limit-access-to-a-draft

Previously our requirements specs contained repetitious code for
checking that different kinds issue could be rendered in the context of
a form and (potentially) on the summary page, which we do by checking
the associated translations. This DRYs-up the code to check issues can
be rendered in form/summary contexts by replacing it with a couple of
RSpec matchers: 'have_form_item' and 'have_summary_item'

## Examples of failure messages

```
# incorrect issue field/key in code/test
I18n::MissingTranslationData:
  translation missing: en.requirements.backdate_date.in_the_futur.form_message

# checker does not raise an issue
Failure/Error: expect(issues).to have_form_item(:backdate_date, :in_the_future)
       expected [{:text=>"Enter a date from 1 January 1995 onwards", :href=>nil, :target=>nil}] to have item {:text=>"Enter a date in the past", :href=>nil, :target=>nil}

# missing interpolation args in code/test
I18n::MissingInterpolationArgument:
  missing interpolation argument :date in "Enter a date from %{date} onwards" ({:force_i18n_to_raise_missing_interpolation_args=>true} given)
```