### PR TITLE
Add contact preview component and use it on contact embed insertion

### DIFF
--- a/app/assets/javascripts/application.js
+++ b/app/assets/javascripts/application.js
@@ -16,6 +16,7 @@
 //= require whatwg-fetch/dist/fetch.umd.js
 
 //= require components/autocomplete.js
+//= require components/contact-preview.js
 //= require components/toolbar-dropdown.js
 //= require components/image-cropper.js
 //= require components/input-length-suggester.js

--- a/app/assets/javascripts/components/autocomplete.js
+++ b/app/assets/javascripts/components/autocomplete.js
@@ -64,6 +64,7 @@ window.GOVUK.Modules = window.GOVUK.Modules || {};
         }
       },
       onConfirm: function (result) {
+        var previouslySelectedIndex = $select.selectedIndex
         var value = result && result.value
         var options = [].filter.call($select.options, function (option) {
           return option.value === value
@@ -75,7 +76,9 @@ window.GOVUK.Modules = window.GOVUK.Modules || {};
           $select.selectedIndex = -1 // no option selected
         }
 
-        $select.dispatchEvent(new window.Event('change'))
+        if (previouslySelectedIndex !== $select.selectedIndex) {
+          $select.dispatchEvent(new window.Event('change'))
+        }
       }
     })
 

--- a/app/assets/javascripts/components/autocomplete.js
+++ b/app/assets/javascripts/components/autocomplete.js
@@ -70,8 +70,12 @@ window.GOVUK.Modules = window.GOVUK.Modules || {};
         })
 
         if (options.length) {
-          options[0].selected = true
+          options[0].selected = true // mirror selection
+        } else {
+          $select.selectedIndex = -1 // no option selected
         }
+
+        $select.dispatchEvent(new window.Event('change'))
       }
     })
 

--- a/app/assets/javascripts/components/contact-preview.js
+++ b/app/assets/javascripts/components/contact-preview.js
@@ -1,0 +1,102 @@
+window.GOVUK = window.GOVUK || {}
+window.GOVUK.Modules = window.GOVUK.Modules || {};
+
+(function (Modules) {
+  function ContactPreview () { }
+
+  ContactPreview.prototype.start = function ($module) {
+    this.$module = $module[0]
+
+    this.path = this.getContactPreviewPath()
+    this.errorMessage = this.$module.querySelector('.js-contact-preview-error-message')
+    this.contactPreview = this.$module.querySelector('.js-contact-preview-html')
+    this.selectId = this.$module.dataset.for
+    this.contactSnippetTemplate = this.$module.dataset.contactSnippetTemplate
+    this.$select = document.querySelector('#' + this.selectId)
+    if (!this.$select) {
+      return
+    }
+    this.$select.addEventListener('change', this.handleChange.bind(this))
+  }
+
+  ContactPreview.prototype.getContactPreviewPath = function () {
+    var documentIdRegex = document.location.pathname.match('/documents/([^/]*)/')
+    if (!documentIdRegex) {
+      return
+    }
+
+    var documentId = documentIdRegex[1]
+    if (!documentId) {
+      console.error('Could not find document ID in pathname')
+      return
+    }
+
+    var path = '/documents/' + documentId + '/govspeak-preview'
+    return path
+  }
+
+  ContactPreview.prototype.getContactSnippet = function () {
+    if (this.contactSnippetTemplate && this.$select.value) {
+      return this.contactSnippetTemplate.replace('#', this.$select.value)
+    }
+  }
+
+  ContactPreview.prototype.showErrorMessage = function () {
+    this.$module.classList.add('app-c-contact-preview--hidden')
+    this.contactPreview.classList.add('app-c-contact-preview__html--hidden')
+    this.errorMessage.classList.remove('app-c-contact-preview__error-message--hidden')
+  }
+
+  ContactPreview.prototype.hideContactPreview = function () {
+    this.$module.classList.add('app-c-contact-preview--hidden')
+    this.contactPreview.classList.add('app-c-contact-preview__html--hidden')
+    this.errorMessage.classList.add('app-c-contact-preview__error-message--hidden')
+  }
+
+  ContactPreview.prototype.showContactPreview = function (html) {
+    this.$module.classList.remove('app-c-contact-preview--hidden')
+    this.contactPreview.classList.remove('app-c-contact-preview__html--hidden')
+    this.errorMessage.classList.add('app-c-contact-preview__error-message--hidden')
+    this.contactPreview.innerHTML = html
+  }
+
+  ContactPreview.prototype.fetchContactPreview = function (contactId) {
+    if (!this.path) {
+      throw Error('Invalid fetch path.')
+    }
+
+    var url = new URL(document.location.origin + this.path)
+
+    var formData = new window.FormData()
+    var contactSnippet = this.getContactSnippet()
+    formData.append('govspeak', contactSnippet)
+
+    var controller = new window.AbortController()
+    var options = { credentials: 'include', signal: controller.signal, method: 'POST', body: formData }
+    setTimeout(function () { controller.abort() }, 15000)
+
+    return window.fetch(url, options)
+      .then(function (response) {
+        if (!response.ok) {
+          throw Error('Unable to generate response.')
+        }
+
+        return response.text()
+      })
+  }
+
+  ContactPreview.prototype.handleChange = function (event) {
+    var select = event.target
+
+    if (!select.value) {
+      this.hideContactPreview()
+      return
+    }
+
+    this.fetchContactPreview(select.value)
+      .then(this.showContactPreview.bind(this))
+      .catch(this.showErrorMessage.bind(this))
+  }
+
+  Modules.ContactPreview = ContactPreview
+})(window.GOVUK.Modules)

