### PR TITLE
Allow discarding drafts when no draft exists in Publishing API

### DIFF
--- a/app/services/delete_draft_service.rb
+++ b/app/services/delete_draft_service.rb
@@ -48,6 +48,14 @@ private
       GdsApi.publishing_api_v2.discard_draft(document.content_id)
     rescue GdsApi::HTTPNotFound
       Rails.logger.warn("No draft to discard for content id #{document.content_id}")
+    rescue GdsApi::HTTPUnprocessableEntity => e
+      no_draft_message = "There is not a draft edition of this document to discard"
+
+      if e.error_details.respond_to?(:dig) && e.error_details.dig("error", "message") == no_draft_message
+        Rails.logger.warn("No draft to discard for content id #{document.content_id}")
+      else
+        raise
+      end
     end
 
     edition.assign_status(:discarded, user).update!(current: false)


### PR DESCRIPTION
To resolve issue raised in: https://govuk.zendesk.com/agent/tickets/3795670

A peculiarity of the Publishing API is that it can respond with either a
404 or a 422 when an attempt to discard a draft is and the draft does
not exist [1]. Presumably this is a consequence of the Publishing API
considering the content a resource rather than the draft or live
edition, so it doesn't seem semantically correct to just change this to
a 404 (and may have consequences).

To resolve we thus respond to both Not Found and Unprocessable Entity
responses and check the message of Unprocessable Entity to check it
meets the scenario.

Content Publisher can fall into this situation when a draft has not been
synced with the Publishing API, such as if if the new doesn't meet
requirements. At this point a user cannot discard a draft and will
receive an error.

The solution here isn't ideal as we have to pattern match a string which
could be changed. In theory we should later improve this as either
making Publishing API simpler in what response it returns (with research
that nothing would break because of this) or tracking whether we've ever
synced a draft to Publishing API to know whether we should make this
request or not.

[1]: https://github.com/alphagov/publishing-api/blob/332792163d68eb2466e45046bce77070a2025388/app/commands/v2/discard_draft.rb#L30