### PR TITLE
Use a bearer token when retrieving export from Whitehall

### DIFF
--- a/lib/tasks/import.rake
+++ b/lib/tasks/import.rake
@@ -1,11 +1,19 @@
 # frozen_string_literal: true
 
+require "gds_api/json_client"
+
 namespace :import do
   desc "Import a single document from Whitehall Publisher using Whitehall's internal document ID e.g. import:whitehall[123]"
   task :whitehall, [:document_id] => :environment do |_, args|
     document_id = args.document_id
     host = Plek.new.external_url_for("whitehall-admin")
-    whitehall_export = JSON.parse(URI.parse("#{host}/government/admin/export/document/#{document_id}").open.read)
+    endpoint = "#{host}/government/admin/export/document/#{document_id}"
+    options = {
+      "bearer_token": ENV["WHITEHALL_BEARER_TOKEN"] || "example",
+    }
+    client = GdsApi::JsonClient.new(options)
+    response = client.get_json(endpoint)
+    whitehall_export = response.to_hash
     importer = Tasks::WhitehallImporter.new(document_id, whitehall_export)
     begin
       importer.import


### PR DESCRIPTION
Since the Whitehall document export API endpoint is behind authentication (with user requiring the 'Export data' permission), we need to use a bearer token in order to be able to login as an API user with the correct permissions.

The bearer tokens are already configured in govuk-secrets.

Trello card: https://trello.com/c/RyVOGpMX