### PR TITLE
Fix access limit exception in payload

### DIFF
--- a/app/services/preview_asset_service/payload.rb
+++ b/app/services/preview_asset_service/payload.rb
@@ -8,9 +8,14 @@ class PreviewAssetService::Payload
   end
 
   def for_update
-    { draft: true,
-      auth_bypass_ids: [auth_bypass_id],
-      access_limited_organisation_ids: access_limited }.compact
+    payload = { draft: true, auth_bypass_ids: [auth_bypass_id] }
+
+    if edition.access_limit
+      org_ids = edition.access_limit_organisation_ids
+      payload[:access_limited_organisation_ids] = org_ids
+    end
+
+    payload
   end
 
   def for_upload(asset)
@@ -21,9 +26,5 @@ private
 
   def auth_bypass_id
     PreviewAuthBypassService.new(edition).auth_bypass_id
-  end
-
-  def access_limited
-    edition.access_limit_organisation_ids
   end
 end

--- a/app/services/publishing_api_payload.rb
+++ b/app/services/publishing_api_payload.rb
@@ -27,12 +27,7 @@ class PublishingApiPayload
         { "path" => edition.base_path, "type" => "exact" },
       ],
       "links" => links,
-      "access_limited" => {
-        "organisations" => edition.access_limit_organisation_ids,
-        "auth_bypass_ids" => [
-          PreviewAuthBypassService.new(edition).auth_bypass_id,
-        ],
-      }.compact,
+      "access_limited" => access_limited,
     }
     payload["change_note"] = edition.change_note if edition.major?
 
@@ -58,6 +53,17 @@ class PublishingApiPayload
   end
 
 private
+
+  def access_limited
+    auth_bypass_id = PreviewAuthBypassService.new(edition).auth_bypass_id
+    access_limited_ids = { "auth_bypass_ids" => [auth_bypass_id] }
+
+    if edition.access_limit
+      access_limited_ids["organisations"] = edition.access_limit_organisation_ids
+    end
+
+    access_limited_ids
+  end
 
   def links
     links = edition.tags["primary_publishing_organisation"].to_a +


### PR DESCRIPTION
https://trello.com/c/jvJZCHPG/989-present-access-limited-documents-to-publishing-api-and-asset-manager

Looks like a combination of PRs introduced a small bug...

This adds a guard conditional to ensure we only set organisation IDs to
limit access to the Publishing API payload when an access limit exists.