### PR TITLE
Introduce a new ApplicationService class

### DIFF
--- a/app/controllers/documents_controller.rb
+++ b/app/controllers/documents_controller.rb
@@ -59,7 +59,7 @@ class DocumentsController < ApplicationController
 
   def generate_path
     edition = Edition.find_current(document: params[:document])
-    base_path = PathGeneratorService.new.path(edition.document, params[:title])
+    base_path = PathGeneratorService.call(edition.document, params[:title])
     render plain: base_path
   end
 

--- a/app/interactors/access_limit/update_interactor.rb
+++ b/app/interactors/access_limit/update_interactor.rb
@@ -72,6 +72,6 @@ private
   end
 
   def update_preview
-    FailsafePreviewService.new(edition).create_preview
+    FailsafePreviewService.call(edition)
   end
 end

--- a/app/interactors/backdate/destroy_interactor.rb
+++ b/app/interactors/backdate/destroy_interactor.rb
@@ -41,6 +41,6 @@ private
   end
 
   def update_preview
-    FailsafePreviewService.new(edition).create_preview
+    FailsafePreviewService.call(edition)
   end
 end

--- a/app/interactors/backdate/update_interactor.rb
+++ b/app/interactors/backdate/update_interactor.rb
@@ -65,6 +65,6 @@ private
   end
 
   def update_preview
-    FailsafePreviewService.new(edition).create_preview
+    FailsafePreviewService.call(edition)
   end
 end

--- a/app/interactors/documents/destroy_interactor.rb
+++ b/app/interactors/documents/destroy_interactor.rb
@@ -23,7 +23,7 @@ private
   end
 
   def discard_draft
-    DeleteDraftService.new(edition.document, user).delete
+    DeleteDraftService.call(edition.document, user)
   rescue GdsApi::BaseError => e
     GovukError.notify(e)
     context.fail!(api_error: true)

--- a/app/interactors/documents/update_interactor.rb
+++ b/app/interactors/documents/update_interactor.rb
@@ -48,7 +48,7 @@ private
   end
 
   def update_preview
-    FailsafePreviewService.new(edition).create_preview
+    FailsafePreviewService.call(edition)
   end
 
   def update_params(edition)
@@ -59,7 +59,7 @@ private
       .tap do |p|
         p[:title] = p[:title]&.strip
         p[:summary] = p[:summary]&.strip
-        p[:base_path] = PathGeneratorService.new.path(edition.document, p[:title])
+        p[:base_path] = PathGeneratorService.call(edition.document, p[:title])
       end
   end
 end

--- a/app/interactors/file_attachments/create_interactor.rb
+++ b/app/interactors/file_attachments/create_interactor.rb
@@ -33,8 +33,8 @@ private
   end
 
   def upload_attachment
-    blob_revision = FileAttachmentBlobService.new(edition.revision, user)
-                                             .create_blob_revision(params[:file])
+    blob_revision = FileAttachmentBlobService.call(edition.revision, user, params[:file])
+
     context.attachment_revision = FileAttachment::Revision.create_initial(
       blob_revision: blob_revision,
       title: params[:title],
@@ -52,6 +52,6 @@ private
   end
 
   def update_preview
-    FailsafePreviewService.new(edition).create_preview
+    FailsafePreviewService.call(edition)
   end
 end

--- a/app/interactors/file_attachments/destroy_interactor.rb
+++ b/app/interactors/file_attachments/destroy_interactor.rb
@@ -37,6 +37,6 @@ private
   end
 
   def update_preview
-    FailsafePreviewService.new(edition).create_preview
+    FailsafePreviewService.call(edition)
   end
 end

--- a/app/interactors/file_attachments/preview_interactor.rb
+++ b/app/interactors/file_attachments/preview_interactor.rb
@@ -31,7 +31,7 @@ private
     asset = attachment_revision.asset
 
     if asset.absent?
-      PreviewAssetService.new(edition).put(asset)
+      PreviewAssetService.call(edition, asset)
       context.can_preview = false
       return
     end

--- a/app/interactors/file_attachments/update_interactor.rb
+++ b/app/interactors/file_attachments/update_interactor.rb
@@ -65,7 +65,7 @@ private
   end
 
   def update_preview
-    FailsafePreviewService.new(edition).create_preview
+    FailsafePreviewService.call(edition)
   end
 
   def attachment_params
@@ -73,7 +73,6 @@ private
   end
 
   def blob_revision(file)
-    FileAttachmentBlobService.new(edition.revision, user)
-                             .create_blob_revision(file, replacing: file_attachment_revision)
+    FileAttachmentBlobService.call(edition.revision, user, file, replacing: file_attachment_revision)
   end
 end

--- a/app/interactors/images/create_interactor.rb
+++ b/app/interactors/images/create_interactor.rb
@@ -38,7 +38,7 @@ private
   end
 
   def create_image_revision
-    blob_revision = ImageBlobService.new(edition.revision, user, temp_image).call
+    blob_revision = ImageBlobService.call(edition.revision, user, temp_image)
     context.image_revision = Image::Revision.create_initial(blob_revision: blob_revision)
   end
 

--- a/app/interactors/images/destroy_interactor.rb
+++ b/app/interactors/images/destroy_interactor.rb
@@ -37,6 +37,6 @@ private
   end
 
   def update_preview
-    FailsafePreviewService.new(edition).create_preview
+    FailsafePreviewService.call(edition)
   end
 end

--- a/app/interactors/images/update_crop_interactor.rb
+++ b/app/interactors/images/update_crop_interactor.rb
@@ -59,6 +59,6 @@ private
   end
 
   def update_preview
-    FailsafePreviewService.new(edition).create_preview
+    FailsafePreviewService.call(edition)
   end
 end

--- a/app/interactors/images/update_interactor.rb
+++ b/app/interactors/images/update_interactor.rb
@@ -73,6 +73,6 @@ private
   end
 
   def update_preview
-    FailsafePreviewService.new(edition).create_preview
+    FailsafePreviewService.call(edition)
   end
 end

--- a/app/interactors/lead_image/choose_interactor.rb
+++ b/app/interactors/lead_image/choose_interactor.rb
@@ -43,6 +43,6 @@ private
   end
 
   def update_preview
-    FailsafePreviewService.new(edition).create_preview
+    FailsafePreviewService.call(edition)
   end
 end

--- a/app/interactors/lead_image/remove_interactor.rb
+++ b/app/interactors/lead_image/remove_interactor.rb
@@ -43,6 +43,6 @@ private
   end
 
   def update_preview
-    FailsafePreviewService.new(edition).create_preview
+    FailsafePreviewService.call(edition)
   end
 end

--- a/app/interactors/preview/create_interactor.rb
+++ b/app/interactors/preview/create_interactor.rb
@@ -29,7 +29,7 @@ private
   end
 
   def create_preview
-    PreviewService.new(edition).create_preview
+    PreviewService.call(edition)
   rescue GdsApi::BaseError => e
     GovukError.notify(e)
     context.fail!(preview_failed: true)

--- a/app/interactors/publish/publish_interactor.rb
+++ b/app/interactors/publish/publish_interactor.rb
@@ -46,7 +46,7 @@ private
   end
 
   def publish_edition
-    PublishService.new(edition).publish(user: user, with_review: with_review?)
+    PublishService.call(edition, user, with_review: with_review?)
   rescue GdsApi::BaseError
     context.fail!(publish_failed: true)
   end

--- a/app/interactors/schedule/create_interactor.rb
+++ b/app/interactors/schedule/create_interactor.rb
@@ -46,7 +46,7 @@ private
                                 reviewed: params[:review_status] == "reviewed",
                                 publish_time: edition.proposed_publish_time)
 
