### PR TITLE
Import all users from Whitehall document export

### DIFF
--- a/lib/tasks/whitehall_importer.rb
+++ b/lib/tasks/whitehall_importer.rb
@@ -16,6 +16,7 @@ module Tasks
     def import
       ActiveRecord::Base.transaction do
         document = create_or_update_document
+        create_users(whitehall_document["users"])
 
         whitehall_document["editions"].each_with_index do |edition, edition_number|
           edition["translations"].each do |translation|
@@ -46,6 +47,15 @@ module Tasks
     end
 
   private
+
+    def create_users(users)
+      users.each do |user|
+        next if User.exists?(uid: user["uid"])
+
+        user_keys = %w[uid name email organisation_slug organisation_content_id]
+        User.create!(user.slice(*user_keys).merge("permissions" => []))
+      end
+    end
 
     def most_recent_edition
       whitehall_document["editions"].max_by { |e| e["created_at"] }

--- a/spec/fixtures/whitehall_export_with_one_edition.json
+++ b/spec/fixtures/whitehall_export_with_one_edition.json
@@ -1,0 +1,66 @@
+{
+  "id": 1,
+  "created_at": "2019-11-01T12:21:16+00:00",
+  "updated_at": "2019-11-01T12:21:16+00:00",
+  "slug": "some-news-document",
+  "content_id": "b98b768d-5393-4088-8a12-3f4a26cc20cc",
+  "editions": [
+    {
+      "id": 1,
+      "created_at": "2019-11-01T12:21:16+00:00",
+      "updated_at": "2019-11-01T12:21:16+00:00",
+      "change_note": "First published",
+      "state": "draft",
+      "translations": [
+        {
+          "id": 1,
+          "locale": "en",
+          "title": "Title",
+          "summary": "Summary",
+          "body": "Body"
+        }
+      ],
+      "organisations": [
+        {
+          "id": 1,
+          "content_id": "424ba2bd-9d2e-4167-b05a-b9fb55d08a6f",
+          "lead": true,
+          "lead_ordering": 1
+        },
+        {
+          "id": 2,
+          "content_id": "bf88b646-9ef0-4303-8a17-5a529afa5274",
+          "lead": false
+        }
+      ],
+      "role_appointments": [
+        {
+          "id": 1,
+          "content_id": "a12d02cc-a753-451a-be23-d7089fc17bac"
+        }
+      ],
+      "topical_events": [
+        {
+          "id": 1,
+          "content_id": "22b08ca1-26cd-4565-bb47-f4c0b224970c"
+        }
+      ],
+      "world_locations": [
+        {
+          "id": 1,
+          "content_id": "9e80a56d-f9ee-4a15-8792-66e98be3dcd2"
+        }
+      ]
+    }
+  ],
+  "users": [
+    {
+      "id": 1,
+      "name": "A Person",
+      "uid": "36d5154e-d3b7-4e3e-aad8-32a50fc9430e",
+      "email": "a-publisher@department.gov.uk",
+      "organisation_slug": "a-government-department",
+      "organisation_content_id": "01892f23-b069-43f5-8404-d082f8dffcb9"
+    }
+  ]
+}

