### PR TITLE
Update focus states in markdown editor

### DIFF
--- a/app/assets/stylesheets/components/_markdown-editor.scss
+++ b/app/assets/stylesheets/components/_markdown-editor.scss
@@ -30,6 +30,7 @@ $app-toolbar-button-size: 50px;
   width: 100%;
   border-bottom: $govuk-border-width-form-element solid $govuk-border-colour;
   background-color: govuk-colour("light-grey");
+  font-size: 0; //fix the spacing between the inline-block toggle buttons
 }
 
 .app-c-markdown-editor__button {
@@ -37,7 +38,7 @@ $app-toolbar-button-size: 50px;
   @include govuk-font(19);
   display: inline-block;
   margin-bottom: -$govuk-border-width-form-element;
-  padding: govuk-spacing(2);
+  padding: govuk-spacing(2) govuk-spacing(2) govuk-spacing(2) - $govuk-border-width-form-element;
   border: $govuk-border-width-form-element solid transparent;
   border-top: 0;
   border-bottom: 0;
@@ -53,6 +54,7 @@ $app-toolbar-button-size: 50px;
 }
 
 .app-c-markdown-editor__button--muted {
+  padding: govuk-spacing(2);
   border-right: $govuk-border-width-form-element solid $govuk-border-colour;
   border-left: $govuk-border-width-form-element solid $govuk-border-colour;
   color: $govuk-text-colour;

--- a/app/assets/stylesheets/components/_markdown-editor.scss
+++ b/app/assets/stylesheets/components/_markdown-editor.scss
@@ -14,8 +14,8 @@ $app-toolbar-button-size: 50px;
 
 .app-c-markdown-editor__container--focused {
   outline: $govuk-focus-width solid $govuk-focus-colour;
-  outline-offset: 0;
-  box-shadow: inset 0 0 0 2px;
+  outline-offset: $govuk-border-width-form-element;
+  box-shadow: $govuk-input-border-colour 0 0 0 $govuk-border-width-form-element;
 }
 
 .app-c-markdown-editor__head {

--- a/app/assets/stylesheets/components/_toolbar-dropdown.scss
+++ b/app/assets/stylesheets/components/_toolbar-dropdown.scss
@@ -5,6 +5,7 @@ $app-dropdown-arrow-spacing: $app-dropdown-arrow-size / 2;
   display: inline-block;
   position: relative;
   min-width: 120px;
+  min-height: 50px;
   background: inherit;
   text-align: left;
 
@@ -38,8 +39,9 @@ $app-dropdown-arrow-spacing: $app-dropdown-arrow-size / 2;
   }
 
   &:focus {
-    outline: $govuk-focus-width solid $govuk-focus-colour;
-    outline-offset: -$govuk-focus-width;
+    @include govuk-focused-text;
+    outline: none;
+    box-shadow: none;
   }
 
   &::after {
@@ -88,8 +90,9 @@ $app-dropdown-arrow-spacing: $app-dropdown-arrow-size / 2;
   }
 
   &:focus {
-    outline: $govuk-focus-width solid $govuk-focus-colour;
-    outline-offset: -$govuk-focus-width;
+    @include govuk-focused-text;
+    outline: none;
+    box-shadow: none;
   }
 
   &::-moz-focus-inner {
@@ -116,8 +119,9 @@ $app-dropdown-arrow-spacing: $app-dropdown-arrow-size / 2;
   }
 
   &:focus {
-    outline: $govuk-focus-width solid $govuk-focus-colour;
-    outline-offset: -$govuk-focus-width;
+    @include govuk-focused-text;
+    outline: none;
+    box-shadow: none;
   }
 
   &::-moz-focus-inner {


### PR DESCRIPTION
Update the focus state used in the markdown editor component and toolbar dropdown component to be aligned with the new styles:
- Fix focus state for markdown editor toggle button
- Align markdown editor focus styling with inputs
- Update focus styles for toolbar dropdown

**Note**
Zoom in for detailed differences or open the images in a new tab

<table>
<tr><th>Before</th><th>After</th></tr>
<tr><td>

<img width="1320" alt="Screen Shot 2019-10-21 at 15 03 30" src="https://user-images.githubusercontent.com/788096/67218992-314ffd00-f41f-11e9-8227-9f1e3def3404.png">


</td><td>

<img width="1320" alt="Screen Shot 2019-10-21 at 15 02 42" src="https://user-images.githubusercontent.com/788096/67218995-344aed80-f41f-11e9-8de6-c5c1a5e84c00.png">


</td></tr>
<tr><td>

<img width="1320" alt="Screen Shot 2019-10-21 at 16 09 31" src="https://user-images.githubusercontent.com/788096/67219006-3ad96500-f41f-11e9-923b-7be331d475cf.png">


</td><td>

<img width="1320" alt="Screen Shot 2019-10-21 at 16 10 26" src="https://user-images.githubusercontent.com/788096/67219014-3dd45580-f41f-11e9-8747-2b5998e32d49.png">


</td></tr>
<tr><td>

<img width="1320" alt="Screen Shot 2019-10-21 at 16 18 12" src="https://user-images.githubusercontent.com/788096/67219026-42990980-f41f-11e9-8dcf-4c635371ed97.png">


</td><td>

<img width="1320" alt="Screen Shot 2019-10-21 at 16 19 16" src="https://user-images.githubusercontent.com/788096/67219043-475dbd80-f41f-11e9-804a-95be6b3f5cd8.png">


</td></tr>
<tr><td>

<img width="1320" alt="Screen Shot 2019-10-21 at 16 18 25" src="https://user-images.githubusercontent.com/788096/67219060-4b89db00-f41f-11e9-8a37-352ed740915e.png">


</td><td>

<img width="1320" alt="Screen Shot 2019-10-21 at 16 19 27" src="https://user-images.githubusercontent.com/788096/67219065-4e84cb80-f41f-11e9-843b-0ee068b709b6.png">


</td></tr>

</table>

[Trello card](https://trello.com/c/z6RKO2Jx)