-    ScheduleService.new(edition).schedule(scheduling, user)
+    ScheduleService.call(edition, user, scheduling)
   end
 
   def create_timeline_entry

--- a/app/interactors/schedule/update_interactor.rb
+++ b/app/interactors/schedule/update_interactor.rb
@@ -43,7 +43,7 @@ private
     context.fail! if publish_time == scheduling.publish_time
 
     new_scheduling = scheduling.dup.tap { |s| s.publish_time = publish_time }
-    ScheduleService.new(edition).schedule(new_scheduling, user)
+    ScheduleService.call(edition, user, new_scheduling)
   end
 
   def create_timeline_entry

--- a/app/interactors/tags/update_interactor.rb
+++ b/app/interactors/tags/update_interactor.rb
@@ -51,7 +51,7 @@ private
   end
 
   def update_preview
-    FailsafePreviewService.new(edition).create_preview
+    FailsafePreviewService.call(edition)
   end
 
   def update_params(edition)

--- a/app/interactors/withdraw/create_interactor.rb
+++ b/app/interactors/withdraw/create_interactor.rb
@@ -44,7 +44,7 @@ private
   end
 
   def withdraw_edition
-    WithdrawService.new.call(edition, params[:public_explanation], user)
+    WithdrawService.call(edition, params[:public_explanation], user)
   rescue GdsApi::BaseError => e
     GovukError.notify(e)
     context.fail!(api_error: true)

--- a/app/services/application_service.rb
+++ b/app/services/application_service.rb
@@ -1,0 +1,9 @@
+# frozen_string_literal: true
+
+class ApplicationService
+  private_class_method :new
+
+  def self.call(*args)
+    new(*args).call
+  end
+end

--- a/app/services/delete_draft_service.rb
+++ b/app/services/delete_draft_service.rb
@@ -1,14 +1,12 @@
 # frozen_string_literal: true
 
-class DeleteDraftService
-  attr_reader :document, :user
-
+class DeleteDraftService < ApplicationService
   def initialize(document, user)
     @document = document
     @user = user
   end
 
-  def delete
+  def call
     edition = document.current_edition
 
     raise "Trying to delete a document without a current edition" unless edition
@@ -27,6 +25,8 @@ class DeleteDraftService
   end
 
 private
+
+  attr_reader :document, :user
 
   def discard_path_reservations(edition)
     paths = edition.revisions.map(&:base_path).uniq.compact

--- a/app/services/draft_asset_cleanup_service.rb
+++ b/app/services/draft_asset_cleanup_service.rb
@@ -1,7 +1,11 @@
 # frozen_string_literal: true
 
-class DraftAssetCleanupService
-  def call(edition)
+class DraftAssetCleanupService < ApplicationService
+  def initialize(edition)
+    @edition = edition
+  end
+
+  def call
     current_revision = edition.revision
     previous_revision = current_revision.preceded_by
 
@@ -11,6 +15,8 @@ class DraftAssetCleanupService
   end
 
 private
+
+  attr_reader :edition
 
   def delete_assets(assets)
     assets.each do |asset|

--- a/app/services/failsafe_preview_service.rb
+++ b/app/services/failsafe_preview_service.rb
@@ -1,18 +1,16 @@
 # frozen_string_literal: true
 
-class FailsafePreviewService
-  attr_reader :edition
-
+class FailsafePreviewService < ApplicationService
   def initialize(edition)
     @edition = edition
   end
 
-  def create_preview
+  def call
     if has_issues?
-      DraftAssetCleanupService.new.call(edition)
+      DraftAssetCleanupService.call(edition)
       edition.update!(revision_synced: false)
     else
-      PreviewService.new(edition).create_preview
+      PreviewService.call(edition)
     end
   rescue GdsApi::BaseError => e
     edition.update!(revision_synced: false)
@@ -20,6 +18,8 @@ class FailsafePreviewService
   end
 
 private
+
+  attr_reader :edition
 
   def has_issues?
     Requirements::EditionChecker.new(edition).pre_preview_issues.any?

--- a/app/services/image_blob_service.rb
+++ b/app/services/image_blob_service.rb
@@ -2,7 +2,7 @@
 
 require "mini_magick"
 
-class ImageBlobService
+class ImageBlobService < ApplicationService
   def initialize(revision, user, temp_image)
     @revision = revision
     @user = user
@@ -36,8 +36,8 @@ private
   def unique_filename
     filenames = revision.image_revisions.map(&:filename)
 
-    @unique_filename ||= UniqueFilenameService.new(filenames)
-      .call(temp_image.original_filename)
+    @unique_filename ||= UniqueFilenameService
+      .call(filenames, temp_image.original_filename)
   end
 
   def centre_crop

--- a/app/services/path_generator_service.rb
+++ b/app/services/path_generator_service.rb
@@ -1,33 +1,35 @@
 # frozen_string_literal: true
 
-class PathGeneratorService
-  class ErrorGeneratingPath < RuntimeError
-  end
-
-  def initialize(max_repeated_titles = 1000)
+class PathGeneratorService < ApplicationService
+  def initialize(document, proposed_title, max_repeated_titles: 1000)
+    @document = document
+    @proposed_title = proposed_title
     @max_repeated_titles = max_repeated_titles
   end
 
-  def path(document, proposed_title)
+  def call
     prefix = document.document_type.path_prefix
     slug = proposed_title.parameterize
     base_path = create_path(prefix, slug)
-    return base_path unless document_exists_with_path?(base_path, document)
+    return base_path unless path_in_use?(base_path)
 
-    find_a_unique_path(document, prefix, slug)
+    find_a_unique_path(prefix, slug)
   end
 
 private
 