--- a/spec/fixtures/whitehall_export_with_two_editions.json
+++ b/spec/fixtures/whitehall_export_with_two_editions.json
@@ -1,0 +1,115 @@
+{
+  "id": 1,
+  "created_at": "2019-11-01T12:21:16+00:00",
+  "updated_at": "2019-11-01T12:21:16+00:00",
+  "slug": "some-news-document",
+  "content_id": "b98b768d-5393-4088-8a12-3f4a26cc20cc",
+  "editions": [
+    {
+      "id": 1,
+      "created_at": "2019-11-01T12:21:16+00:00",
+      "updated_at": "2019-11-01T12:21:16+00:00",
+      "change_note": "First published",
+      "state": "draft",
+      "translations": [
+        {
+          "id": 1,
+          "locale": "en",
+          "title": "Title",
+          "summary": "Summary",
+          "body": "Body"
+        }
+      ],
+      "organisations": [
+        {
+          "id": 1,
+          "content_id": "424ba2bd-9d2e-4167-b05a-b9fb55d08a6f",
+          "lead": true,
+          "lead_ordering": 1
+        },
+        {
+          "id": 2,
+          "content_id": "bf88b646-9ef0-4303-8a17-5a529afa5274",
+          "lead": false
+        }
+      ],
+      "role_appointments": [      
+        {
+          "id": 1,
+          "content_id": "a12d02cc-a753-451a-be23-d7089fc17bac"
+        }
+      ],
+      "topical_events": [      
+        { 
+          "id": 1,
+          "content_id": "22b08ca1-26cd-4565-bb47-f4c0b224970c"
+        }
+      ],    
+      "world_locations": [      
+        { 
+          "id": 1,
+          "content_id": "9e80a56d-f9ee-4a15-8792-66e98be3dcd2"
+        }
+      ]
+    },
+    {
+      "id": 2,
+      "created_at": "2019-11-01T12:21:16+00:00",
+      "updated_at": "2019-11-01T12:21:16+00:00",
+      "title": "Title",
+      "summary": "Summary",
+      "change_note": "First published",
+      "state": "draft",
+      "translations": [
+        {
+          "id": 2,
+          "locale": "en",
+          "title": "Title",
+          "summary": "Summary",
+          "body": "Body"
+        }
+      ],
+      "organisations": [
+        {
+          "id": 1,
+          "content_id": "424ba2bd-9d2e-4167-b05a-b9fb55d08a6f",
+          "lead": true,
+          "lead_ordering": 1
+        },
+        {
+          "id": 2,
+          "content_id": "bf88b646-9ef0-4303-8a17-5a529afa5274",
+          "lead": false
+        }
+      ],
+      "role_appointments": [      
+        {
+          "id": 1,
+          "content_id": "a12d02cc-a753-451a-be23-d7089fc17bac"
+        }
+      ],
+      "topical_events": [      
+        { 
+          "id": 1,
+          "content_id": "22b08ca1-26cd-4565-bb47-f4c0b224970c"
+        }
+      ],    
+      "world_locations": [      
+        { 
+          "id": 1,
+          "content_id": "9e80a56d-f9ee-4a15-8792-66e98be3dcd2"
+        }
+      ]
+    }
+  ],
+  "users": [
+    {
+      "id": 1,
+      "name": "A Person",
+      "uid": "36d5154e-d3b7-4e3e-aad8-32a50fc9430e",
+      "email": "a-publisher@department.gov.uk",
+      "organisation_slug": "a-government-department",
+      "organisation_content_id": "01892f23-b069-43f5-8404-d082f8dffcb9"
+    }
+  ]
+}

--- a/spec/support/fixtures_helper.rb
+++ b/spec/support/fixtures_helper.rb
@@ -1,0 +1,15 @@
+# frozen_string_literal: true
+
+module FixturesHelper
+  def fixtures_path
+    File.expand_path(Rails.root + "spec/fixtures")
+  end
+
+  def whitehall_export_with_one_edition
+    JSON.parse(File.read(fixtures_path + "/whitehall_export_with_one_edition.json"))
+  end
+
+  def whitehall_export_with_two_editions
+    JSON.parse(File.read(fixtures_path + "/whitehall_export_with_two_editions.json"))
+  end
+end

--- a/spec/tasks/import_spec.rb
+++ b/spec/tasks/import_spec.rb
@@ -1,55 +1,11 @@
 # frozen_string_literal: true
 
 RSpec.describe "Import tasks" do
+  include FixturesHelper
+
   describe "import:whitehall" do
     let(:whitehall_host) { Plek.new.external_url_for("whitehall-admin") }
-    let(:import_data) do
-      {
-        "id" => 1,
-        "created_at" => Time.current,
-        "updated_at" => Time.current,
-        "slug" => "some-news-document",
-        "content_id" => SecureRandom.uuid,
-        "editions" => [
-          {
-            "id" => 1,
-            "created_at" => Time.current,
-            "updated_at" => Time.current,
-            "title" => "Title",
-            "summary" => "Summary",
-            "change_note" => "First published",
-            "state" => "draft",
-            "translations" => [
-              {
-                "id" => 1,
-                "locale" => "en",
-                "title" => "Title",
-                "summary" => "Summary",
-                "body" => "Body",
-              },
-            ],
-            "organisations" => [
-              {
-                "id" => 1,
-                "content_id" => SecureRandom.uuid,
-                "lead" => true,
-                "lead_ordering" => 1,
-              },
-            ],
-          },
-        ],
-        "users" => [
-          {
-            "id" => 1,
-            "name" => "A Person",
-            "uid" => "36d5154e-d3b7-4e3e-aad8-32a50fc9430e",
-            "email" => "a-publisher@department.gov.uk",
-            "organisation_slug" => "a-government-department",
-            "organisation_content_id" => "01892f23-b069-43f5-8404-d082f8dffcb9",
-          },
-        ],
-      }
-    end
+    let(:import_data) { whitehall_export_with_one_edition }
 
     before do
       Rake::Task["import:whitehall"].reenable