--- a/app/assets/javascripts/components/contact-preview.js
+++ b/app/assets/javascripts/components/contact-preview.js
@@ -8,6 +8,7 @@ window.GOVUK.Modules = window.GOVUK.Modules || {};
     this.$module = $module[0]
 
     this.errorMessage = this.$module.querySelector('.js-contact-preview-error-message')
+    this.loadingSpinner = this.$module.querySelector('.js-contact-preview-loading-spinner')
     this.contactPreview = this.$module.querySelector('.js-contact-preview-html')
     this.selectId = this.$module.dataset.for
     this.contactSnippetTemplate = this.$module.dataset.contactSnippetTemplate
@@ -28,12 +29,14 @@ window.GOVUK.Modules = window.GOVUK.Modules || {};
   ContactPreview.prototype.showErrorMessage = function () {
     this.$module.classList.add('app-c-contact-preview--hidden')
     this.contactPreview.classList.add('app-c-contact-preview__html--hidden')
+    this.loadingSpinner.classList.add('app-c-contact-preview__loading-spinner--hidden')
     this.errorMessage.classList.remove('app-c-contact-preview__error-message--hidden')
   }
 
   ContactPreview.prototype.hideContactPreview = function () {
     this.$module.classList.add('app-c-contact-preview--hidden')
     this.contactPreview.classList.add('app-c-contact-preview__html--hidden')
+    this.loadingSpinner.classList.add('app-c-contact-preview__loading-spinner--hidden')
     this.errorMessage.classList.add('app-c-contact-preview__error-message--hidden')
   }
 
@@ -41,7 +44,15 @@ window.GOVUK.Modules = window.GOVUK.Modules || {};
     this.$module.classList.remove('app-c-contact-preview--hidden')
     this.contactPreview.classList.remove('app-c-contact-preview__html--hidden')
     this.errorMessage.classList.add('app-c-contact-preview__error-message--hidden')
+    this.loadingSpinner.classList.add('app-c-contact-preview__loading-spinner--hidden')
     this.contactPreview.innerHTML = html