-  def find_a_unique_path(document, prefix, slug)
-    (1..@max_repeated_titles).each do |appended_count|
+  attr_reader :document, :proposed_title, :max_repeated_titles
+
+  def find_a_unique_path(prefix, slug)
+    (1..max_repeated_titles).each do |appended_count|
       base_path = create_path(prefix, slug, appended_count)
-      return base_path unless document_exists_with_path?(base_path, document)
+      return base_path unless path_in_use?(base_path)
     end
-    raise(ErrorGeneratingPath, "Already >#{@max_repeated_titles} paths with same title.")
+
+    raise "Already >#{max_repeated_titles} paths with same title."
   end
 
-  def document_exists_with_path?(base_path, document)
+  def path_in_use?(base_path)
     Document.using_base_path(base_path)
             .where.not("documents.id": document.id)
             .exists?

--- a/app/services/preview_asset_service.rb
+++ b/app/services/preview_asset_service.rb
@@ -1,13 +1,12 @@
 # frozen_string_literal: true
 
-class PreviewAssetService
-  attr_reader :edition
-
-  def initialize(edition)
+class PreviewAssetService < ApplicationService
+  def initialize(edition, asset)
     @edition = edition
+    @asset = asset
   end
 
-  def put(asset)
+  def call
     if asset.draft?
       update(asset)
     elsif asset.absent?
@@ -19,6 +18,8 @@ class PreviewAssetService
   end
 
 private
+
+  attr_reader :edition, :asset
 
   def update(asset)
     payload = Payload.new(edition).for_update

--- a/app/services/publish_asset_service.rb
+++ b/app/services/publish_asset_service.rb
@@ -1,13 +1,20 @@
 # frozen_string_literal: true
 
-class PublishAssetService
-  def publish_assets(edition, live_edition)
+class PublishAssetService < ApplicationService
+  def initialize(edition, live_edition)
+    @edition = edition
+    @live_edition = live_edition
+  end
+
+  def call
     edition.assets.each { |asset| publish_asset(asset) }
-    retire_old_file_attachments(edition, live_edition)
-    retire_old_images(edition, live_edition)
+    retire_old_file_attachments
+    retire_old_images
   end
 
 private
+
+  attr_reader :edition, :live_edition
 
   def publish_asset(asset)
     raise "Expected asset to be on asset manager" if asset.absent?
@@ -23,7 +30,7 @@ private
     asset.live!
   end
 
-  def retire_old_file_attachments(edition, live_edition)
+  def retire_old_file_attachments
     return unless live_edition
 
     live_edition.file_attachment_revisions.each do |live_revision|
@@ -37,7 +44,7 @@ private
     end
   end
 
-  def retire_old_images(edition, live_edition)
+  def retire_old_images
     return unless live_edition
 
     live_edition.image_revisions.each do |live_revision|

--- a/app/services/schedule_service.rb
+++ b/app/services/schedule_service.rb
@@ -1,19 +1,21 @@
 # frozen_string_literal: true
 
-class ScheduleService
-  attr_reader :edition
-
-  def initialize(edition)
+class ScheduleService < ApplicationService
+  def initialize(edition, user, scheduling)
     @edition = edition
+    @user = user
+    @scheduling = scheduling
   end
 
-  def schedule(scheduling, user)
+  def call
     update_edition(scheduling, user)
     create_or_update_publish_intent
     schedule_to_publish(scheduling)
   end
 
 private
+
+  attr_reader :edition, :user, :scheduling
 
   def update_edition(scheduling, user)
     updater = Versioning::RevisionUpdater.new(edition.revision, user)

--- a/app/services/scheduled_publishing_failed_service.rb
+++ b/app/services/scheduled_publishing_failed_service.rb
@@ -1,7 +1,11 @@
 # frozen_string_literal: true
 
-class ScheduledPublishingFailedService
-  def call(edition_id)
+class ScheduledPublishingFailedService < ApplicationService
+  def initialize(edition_id)
+    @edition_id = edition_id
+  end
+
+  def call
     edition = nil
 
     Edition.transaction do
@@ -14,6 +18,8 @@ class ScheduledPublishingFailedService
   end
 
 private
+
+  attr_reader :edition_id
 
   def update_status(edition)
     raise "Expected edition to be scheduled" unless edition.scheduled?

--- a/app/services/unique_filename_service.rb
+++ b/app/services/unique_filename_service.rb
@@ -1,18 +1,17 @@
 # frozen_string_literal: true
 
-class UniqueFilenameService
+class UniqueFilenameService < ApplicationService
   MAX_LENGTH = 65
 
-  def initialize(existing_filenames)
+  def initialize(existing_filenames, suggested_name)
     @existing_filenames = existing_filenames
+    @suggested_name = suggested_name
   end
 
-  def call(suggested_name)
+  def call
     filename = ActiveStorage::Filename.new(suggested_name)
-
     base = filename.base.parameterize.slice 0...MAX_LENGTH
     base = ensure_unique(base)
-
     return base if filename.extension.blank?
 
     "#{base}.#{filename.extension}"
@@ -20,7 +19,7 @@ class UniqueFilenameService
 
 private
 
-  attr_reader :existing_filenames
+  attr_reader :existing_filenames, :suggested_name
 
   def ensure_unique(base)
     potential_conflicts = existing_filenames

--- a/lib/tasks/unpublish.rake
+++ b/lib/tasks/unpublish.rake
@@ -15,7 +15,7 @@ namespace :unpublish do
     removal = Removal.new(explanatory_note: explanatory_note,
                           alternative_path: alternative_path)
 
-    RemoveService.new.call(document.live_edition, removal)
+    RemoveService.call(document.live_edition, removal)
   end
 
   desc "Remove and redirect a document on GOV.UK e.g. unpublish:remove_and_redirect['a-content-id'] NEW_PATH='/redirect-to-here'"
@@ -34,6 +34,6 @@ namespace :unpublish do
                           explanatory_note: explanatory_note,
                           alternative_path: redirect_path)
 
-    RemoveService.new.call(document.live_edition, removal)
+    RemoveService.call(document.live_edition, removal)
   end
 end

--- a/spec/interactors/file_attachments/preview_interactor_spec.rb
+++ b/spec/interactors/file_attachments/preview_interactor_spec.rb
@@ -9,12 +9,8 @@ RSpec.describe FileAttachments::PreviewInteractor do
       { document: edition.document.to_param, file_attachment_id: file_attachment.id }
     end
 
-    let(:preview_asset_service) do
-      instance_double(PreviewAssetService)
-    end
-
     before do
-      allow(PreviewAssetService).to receive(:new) { preview_asset_service }
+      allow(PreviewAssetService).to receive(:call)
     end
 
     context "when the asset is present on Asset Manager" do
@@ -54,12 +50,11 @@ RSpec.describe FileAttachments::PreviewInteractor do
       end
 
       before do
