### PR TITLE
Flag imported documents as imported

### DIFF
--- a/app/models/document.rb
+++ b/app/models/document.rb
@@ -27,7 +27,7 @@ class Document < ApplicationRecord
 
   has_many :timeline_entries
 
-  enum imported_from: { whitehall: "whitehall" }, _prefix: :imported_from
+  enum imported_from: { whitehall: "whitehall" }, _prefix: true
 
   delegate :topics, to: :document_topics
 

--- a/app/models/document.rb
+++ b/app/models/document.rb
@@ -27,6 +27,8 @@ class Document < ApplicationRecord
 
   has_many :timeline_entries
 
+  enum imported_from: { whitehall: "whitehall" }, _prefix: :imported_from
+
   delegate :topics, to: :document_topics
 
   scope :with_current_edition, -> do

--- a/db/migrate/20191030085853_add_imported_from_to_document.rb
+++ b/db/migrate/20191030085853_add_imported_from_to_document.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+class AddImportedFromToDocument < ActiveRecord::Migration[5.2]
+  def change
+    add_column :documents, :imported_from, :string
+  end
+end

--- a/db/migrate/20191030093601_add_imported_to_revision.rb
+++ b/db/migrate/20191030093601_add_imported_to_revision.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+class AddImportedToRevision < ActiveRecord::Migration[5.2]
+  def change
+    add_column :revisions, :imported, :boolean, default: false
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2019_10_30_085853) do
+ActiveRecord::Schema.define(version: 2019_10_30_093601) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -228,6 +228,7 @@ ActiveRecord::Schema.define(version: 2019_10_30_085853) do
     t.bigint "tags_revision_id", null: false
     t.bigint "preceded_by_id"
     t.integer "number", null: false
+    t.boolean "imported", default: false
     t.index ["content_revision_id"], name: "index_revisions_on_content_revision_id"
     t.index ["created_by_id"], name: "index_revisions_on_created_by_id"
     t.index ["document_id"], name: "index_revisions_on_document_id"

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2019_07_29_145805) do
+ActiveRecord::Schema.define(version: 2019_10_30_085853) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -61,6 +61,7 @@ ActiveRecord::Schema.define(version: 2019_07_29_145805) do
     t.datetime "updated_at", null: false
     t.bigint "created_by_id"
     t.datetime "first_published_at"
+    t.string "imported_from"
     t.index ["content_id", "locale"], name: "index_documents_on_content_id_and_locale", unique: true
     t.index ["created_by_id"], name: "index_documents_on_created_by_id"
   end

--- a/lib/tasks/whitehall_importer.rb
+++ b/lib/tasks/whitehall_importer.rb
@@ -66,6 +66,7 @@ module Tasks
       revision = Revision.create!(
         document: document,
         number: document.next_revision_number,
+        imported: true,
         content_revision: ContentRevision.new(
           title: translation["title"],
           base_path: "/government/news/" + whitehall_document["document"]["slug"],

--- a/lib/tasks/whitehall_importer.rb
+++ b/lib/tasks/whitehall_importer.rb
@@ -58,6 +58,7 @@ module Tasks
         document_type_id: "news_story", ## To be updated once Whitehall exports this value
         created_at: whitehall_document["document"]["created_at"],
         updated_at: whitehall_document["document"]["updated_at"],
+        imported_from: "whitehall",
       )
     end
 

--- a/spec/tasks/whitehall_importer_spec.rb
+++ b/spec/tasks/whitehall_importer_spec.rb
@@ -191,5 +191,12 @@ RSpec.describe Tasks::WhitehallImporter do
       expect(Edition.last.status).to be_draft
       expect(Edition.last).not_to be_live
     end
+
+    it "sets imported to true on revision" do
+      importer = Tasks::WhitehallImporter.new(123, import_published_then_drafted_data)
+      importer.import
+
+      expect(Revision.last.imported).to be true
+    end
   end
 end

--- a/spec/tasks/whitehall_importer_spec.rb
+++ b/spec/tasks/whitehall_importer_spec.rb
@@ -53,6 +53,14 @@ RSpec.describe Tasks::WhitehallImporter do
     expect(edition.update_type).to eq("major")
   end
 
+  it "sets import_from as Whitehall" do
+    importer = Tasks::WhitehallImporter.new(123, import_data)
+    importer.import
+
+    document = Document.last
+    expect(document.imported_from_whitehall?).to be true
+  end
+
   it "sets the correct states when Whitehall document state is 'published'" do
     import_data["editions"][0]["edition"]["state"] = "published"
     importer = Tasks::WhitehallImporter.new(123, import_data)


### PR DESCRIPTION
The changes here allow GOV.UK developers to see if a document (and which of it's revisions) was imported to Content Publisher, and if so, from which application.

For documents, we are setting the origin application name.  For revisions, we only set a boolean, since the origin application can be determined from the parent document.

Additionally, the Whitehall import process has been updated to set the relevant values for those imported documents.

Trello card: https://trello.com/c/C6UBegEP