### PR TITLE
Move API retrieval non-services to lib

### DIFF
--- a/app/controllers/contacts_controller.rb
+++ b/app/controllers/contacts_controller.rb
@@ -4,7 +4,7 @@ class ContactsController < ApplicationController
   def index
     @edition = Edition.find_current(document: params[:document])
     assert_edition_state(@edition, &:editable?)
-    @contacts_by_organisation = ContactsService.new.all_by_organisation
+    @contacts_by_organisation = Contacts.new.all_by_organisation
     render layout: rendering_context
   rescue GdsApi::BaseError => e
     GovukError.notify(e)

--- a/app/models/document.rb
+++ b/app/models/document.rb
@@ -77,7 +77,7 @@ class Document < ApplicationRecord
   end
 
   def document_topics
-    @document_topics_index ||= TopicIndexService.new
+    @document_topics_index ||= TopicIndex.new
     DocumentTopics.find_by_document(self, @document_topics_index)
   end
 

--- a/app/models/topic.rb
+++ b/app/models/topic.rb
@@ -4,7 +4,7 @@ class Topic
   include ActiveModel::Model
 
   def self.govuk_homepage(index)
-    find(TopicIndexService::GOVUK_HOMEPAGE_CONTENT_ID, index)
+    find(TopicIndex::GOVUK_HOMEPAGE_CONTENT_ID, index)
   end
 
   def self.find(topic_content_id, index)

--- a/app/views/access_limit/edit.html.erb
+++ b/app/views/access_limit/edit.html.erb
@@ -2,7 +2,7 @@
 <% content_for :browser_title, t("access_limit.edit.browser_title") %>
 <% content_for :back_link, render_back_link(href: document_path(@edition.document)) %>
 
-<% service = LinkablesService.new("organisation") %>
+<% service = Linkables.new("organisation") %>
 
 <% if @edition.primary_publishing_organisation_id %>
   <% primary_org_id = @edition.primary_publishing_organisation_id %>

--- a/app/views/documents/forbidden.html.erb
+++ b/app/views/documents/forbidden.html.erb
@@ -6,7 +6,7 @@
 
 <div class="govuk-body">
   <% begin %>
-    <% primary_org = LinkablesService.new("organisation")
+    <% primary_org = Linkables.new("organisation")
       .by_content_id(@edition.primary_publishing_organisation_id) %>
 
     <% if primary_org %>

--- a/app/views/documents/index/_filters.html.erb
+++ b/app/views/documents/index/_filters.html.erb
@@ -16,7 +16,7 @@
 
   <div class="govuk-form-group">
     <% organisation_select = begin
-      LinkablesService.new("organisation").select_options
+      Linkables.new("organisation").select_options
     rescue GdsApi::BaseError => e
       GovukError.notify(e)
       []

--- a/app/views/documents/show/_tags.html.erb
+++ b/app/views/documents/show/_tags.html.erb
@@ -1,6 +1,6 @@
 <% begin %>
   <% tags = @edition.document_type.tags.map { |tag_field|
-    service = LinkablesService.new(tag_field.document_type)
+    service = Linkables.new(tag_field.document_type)
 
     values = @edition.tags[tag_field.id].to_a
       .map { |content_id| service.by_content_id(content_id) }

--- a/app/views/tags/tags/_multi_tag_input.html.erb
+++ b/app/views/tags/tags/_multi_tag_input.html.erb
@@ -7,7 +7,7 @@
   },
   hint: tag_field.hint,
   select: {
-    options: LinkablesService.new(tag_field.document_type).select_options,
+    options: Linkables.new(tag_field.document_type).select_options,
     selected: tags[tag_field.id],
     multiple: true,
     size: 10,

--- a/app/views/tags/tags/_single_tag_input.html.erb
+++ b/app/views/tags/tags/_single_tag_input.html.erb
@@ -7,7 +7,7 @@
   },
   hint: tag_field.hint,
   select: {
-    options: [""] + LinkablesService.new(tag_field.document_type).select_options,
+    options: [""] + Linkables.new(tag_field.document_type).select_options,
     selected: tags[tag_field.id],
   },
   error_items: issues&.items_for(tag_field.id.to_sym),