-        allow(preview_asset_service).to receive(:put)
         edition.file_attachment_revisions << attachment_revision
       end
 
       it "uploads the asset" do
-        expect(preview_asset_service).to receive(:put)
+        expect(PreviewAssetService).to receive(:call)
         FileAttachments::PreviewInteractor.call(params: params)
       end
 
@@ -69,7 +64,7 @@ RSpec.describe FileAttachments::PreviewInteractor do
       end
 
       it "returns an api_error flag when Asset Manager is down" do
-        allow(preview_asset_service).to receive(:put).and_raise(GdsApi::BaseError)
+        allow(PreviewAssetService).to receive(:call).and_raise(GdsApi::BaseError)
         result = FileAttachments::PreviewInteractor.call(params: params)
         expect(result.api_error).to be_truthy
       end

--- a/spec/jobs/scheduled_publishing_job_spec.rb
+++ b/spec/jobs/scheduled_publishing_job_spec.rb
@@ -55,6 +55,7 @@ RSpec.describe ScheduledPublishingJob do
   context "when an exception is raised" do
     before do
       allow(PublishService).to receive(:new).and_raise(RuntimeError)
+      allow(ScheduledPublishingFailedService).to receive(:call)
     end
 
     it "retries the job" do
@@ -64,11 +65,7 @@ RSpec.describe ScheduledPublishingJob do
     end
 
     it "when it is out of retries it calls the failed service" do
-      failed_service = instance_double(ScheduledPublishingFailedService)
-      allow(ScheduledPublishingFailedService)
-        .to receive(:new).and_return(failed_service)
-
-      expect(failed_service).to receive(:call).with(scheduled_edition.id)
+      expect(ScheduledPublishingFailedService).to receive(:call).with(scheduled_edition.id)
 
       perform_enqueued_jobs do
         ScheduledPublishingJob.perform_later(scheduled_edition.id)

--- a/spec/services/draft_asset_cleanup_service_spec.rb
+++ b/spec/services/draft_asset_cleanup_service_spec.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 RSpec.describe DraftAssetCleanupService do
-  describe "#call" do
+  describe ".call" do
     context "when the previous revision has draft assets that aren't used" do
       it "deletes the assets that aren't used" do
         image_revision = create(:image_revision, :on_asset_manager, state: :draft)
@@ -16,7 +16,7 @@ RSpec.describe DraftAssetCleanupService do
 
         request = stub_asset_manager_deletes_any_asset
 
-        DraftAssetCleanupService.new.call(edition)
+        DraftAssetCleanupService.call(edition)
 
         expect(request).to have_been_requested.at_least_once
         expect(image_revision.assets.map(&:state).uniq).to match(%w[absent])
@@ -42,7 +42,7 @@ RSpec.describe DraftAssetCleanupService do
 
         request = stub_asset_manager_deletes_any_asset
 
-        DraftAssetCleanupService.new.call(edition)
+        DraftAssetCleanupService.call(edition)
 
         expect(request).not_to have_been_requested
         expect(image_revision.assets.map(&:state).uniq).to match(%w[draft])
@@ -64,7 +64,7 @@ RSpec.describe DraftAssetCleanupService do
 
         request = stub_asset_manager_deletes_any_asset
 
-        DraftAssetCleanupService.new.call(edition)
+        DraftAssetCleanupService.call(edition)
 
         expect(request).not_to have_been_requested
         expect(image_revision.assets.map(&:state).uniq).to match(%w[live])
@@ -77,7 +77,7 @@ RSpec.describe DraftAssetCleanupService do
         revision = create(:revision, preceded_by: nil)
         edition = create(:edition, revision: revision)
 
-        expect { DraftAssetCleanupService.new.call(edition) }
+        expect { DraftAssetCleanupService.call(edition) }
           .not_to raise_error
       end
     end
@@ -96,7 +96,7 @@ RSpec.describe DraftAssetCleanupService do
 
         stub_asset_manager_deletes_any_asset.to_return(status: 404)
 
-        DraftAssetCleanupService.new.call(edition)
+        DraftAssetCleanupService.call(edition)
 
         expect(image_revision.assets.map(&:state).uniq).to match(%w[absent])
         expect(file_attachment_revision.asset).to be_absent

--- a/spec/services/failsafe_preview_service_spec.rb
+++ b/spec/services/failsafe_preview_service_spec.rb
@@ -1,28 +1,23 @@
 # frozen_string_literal: true
 
 RSpec.describe FailsafePreviewService do
-  let(:preview_service) do
-    instance_double(PreviewService, create_preview: nil)
-  end
-
   before do
-    allow(PreviewService).to receive(:new) { preview_service }
-    allow_any_instance_of(DraftAssetCleanupService).to receive(:call)
+    allow(PreviewService).to receive(:call)
+    allow(DraftAssetCleanupService).to receive(:call)
   end
 
-  describe "#create_preview" do
+  describe ".call" do
     it "delegates to the PreviewService" do
       edition = create(:edition)
-      service = FailsafePreviewService.new(edition)
-      expect(preview_service).to receive(:create_preview)
-      service.create_preview
+      expect(PreviewService).to receive(:call)
+      FailsafePreviewService.call(edition)
     end
 
     context "when an external service is down" do
       it "sets revision_synced to false on the edition" do
-        allow(preview_service).to receive(:create_preview).and_raise(GdsApi::BaseError)
+        allow(PreviewService).to receive(:call).and_raise(GdsApi::BaseError)
         edition = create(:edition, revision_synced: true)
-        FailsafePreviewService.new(edition).create_preview
+        FailsafePreviewService.call(edition)
         expect(edition.revision_synced).to be(false)
       end
     end
@@ -31,19 +26,19 @@ RSpec.describe FailsafePreviewService do
       let(:edition) { create(:edition, title: "", revision_synced: true) }
 
       it "sets revision_synced to false on the edition" do
-        FailsafePreviewService.new(edition).create_preview
+        FailsafePreviewService.call(edition)
         expect(edition.revision_synced).to be(false)
       end
 
       it "doesn't send to the Publishing API" do
         request = stub_publishing_api_put_content(edition.content_id, {})
-        FailsafePreviewService.new(edition).create_preview
+        FailsafePreviewService.call(edition)
         expect(request).not_to have_been_requested
       end
 
       it "delegates cleaning up draft assets" do
-        expect_any_instance_of(DraftAssetCleanupService).to receive(:call)
-        FailsafePreviewService.new(edition).create_preview
+        expect(DraftAssetCleanupService).to receive(:call)
+        FailsafePreviewService.call(edition)
       end
     end
   end

