### PR TITLE
Refactor date/time parsers to use new interfaces

### DIFF
--- a/lib/date_parser.rb
+++ b/lib/date_parser.rb
@@ -1,31 +1,27 @@
 # frozen_string_literal: true
 
 class DateParser
+  attr_reader :raw_date, :issue_prefix, :issues
+
   def initialize(date:, issue_prefix:)
     @raw_date = date.to_h
     @issue_prefix = issue_prefix
-  end
-
-  def issues
-    Requirements::CheckerIssues.new(issue_items)
+    @issues = Requirements::CheckerIssues.new
   end
 
   def parse
-    @issue_items = []
-
+    @issues = Requirements::CheckerIssues.new
     check_date_is_valid
-    issue_items.any? ? return : parsed_date
+    parsed_date if issues.none?
   end
 
 private
-
-  attr_reader :raw_date, :issue_prefix, :issue_items
 
   def check_date_is_valid
     parsed_date
   rescue ArgumentError
     field_name = "#{issue_prefix}_date".to_sym
-    issue_items << Requirements::Issue.new(field_name, :invalid)
+    issues << Requirements::Issue.new(field_name, :invalid)
   end
 
   def parsed_date

--- a/spec/lib/date_parser_spec.rb
+++ b/spec/lib/date_parser_spec.rb
@@ -24,26 +24,23 @@ RSpec.describe DateParser do
     it "returns no issues when there are none" do
       params = { day: "10", month: "1", year: "2019" }
       parser = DateParser.new(date: params, issue_prefix: :backdate)
-      parser.parse
 
+      parser.parse
       expect(parser.issues.items).to be_empty
     end
 
     it "returns issues when the date is blank" do
       parser = DateParser.new(date: nil, issue_prefix: :backdate)
       parser.parse
-
-      date_form_message = parser.issues.items_for(:backdate_date).first[:text]
-      expect(date_form_message).to eq(I18n.t!("requirements.backdate_date.invalid.form_message"))
+      expect(parser.issues).to have_issue(:backdate_date, :invalid)
     end
 
     it "returns an issue when the date is invalid" do
       params = { day: "10", month: "60", year: "11" }
       parser = DateParser.new(date: params, issue_prefix: :backdate)
-      parser.parse
 
-      form_message = parser.issues.items_for(:backdate_date).first[:text]
-      expect(form_message).to eq(I18n.t!("requirements.backdate_date.invalid.form_message"))
+      parser.parse
+      expect(parser.issues).to have_issue(:backdate_date, :invalid)
     end
   end
 end

--- a/spec/lib/datetime_parser_spec.rb
+++ b/spec/lib/datetime_parser_spec.rb
@@ -77,15 +77,8 @@ RSpec.describe DatetimeParser do
       parser = DatetimeParser.new(date: nil, time: nil, issue_prefix: :schedule)
       parser.parse
 
-      date_form_message = parser.issues.items_for(:schedule_date).first[:text]
-      expect(date_form_message).to eq(
-        I18n.t!("requirements.schedule_date.invalid.form_message"),
-      )
-
-      time_form_message = parser.issues.items_for(:schedule_time).first[:text]
-      expect(time_form_message).to eq(
-        I18n.t!("requirements.schedule_time.invalid.form_message"),
-      )
+      expect(parser.issues).to have_issue(:schedule_date, :invalid)
+      expect(parser.issues).to have_issue(:schedule_time, :invalid)
     end
 
     it "returns an issue when the date is invalid" do
@@ -94,11 +87,7 @@ RSpec.describe DatetimeParser do
                  issue_prefix: :schedule }
       parser = DatetimeParser.new(params)
       parser.parse
-
-      form_message = parser.issues.items_for(:schedule_date).first[:text]
-      expect(form_message).to eq(
-        I18n.t!("requirements.schedule_date.invalid.form_message"),
-      )
+      expect(parser.issues).to have_issue(:schedule_date, :invalid)
     end
 
     it "returns an issue when the time is invalid" do
@@ -107,11 +96,7 @@ RSpec.describe DatetimeParser do
                  issue_prefix: :schedule }
       parser = DatetimeParser.new(params)
       parser.parse
-
-      form_message = parser.issues.items_for(:schedule_time).first[:text]
-      expect(form_message).to eq(
-        I18n.t!("requirements.schedule_time.invalid.form_message"),
-      )
+      expect(parser.issues).to have_issue(:schedule_time, :invalid)
     end
   end
 end


### PR DESCRIPTION
https://trello.com/c/6WhtlGQB/1115-finish-work-separating-services-and-non-services-from-services

This got missed when the original changes were made...

This refactors the date/time parsers to take advantage the new interface
for Requirements::CheckerIssues. This also refactors the associated
specs to make use the the new matcher for requirements.