### PR TITLE
Refactor preview services

### DIFF
--- a/app/interactors/access_limit/update_interactor.rb
+++ b/app/interactors/access_limit/update_interactor.rb
@@ -72,6 +72,6 @@ private
   end
 
   def update_preview
-    PreviewService.new(edition).try_create_preview
+    FailsafePreviewService.new(edition).create_preview
   end
 end

--- a/app/interactors/backdate/destroy_interactor.rb
+++ b/app/interactors/backdate/destroy_interactor.rb
@@ -41,6 +41,6 @@ private
   end
 
   def update_preview
-    PreviewService.new(edition).try_create_preview
+    FailsafePreviewService.new(edition).create_preview
   end
 end

--- a/app/interactors/backdate/update_interactor.rb
+++ b/app/interactors/backdate/update_interactor.rb
@@ -65,6 +65,6 @@ private
   end
 
   def update_preview
-    PreviewService.new(edition).try_create_preview
+    FailsafePreviewService.new(edition).create_preview
   end
 end

--- a/app/interactors/documents/update_interactor.rb
+++ b/app/interactors/documents/update_interactor.rb
@@ -48,7 +48,7 @@ private
   end
 
   def update_preview
-    PreviewService.new(edition).try_create_preview
+    FailsafePreviewService.new(edition).create_preview
   end
 
   def update_params(edition)

--- a/app/interactors/file_attachments/create_interactor.rb
+++ b/app/interactors/file_attachments/create_interactor.rb
@@ -52,6 +52,6 @@ private
   end
 
   def update_preview
-    PreviewService.new(edition).try_create_preview
+    FailsafePreviewService.new(edition).create_preview
   end
 end

--- a/app/interactors/file_attachments/destroy_interactor.rb
+++ b/app/interactors/file_attachments/destroy_interactor.rb
@@ -37,6 +37,6 @@ private
   end
 
   def update_preview
-    PreviewService.new(edition).try_create_preview
+    FailsafePreviewService.new(edition).create_preview
   end
 end

--- a/app/interactors/file_attachments/update_interactor.rb
+++ b/app/interactors/file_attachments/update_interactor.rb
@@ -65,7 +65,7 @@ private
   end
 
   def update_preview
-    PreviewService.new(edition).try_create_preview
+    FailsafePreviewService.new(edition).create_preview
   end
 
   def attachment_params

--- a/app/interactors/images/destroy_interactor.rb
+++ b/app/interactors/images/destroy_interactor.rb
@@ -37,6 +37,6 @@ private
   end
 
   def update_preview
-    PreviewService.new(edition).try_create_preview
+    FailsafePreviewService.new(edition).create_preview
   end
 end

--- a/app/interactors/images/update_crop_interactor.rb
+++ b/app/interactors/images/update_crop_interactor.rb
@@ -59,6 +59,6 @@ private
   end
 
   def update_preview
-    PreviewService.new(edition).try_create_preview
+    FailsafePreviewService.new(edition).create_preview
   end
 end

--- a/app/interactors/images/update_interactor.rb
+++ b/app/interactors/images/update_interactor.rb
@@ -73,6 +73,6 @@ private
   end
 
   def update_preview
-    PreviewService.new(edition).try_create_preview
+    FailsafePreviewService.new(edition).create_preview
   end
 end

--- a/app/interactors/lead_image/choose_interactor.rb
+++ b/app/interactors/lead_image/choose_interactor.rb
@@ -43,6 +43,6 @@ private
   end
 
   def update_preview
-    PreviewService.new(edition).try_create_preview
+    FailsafePreviewService.new(edition).create_preview
   end
 end

--- a/app/interactors/lead_image/remove_interactor.rb
+++ b/app/interactors/lead_image/remove_interactor.rb
@@ -43,6 +43,6 @@ private
   end
 
   def update_preview
-    PreviewService.new(edition).try_create_preview
+    FailsafePreviewService.new(edition).create_preview
   end
 end

--- a/app/interactors/tags/update_interactor.rb
+++ b/app/interactors/tags/update_interactor.rb
@@ -51,7 +51,7 @@ private
   end
 
   def update_preview
-    PreviewService.new(edition).try_create_preview
+    FailsafePreviewService.new(edition).create_preview
   end
 
   def update_params(edition)

