### PR TITLE
Handle tags to taxons outside the GOV.UK single taxonomy

### DIFF
--- a/app/models/document.rb
+++ b/app/models/document.rb
@@ -77,8 +77,7 @@ class Document < ApplicationRecord
   end
 
   def document_topics
-    @document_topics_index ||= TopicIndex.new
-    DocumentTopics.find_by_document(self, @document_topics_index)
+    @document_topics ||= DocumentTopics.find_by_document(self, TopicIndex.new)
   end
 
   def newly_created?

--- a/app/models/document_topics.rb
+++ b/app/models/document_topics.rb
@@ -3,25 +3,24 @@
 class DocumentTopics
   include ActiveModel::Model
 
-  attr_accessor :document, :version, :topics, :index
+  attr_accessor :document, :version, :topic_content_ids, :index
 
   def self.find_by_document(document, index)
     publishing_api = GdsApi.publishing_api_v2
     links = publishing_api.get_links(document.content_id)
-    topic_content_ids = links.dig("links", "taxons").to_a
 
     new(
       index: index,
       document: document,
       version: links["version"],
-      topics: topic_content_ids.map { |topic_content_id| Topic.find(topic_content_id, index) }.compact,
+      topic_content_ids: links.dig("links", "taxons").to_a,
     )
   rescue GdsApi::HTTPNotFound
     new(
       index: index,
       document: document,
       version: nil,
-      topics: [],
+      topic_content_ids: [],
     )
   end
 
@@ -37,6 +36,10 @@ class DocumentTopics
       },
       previous_version: version,
     )
+  end
+
+  def topics
+    @topics ||= topic_content_ids.map { |topic_content_id| Topic.find(topic_content_id, index) }.compact
   end
 
 private

--- a/app/models/document_topics.rb
+++ b/app/models/document_topics.rb
@@ -32,7 +32,7 @@ class DocumentTopics
     GdsApi.publishing_api_v2.patch_links(
       document.content_id,
       links: {
-        taxons: leaf_topic_content_ids(topics),
+        taxons: leaf_topic_content_ids(topics) + unknown_taxon_content_ids,
         topics: legacy_topic_content_ids(topics),
       },
       previous_version: version,
@@ -49,5 +49,14 @@ private
   def legacy_topic_content_ids(topics)
     breadcrumbs = topics.map(&:breadcrumb).flatten
     breadcrumbs.map(&:legacy_topic_content_ids).flatten.uniq
+  end
+
+  def unknown_taxon_content_ids
+    links = GdsApi.publishing_api_v2.get_links(document.content_id)
+    previous_topic_content_ids = links.dig("links", "taxons").to_a
+
+    previous_topic_content_ids.reject { |topic_content_id| index.lookup(topic_content_id) }
+  rescue GdsApi::HTTPNotFound
+    []
   end
 end

--- a/app/models/document_topics.rb
+++ b/app/models/document_topics.rb
@@ -25,8 +25,8 @@ class DocumentTopics
     )
   end
 
-  def patch(topic_content_ids, version)
-    topics = topic_content_ids.map { |topic_content_id| Topic.find(topic_content_id, index) }.compact
+  def patch(updated_topic_content_ids, version)
+    topics = updated_topic_content_ids.map { |topic_content_id| Topic.find(topic_content_id, index) }.compact
     self.version = version
 
     GdsApi.publishing_api_v2.patch_links(

--- a/app/models/document_topics.rb
+++ b/app/models/document_topics.rb
@@ -26,14 +26,14 @@ class DocumentTopics
   end
 
   def patch(updated_topic_content_ids, version)
-    topics = updated_topic_content_ids.map { |topic_content_id| Topic.find(topic_content_id, index) }.compact
+    valid_user_topics = updated_topic_content_ids.map { |topic_content_id| Topic.find(topic_content_id, index) }.compact
     self.version = version
 
     GdsApi.publishing_api_v2.patch_links(
       document.content_id,
       links: {
-        taxons: leaf_topic_content_ids(topics) + unknown_taxon_content_ids,
-        topics: legacy_topic_content_ids(topics),
+        taxons: leaf_topic_content_ids(valid_user_topics) + unknown_taxon_content_ids,
+        topics: legacy_topic_content_ids(valid_user_topics),
       },
       previous_version: version,
     )

--- a/app/models/document_topics.rb
+++ b/app/models/document_topics.rb
@@ -14,7 +14,7 @@ class DocumentTopics
       index: index,
       document: document,
       version: links["version"],
-      topics: topic_content_ids.map { |topic_content_id| Topic.find(topic_content_id, index) },
+      topics: topic_content_ids.map { |topic_content_id| Topic.find(topic_content_id, index) }.compact,
     )
   rescue GdsApi::HTTPNotFound
     new(
@@ -26,7 +26,7 @@ class DocumentTopics
   end
 
   def patch(topic_content_ids, version)
-    topics = topic_content_ids.map { |topic_content_id| Topic.find(topic_content_id, index) }
+    topics = topic_content_ids.map { |topic_content_id| Topic.find(topic_content_id, index) }.compact
     self.version = version
 
     GdsApi.publishing_api_v2.patch_links(

--- a/app/models/document_topics.rb
+++ b/app/models/document_topics.rb
@@ -55,11 +55,6 @@ private
   end
 
   def unknown_taxon_content_ids
-    links = GdsApi.publishing_api_v2.get_links(document.content_id)
-    previous_topic_content_ids = links.dig("links", "taxons").to_a
-
-    previous_topic_content_ids.reject { |topic_content_id| index.lookup(topic_content_id) }
-  rescue GdsApi::HTTPNotFound
-    []
+    topic_content_ids.reject { |topic_content_id| index.lookup(topic_content_id) }
   end
 end

--- a/spec/models/document_topics_spec.rb
+++ b/spec/models/document_topics_spec.rb
@@ -77,6 +77,7 @@ RSpec.describe DocumentTopics do
         }
 
         assert_publishing_api_patch_links(document.content_id, expected_links, 1)
+        expect(document.document_topics.topic_content_ids).to eq(%w(level_one_topic))
       end
     end
 
@@ -102,6 +103,7 @@ RSpec.describe DocumentTopics do
         }
 
         assert_publishing_api_patch_links(document.content_id, expected_links, 1)
