### PR TITLE
Refactor ScheduleService to have single method

### DIFF
--- a/app/interactors/schedule/create_interactor.rb
+++ b/app/interactors/schedule/create_interactor.rb
@@ -42,8 +42,11 @@ private
   end
 
   def schedule_to_publish
-    reviewed = params[:review_status] == "reviewed"
-    ScheduleService.new(edition).schedule(user: user, reviewed: reviewed)
+    scheduling = Scheduling.new(pre_scheduled_status: edition.status,
+                                reviewed: params[:review_status] == "reviewed",
+                                publish_time: edition.proposed_publish_time)
+
+    ScheduleService.new(edition).schedule(scheduling, user)
   end
 
   def create_timeline_entry

--- a/app/interactors/schedule/update_interactor.rb
+++ b/app/interactors/schedule/update_interactor.rb
@@ -42,7 +42,8 @@ private
     scheduling = edition.status.details
     context.fail! if publish_time == scheduling.publish_time
 
-    ScheduleService.new(edition).reschedule(publish_time: publish_time, user: user)
+    new_scheduling = scheduling.dup.tap { |s| s.publish_time = publish_time }
+    ScheduleService.new(edition).schedule(new_scheduling, user)
   end
 
   def create_timeline_entry

--- a/spec/services/schedule_service_spec.rb
+++ b/spec/services/schedule_service_spec.rb
@@ -17,87 +17,32 @@ RSpec.describe ScheduleService do
   end
 
   describe "#schedule" do
+    let(:user) { create :user }
     let(:edition) { create :edition, proposed_publish_time: Time.current.tomorrow }
+    let(:scheduling) { create :scheduling, publish_time: edition.proposed_publish_time }
 
     it "sets an edition's state to 'scheduled'" do
-      ScheduleService.new(edition).schedule(reviewed: true)
+      ScheduleService.new(edition).schedule(scheduling, user)
       expect(edition).to be_scheduled
     end
 
-    it "saves the edition's pre-scheduling status" do
-      pre_scheduling_status = edition.status
-      ScheduleService.new(edition).schedule(reviewed: true)
-      expect(edition.status.details.pre_scheduled_status).to eq(pre_scheduling_status)
-    end
-
     it "clears the editions proposed publish time" do
-      ScheduleService.new(edition).schedule(reviewed: true)
+      ScheduleService.new(edition).schedule(scheduling, user)
       expect(edition.reload.proposed_publish_time).to be_nil
     end
 
     it "creates a publishing intent" do
       request = stub_publishing_api_put_intent(edition.base_path, '"payload"')
-      ScheduleService.new(edition).schedule(reviewed: true)
+      ScheduleService.new(edition).schedule(scheduling, user)
       expect(request).to have_been_requested
-    end
-
-    context "when the edition has been reviewed" do
-      it "sets the scheduling reviewed state to true" do
-        ScheduleService.new(edition).schedule(reviewed: true)
-        expect(edition.status.details.reviewed).to be true
-      end
-    end
-
-    context "when the edition has not been reviewed" do
-      it "sets the scheduling reviewed state to false" do
-        ScheduleService.new(edition).schedule(reviewed: false)
-        expect(edition.status.details.reviewed).to be false
-      end
     end
 
     it "schedules the edition to publish" do
       datetime = edition.proposed_publish_time
-      ScheduleService.new(edition).schedule(reviewed: false)
+      ScheduleService.new(edition).schedule(scheduling, user)
       expect(enqueued_jobs.count).to eq 1
       expect(enqueued_jobs.first[:args].first).to eq edition.id
       expect(enqueued_jobs.first[:at].to_i).to eq datetime.to_i
-    end
-  end
-
-  describe "#reschedule" do
-    let(:edition) do
-      create(:edition,
-             :scheduled,
-             scheduling: create(:scheduling, publish_time: Time.current.tomorrow))
-    end
-    let(:new_publish_time) { Time.current.advance(days: 2) }
-
-    it "maintains the edition's state as 'scheduled'" do
-      ScheduleService.new(edition).reschedule(publish_time: new_publish_time)
-      expect(edition).to be_scheduled
-    end
-
-    it "creates a new scheduling status using details from the previous" do
-      old_scheduling = edition.status.details
-      ScheduleService.new(edition).reschedule(publish_time: new_publish_time)
-      new_scheduling = edition.status.details
-
-      expect(new_scheduling.publish_time).to eq new_publish_time
-      expect(new_scheduling.slice(:reviewed, :pre_scheduled_status))
-        .to eql old_scheduling.slice(:reviewed, :pre_scheduled_status)
-    end
-
-    it "updates the existing publishing intent" do
-      request = stub_publishing_api_put_intent(edition.base_path, '"payload"')
-      ScheduleService.new(edition).reschedule(publish_time: new_publish_time)
-      expect(request).to have_been_requested
-    end
-
-    it "schedules the edition to publish" do
-      ScheduleService.new(edition).reschedule(publish_time: new_publish_time)
-      expect(enqueued_jobs.count).to eq 1
-      expect(enqueued_jobs.last[:args].first).to eq edition.id
-      expect(enqueued_jobs.last[:at].to_i).to eq new_publish_time.to_i
     end
   end
 end


### PR DESCRIPTION
https://trello.com/c/6WhtlGQB/1115-finish-work-separating-services-and-non-services-from-services

Previously the ScheduleService had both a 'schedule' and 'reschedule'
method, each differing in the way they constructed a Scheduling object.
This moves the construction logic into the lone callers for each method,
reducing the ScheduleService to a single 'schedule' method that is more
compliant with our intended interface for services.

Note that two of the aspects of the construction are still covered at
the feature test level, despite the code moving into interactors:

   - storing the previous edition state (when unscheduled)
   - storing the intended review status for after publishing