--- a/app/services/failsafe_preview_service.rb
+++ b/app/services/failsafe_preview_service.rb
@@ -1,0 +1,27 @@
+# frozen_string_literal: true
+
+class FailsafePreviewService
+  attr_reader :edition
+
+  def initialize(edition)
+    @edition = edition
+  end
+
+  def create_preview
+    if has_issues?
+      DraftAssetCleanupService.new.call(edition)
+      edition.update!(revision_synced: false)
+    else
+      PreviewService.new(edition).create_preview
+    end
+  rescue GdsApi::BaseError => e
+    edition.update!(revision_synced: false)
+    GovukError.notify(e)
+  end
+
+private
+
+  def has_issues?
+    Requirements::EditionChecker.new(edition).pre_preview_issues.any?
+  end
+end

--- a/app/services/preview_asset_service.rb
+++ b/app/services/preview_asset_service.rb
@@ -7,11 +7,6 @@ class PreviewAssetService
     @edition = edition
   end
 
-  def put_all
-    edition.image_revisions.each(&:ensure_assets)
-    edition.assets.each { |asset| put(asset) }
-  end
-
   def put(asset)
     if asset.draft?
       update(asset)

--- a/app/services/preview_service.rb
+++ b/app/services/preview_service.rb
@@ -16,23 +16,7 @@ class PreviewService
     raise
   end
 
-  def try_create_preview
-    if has_issues?
-      DraftAssetCleanupService.new.call(edition)
-      edition.update!(revision_synced: false)
-    else
-      create_preview
-    end
-  rescue GdsApi::BaseError => e
-    edition.update!(revision_synced: false)
-    GovukError.notify(e)
-  end
-
 private
-
-  def has_issues?
-    Requirements::EditionChecker.new(edition).pre_preview_issues.any?
-  end
 
   def publish_draft
     payload = Payload.new(edition).payload

--- a/spec/services/failsafe_preview_service_spec.rb
+++ b/spec/services/failsafe_preview_service_spec.rb
@@ -1,0 +1,50 @@
+# frozen_string_literal: true
+
+RSpec.describe FailsafePreviewService do
+  let(:preview_service) do
+    instance_double(PreviewService, create_preview: nil)
+  end
+
+  before do
+    allow(PreviewService).to receive(:new) { preview_service }
+    allow_any_instance_of(DraftAssetCleanupService).to receive(:call)
+  end
+
+  describe "#create_preview" do
+    it "delegates to the PreviewService" do
+      edition = create(:edition)
+      service = FailsafePreviewService.new(edition)
+      expect(preview_service).to receive(:create_preview)
+      service.create_preview
+    end
+
+    context "when an external service is down" do
+      it "sets revision_synced to false on the edition" do
+        allow(preview_service).to receive(:create_preview).and_raise(GdsApi::BaseError)
+        edition = create(:edition, revision_synced: true)
+        FailsafePreviewService.new(edition).create_preview
+        expect(edition.revision_synced).to be(false)
+      end
+    end
+
+    context "when there are pre-preview issues" do
+      let(:edition) { create(:edition, title: "", revision_synced: true) }
+
+      it "sets revision_synced to false on the edition" do
+        FailsafePreviewService.new(edition).create_preview
+        expect(edition.revision_synced).to be(false)
+      end
+
+      it "doesn't send to the Publishing API" do
+        request = stub_publishing_api_put_content(edition.content_id, {})
+        FailsafePreviewService.new(edition).create_preview
+        expect(request).not_to have_been_requested
+      end
+
+      it "delegates cleaning up draft assets" do
+        expect_any_instance_of(DraftAssetCleanupService).to receive(:call)
+        FailsafePreviewService.new(edition).create_preview
+      end
+    end
+  end
+end

--- a/spec/services/preview_asset_service_spec.rb
+++ b/spec/services/preview_asset_service_spec.rb
@@ -1,22 +1,6 @@
 # frozen_string_literal: true
 
 RSpec.describe PreviewAssetService do
-  describe "#put_all" do
-    it "uploads the image assets" do
-      image_revision = create(:image_revision)
-      edition = create(:edition, image_revisions: [image_revision])
-      expect_any_instance_of(PreviewAssetService).to receive(:put).at_least(:once)
-      PreviewAssetService.new(edition).put_all
-    end
-
-    it "uploads the file attachment assets" do
-      file_attachment_revision = create(:file_attachment_revision)
-      edition = create(:edition, file_attachment_revisions: [file_attachment_revision])
-      expect_any_instance_of(PreviewAssetService).to receive(:put).at_least(:once)
-      PreviewAssetService.new(edition).put_all
-    end
-  end
-
   describe "#put" do
     let(:edition) { create :edition }
 

