### PR TITLE
Fix back button bug

### DIFF
--- a/app/views/images/edit.html.erb
+++ b/app/views/images/edit.html.erb
@@ -3,8 +3,14 @@ title_key = rendering_context == "modal" ? "images.edit.title_modal" : "images.e
 content_for :title, t(title_key, title: @edition.title_or_fallback)
 %>
 
+<% back_link_path = if params[:wizard] == 'upload'
+                      crop_image_path(@edition.document, @image_revision.image_id, wizard: params[:wizard])
+                    else
+                      images_path(@edition.document)
+                    end %>
+
 <% content_for :back_link, render_back_link(
-  href: crop_image_path(@edition.document, @image_revision.image_id, wizard: params[:wizard]),
+  href: back_link_path,
   data_attributes: { "modal-action": "metaBack" }
 ) %>
 


### PR DESCRIPTION
As we split the editing image link into two actions here -
https://trello.com/c/TL1An3FR/1077-iterate-crop-edit-workflow-for-lead-and-inline-images
this caused a bug to be introduced where when the user clicks the back
button on the edit image page they are taken back to the crop image
page.

This should only happen when they are uploading a new image, when
they are editing an existing image they should be taken back to the
images index.