### PR TITLE
Ensure all action links have the same font size

### DIFF
--- a/app/assets/stylesheets/objects/_side.scss
+++ b/app/assets/stylesheets/objects/_side.scss
@@ -34,4 +34,8 @@
   .govuk-details__text {
     padding: govuk-spacing(3);
   }
+
+  .govuk-link {
+    @include govuk-font(19);
+  }
 }


### PR DESCRIPTION
Ensure all links in the action block are rendered with the same font-size - regardless of being wrapped in a paragraph with `govuk-body` applied to it or not.

[Trello card](https://trello.com/c/oo6GrYo7)