--- a/spec/services/file_attachment_blob_service_spec.rb
+++ b/spec/services/file_attachment_blob_service_spec.rb
@@ -4,11 +4,10 @@ RSpec.describe FileAttachmentBlobService do
   let(:file) { fixture_file_upload("files/text-file.txt") }
   let(:revision) { build(:revision) }
   let(:user) { build(:user) }
-  let(:instance) { FileAttachmentBlobService.new(revision, user) }
 
-  describe "#create_blob_revision" do
+  describe ".call" do
     it "creates a file attachment blob revision" do
-      expect(instance.create_blob_revision(file))
+      expect(FileAttachmentBlobService.call(revision, user, file))
         .to be_a(FileAttachment::BlobRevision)
     end
 
@@ -17,12 +16,12 @@ RSpec.describe FileAttachmentBlobService do
       let(:revision) { build(:revision, file_attachment_revisions: [existing_attachment]) }
 
       it "creates a unique filename" do
-        blob_revision = instance.create_blob_revision(file)
+        blob_revision = FileAttachmentBlobService.call(revision, user, file)
         expect(blob_revision.filename).to eql("text-file-1.txt")
       end
 
       it "allows keeping the name if this is a replacement for the attachment with the same name" do
-        blob_revision = instance.create_blob_revision(file, replacing: existing_attachment)
+        blob_revision = FileAttachmentBlobService.call(revision, user, file, replacing: existing_attachment)
         expect(blob_revision.filename).to eql("text-file.txt")
       end
     end
@@ -31,14 +30,14 @@ RSpec.describe FileAttachmentBlobService do
       let(:file) { fixture_file_upload("files/13kb-1-page-attachment.pdf", "application/pdf") }
 
       it "calculates the number of pages" do
-        blob_revision = instance.create_blob_revision(file)
+        blob_revision = FileAttachmentBlobService.call(revision, user, file)
         expect(blob_revision.number_of_pages).to eql(1)
       end
     end
 
     context "when the upload is not a pdf" do
       it "sets nil for the number of pages" do
-        blob_revision = instance.create_blob_revision(file)
+        blob_revision = FileAttachmentBlobService.call(revision, user, file)
         expect(blob_revision.number_of_pages).to be_nil
       end
     end

--- a/spec/services/image_blob_service_spec.rb
+++ b/spec/services/image_blob_service_spec.rb
@@ -9,9 +9,9 @@ RSpec.describe ImageBlobService do
     ImageNormaliser::TempImage.new(fixture_file_upload("files/1000x1000.jpg"))
   end
 
-  describe "#call" do
+  describe ".call" do
     it "creates a image blob revision" do
-      expect(ImageBlobService.new(revision, user, temp_image).call)
+      expect(ImageBlobService.call(revision, user, temp_image))
         .to be_a(Image::BlobRevision)
     end
 
@@ -20,7 +20,7 @@ RSpec.describe ImageBlobService do
       let(:revision) { build(:revision, image_revisions: [existing_image]) }
 
       it "creates a unique filename" do
-        blob_revision = ImageBlobService.new(revision, user, temp_image).call
+        blob_revision = ImageBlobService.call(revision, user, temp_image)
         expect(blob_revision.filename).to eql("1000x1000-1.jpg")
       end
     end

--- a/spec/services/path_generator_service_spec.rb
+++ b/spec/services/path_generator_service_spec.rb
@@ -1,26 +1,24 @@
 # frozen_string_literal: true
 
 RSpec.describe PathGeneratorService do
-  describe "#path" do
+  describe ".call" do
+    let(:document) { create(:document, :with_current_edition) }
+
     it "generates a base path which is unique to our database" do
-      service = PathGeneratorService.new
-      original_document = create(:document, :with_current_edition)
-      new_document = build(:document, document_type_id: original_document.document_type_id)
-      stub_publishing_api_has_lookups("#{original_document.current_edition.base_path}": nil)
-      expect(service.path(new_document, original_document.current_edition.title))
-        .to eq("#{original_document.current_edition.base_path}-1")
+      new_document = build(:document, document_type_id: document.document_type_id)
+      stub_publishing_api_has_lookups("#{document.current_edition.base_path}": nil)
+
+      expect(PathGeneratorService.call(new_document, document.current_edition.title))
+        .to eq("#{document.current_edition.base_path}-1")
     end
 
-    it "raises a 'Path unable to be generated' when many variations of that path are in use" do
-      service = PathGeneratorService.new(2)
-      document = build(:document, :with_current_edition)
-
+    it "raises an error when many variations of that path are in use" do
       prefix = document.document_type.path_prefix
       existing_paths = ["#{prefix}/a-title", "#{prefix}/a-title-1", "#{prefix}/a-title-2"]
       existing_paths.each { |path| create(:edition, base_path: path) }
 
-      expect { service.path(document, "A title") }
-        .to raise_error(PathGeneratorService::ErrorGeneratingPath, "Already >2 paths with same title.")
+      expect { PathGeneratorService.call(document, "A title", max_repeated_titles: 2) }
+        .to raise_error("Already >2 paths with same title.")
     end
   end
 end

--- a/spec/services/preview_asset_service_spec.rb
+++ b/spec/services/preview_asset_service_spec.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 RSpec.describe PreviewAssetService do
-  describe "#put" do
+  describe ".call" do
     let(:edition) { create :edition }
 
     let(:asset) do
@@ -32,7 +32,7 @@ RSpec.describe PreviewAssetService do
         expect(asset).to receive(:update!)
           .with a_hash_including(state: :draft, file_url: file_url)
 
-        PreviewAssetService.new(edition).put(asset)
+        PreviewAssetService.call(edition, asset)
         expect(request).to have_been_requested.at_least_once
       end
 
@@ -45,7 +45,7 @@ RSpec.describe PreviewAssetService do
           expect(req.body).to include("foo")
         end
 
-        PreviewAssetService.new(edition).put(asset)
+        PreviewAssetService.call(edition, asset)
         expect(request).to have_been_requested
       end
     end
@@ -61,7 +61,7 @@ RSpec.describe PreviewAssetService do
 
       it "updates the asset" do
         request = stub_asset_manager_update_asset("id")
-        PreviewAssetService.new(edition).put(asset)
+        PreviewAssetService.call(edition, asset)
         expect(request).to have_been_requested
       end
 
@@ -72,7 +72,7 @@ RSpec.describe PreviewAssetService do
           expect(req.body).to include("foo")
         end
 
-        PreviewAssetService.new(edition).put(asset)
+        PreviewAssetService.call(edition, asset)
         expect(request).to have_been_requested
       end
     end
@@ -82,7 +82,7 @@ RSpec.describe PreviewAssetService do
         request = stub_asset_manager_update_asset("id")
         allow(asset).to receive(:draft?) { false }
         allow(asset).to receive(:absent?) { false }
