### PR TITLE
Use new auth_bypass_ids field in publishing-api

### DIFF
--- a/app/services/preview_service/payload.rb
+++ b/app/services/preview_service/payload.rb
@@ -28,6 +28,7 @@ class PreviewService::Payload
       ],
       "links" => links,
       "access_limited" => access_limited,
+      "auth_bypass_ids" => auth_bypass_ids,
     }
     payload["change_note"] = edition.change_note if edition.major?
 
@@ -42,14 +43,14 @@ class PreviewService::Payload
 private
 
   def access_limited
+    return {} unless edition.access_limit
+
+    { "organisations" => edition.access_limit_organisation_ids }
+  end
+
+  def auth_bypass_ids
     auth_bypass_id = PreviewAuthBypass.new(edition).auth_bypass_id
-    access_limited_ids = { "auth_bypass_ids" => [auth_bypass_id] }
-
-    if edition.access_limit
-      access_limited_ids["organisations"] = edition.access_limit_organisation_ids
-    end
-
-    access_limited_ids
+    [auth_bypass_id]
   end
 
   def links

--- a/spec/services/preview_service/payload_spec.rb
+++ b/spec/services/preview_service/payload_spec.rb
@@ -32,7 +32,7 @@ RSpec.describe PreviewService::Payload do
       edition = build(:edition)
       allow_any_instance_of(PreviewAuthBypass).to receive(:auth_bypass_id) { "id" }
       payload = PreviewService::Payload.new(edition).payload
-      expect(payload["access_limited"]).to eq("auth_bypass_ids" => %w[id])
+      expect(payload["auth_bypass_ids"]).to eq(%w[id])
     end
 
     it "specifies organistions when the edition is access limited" do


### PR DESCRIPTION
Trello: https://trello.com/c/sUjBwDG0

Follows on from:
- https://github.com/alphagov/govuk-rfcs/blob/master/rfc-113-expanding-draft-access-for-unauthenticated-users.md
- alphagov/publishing-api#1614

`auth_bypass_ids` have been separated from the `access_limited` hash in publishing-api.
This updates content-publisher to send `auth_bypass_ids` to the new field.