+  }
+
+  ContactPreview.prototype.showLoadingSpinner = function (html) {
+    this.$module.classList.remove('app-c-contact-preview--hidden')
+    this.contactPreview.classList.add('app-c-contact-preview__html--hidden')
+    this.errorMessage.classList.add('app-c-contact-preview__error-message--hidden')
+    this.loadingSpinner.classList.remove('app-c-contact-preview__loading-spinner--hidden')
   }
 
   ContactPreview.prototype.fetchContactPreview = function (contactId) {
@@ -54,6 +65,8 @@ window.GOVUK.Modules = window.GOVUK.Modules || {};
     var controller = new window.AbortController()
     var options = { credentials: 'include', signal: controller.signal, method: 'POST', body: formData }
     setTimeout(function () { controller.abort() }, 15000)
+
+    this.showLoadingSpinner()
 
     return window.fetch(url, options)
       .then(function (response) {

--- a/app/assets/javascripts/components/contact-preview.js
+++ b/app/assets/javascripts/components/contact-preview.js
@@ -7,36 +7,20 @@ window.GOVUK.Modules = window.GOVUK.Modules || {};
   ContactPreview.prototype.start = function ($module) {
     this.$module = $module[0]
 
-    this.path = this.getContactPreviewPath()
     this.errorMessage = this.$module.querySelector('.js-contact-preview-error-message')
     this.contactPreview = this.$module.querySelector('.js-contact-preview-html')
     this.selectId = this.$module.dataset.for
     this.contactSnippetTemplate = this.$module.dataset.contactSnippetTemplate
+    this.path = this.$module.dataset.govspeakPath
     this.$select = document.querySelector('#' + this.selectId)
-    if (!this.$select) {
+    if (!this.$select || !this.path || !this.contactSnippetTemplate) {
       return
     }
     this.$select.addEventListener('change', this.handleChange.bind(this))
   }
 
-  ContactPreview.prototype.getContactPreviewPath = function () {
-    var documentIdRegex = document.location.pathname.match('/documents/([^/]*)/')
-    if (!documentIdRegex) {
-      return
-    }
-
-    var documentId = documentIdRegex[1]
-    if (!documentId) {
-      console.error('Could not find document ID in pathname')
-      return
-    }
-
-    var path = '/documents/' + documentId + '/govspeak-preview'
-    return path
-  }
-
   ContactPreview.prototype.getContactSnippet = function () {
-    if (this.contactSnippetTemplate && this.$select.value) {
+    if (this.$select.value) {
       return this.contactSnippetTemplate.replace('#', this.$select.value)
     }
   }
@@ -61,10 +45,6 @@ window.GOVUK.Modules = window.GOVUK.Modules || {};
   }
 
   ContactPreview.prototype.fetchContactPreview = function (contactId) {
-    if (!this.path) {
-      throw Error('Invalid fetch path.')
-    }
-
     var url = new URL(document.location.origin + this.path)
 
     var formData = new window.FormData()

--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -9,6 +9,7 @@
 
 @import "components/autocomplete";
 @import "components/attachment-meta";
+@import "components/contact-preview";
 @import "components/formatted-text";
 @import "components/image-cropper";
 @import "components/image-meta";

--- a/app/assets/stylesheets/components/_contact-preview.scss
+++ b/app/assets/stylesheets/components/_contact-preview.scss
@@ -12,6 +12,10 @@
       border: 0;
     }
   }
+
+  .app-c-loading-spinner {
+    padding: govuk-spacing(8);
+  }
 }
 
 .app-c-contact-preview__error-message,
@@ -21,6 +25,7 @@
 
 .app-c-contact-preview--hidden,
 .app-c-contact-preview__error-message--hidden,
-.app-c-contact-preview__html--hidden {
+.app-c-contact-preview__html--hidden,
+.app-c-contact-preview__loading-spinner--hidden {
   display: none;
 }

--- a/app/assets/stylesheets/components/_contact-preview.scss
+++ b/app/assets/stylesheets/components/_contact-preview.scss
@@ -1,0 +1,26 @@
+.app-c-contact-preview {
+  @include govuk-font(19);
+
+  @include govuk-responsive-margin(6, "bottom");
+
+  .govuk-inset-text {
+    margin-top: 0;
+
+    .contact {
+      margin: 0;
+      padding: 0;
+      border: 0;
+    }
+  }
+}
+
+.app-c-contact-preview__error-message,
+.app-c-contact-preview__html {
+  margin: 0;
+}
+
+.app-c-contact-preview--hidden,
+.app-c-contact-preview__error-message--hidden,
+.app-c-contact-preview__html--hidden {
+  display: none;
+}

--- a/app/controllers/contact_embed_controller.rb
+++ b/app/controllers/contact_embed_controller.rb
@@ -7,24 +7,30 @@ class ContactEmbedController < ApplicationController
   end
 
   def new
+    @edition = Edition.find_current(document: params[:document])
     render layout: rendering_context
   end
 
   def create
     result = ContactEmbed::CreateInteractor.call(params: params)
-    markdown_code, issues = result.to_h.values_at(:markdown_code, :issues)
+
+    edition, markdown_code, issues = result.to_h.values_at(:edition,
+                                                           :markdown_code,
+                                                           :issues)
 
     if issues
       flash.now["requirements"] = { "items" => issues.items }
 
       render :new,
-             assigns: { issues: issues },
+             assigns: { edition: edition, issues: issues },
              layout: rendering_context,
              status: :unprocessable_entity
     elsif rendering_context == "modal"
       render inline: markdown_code
     else
-      render "new", layout: rendering_context
+      render :new,
+             assigns: { markdown_code: markdown_code, edition: edition },
+             layout: rendering_context
     end
   end
 end

--- a/app/interactors/contact_embed/create_interactor.rb
+++ b/app/interactors/contact_embed/create_interactor.rb
@@ -3,15 +3,21 @@
 class ContactEmbed::CreateInteractor < ApplicationInteractor
   delegate :params,
            :markdown_code,
+           :edition,
            :issues,
            to: :context
 
   def call
+    find_edition
     check_for_issues
     generate_markdown_code
   end
 
 private
+
+  def find_edition
+    context.edition = Edition.find_current(document: params[:document])
+  end
 
   def check_for_issues
     return if params[:contact_id].present?

--- a/app/views/components/_contact_preview.html.erb
+++ b/app/views/components/_contact_preview.html.erb
@@ -1,0 +1,17 @@
+<%
+  error_message ||= nil
+  html ||= nil
+  data_attributes ||= {}
+  root_classes = %w[app-c-contact-preview]
+  root_classes << "app-c-contact-preview--hidden" unless html
+%>
+<%= tag.div class: root_classes, data: data_attributes.merge(module: "contact-preview") do %>
+  <% contact_preview = capture do %>
+    <%= tag.p error_message, class: "app-c-contact-preview__error-message app-c-contact-preview__error-message--hidden js-contact-preview-error-message" %>
+    <%= tag.div html, class: "app-c-contact-preview__html js-contact-preview-html" %>
+  <% end %>
+
+  <%= render "govuk_publishing_components/components/inset_text", {
+    text: contact_preview
+  } %>
+<% end %>

--- a/app/views/components/_contact_preview.html.erb
+++ b/app/views/components/_contact_preview.html.erb
@@ -8,6 +8,7 @@
 <%= tag.div class: root_classes, data: data_attributes.merge(module: "contact-preview") do %>
   <% contact_preview = capture do %>
     <%= tag.p error_message, class: "app-c-contact-preview__error-message app-c-contact-preview__error-message--hidden js-contact-preview-error-message" %>
+    <%= tag.div render("components/loading_spinner"), class: "app-c-contact-preview__loading-spinner app-c-contact-preview__loading-spinner--hidden js-contact-preview-loading-spinner" %>
     <%= tag.div html, class: "app-c-contact-preview__html js-contact-preview-html" %>
   <% end %>
 

--- a/app/views/components/docs/contact_preview.yml
+++ b/app/views/components/docs/contact_preview.yml
@@ -1,0 +1,27 @@
+name: Contact preview
+description: Generates a preview of a given govspeak contact snippet from a select element
+body: |
+  This component uses a select element to get the contact ID, converts the ID to a govspeak contact snippet
+  and sends it to a server endpoint to get the appropriate response.
+
+  It also supports the a static approach, where the preview is passed to the `html` option.
+accessibility_criteria: |
+  The component must:
+
+  * update its content to reflect changes in the referenced select element
+examples:
+  default:
+    data:
+      html: |
+        <div class="gem-c-govspeak">
+          <div class="contact">
+            <div class="content">
+              <h3>Government Legal Department</h3>
+              <div class="vcard contact-inner">
+                <p class="adr">Croydon, CR90 9QU</p>
+              </div>
+              <p class="comments">Find contact details and the opening hours.</p>
+            </div>
+          </div>
+        </div>
+      error_message: Unable to generate preview

--- a/app/views/contact_embed/new.html.erb
+++ b/app/views/contact_embed/new.html.erb
@@ -49,9 +49,7 @@
     margin_bottom: 3,
   } %>
 
-  <p class="govuk-body"><%= t("contact_embed.new.contact_instructions") %></p>
+  <%= tag.p t("contact_embed.new.contact_instructions"), class: "govuk-body" %>
 <% end %>
 
-<%= tag.p class: "govuk-body" do %>
-  <%= render_govspeak(t("contact_embed.new.contact_not_available_govspeak")) %>
-<% end %>
+<%= render_govspeak(t("contact_embed.new.contact_not_available_govspeak")) %>

--- a/app/views/contact_embed/new.html.erb
+++ b/app/views/contact_embed/new.html.erb
@@ -31,6 +31,16 @@
     search: true,
   } %>
 
+  <% contact_preview = render_govspeak(t("contact_embed.new.contact_markdown", id: params[:contact_id])) if params[:contact_id].present? %>
+  <%= render "components/contact_preview", {
+    error_message: t("contact_embed.new.preview_error"),
+    data_attributes: {
+      "for": "contact-id-select",
+      "contact-snippet-template": t("contact_embed.new.contact_markdown", id: "#")
+    },
+    html: contact_preview
+  } %>
+
   <%= render "govuk_publishing_components/components/button", {
     text: rendering_context == "modal" ? "Insert contact" : "Show markdown code",
     margin_bottom: true

--- a/app/views/contact_embed/new.html.erb
+++ b/app/views/contact_embed/new.html.erb
@@ -31,12 +31,16 @@
     search: true,
   } %>
 
-  <% contact_preview = render_govspeak(t("contact_embed.new.contact_markdown", id: params[:contact_id])) if params[:contact_id].present? %>
+  <% if @markdown_code.present? %>
+    <% contact_preview = raw(GovspeakDocument.new(@markdown_code, @edition).in_app_html) %>
+  <% end %>
+
   <%= render "components/contact_preview", {
     error_message: t("contact_embed.new.preview_error"),
     data_attributes: {
       "for": "contact-id-select",
-      "contact-snippet-template": t("contact_embed.new.contact_markdown", id: "#")
+      "contact-snippet-template": t("contact_embed.new.contact_markdown", id: "#"),
+      "govspeak-path": govspeak_preview_path(@edition.document)
     },
     html: contact_preview
   } %>

--- a/config/locales/en/contact_embed/new.yml
+++ b/config/locales/en/contact_embed/new.yml
@@ -12,3 +12,4 @@ en:
         where you want the file to appear.
       contact_not_available_govspeak: |
         If the contact you need is not available or is out of date, edit your organisation's contacts. [Full guidance on adding or editing contacts](https://www.gov.uk/guidance/how-to-publish-on-gov-uk/organisation-pages#organisation-contacts){:target="_blank"}.
+      preview_error: Unable to preview contact.

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -78,6 +78,9 @@ Rails.application.routes.draw do
 
     post "/editions" => "editions#create", as: :create_edition
 
+    get "/contact-embed" => "contact_embed#new"
+    post "/contact-embed" => "contact_embed#create"
+
     post "/govspeak-preview" => "govspeak_preview#to_html", as: :govspeak_preview
 
     get "/file-attachments" => "file_attachments#index", as: :file_attachments
@@ -97,9 +100,6 @@ Rails.application.routes.draw do
 
   get "/video-embed" => "video_embed#new", as: :video_embed
   post "/video-embed" => "video_embed#create", as: :create_video_embed
-
-  get "/contact-embed" => "contact_embed#new"
-  post "/contact-embed" => "contact_embed#create"
 
   scope via: :all do
     match "/400" => "errors#bad_request"

--- a/spec/features/editing_content/insert_contact_embed_no_js_spec.rb
+++ b/spec/features/editing_content/insert_contact_embed_no_js_spec.rb
@@ -9,6 +9,7 @@ RSpec.feature "Insert contact embed without Javascript" do
     and_i_go_to_add_a_contact
     when_i_select_a_contact
     then_i_see_the_contact_markdown_snippet
+    and_i_see_a_preview_of_the_contact
   end
 
   def given_there_is_an_edition
@@ -47,5 +48,11 @@ RSpec.feature "Insert contact embed without Javascript" do
   def then_i_see_the_contact_markdown_snippet
     snippet = I18n.t("contact_embed.new.contact_markdown", id: @contact["content_id"])
     expect(page).to have_content(snippet)
+  end
+
+  def and_i_see_a_preview_of_the_contact
+    within(".app-c-contact-preview") do
+      expect(page).to have_content(@contact["title"])
+    end
   end
 end

--- a/spec/features/editing_content/insert_contact_embed_spec.rb
+++ b/spec/features/editing_content/insert_contact_embed_spec.rb
@@ -8,6 +8,8 @@ RSpec.feature "Insert contact embed", js: true do
     when_i_go_to_edit_the_edition
     and_i_click_to_insert_a_contact
     and_i_select_a_contact
+    then_i_see_the_contact_preview
+    when_i_click_insert_contact
     then_i_see_the_snippet_is_inserted
   end
 
@@ -43,6 +45,15 @@ RSpec.feature "Insert contact embed", js: true do
     accessible_autocomplete_select "Contact",
                                    for_id: "contact-id",
                                    value: @contact["content_id"]
+  end
+
+  def then_i_see_the_contact_preview
+    within(".gem-c-modal-dialogue .app-c-contact-preview") do
+      expect(page).to have_content(@contact["title"])
+    end
+  end
+
+  def when_i_click_insert_contact
     click_on "Insert contact"
   end
 

--- a/spec/javascripts/components/contact-preview-spec.js
+++ b/spec/javascripts/components/contact-preview-spec.js
@@ -14,7 +14,7 @@ describe('Contact preview component', function () {
         '<option value="63e37a39-aa4a-417a-9844-5aa308c7bf0d">Government Legal Department</option>' +
       '</select>' +
 
-      '<div class="app-c-contact-preview app-c-contact-preview--hidden" data-module="contact-preview" data-for="contact-id-select" data-contact-snippet-template="[Contact: #]">' +
+      '<div class="app-c-contact-preview app-c-contact-preview--hidden" data-module="contact-preview" data-for="contact-id-select" data-contact-snippet-template="[Contact: #]" data-govspeak-path="/">' +
         '<div class="gem-c-inset-text govuk-inset-text">' +
           '<p class="app-c-contact-preview__error-message app-c-contact-preview__error-message--hidden js-contact-preview-error-message">Unable to generate preview</p>' +
           '<div class="app-c-contact-preview__html js-contact-preview-html"></div>' +

--- a/spec/javascripts/components/contact-preview-spec.js
+++ b/spec/javascripts/components/contact-preview-spec.js
@@ -17,6 +17,7 @@ describe('Contact preview component', function () {
       '<div class="app-c-contact-preview app-c-contact-preview--hidden" data-module="contact-preview" data-for="contact-id-select" data-contact-snippet-template="[Contact: #]" data-govspeak-path="/">' +
         '<div class="gem-c-inset-text govuk-inset-text">' +
           '<p class="app-c-contact-preview__error-message app-c-contact-preview__error-message--hidden js-contact-preview-error-message">Unable to generate preview</p>' +
+          '<div class="app-c-contact-preview__loading-spinner app-c-contact-preview__loading-spinner--hidden js-contact-preview-loading-spinner">Loading...</div>' +
           '<div class="app-c-contact-preview__html js-contact-preview-html"></div>' +
         '</div>' +
       '</div>'
@@ -60,6 +61,9 @@ describe('Contact preview component', function () {
 
     var errorMessage = document.querySelector('.js-contact-preview-error-message')
     expect(errorMessage).toBeHidden()
+
+    var loadingContainer = document.querySelector('.js-contact-preview-loading-spinner')
+    expect(loadingContainer).toBeHidden()
   })
 
   it('should remove the preview container if no option is selected', async function () {

--- a/spec/javascripts/components/contact-preview-spec.js
+++ b/spec/javascripts/components/contact-preview-spec.js
@@ -1,0 +1,78 @@
+/* eslint-env jasmine, jquery */
+/* global GOVUK */
+
+describe('Contact preview component', function () {
+  'use strict'
+
+  var container
+
+  beforeEach(function () {
+    container = document.createElement('div')
+    container.innerHTML =
+      '<select name="contact_id" id="contact-id-select" class="govuk-select">' +
+        '<option value=""></option>' +
+        '<option value="63e37a39-aa4a-417a-9844-5aa308c7bf0d">Government Legal Department</option>' +
+      '</select>' +
+
+      '<div class="app-c-contact-preview app-c-contact-preview--hidden" data-module="contact-preview" data-for="contact-id-select" data-contact-snippet-template="[Contact: #]">' +
+        '<div class="gem-c-inset-text govuk-inset-text">' +
+          '<p class="app-c-contact-preview__error-message app-c-contact-preview__error-message--hidden js-contact-preview-error-message">Unable to generate preview</p>' +
+          '<div class="app-c-contact-preview__html js-contact-preview-html"></div>' +
+        '</div>' +
+      '</div>'
+
+    document.body.appendChild(container)
+    var element = document.querySelector('[data-module="contact-preview"]')
+    new GOVUK.Modules.ContactPreview().start($(element))
+  })
+
+  afterEach(function () {
+    document.body.removeChild(container)
+  })
+
+  it('should display the contact preview if an option is selected', async function () {
+    var contactPreview = '<div class="gem-c-govspeak">' +
+      '<div class="contact">' +
+        '<div class="content">' +
+          '<h3>Government Legal Department</h3>' +
+          '<div class="vcard contact-inner">' +
+            '<p class="adr">Croydon, CR90 9QU</p>' +
+          '</div>' +
+          '<p class="comments">Find contact details and the opening hours.</p>' +
+        '</div>' +
+      '</div>' +
+    '</div>'
+
+    spyOn(GOVUK.Modules.ContactPreview.prototype, 'fetchContactPreview').and.returnValue(Promise.resolve(contactPreview))
+
+    var select = document.querySelector('#contact-id-select')
+    select.options[1].selected = true
+    await select.dispatchEvent(new window.Event('change'))
+
+    expect(GOVUK.Modules.ContactPreview.prototype.fetchContactPreview).toHaveBeenCalledWith(select.value)
+
+    var element = document.querySelector('[data-module="contact-preview"]')
+    expect(element).toBeVisible()
+
+    var previewContainer = document.querySelector('.js-contact-preview-html')
+    expect(previewContainer).toBeVisible()
+    expect(previewContainer.innerHTML).toEqual(contactPreview)
+
+    var errorMessage = document.querySelector('.js-contact-preview-error-message')
+    expect(errorMessage).toBeHidden()
+  })
+
+  it('should remove the preview container if no option is selected', async function () {
+    spyOn(GOVUK.Modules.ContactPreview.prototype, 'hideContactPreview').and.callThrough()
+
+    var select = document.querySelector('#contact-id-select')
+    select.options[1].selected = true // select first item
+    select.selectedIndex = -1 // reset option selection
+    await select.dispatchEvent(new window.Event('change'))
+
+    expect(GOVUK.Modules.ContactPreview.prototype.hideContactPreview).toHaveBeenCalled()
+
+    var element = document.querySelector('[data-module="contact-preview"]')
+    expect(element).toBeHidden()
+  })
+})


### PR DESCRIPTION
This PR:
- creates a new contact preview component (following the pattern used in the url preview component) - this component refers and uses a select element as a source of truth, a govspeak snippet template and a govspeak path (all being passed as data attributes at component's root level)
- uses the contact preview component it in the contact embed view and
- updates the contact autocomplete to properly sync the select element that's enhanced by it.

See previews in the [previous approach](https://github.com/alphagov/content-publisher/pull/1310) (as the outcome is the same).

[Trello card](https://trello.com/c/8NN6jQiI/1025-modal-experience-for-contacts)
[Trello card](https://trello.com/c/6uzRis6D/1145-when-a-user-chooses-a-contact-they-can-preview-it-and-insert-it-in-content)