### PR TITLE
Split PublishingApiPayload into supporting classes

### DIFF
--- a/app/services/delete_draft_service.rb
+++ b/app/services/delete_draft_service.rb
@@ -30,7 +30,7 @@ private
 
   def discard_path_reservations(edition)
     paths = edition.revisions.map(&:base_path).uniq.compact
-    publishing_app = PublishingApiPayload::PUBLISHING_APP
+    publishing_app = PreviewService::Payload::PUBLISHING_APP
 
     paths.each do |path|
       GdsApi.publishing_api.unreserve_path(path, publishing_app)

--- a/app/services/preview_service.rb
+++ b/app/services/preview_service.rb
@@ -35,7 +35,7 @@ private
   end
 
   def publish_draft
-    payload = PublishingApiPayload.new(edition).payload
+    payload = Payload.new(edition).payload
     GdsApi.publishing_api_v2.put_content(edition.content_id, payload)
     edition.update!(revision_synced: true)
   end

--- a/app/services/preview_service/payload.rb
+++ b/app/services/preview_service/payload.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-class PublishingApiPayload
+class PreviewService::Payload
   PUBLISHING_APP = "content-publisher"
 
   attr_reader :edition, :document_type, :publishing_metadata
@@ -37,19 +37,6 @@ class PublishingApiPayload
     end
 
     payload
-  end
-
-  def intent_payload
-    raise "Edition must be scheduled to create an intent" unless edition.scheduled?
-
-    scheduling = edition.status.details
-    rendering_app = publishing_metadata.rendering_app
-
-    {
-      publish_time: scheduling.publish_time,
-      publishing_app: PUBLISHING_APP,
-      rendering_app: rendering_app,
-    }
   end
 
 private

--- a/app/services/schedule_service.rb
+++ b/app/services/schedule_service.rb
@@ -42,7 +42,7 @@ private
   end
 
   def create_publish_intent
-    payload = PublishingApiPayload.new(edition).intent_payload
+    payload = Payload.new(edition).intent_payload
     GdsApi.publishing_api.put_intent(edition.base_path, payload)
   end
 

--- a/app/services/schedule_service/payload.rb
+++ b/app/services/schedule_service/payload.rb
@@ -1,0 +1,28 @@
+# frozen_string_literal: true
+
+class ScheduleService::Payload
+  attr_reader :edition
+
+  def initialize(edition)
+    @edition = edition
+  end
+
+  def intent_payload
+    {
+      publish_time: publish_time,
+      publishing_app: PreviewService::Payload::PUBLISHING_APP,
+      rendering_app: rendering_app,
+    }
+  end
+
+private
+
+  def publish_time
+    scheduling = edition.status.details
+    scheduling.publish_time
+  end
+
+  def rendering_app
+    edition.document_type.publishing_metadata.rendering_app
+  end
+end

--- a/spec/services/delete_draft_service_spec.rb
+++ b/spec/services/delete_draft_service_spec.rb
@@ -53,12 +53,12 @@ RSpec.describe DeleteDraftService do
 
       unreserve_request1 = stub_publishing_api_unreserve_path(
         edition.base_path,
-        PublishingApiPayload::PUBLISHING_APP,
+        PreviewService::Payload::PUBLISHING_APP,
       )
 
       unreserve_request2 = stub_publishing_api_unreserve_path(
         previous_revision.base_path,
-        PublishingApiPayload::PUBLISHING_APP,
+        PreviewService::Payload::PUBLISHING_APP,
       )
 
       DeleteDraftService.new(edition.document, user).delete

--- a/spec/services/schedule_service/payload_spec.rb
+++ b/spec/services/schedule_service/payload_spec.rb
@@ -1,0 +1,25 @@
+# frozen_string_literal: true
+
+RSpec.describe ScheduleService::Payload do
+  describe "#intent_payload" do
+    it "generates a payload for the publishing API" do
+      document_type = build(:document_type, rendering_app: "government-frontend")
+      publish_time = Time.current.tomorrow.at_noon
+
+      edition = build(:edition,
+                      :scheduled,
+                      document_type_id: document_type.id,
+                      publish_time: publish_time)
+
+      payload = ScheduleService::Payload.new(edition).intent_payload
+
+      payload_hash = {
+        publish_time: publish_time,
+        publishing_app: PreviewService::Payload::PUBLISHING_APP,
+        rendering_app: "government-frontend",
+      }
+
+      expect(payload).to match a_hash_including(payload_hash)
+    end
+  end
+end

--- a/spec/services/schedule_service_spec.rb
+++ b/spec/services/schedule_service_spec.rb
@@ -1,7 +1,9 @@
 # frozen_string_literal: true
 
 RSpec.describe ScheduleService do
-  let(:publishing_api_payload) { instance_double(PublishingApiPayload, intent_payload: "payload") }
+  let(:payload) do
+    instance_double(ScheduleService::Payload, intent_payload: "payload")
+  end
 
   include ActiveJob::TestHelper
 
@@ -11,7 +13,7 @@ RSpec.describe ScheduleService do
 
   before(:each) do
     stub_default_publishing_api_put_intent
-    allow(PublishingApiPayload).to receive(:new) { publishing_api_payload }
+    allow(ScheduleService::Payload).to receive(:new) { payload }
   end
 
   describe "#schedule" do


### PR DESCRIPTION
https://trello.com/c/6WhtlGQB/1115-finish-work-separating-services-and-non-services-from-services

Previously we had a single PublishingApiPayload class to generate
payloads for scheduling and draft preview. This splits up the class
into a couple of supporting classes for their respective services,
as part of the work to tidy up the 'app/services/' directory.

One potential issue was the location of the 'PUBLISHING_APP' constant,
which is used by three services. It makes sense for the constant to be
defined close to the 'put content' payload, since the other two services
that use this constant are coupled to the value specified here.