### PR TITLE
Add information on adding content to Document Collections

### DIFF
--- a/app/views/publisher_information/beta_capabilities.govspeak.md
+++ b/app/views/publisher_information/beta_capabilities.govspeak.md
@@ -9,6 +9,8 @@ Content created in Content Publisher cannot be edited in Whitehall publisher. Wh
 
 Content created in Content Publisher can be featured on organisation homepages in Whitehall using the option to 'Feature non-GOV.UK government link'.
 
+Content created in Content Publisher can be added to document collections in Whitehall using the option to 'Add GOV.UK content created outside of Whitehall to a group'.
+
 It is possible to remove (unpublish) pages on request.
 
 Content Publisher cannot be used to publish any translations. If content needs a translated version you need to use Whitehall.

--- a/app/views/publisher_information/how_to_use_publisher.govspeak.md
+++ b/app/views/publisher_information/how_to_use_publisher.govspeak.md
@@ -187,9 +187,9 @@ Or you can save a proposed date and time to inform colleagues when content shoul
 
 If content has been scheduled but has not yet gone live you can stop the automatic scheduled publishing if you need to make changes.
 
-Once content has gone live you will recieve a confirmation email. 
+Once content has gone live you will receive a confirmation email. 
 
-If there are any problems you will recieve an alert email.
+If there are any problems you will receive an alert email.
 
 ---
 

--- a/app/views/publisher_information/how_to_use_publisher.govspeak.md
+++ b/app/views/publisher_information/how_to_use_publisher.govspeak.md
@@ -203,3 +203,12 @@ You need to use the option in Whitehall to 'Feature non-GOV.UK government link'.
 
 We have added document types for Content Publisher documents so that they appear just like Whitehall content.
 
+---
+
+##Document Collections
+
+You can add Content Publisher to document collections that are managed in Whitehall publisher.
+
+When editing a document collection in Whitehall you need to select the 'Add GOV.UK content created outside of Whitehall to a group' option on the 'Collection documents' screen. You will then need to paste in the public URL of the document to add it to the collection.
+
+You can add any documents created outside Whitehall this way.

--- a/app/views/publisher_information/publisher_updates.govspeak.md
+++ b/app/views/publisher_information/publisher_updates.govspeak.md
@@ -1,3 +1,8 @@
+### Adding to Document Collections <span class="govuk-caption-m">4 September 2019</span>
+You can now add content created in Content Publisher to document collections in Whitehall publisher.
+
+This can be done by editing the document collection in Whitehall and selecting the 'Add GOV.UK content created outside of Whitehall to a group' option on the 'Collection documents' screen.
+
 ### Access limiting <span class="govuk-caption-m">6 August 2019</span>
 You can now limit who is able to find and edit a document. You can only limit access before it is published. You can limit it to just publishers in the primary organisation, or to publishers in any tagged organisation. 
 

--- a/app/views/publisher_information/publisher_updates.govspeak.md
+++ b/app/views/publisher_information/publisher_updates.govspeak.md
@@ -48,7 +48,7 @@ When you paste text into the body field Content Publisher will try to convert it
 You can now embed YouTube videos in the body text of content using the Insert menu.
 
 ### Email notification when content is published <span class="govuk-caption-m">8 April 2019</span>
-You will now recieve an email notification when a content edition you have worked on is published on GOV.UK.
+You will now receive an email notification when a content edition you have worked on is published on GOV.UK.
 
 ### Document list defaults to your organisation <span class="govuk-caption-m">21 March 2019</span>
 The document search list will now only show content tagged to your organisation. You can clear filters to see all content tagged to any organisation.


### PR DESCRIPTION
This updates the documentation to reflect that Whitehall has now been
changed to allow adding content that is created outside of Whitehall to
document collections.

Screenshots:

![Screen Shot 2019-09-04 at 11 18 25](https://user-images.githubusercontent.com/282717/64246973-c8abd000-cf05-11e9-9582-2e318ae84fa8.png)
![Screen Shot 2019-09-04 at 11 18 33](https://user-images.githubusercontent.com/282717/64246980-ca759380-cf05-11e9-87fd-110be34c549e.png)
![Screen Shot 2019-09-04 at 11 18 39](https://user-images.githubusercontent.com/282717/64246984-ccd7ed80-cf05-11e9-912a-f079a509b595.png)