-        PreviewAssetService.new(edition).put(asset)
+        PreviewAssetService.call(edition, asset)
         expect(request).to_not have_been_requested
       end
     end

--- a/spec/services/preview_service_spec.rb
+++ b/spec/services/preview_service_spec.rb
@@ -1,52 +1,44 @@
 # frozen_string_literal: true
 
 RSpec.describe PreviewService do
-  let(:draft_asset_cleanup_service) do
-    instance_double(DraftAssetCleanupService, call: nil)
-  end
-
-  let(:preview_asset_service) do
-    instance_double(PreviewAssetService, put: nil)
-  end
-
   before do
     stub_any_publishing_api_put_content
-    allow(DraftAssetCleanupService).to receive(:new) { draft_asset_cleanup_service }
-    allow(PreviewAssetService).to receive(:new) { preview_asset_service }
+    allow(PreviewAssetService).to receive(:call)
+    allow(DraftAssetCleanupService).to receive(:call)
   end
 
-  describe "#create_preview" do
+  describe ".call" do
     it "updates the Publishing API" do
       edition = create(:edition)
       request = stub_publishing_api_put_content(edition.content_id, {})
-      PreviewService.new(edition).create_preview
+      PreviewService.call(edition)
       expect(request).to have_been_requested
     end
 
     it "marks the edition as 'revision_synced'" do
       edition = create(:edition, revision_synced: false)
-      PreviewService.new(edition).create_preview
+      PreviewService.call(edition)
       expect(edition.reload.revision_synced).to be(true)
     end
 
     it "delegates cleaning up draft assets" do
       edition = create(:edition)
-      expect(draft_asset_cleanup_service).to receive(:call).with(edition)
-      PreviewService.new(edition).create_preview
+      expect(DraftAssetCleanupService).to receive(:call).with(edition)
+      PreviewService.call(edition)
     end
 
     it "uploads any image assets" do
       image_revision = create(:image_revision)
       edition = create(:edition, image_revisions: [image_revision])
-      expect(preview_asset_service).to receive(:put).at_least(:once)
-      PreviewService.new(edition).create_preview
+      expect(PreviewAssetService).to receive(:call).at_least(:once)
+      PreviewService.call(edition)
     end
 
     it "uploads any file attachment assets" do
       file_attachment_revision = create(:file_attachment_revision)
       edition = create(:edition, file_attachment_revisions: [file_attachment_revision])
-      expect(preview_asset_service).to receive(:put).at_least(:once)
-      PreviewService.new(edition).create_preview
+      expect(PreviewAssetService).to receive(:call).at_least(:once)
+      PreviewService.call(edition)
     end
 
     context "when Publishing API is down" do
@@ -56,20 +48,20 @@ RSpec.describe PreviewService do
 
       it "sets revision_synced to false on the edition" do
         edition = create(:edition, revision_synced: true)
-        expect { PreviewService.new(edition).create_preview }.to raise_error(GdsApi::BaseError)
+        expect { PreviewService.call(edition) }.to raise_error(GdsApi::BaseError)
         expect(edition.revision_synced).to be(false)
       end
     end
 
     context "when the asset upload fails" do
       before do
-        allow(preview_asset_service).to receive(:put).and_raise(GdsApi::BaseError)
+        allow(PreviewAssetService).to receive(:call).and_raise(GdsApi::BaseError)
       end
 
       it "sets revision_synced to false on the edition" do
         image_revision = create(:image_revision)
         edition = create(:edition, image_revisions: [image_revision], revision_synced: true)
-        expect { PreviewService.new(edition).create_preview }.to raise_error(GdsApi::BaseError)
+        expect { PreviewService.call(edition) }.to raise_error(GdsApi::BaseError)
         expect(edition.revision_synced).to be(false)
       end
     end

--- a/spec/services/publish_asset_service_spec.rb
+++ b/spec/services/publish_asset_service_spec.rb
@@ -1,17 +1,18 @@
 # frozen_string_literal: true
 
 RSpec.describe PublishAssetService do
-  describe "#publish_assets" do
+  describe ".call" do
     it "publishes the draft assets and marks them as live" do
       image_revision = create(:image_revision, :on_asset_manager, state: :draft)
       file_attachment_revision = create(:file_attachment_revision, :on_asset_manager, state: :draft)
+
       edition = create(:edition,
                        :publishable,
                        file_attachment_revisions: [file_attachment_revision],
                        image_revisions: [image_revision])
 
       request = stub_asset_manager_updates_any_asset
-      PublishAssetService.new.publish_assets(edition, nil)
+      PublishAssetService.call(edition, nil)
       expect(image_revision.assets.map(&:state).uniq).to eq(%w[live])
       expect(file_attachment_revision.asset).to be_live
       expect(request).to have_been_requested.at_least_once
@@ -20,6 +21,7 @@ RSpec.describe PublishAssetService do
     it "doesn't republish the assets that are already live" do
       image_revision = create(:image_revision, :on_asset_manager, state: :live)
       file_attachment_revision = create(:file_attachment_revision, :on_asset_manager, state: :live)
+
       live_edition = create(:edition,
                             :published,
                             file_attachment_revisions: [file_attachment_revision],
@@ -32,7 +34,7 @@ RSpec.describe PublishAssetService do
                        document: live_edition.document)
 
       request = stub_any_asset_manager_call
-      PublishAssetService.new.publish_assets(edition, live_edition)
+      PublishAssetService.call(edition, live_edition)
       expect(request).to_not have_been_requested
     end
 
@@ -42,12 +44,13 @@ RSpec.describe PublishAssetService do
                        :publishable,
                        image_revisions: [image_revision])
 
-      expect { PublishAssetService.new.publish_assets(edition, nil) }.to raise_error("Expected asset to be on asset manager")
+      expect { PublishAssetService.call(edition, nil) }.to raise_error("Expected asset to be on asset manager")
     end
 
     it "removes an asset not used by the current edition" do
       image_revision_to_remove = create(:image_revision, :on_asset_manager, state: :live)
       file_attachment_revision_to_remove = create(:file_attachment_revision, :on_asset_manager, state: :live)