--- a/spec/tasks/import_spec.rb
+++ b/spec/tasks/import_spec.rb
@@ -38,6 +38,16 @@ RSpec.describe "Import tasks" do
             ],
           },
         ],
+        "users" => [
+          {
+            "id" => 1,
+            "name" => "A Person",
+            "uid" => "36d5154e-d3b7-4e3e-aad8-32a50fc9430e",
+            "email" => "a-publisher@department.gov.uk",
+            "organisation_slug" => "a-government-department",
+            "organisation_content_id" => "01892f23-b069-43f5-8404-d082f8dffcb9",
+          },
+        ],
       }
     end
 

--- a/spec/tasks/whitehall_importer_spec.rb
+++ b/spec/tasks/whitehall_importer_spec.rb
@@ -57,6 +57,16 @@ RSpec.describe Tasks::WhitehallImporter do
           ],
         },
       ],
+      "users" => [
+        {
+          "id" => 1,
+          "name" => "A Person",
+          "uid" => "36d5154e-d3b7-4e3e-aad8-32a50fc9430e",
+          "email" => "a-publisher@department.gov.uk",
+          "organisation_slug" => "a-government-department",
+          "organisation_content_id" => "01892f23-b069-43f5-8404-d082f8dffcb9",
+        },
+      ],
     }
   end
 
@@ -74,6 +84,24 @@ RSpec.describe Tasks::WhitehallImporter do
     expect(edition.number).to eql(1)
     expect(edition.status).to be_draft
     expect(edition.update_type).to eq("major")
+  end
+
+  it "adds users who have never logged into Content Publisher" do
+    importer = Tasks::WhitehallImporter.new(123, import_data)
+    importer.import
+
+    expect(User.last.uid).to eq "36d5154e-d3b7-4e3e-aad8-32a50fc9430e"
+    expect(User.last.name).to eq "A Person"
+    expect(User.last.email).to eq "a-publisher@department.gov.uk"
+    expect(User.last.organisation_slug).to eq "a-government-department"
+    expect(User.last.organisation_content_id).to eq "01892f23-b069-43f5-8404-d082f8dffcb9"
+  end
+
+  it "does not add users who have logged into Content Publisher" do
+    importer = Tasks::WhitehallImporter.new(123, import_data)
+    User.create!(uid: "36d5154e-d3b7-4e3e-aad8-32a50fc9430e")
+
+    expect { importer.import }.not_to(change { User.count })
   end
 
   it "sets import_from as Whitehall" do
@@ -286,6 +314,16 @@ RSpec.describe Tasks::WhitehallImporter do
                 "lead_ordering" => 1,
               },
             ],
+          },
+        ],
+        "users" => [
+          {
+            "id" => 1,
+            "name" => "A Person",
+            "uid" => "36d5154e-d3b7-4e3e-aad8-32a50fc9430e",
+            "email" => "a-publisher@department.gov.uk",
+            "organisation_slug" => "a-government-department",
+            "organisation_content_id" => "01892f23-b069-43f5-8404-d082f8dffcb9",
           },
         ],
       }

--- a/spec/tasks/whitehall_importer_spec.rb
+++ b/spec/tasks/whitehall_importer_spec.rb
@@ -1,74 +1,9 @@
 # frozen_string_literal: true
 
 RSpec.describe Tasks::WhitehallImporter do