--- a/spec/services/preview_service_spec.rb
+++ b/spec/services/preview_service_spec.rb
@@ -6,7 +6,7 @@ RSpec.describe PreviewService do
   end
 
   let(:preview_asset_service) do
-    instance_double(PreviewAssetService, put_all: nil)
+    instance_double(PreviewAssetService, put: nil)
   end
 
   before do
@@ -35,27 +35,40 @@ RSpec.describe PreviewService do
       PreviewService.new(edition).create_preview
     end
 
-    it "delegates previewing assets" do
-      edition = create(:edition)
-      expect(preview_asset_service).to receive(:put_all)
+    it "uploads any image assets" do
+      image_revision = create(:image_revision)
+      edition = create(:edition, image_revisions: [image_revision])
+      expect(preview_asset_service).to receive(:put).at_least(:once)
+      PreviewService.new(edition).create_preview
+    end
+
+    it "uploads any file attachment assets" do
+      file_attachment_revision = create(:file_attachment_revision)
+      edition = create(:edition, file_attachment_revisions: [file_attachment_revision])
+      expect(preview_asset_service).to receive(:put).at_least(:once)
       PreviewService.new(edition).create_preview
     end
 
     context "when Publishing API is down" do
-      it "sets revision_synced to false on the edition" do
+      before do
         stub_publishing_api_isnt_available
-        edition = create(:edition, revision_synced: true)
+      end
 
-        expect { PreviewService.new(edition).create_preview }
-          .to raise_error(GdsApi::BaseError)
+      it "sets revision_synced to false on the edition" do
+        edition = create(:edition, revision_synced: true)
+        expect { PreviewService.new(edition).create_preview }.to raise_error(GdsApi::BaseError)
         expect(edition.revision_synced).to be(false)
       end
     end
 
     context "when the asset upload fails" do
+      before do
+        allow(preview_asset_service).to receive(:put).and_raise(GdsApi::BaseError)
+      end
+
       it "sets revision_synced to false on the edition" do
-        allow(preview_asset_service).to receive(:put_all).and_raise(GdsApi::BaseError)
-        edition = create(:edition, revision_synced: true)
+        image_revision = create(:image_revision)
+        edition = create(:edition, image_revisions: [image_revision], revision_synced: true)
         expect { PreviewService.new(edition).create_preview }.to raise_error(GdsApi::BaseError)
         expect(edition.revision_synced).to be(false)
       end

--- a/spec/services/preview_service_spec.rb
+++ b/spec/services/preview_service_spec.rb
@@ -61,45 +61,4 @@ RSpec.describe PreviewService do
       end
     end
   end
-
-  describe "#try_create_preview" do
-    it "delegates to create_preview" do
-      edition = create(:edition)
-      service = PreviewService.new(edition)
-      expect(service).to receive(:create_preview)
-      service.try_create_preview
-    end
-
-    context "when an external service is down" do
-      it "sets revision_synced to false on the edition" do
-        stub_publishing_api_isnt_available
-        edition = create(:edition, revision_synced: true)
-        PreviewService.new(edition).try_create_preview
-        expect(edition.revision_synced).to be(false)
-      end
-    end
-
-    context "when there are pre-preview issues" do
-      let(:edition) { create(:edition, title: "", revision_synced: true) }
-
-      it "sets revision_synced to false on the edition" do
-        PreviewService.new(edition).try_create_preview
-
-        expect(edition.revision_synced).to be(false)
-      end
-
-      it "doesn't send to the Publishing API" do
-        request = stub_publishing_api_put_content(edition.content_id, {})
-
-        PreviewService.new(edition).try_create_preview
-
-        expect(request).not_to have_been_requested
-      end
-
-      it "delegates cleaning up draft assets" do
-        expect(draft_asset_cleanup_service).to receive(:call).with(edition)
-        PreviewService.new(edition).try_create_preview
-      end
-    end
-  end
 end


### PR DESCRIPTION
https://trello.com/c/6WhtlGQB/1115-finish-work-separating-services-and-non-services-from-services

This refactors the 'try' aspect of the existing PreviewService into a new 'Failsafe' version of the class, working towards our aim of each service having a single responsibility. Doing this creates some 'room' to solve a similar multiple-responsibility issue on the PreviewAssetService.

Please see the commits for more details.