+
       live_edition = create(:edition,
                             :published,
                             image_revisions: [image_revision_to_remove],
@@ -61,7 +64,7 @@ RSpec.describe PublishAssetService do
 
       delete_request = stub_asset_manager_deletes_any_asset
 
-      PublishAssetService.new.publish_assets(edition, live_edition)
+      PublishAssetService.call(edition, live_edition)
       expect(image_revision_to_remove.assets.map(&:state).uniq).to eq(%w[absent])
       expect(file_attachment_revision_to_remove.asset).to be_absent
       expect(delete_request).to have_been_requested.at_least_once
@@ -71,6 +74,7 @@ RSpec.describe PublishAssetService do
   it "retains assets used by the current and live edition" do
     image_revision_to_keep = create(:image_revision, :on_asset_manager, state: :live)
     file_attachment_revision_to_keep = create(:file_attachment_revision, :on_asset_manager, state: :live)
+
     live_edition = create(:edition,
                           :published,
                           image_revisions: [image_revision_to_keep],
@@ -82,8 +86,7 @@ RSpec.describe PublishAssetService do
                      file_attachment_revisions: [file_attachment_revision_to_keep],
                      document: live_edition.document)
 
-    PublishAssetService.new.publish_assets(edition, live_edition)
-
+    PublishAssetService.call(edition, live_edition)
     expect(image_revision_to_keep.assets.map(&:state).uniq).to eq(%w[live])
     expect(file_attachment_revision_to_keep.asset).to be_live
   end
@@ -106,9 +109,7 @@ RSpec.describe PublishAssetService do
                      document: live_edition.document)
 
     request = stub_asset_manager_updates_any_asset
-
-    PublishAssetService.new.publish_assets(edition, live_edition)
-
+    PublishAssetService.call(edition, live_edition)
     expect(old_image_revision.assets.map(&:state).uniq).to eq(%w[superseded])
     expect(old_file_attachment_revision.asset).to be_superseded
     expect(request).to have_been_requested.at_least_once

--- a/spec/services/remove_service_spec.rb
+++ b/spec/services/remove_service_spec.rb
@@ -11,14 +11,14 @@ RSpec.describe RemoveService do
         edition.content_id,
         body: hash_including(locale: edition.locale),
       )
-      RemoveService.new.call(edition, build(:removal))
+      RemoveService.call(edition, build(:removal))
       expect(request).to have_been_requested
     end
 
     it "creates a timeline entry" do
       removal = build(:removal)
 
-      expect { RemoveService.new.call(edition, removal) }
+      expect { RemoveService.call(edition, removal) }
         .to change { TimelineEntry.count }
         .by(1)
 
@@ -30,7 +30,7 @@ RSpec.describe RemoveService do
     it "updates the edition status" do
       removal = build(:removal)
 
-      expect { RemoveService.new.call(edition, removal) }
+      expect { RemoveService.call(edition, removal) }
         .to change { edition.reload.state }
         .to("removed")
 
@@ -53,7 +53,7 @@ RSpec.describe RemoveService do
             type: "redirect",
           },
         )
-        RemoveService.new.call(edition, removal)
+        RemoveService.call(edition, removal)
         expect(request).to have_been_requested
       end
     end
@@ -74,7 +74,7 @@ RSpec.describe RemoveService do
             type: "gone",
           },
         )
-        RemoveService.new.call(edition, removal)
+        RemoveService.call(edition, removal)
         expect(request).to have_been_requested
       end
     end
@@ -83,7 +83,7 @@ RSpec.describe RemoveService do
       before { stub_publishing_api_isnt_available }
 
       it "doesn't change the editions state" do
-        expect { RemoveService.new.call(edition, build(:removal)) }
+        expect { RemoveService.call(edition, build(:removal)) }
           .to raise_error(GdsApi::BaseError)
         expect(edition.reload.state).to eq("published")
       end
@@ -100,7 +100,7 @@ RSpec.describe RemoveService do
 
         delete_request = stub_asset_manager_deletes_any_asset
 
-        RemoveService.new.call(edition, build(:removal))
+        RemoveService.call(edition, build(:removal))
 
         expect(delete_request).to have_been_requested.at_least_once
         expect(image_revision.assets.map(&:state).uniq).to eq(%w[absent])
@@ -117,7 +117,7 @@ RSpec.describe RemoveService do
 
         delete_request = stub_asset_manager_deletes_any_asset.to_return(status: 404)
 
-        RemoveService.new.call(edition, build(:removal))
+        RemoveService.call(edition, build(:removal))
 
         expect(delete_request).to have_been_requested.at_least_once
         expect(image_revision.assets.map(&:state).uniq).to eq(%w[absent])
@@ -134,7 +134,7 @@ RSpec.describe RemoveService do
 
         delete_request = stub_asset_manager_deletes_any_asset
 
-        RemoveService.new.call(edition, build(:removal))
+        RemoveService.call(edition, build(:removal))
 
         expect(delete_request).not_to have_been_requested
       end
@@ -151,7 +151,7 @@ RSpec.describe RemoveService do
                          lead_image_revision: image_revision,
                          file_attachment_revisions: [file_attachment_revision])
 
-        expect { RemoveService.new.call(edition, build(:removal)) }
+        expect { RemoveService.call(edition, build(:removal)) }
           .to raise_error(GdsApi::BaseError)
 
         expect(edition.reload.state).to eq("removed")
@@ -161,8 +161,8 @@ RSpec.describe RemoveService do
     context "when the given edition is a draft" do
       it "raises an error" do
         draft_edition = create(:edition)
-        expect { RemoveService.new.call(draft_edition, build(:removal)) }
-          .to raise_error RuntimeError, "attempted to remove an edition other than the live edition"
+        expect { RemoveService.call(draft_edition, build(:removal)) }
+          .to raise_error "attempted to remove an edition other than the live edition"
       end
     end
 
@@ -174,8 +174,8 @@ RSpec.describe RemoveService do
                               current: false,
                               document: draft_edition.document)
 
-        expect { RemoveService.new.call(live_edition, build(:removal)) }
-          .to raise_error RuntimeError, "Publishing API does not support unpublishing while there is a draft"
+        expect { RemoveService.call(live_edition, build(:removal)) }
+          .to raise_error "Publishing API does not support unpublishing while there is a draft"
       end
     end
   end

--- a/spec/services/schedule_service_spec.rb
+++ b/spec/services/schedule_service_spec.rb
@@ -16,30 +16,30 @@ RSpec.describe ScheduleService do
     allow(ScheduleService::Payload).to receive(:new) { payload }
   end
 
-  describe "#schedule" do
+  describe "#call" do
     let(:user) { create :user }
     let(:edition) { create :edition, proposed_publish_time: Time.current.tomorrow }
     let(:scheduling) { create :scheduling, publish_time: edition.proposed_publish_time }
 
     it "sets an edition's state to 'scheduled'" do
-      ScheduleService.new(edition).schedule(scheduling, user)
+      ScheduleService.call(edition, user, scheduling)
       expect(edition).to be_scheduled
     end
 
     it "clears the editions proposed publish time" do
-      ScheduleService.new(edition).schedule(scheduling, user)
+      ScheduleService.call(edition, user, scheduling)
       expect(edition.reload.proposed_publish_time).to be_nil
     end
 
     it "creates a publishing intent" do
       request = stub_publishing_api_put_intent(edition.base_path, '"payload"')