-  let(:import_data) do
-    {
-      "id" => 1,
-      "created_at" => Time.current,
-      "updated_at" => Time.current,
-      "slug" => "some-news-document",
-      "content_id" => SecureRandom.uuid,
-      "editions" => [
-        {
-          "id" => 1,
-          "created_at" => Time.current,
-          "updated_at" => Time.current,
-          "change_note" => "First published",
-          "state" => "draft",
-          "translations" => [
-            {
-              "id" => 1,
-              "locale" => "en",
-              "title" => "Title",
-              "summary" => "Summary",
-              "body" => "Body",
-            },
-          ],
-          "organisations" => [
-            {
-              "id" => 1,
-              "content_id" => SecureRandom.uuid,
-              "lead" => true,
-              "lead_ordering" => 1,
-            },
-            {
-              "id" => 2,
-              "content_id" => SecureRandom.uuid,
-              "lead" => false,
-            },
-          ],
-          "role_appointments" => [
-             {
-               "id" => 1,
-               "content_id" => SecureRandom.uuid,
-             },
-           ],
-          "topical_events" => [
-            {
-              "id" => 1,
-              "content_id" => SecureRandom.uuid,
-            },
-          ],
-          "world_locations" => [
-            {
-              "id" => 1,
-              "content_id" => SecureRandom.uuid,
-            },
-          ],
-        },
-      ],
-      "users" => [
-        {
-          "id" => 1,
-          "name" => "A Person",
-          "uid" => "36d5154e-d3b7-4e3e-aad8-32a50fc9430e",
-          "email" => "a-publisher@department.gov.uk",
-          "organisation_slug" => "a-government-department",
-          "organisation_content_id" => "01892f23-b069-43f5-8404-d082f8dffcb9",
-        },
-      ],
-    }
-  end
+  include FixturesHelper
+
+  let(:import_data) { whitehall_export_with_one_edition }
 
   it "can import JSON data from Whitehall" do
     importer = Tasks::WhitehallImporter.new(123, import_data)
@@ -255,80 +190,7 @@ RSpec.describe Tasks::WhitehallImporter do
   end
 
   context "when an imported document has more than one edition" do
-    let(:import_published_then_drafted_data) do
-      {
-        "id" => 1,
-        "created_at" => Time.current,
-        "updated_at" => Time.current,
-        "slug" => "some-news-document",
-        "content_id" => SecureRandom.uuid,
-        "editions" => [
-          {
-            "id" => 1,
-            "created_at" => Time.current,
-            "updated_at" => Time.current,
-            "title" => "Title",
-            "summary" => "Summary",
-            "change_note" => "First published",
-            "state" => "published",
-            "translations" => [
-              {
-                "id" => 1,
-                "locale" => "en",
-                "title" => "Title",
-                "summary" => "Summary",
-                "body" => "Body",
-              },
-            ],
-            "organisations" => [
-              {
-                "id" => 1,
-                "content_id" => SecureRandom.uuid,
-                "lead" => true,
-                "lead_ordering" => 1,
-              },
-            ],
-          },
-          {
-            "id" => 2,
-            "created_at" => Time.current,
-            "updated_at" => Time.current,
-            "title" => "Title",
-            "summary" => "Summary",
-            "change_note" => "First published",
-            "state" => "draft",
-            "translations" => [
-              {
-                "id" => 2,
-                "locale" => "en",
-                "title" => "Title",
-                "summary" => "Summary",
-                "body" => "Body",
-              },
-            ],
-            "organisations" => [
-              {
-                "id" => 1,
-                "content_id" => SecureRandom.uuid,
-                "lead" => true,
-                "lead_ordering" => 1,
-              },
-            ],
-          },
-        ],
-        "users" => [
-          {
-            "id" => 1,
-            "name" => "A Person",
-            "uid" => "36d5154e-d3b7-4e3e-aad8-32a50fc9430e",
-            "email" => "a-publisher@department.gov.uk",
-            "organisation_slug" => "a-government-department",
-            "organisation_content_id" => "01892f23-b069-43f5-8404-d082f8dffcb9",
-          },
-        ],
-      }
-    end
-
+    let(:import_published_then_drafted_data) { whitehall_export_with_two_editions }
 
     it "only creates the latest edition" do
       importer = Tasks::WhitehallImporter.new(123, import_published_then_drafted_data)


### PR DESCRIPTION
Editors of documents in Whitehall may never have logged into Content Publisher, so we will not have a row in the users table for them.  This change creates a user entry for every person who has ever edited the Whitehall document that is imported.

For security, we give these users no permissions in the Content Publisher database.  If they log into the application in the future, the permissions will get updated based on the values in Sign On.

Users who have logged into Content Publisher are skipped.

This code is branched from https://github.com/alphagov/content-publisher/pull/1416, so should not be merged until that PR is also merged.  It is also dependent on a users array being implemented in the Whitehall document export.

Trello card: https://trello.com/c/JPerZkxp