--- a/lib/contacts.rb
+++ b/lib/contacts.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-class ContactsService
+class Contacts
   CACHE_OPTIONS = { expires_in: 15.minutes, race_condition_ttl: 30.seconds }.freeze
   EDITION_PARAMS = {
     document_types: %w[contact].freeze,
@@ -36,7 +36,7 @@ private
   end
 
   def organisation_select_options
-    @organisation_select_options ||= LinkablesService.new("organisation").select_options
+    @organisation_select_options ||= Linkables.new("organisation").select_options
   end
 
   def load_contacts_by_organisation

--- a/lib/govspeak_document/in_app_options.rb
+++ b/lib/govspeak_document/in_app_options.rb
@@ -22,7 +22,7 @@ private
   end
 
   def attachment_attributes(attachment_revision)
-    alt_email = OrganisationService.new(edition).alternative_format_contact_email
+    alt_email = Organisations.new(edition).alternative_format_contact_email
     attributes = file_attachment_attributes(attachment_revision, edition.document)
     attributes.merge(alternative_format_contact_email: alt_email)
   end

--- a/lib/govspeak_document/options.rb
+++ b/lib/govspeak_document/options.rb
@@ -17,10 +17,7 @@ private
   def contacts
     @contacts ||= begin
       contact_content_ids = Govspeak::Document.new(text).extract_contact_content_ids
-      contacts = contact_content_ids.map do |id|
-        ContactsService.new.by_content_id(id)
-      end
-      contacts.compact
+      contact_content_ids.map { |id| Contacts.new.by_content_id(id) }.compact
     end
   end
 end

--- a/lib/govspeak_document/payload_options.rb
+++ b/lib/govspeak_document/payload_options.rb
@@ -34,7 +34,7 @@ private
   end
 
   def attachment_attributes(attachment_revision)
-    alt_email = OrganisationService.new(edition).alternative_format_contact_email
+    alt_email = Organisations.new(edition).alternative_format_contact_email
     attributes = file_attachment_attributes(attachment_revision, edition.document)
 
     attributes.merge(

--- a/lib/linkables.rb
+++ b/lib/linkables.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-class LinkablesService
+class Linkables
   CACHE_OPTIONS = { expires_in: 5.minutes, race_condition_ttl: 10.seconds }.freeze
 
   attr_reader :document_type

--- a/lib/organisations.rb
+++ b/lib/organisations.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-class OrganisationService
+class Organisations
   DEFAULT_ALTERNATIVE_FORMAT_CONTACT_EMAIL = "govuk-feedback@digital.cabinet-office.gov.uk"
   CACHE_OPTIONS = { expires_in: 15.minutes, race_condition_ttl: 30.seconds }.freeze
 

--- a/lib/topic_index.rb
+++ b/lib/topic_index.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-class TopicIndexService
+class TopicIndex
   GOVUK_HOMEPAGE_CONTENT_ID = "f3bbdec2-0e62-4520-a7fd-6ffd5d36e03a"
   CACHE_OPTIONS = { expires_in: 5.minutes, race_condition_ttl: 10.seconds }.freeze
   TOPIC_INDEX_TIMEOUT = 10.seconds

--- a/spec/features/editing_content/insert_contact_no_js_spec.rb
+++ b/spec/features/editing_content/insert_contact_no_js_spec.rb
@@ -33,7 +33,7 @@ RSpec.feature "Insert contact without Javascript" do
       "links" => { "organisations" => [organisation["content_id"]] },
     }
     stub_publishing_api_has_linkables([organisation], document_type: "organisation")
-    stub_publishing_api_get_editions([@contact], ContactsService::EDITION_PARAMS)
+    stub_publishing_api_get_editions([@contact], Contacts::EDITION_PARAMS)
     stub_publishing_api_put_content(@edition.content_id, {})
     find("markdown-toolbar details").click
     click_on "Contact"

--- a/spec/features/editing_content/insert_contact_spec.rb
+++ b/spec/features/editing_content/insert_contact_spec.rb
@@ -33,7 +33,7 @@ RSpec.feature "Insert contact", js: true do
       "links" => { "organisations" => [organisation["content_id"]] },
     }
     stub_publishing_api_has_linkables([organisation], document_type: "organisation")
-    stub_publishing_api_get_editions([@contact], ContactsService::EDITION_PARAMS)
+    stub_publishing_api_get_editions([@contact], Contacts::EDITION_PARAMS)
     stub_publishing_api_put_content(@edition.content_id, {})
     find("markdown-toolbar details").click
     click_on "Contact"

--- a/spec/lib/contacts_spec.rb
+++ b/spec/lib/contacts_spec.rb
@@ -1,21 +1,21 @@
 # frozen_string_literal: true
 
-RSpec.describe ContactsService do
+RSpec.describe Contacts do
   describe "#by_content_id" do
     context "when a contact is found" do
       it "returns the contact" do
         content_id = SecureRandom.uuid
         editions = [{ "content_id" => content_id, "locale" => "en", "title" => "Clark Kent" }]
-        stub_publishing_api_get_editions(editions, ContactsService::EDITION_PARAMS)
+        stub_publishing_api_get_editions(editions, Contacts::EDITION_PARAMS)
 
