### PR TITLE
Iterate images workflow

### DIFF
--- a/app/controllers/images_controller.rb
+++ b/app/controllers/images_controller.rb
@@ -37,9 +37,14 @@ class ImagesController < ApplicationController
   def update_crop
     result = Images::UpdateCropInteractor.call(params: params, user: current_user)
     image_revision = result.image_revision
-    redirect_to edit_image_path(params[:document],
-                                image_revision.image_id,
-                                wizard: params[:wizard])
+
+    if params[:wizard] == "upload"
+      redirect_to edit_image_path(params[:document],
+                                  image_revision.image_id,
+                                  wizard: params[:wizard])
+    else
+      redirect_to images_path(params[:document])
+    end
   end
 
   def edit

--- a/app/views/images/_image.html.erb
+++ b/app/views/images/_image.html.erb
@@ -1,14 +1,12 @@
 <% actions = [] %>
 
-<% actions << link_to(
-  "Edit image",
-  crop_image_path(document, image.image_id),
-  class: "govuk-link",
-  data: {
-    "modal-action": "edit",
-    gtm: "edit-image"
-  }
-) %>
+<% actions << link_to("Edit details", edit_image_path(document, image.image_id),
+                      class: "govuk-link",
+                      data: { "modal-action": "edit", gtm: "edit-image" }) %>
+
+<% actions << link_to("Crop image", crop_image_path(document, image.image_id),
+                      class: "govuk-link",
+                      data: { "modal-action": "edit", gtm: "crop-image" }) %>
 
 <% actions << capture do %>
   <%= form_tag(

--- a/app/views/images/_lead_image.html.erb
+++ b/app/views/images/_lead_image.html.erb
@@ -8,9 +8,14 @@
                       data: { gtm: "download-lead-image" }) %>
 
 <% unless rendering_context == "modal" %>
-  <% actions << link_to("Edit image", crop_image_path(document, lead_image.image_id),
+
+  <% actions << link_to("Edit details", edit_image_path(document, lead_image.image_id),
                         class: "govuk-link",
-                        data: { gtm: "edit-lead-image" }) %>
+                        data: { "modal-action": "edit", gtm: "edit-lead-image" }) %>
+
+  <% actions << link_to("Crop image", crop_image_path(document, lead_image.image_id),
+                        class: "govuk-link",
+                        data: { gtm: "crop-lead-image" }) %>
 
   <% actions << capture do %>
     <%= form_tag remove_lead_image_path(document),

--- a/app/views/images/crop.html.erb
+++ b/app/views/images/crop.html.erb
@@ -34,7 +34,7 @@ content_for :title,t(title_key, title: @edition.title_or_fallback)
 
   <div class="app-js-only">
     <%= render "govuk_publishing_components/components/button", {
-      text: (@image_revision.at_exact_dimensions?) ? "Continue" : "Crop image",
+      text: (@image_revision.at_exact_dimensions?) || params[:wizard] == 'upload' ? "Continue" : "Crop image",
       margin_bottom: true
     } %>
   </div>

--- a/spec/features/editing_images/edit_image_metadata_requirements_spec.rb
+++ b/spec/features/editing_images/edit_image_metadata_requirements_spec.rb
@@ -43,8 +43,7 @@ RSpec.feature "Edit image metadata with requirements issues", js: true do
     stub_asset_manager_receives_an_asset
     stub_asset_manager_deletes_any_asset
 
-    click_on "Edit image"
-    click_on "Crop image"
+    click_on "Edit details"
 
     expect(page).to have_selector(".app-c-image-meta")
     fill_in "image_revision[alt_text]", with: ""

--- a/spec/features/editing_images/edit_image_spec.rb
+++ b/spec/features/editing_images/edit_image_spec.rb
@@ -56,7 +56,7 @@ RSpec.feature "Edit image", js: true do
   end
 
   def and_i_edit_the_image_crop
-    click_on "Edit image"
+    click_on "Crop image"
 
     # drag towards the top of the page where the page header is located
     crop_box = find(".cropper-crop-box")
@@ -74,6 +74,8 @@ RSpec.feature "Edit image", js: true do
   end
 
   def when_i_edit_the_image_metadata
+    click_on "Edit details"
+
     fill_in "image_revision[alt_text]", with: "Some alt text"
     fill_in "image_revision[caption]", with: "A caption"
     fill_in "image_revision[credit]", with: "A credit"

--- a/spec/features/editing_images/upload_image_spec.rb
+++ b/spec/features/editing_images/upload_image_spec.rb
@@ -48,7 +48,7 @@ RSpec.feature "Upload an image", js: true do
 
   def and_i_crop_the_image
     stub_publishing_api_put_content(@edition.content_id, {})
-    click_on "Crop image"
+    click_on "Continue"
     reset_executed_requests!
   end
 


### PR DESCRIPTION
This pr makes a few small changes to the workflow for lead and inline images to better support users for actions involving crop and editing metadata.

For more information take look at the design document - https://docs.google.com/document/d/1DQvG8Q64SeHBYxplDIRaoFqGyMPdDdDGAkb3ovn2zbU/edit. 

Trello:
https://trello.com/c/TL1An3FR/1077-iterate-crop-edit-workflow-for-lead-and-inline-images
