### PR TITLE
Add guidance link to footer

### DIFF
--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -117,23 +117,23 @@
         items: [
           {
             href: "https://support.publishing.service.gov.uk/technical_fault_report/new",
-            text: "Raise a support request",
+            text: t("application.footer.raise_a_support_request"),
             attributes: { target: "_blank", "data-gtm": "footer-raise-support-request" }
           },
           {
             href: "https://support.publishing.service.gov.uk/content_publisher_feedback_request/new",
-            text: "Send us feedback",
+            text: t("application.footer.send_us_feedback"),
             attributes: { target: "_blank", "data-gtm": "footer-send-feedback" }
 
           },
           {
             href: "https://status.publishing.service.gov.uk",
-            text: "GOV.UK Status",
+            text: t("application.footer.govuk_status"),
             attributes: { "data-gtm": "footer-view-govuk-status" }
           },
           {
             href: "https://www.gov.uk/government/content-publishing",
-            text: "How to write, publish, and improve content",
+            text: t("application.footer.how_to_write_content"),
             attributes: { "data-gtm": "footer-content-publishing-guidance" }
           }
         ]
@@ -143,22 +143,22 @@
         items: [
           {
             href: beta_capabilities_path,
-            text: "What the Beta can and cannot do",
+            text: t("application.footer.what_the_beta_can_do"),
             attributes: { "data-gtm": "footer-beta-capabilities" }
           },
           {
             href: how_to_use_publisher_path,
-            text: "How to use Content Publisher",
+            text: t("application.footer.how_to_use_content_publisher"),
             attributes: { "data-gtm": "footer-how-to-use-app" }
           },
           {
             href: publisher_updates_path,
-            text: "What’s new in Content Publisher",
+            text: t("application.footer.whats_new_in_content_publisher"),
             attributes: { "data-gtm": "footer-view-whats-new" }
           },
           {
             href: guidance_path,
-            text: "What to publish on GOV.UK",
+            text: t("application.footer.what_to_publish"),
             attributes: { "data-gtm": "footer-what-to-publish"}
           }
         ]

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -155,6 +155,11 @@
             href: publisher_updates_path,
             text: "What’s new in Content Publisher",
             attributes: { "data-gtm": "footer-view-whats-new" }
+          },
+          {
+            href: guidance_path,
+            text: "What to publish on GOV.UK",
+            attributes: { "data-gtm": "footer-what-to-publish"}
           }
         ]
       },

--- a/config/locales/en/application.yml
+++ b/config/locales/en/application.yml
@@ -10,3 +10,12 @@ en:
     footer:
       support_and_feedback: Support and feedback
       documentation: Documentation
+      raise_a_support_request: Raise a support request
+      send_us_feedback: Send us feedback
+      govuk_status: GOV.UK Status
+      how_to_write_content: How to write, publish, and improve content
+      what_the_beta_can_do: What the Beta can and cannot do
+      how_to_use_content_publisher: How to use Content Publisher
+      whats_new_in_content_publisher: What’s new in Content Publisher
+      what_to_publish: What to publish on GOV.UK
+      


### PR DESCRIPTION
- Add link to guidance in footer
- Move footer content into locales so it can be edited by content designer

Requested by content designer and agreed with project manager.