-        expect(ContactsService.new.by_content_id(content_id)).to eq(editions.first)
+        expect(Contacts.new.by_content_id(content_id)).to eq(editions.first)
       end
     end
 
     context "when a contact is not found" do
       it "returns nil" do
-        stub_publishing_api_get_editions([], ContactsService::EDITION_PARAMS)
-        expect(ContactsService.new.by_content_id(SecureRandom.uuid)).to be_nil
+        stub_publishing_api_get_editions([], Contacts::EDITION_PARAMS)
+        expect(Contacts.new.by_content_id(SecureRandom.uuid)).to be_nil
       end
     end
   end
@@ -34,9 +34,9 @@ RSpec.describe ContactsService do
         org2_contacts = [
           { "content_id" => SecureRandom.uuid, "locale" => "en", "title" => "Contact 3", "links" => { "organisations" => [org2["content_id"]] } },
         ]
-        stub_publishing_api_get_editions(org1_contacts + org2_contacts, ContactsService::EDITION_PARAMS)
+        stub_publishing_api_get_editions(org1_contacts + org2_contacts, Contacts::EDITION_PARAMS)
 
-        expect(ContactsService.new.all_by_organisation).to match([
+        expect(Contacts.new.all_by_organisation).to match([
           { "name" => org1["internal_name"], "content_id" => org1["content_id"], "contacts" => org1_contacts },
           { "name" => org2["internal_name"], "content_id" => org2["content_id"], "contacts" => org2_contacts },
         ])
@@ -48,9 +48,9 @@ RSpec.describe ContactsService do
         org1 = { "content_id" => SecureRandom.uuid, "internal_name" => "Org 1" }
         stub_publishing_api_has_linkables([org1], document_type: "organisation")
 
-        stub_publishing_api_get_editions([], ContactsService::EDITION_PARAMS)
+        stub_publishing_api_get_editions([], Contacts::EDITION_PARAMS)
 
-        expect(ContactsService.new.all_by_organisation).to match([
+        expect(Contacts.new.all_by_organisation).to match([
           { "name" => org1["internal_name"], "content_id" => org1["content_id"], "contacts" => [] },
         ])
       end
@@ -59,8 +59,8 @@ RSpec.describe ContactsService do
     context "when there are no organisations" do
       it "returns an empty array" do
         stub_publishing_api_has_linkables([], document_type: "organisation")
-        stub_publishing_api_get_editions([], ContactsService::EDITION_PARAMS)
-        expect(ContactsService.new.all_by_organisation).to eql([])
+        stub_publishing_api_get_editions([], Contacts::EDITION_PARAMS)
+        expect(Contacts.new.all_by_organisation).to eql([])
       end
     end
   end

--- a/spec/lib/govspeak_document/in_app_options_spec.rb
+++ b/spec/lib/govspeak_document/in_app_options_spec.rb
@@ -3,10 +3,10 @@
 RSpec.describe GovspeakDocument::InAppOptions do
   include Rails.application.routes.url_helpers
 
-  let(:organisation_service) { instance_double(OrganisationService) }
+  let(:organisation_service) { instance_double(Organisations) }
 
   before do
-    allow(OrganisationService).to receive(:new) { organisation_service }
+    allow(Organisations).to receive(:new) { organisation_service }
   end
 
   describe "#to_h" do

--- a/spec/lib/govspeak_document/options_spec.rb
+++ b/spec/lib/govspeak_document/options_spec.rb
@@ -1,10 +1,10 @@
 # frozen_string_literal: true
 
 RSpec.describe GovspeakDocument::Options do
-  let(:contacts_service) { instance_double(ContactsService) }
+  let(:contacts_service) { instance_double(Contacts) }
 
   before do
-    allow(ContactsService).to receive(:new).and_return(contacts_service)
+    allow(Contacts).to receive(:new).and_return(contacts_service)
   end
 
   context "when an unknown contact is referenced" do

--- a/spec/lib/govspeak_document/payload_options_spec.rb
+++ b/spec/lib/govspeak_document/payload_options_spec.rb
@@ -1,10 +1,10 @@
 # frozen_string_literal: true
 
 RSpec.describe GovspeakDocument::PayloadOptions do
-  let(:organisation_service) { instance_double(OrganisationService) }
+  let(:organisation_service) { instance_double(Organisations) }
 
   before do
-    allow(OrganisationService).to receive(:new) { organisation_service }
+    allow(Organisations).to receive(:new) { organisation_service }
   end
 
   describe "#to_h" do

--- a/spec/lib/linkables_spec.rb
+++ b/spec/lib/linkables_spec.rb
@@ -1,13 +1,13 @@
 # frozen_string_literal: true
 
-RSpec.describe LinkablesService do
+RSpec.describe Linkables do
   describe "#select_options" do
     it "returns a sorted array of linkables" do
       linkable1 = { "content_id" => SecureRandom.uuid, "internal_name" => "linkable 1" }
       linkable2 = { "content_id" => SecureRandom.uuid, "internal_name" => "Linkable 2" }
       stub_publishing_api_has_linkables([linkable2, linkable1], document_type: "topical_event")
 
-      options = LinkablesService.new("topical_event").select_options
+      options = Linkables.new("topical_event").select_options
 
       expect(options).to eq([[linkable1["internal_name"], linkable1["content_id"]],
                              [linkable2["internal_name"], linkable2["content_id"]]])
@@ -19,7 +19,7 @@ RSpec.describe LinkablesService do
       linkable = { "content_id" => SecureRandom.uuid, "internal_name" => "Linkable 1" }
       stub_publishing_api_has_linkables([linkable], document_type: "topical_event")
 
-      service = LinkablesService.new("topical_event")
+      service = Linkables.new("topical_event")
       expect(service.by_content_id(linkable["content_id"])).to eq(linkable)
       expect(service.by_content_id("something-else")).to be_nil
     end

--- a/spec/lib/organisations_spec.rb
+++ b/spec/lib/organisations_spec.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-RSpec.describe OrganisationService do
+RSpec.describe Organisations do
   describe "#alternative_format_contact_email" do
     context "when the edition has a primary org" do
       let(:org_content_id) { SecureRandom.uuid }
@@ -20,7 +20,7 @@ RSpec.describe OrganisationService do
         end
 
         it "returns the specified email" do
-          email = OrganisationService.new(edition).alternative_format_contact_email
+          email = Organisations.new(edition).alternative_format_contact_email
           expect(email).to eq "foo@bar.com"
         end
       end
@@ -36,8 +36,8 @@ RSpec.describe OrganisationService do
         end
 
         it "returns the default alt email" do
-          email = OrganisationService.new(edition).alternative_format_contact_email
-          expect(email).to eq OrganisationService::DEFAULT_ALTERNATIVE_FORMAT_CONTACT_EMAIL
+          email = Organisations.new(edition).alternative_format_contact_email
+          expect(email).to eq Organisations::DEFAULT_ALTERNATIVE_FORMAT_CONTACT_EMAIL
         end
       end
 
@@ -47,8 +47,8 @@ RSpec.describe OrganisationService do
         end
 
         it "returns the default alt email" do
-          email = OrganisationService.new(edition).alternative_format_contact_email
-          expect(email).to eq OrganisationService::DEFAULT_ALTERNATIVE_FORMAT_CONTACT_EMAIL
+          email = Organisations.new(edition).alternative_format_contact_email
+          expect(email).to eq Organisations::DEFAULT_ALTERNATIVE_FORMAT_CONTACT_EMAIL
         end
       end
     end
@@ -57,8 +57,8 @@ RSpec.describe OrganisationService do
       let(:edition) { build :edition }
 
       it "returns the default alt email" do
-        email = OrganisationService.new(edition).alternative_format_contact_email
-        expect(email).to eq OrganisationService::DEFAULT_ALTERNATIVE_FORMAT_CONTACT_EMAIL
+        email = Organisations.new(edition).alternative_format_contact_email
+        expect(email).to eq Organisations::DEFAULT_ALTERNATIVE_FORMAT_CONTACT_EMAIL
       end
     end
   end

--- a/spec/models/document_topics_spec.rb
+++ b/spec/models/document_topics_spec.rb
@@ -17,7 +17,7 @@ RSpec.describe DocumentTopics do
           "version" => 1,
         )
 
-        document_topics = DocumentTopics.find_by_document(document, TopicIndexService.new)
+        document_topics = DocumentTopics.find_by_document(document, TopicIndex.new)
 
         expect(document_topics.version).to eq(1)
         expect(document_topics.document).to be(document)
@@ -29,7 +29,7 @@ RSpec.describe DocumentTopics do
       it "returns an empty object" do
         document = build(:document)
         stub_publishing_api_does_not_have_links(document.content_id)
-        document_topics = DocumentTopics.find_by_document(document, TopicIndexService.new)
+        document_topics = DocumentTopics.find_by_document(document, TopicIndex.new)
 
         expect(document_topics.version).to be_nil
         expect(document_topics.document).to be(document)


### PR DESCRIPTION
https://trello.com/c/6WhtlGQB/1115-finish-work-separating-services-and-non-services-from-services

As part of our work to cleanup the 'app/services' directory, we
identified a few non-services that act as adapters/interfaces to
retrieve data from external APIs. This moves these non-services to
the 'lib/' directory, pending further decisions on how they should
be structured (names, interfaces, directories).