+        expect(document.document_topics.topic_content_ids).to eq(%w(level_two_topic))
       end
     end
 
@@ -127,6 +129,7 @@ RSpec.describe DocumentTopics do
         }
 
         assert_publishing_api_patch_links(document.content_id, expected_links, 1)
+        expect(document.document_topics.topic_content_ids).to eq(%w(level_two_topic unknown_taxon_content_id))
       end
     end
   end

--- a/spec/models/document_topics_spec.rb
+++ b/spec/models/document_topics_spec.rb
@@ -104,5 +104,30 @@ RSpec.describe DocumentTopics do
         assert_publishing_api_patch_links(document.content_id, expected_links, 1)
       end
     end
+
+    context "when a document is tagged to taxons not in the single taxonomy" do
+      it "does not overwrite the unknown taxons" do
+        document = build(:document)
+        stub_publishing_api_has_links(
+          "content_id" => document.content_id,
+          "links" => {
+            "taxons" => %w(level_one_topic unknown_taxon_content_id),
+          },
+          "version" => 1,
+        )
+
+        document.document_topics.patch(%w(level_two_topic), 1)
+
+        expected_links = {
+          links: {
+            taxons: %w(level_two_topic unknown_taxon_content_id),
+            topics: %w(specialist_sector_1 specialist_sector_2),
+          },
+          previous_version: 1,
+        }
+
+        assert_publishing_api_patch_links(document.content_id, expected_links, 1)
+      end
+    end
   end
 end

--- a/spec/models/document_topics_spec.rb
+++ b/spec/models/document_topics_spec.rb
@@ -36,5 +36,25 @@ RSpec.describe DocumentTopics do
         expect(document_topics.topics).to be_empty
       end
     end
+
+    context "when it contains topics that are not in the single taxonomy" do
+      it "removes the unknown topics from the object" do
+        document = build(:document)
+        stub_publishing_api_has_links(
+          "content_id" => document.content_id,
+          "links" => {
+            "taxons" => %w(level_one_topic unknown_taxon_content_id),
+          },
+          "version" => 1,
+        )
+
+        document_topics = DocumentTopics.find_by_document(document, TopicIndex.new)
+
+        expect(document_topics.topics.count).to eq(1)
+        expect(document_topics.version).to eq(1)
+        expect(document_topics.document).to be(document)
+        expect(document_topics.topics.first&.content_id).to eq("level_one_topic")
+      end
+    end
   end
 end


### PR DESCRIPTION
Trello: https://trello.com/c/N9Loqi9G

## What's changed?

Stops Content Publisher from throwing a 500 error if a document is tagged to a taxon that is not in the single taxonomy.

Also makes sure that these tags are not overwritten when a user updates the taxons that a document is tagged to via Content Publisher.

## Why?
Content Publisher only knows about taxons that have the gov.uk homepage as the root taxon.

However there is another branch of the taxonomy called Worldwide that has `/world/all` as its root taxon.

If a document is tagged to one of these Worldwide taxons (usually via another app like Content Tagger), Content Publisher throws a 500 exception because it's trying to populate the miller columns on the edit Topics page with a nil value. This means that we can have live documents that can't be edited.

While rare, there could be valid reasons why a document has been tagged to a world taxon, so we also need to make sure that these changes are not lost if the user updates their taxon selections via Content Publisher.

## Before
![Screenshot 2019-10-25 at 17 58 32](https://user-images.githubusercontent.com/5793815/67589759-1ea43380-f751-11e9-86eb-d13a4e5cb789.png)

## After
![Screenshot 2019-10-25 at 17 58 09](https://user-images.githubusercontent.com/5793815/67589767-249a1480-f751-11e9-9707-16f71900eb84.png)