-      ScheduleService.new(edition).schedule(scheduling, user)
+      ScheduleService.call(edition, user, scheduling)
       expect(request).to have_been_requested
     end
 
     it "schedules the edition to publish" do
       datetime = edition.proposed_publish_time
-      ScheduleService.new(edition).schedule(scheduling, user)
+      ScheduleService.call(edition, user, scheduling)
       expect(enqueued_jobs.count).to eq 1
       expect(enqueued_jobs.first[:args].first).to eq edition.id
       expect(enqueued_jobs.first[:at].to_i).to eq datetime.to_i

--- a/spec/services/unique_filename_service_spec.rb
+++ b/spec/services/unique_filename_service_spec.rb
@@ -5,24 +5,24 @@ RSpec.describe UniqueFilenameService do
 
   describe "#call" do
     it "parameterises the base filename" do
-      name = UniqueFilenameService.new(existing_filenames).call("File $ name.jpg")
+      name = UniqueFilenameService.call(existing_filenames, "File $ name.jpg")
       expect(name).to eq "file-name.jpg"
     end
 
     it "copes if the file has no extension" do
-      name = UniqueFilenameService.new(existing_filenames).call("file")
+      name = UniqueFilenameService.call(existing_filenames, "file")
       expect(name).to eq "file"
     end
 
     it "truncates lengthy base filenames" do
       stub_const "UniqueFilenameService::MAX_LENGTH", 3
-      name = UniqueFilenameService.new(existing_filenames).call("mylongname.jpg")
+      name = UniqueFilenameService.call(existing_filenames, "mylongname.jpg")
       expect(name).to eq "myl.jpg"
     end
 
     it "ensures the filename is unique for a list of filenames" do
       existing_filenames << "file.jpg"
-      name = UniqueFilenameService.new(existing_filenames).call("file.jpg")
+      name = UniqueFilenameService.call(existing_filenames, "file.jpg")
       expect(name).to eq "file-1.jpg"
     end
   end

--- a/spec/services/withdraw_service_spec.rb
+++ b/spec/services/withdraw_service_spec.rb
@@ -16,7 +16,7 @@ RSpec.describe WithdrawService do
                                               body: { type: "withdrawal",
                                                       explanation: converted_public_explanation,
                                                       locale: edition.locale })
-      WithdrawService.new.call(edition, public_explanation, user)
+      WithdrawService.call(edition, public_explanation, user)
 
       expect(request).to have_been_requested
     end
@@ -24,7 +24,7 @@ RSpec.describe WithdrawService do
 
     it "updates the edition status to withdrawn" do
       travel_to(Time.current) do
-        WithdrawService.new.call(edition, public_explanation, user)
+        WithdrawService.call(edition, public_explanation, user)
         edition.reload
         withdrawal = edition.status.details
 
@@ -37,7 +37,7 @@ RSpec.describe WithdrawService do
     it "saves the published_status to the withdrawal record" do
       previous_published_status = edition.status
 
-      WithdrawService.new.call(edition, public_explanation, user)
+      WithdrawService.call(edition, public_explanation, user)
       edition.reload
 
       withdrawal = edition.status.details
@@ -49,7 +49,7 @@ RSpec.describe WithdrawService do
       withdrawn_edition = create(:edition, :withdrawn)
       previous_withdrawal = withdrawn_edition.status.details
 
-      WithdrawService.new.call(withdrawn_edition, public_explanation, user)
+      WithdrawService.call(withdrawn_edition, public_explanation, user)
 
       withdrawal = withdrawn_edition.status.details
 
@@ -59,8 +59,8 @@ RSpec.describe WithdrawService do
     context "when the given edition is a draft" do
       it "raises an error" do
         draft_edition = create(:edition)
-        expect { WithdrawService.new.call(draft_edition, public_explanation, user) }
-          .to raise_error RuntimeError, "attempted to withdraw an edition other than the live edition"
+        expect { WithdrawService.call(draft_edition, public_explanation, user) }
+          .to raise_error "attempted to withdraw an edition other than the live edition"
       end
     end
 
@@ -72,8 +72,8 @@ RSpec.describe WithdrawService do
                               current: false,
                               document: draft_edition.document)
 
-        expect { WithdrawService.new.call(live_edition, public_explanation, user) }
-          .to raise_error RuntimeError, "Publishing API does not support unpublishing while there is a draft"
+        expect { WithdrawService.call(live_edition, public_explanation, user) }
+          .to raise_error "Publishing API does not support unpublishing while there is a draft"
       end
     end
 
@@ -82,7 +82,7 @@ RSpec.describe WithdrawService do
         image_revision = create(:image_revision, :on_asset_manager)
         edition = create(:edition, :published, lead_image_revision: image_revision)
         delete_request = stub_asset_manager_deletes_any_asset
-        WithdrawService.new.call(edition, public_explanation, user)
+        WithdrawService.call(edition, public_explanation, user)
         expect(delete_request).not_to have_been_requested
       end
     end
@@ -90,7 +90,7 @@ RSpec.describe WithdrawService do
     context "when an edition is already withdrawn and public_explanation differs" do
       it "updates public_explanation" do
         withdrawn_edition = create(:edition, :withdrawn)
-        expect { WithdrawService.new.call(withdrawn_edition, public_explanation, user) }
+        expect { WithdrawService.call(withdrawn_edition, public_explanation, user) }
           .to change { withdrawn_edition.reload.status.details.public_explanation }
           .to(public_explanation)
       end
@@ -99,7 +99,8 @@ RSpec.describe WithdrawService do
         withdrawn_at = 10.days.ago.midnight
         withdrawal = build(:withdrawal, withdrawn_at: withdrawn_at)
         withdrawn_edition = create(:edition, :withdrawn, withdrawal: withdrawal)
-        expect { WithdrawService.new.call(withdrawn_edition, public_explanation, user) }
+
+        expect { WithdrawService.call(withdrawn_edition, public_explanation, user) }
           .not_to change { withdrawn_edition.reload.status.details.withdrawn_at }
           .from(withdrawn_at)
       end


### PR DESCRIPTION
https://trello.com/c/6WhtlGQB/1115-finish-work-separating-services-and-non-services-from-services

This introduces a new ApplicationService class that all top-level
classes in 'app/services' should inherit from, enforcing a common
interface among our services. Enforcing this interface requires a
variety of small code changes around the app, so that all service
calls are made like 'ServiceClass.call(args)'.

ScheduleService is the only class that still doesn't follow this
interface, which we intend to address in future work.

Sorry in advance that this is quite a large PR/commit, which is 
partly because we don't have time to do lots of smaller PRs and 
having a single commit will make it easier to address major comments. 
It does have the advantage of showing the big picture :-).