### PR TITLE
Tag imported documents

### DIFF
--- a/lib/tasks/whitehall_importer.rb
+++ b/lib/tasks/whitehall_importer.rb
@@ -85,6 +85,7 @@ module Tasks
             "organisations" => supporting_organisations(whitehall_edition["organisations"]),
             "role_appointments" => tags(whitehall_edition["role_appointments"]),
             "topical_events" => tags(whitehall_edition["topical_events"]),
+            "world_locations" => tags(whitehall_edition["world_locations"]),
           },
         ),
         created_at: whitehall_edition["created_at"],

--- a/lib/tasks/whitehall_importer.rb
+++ b/lib/tasks/whitehall_importer.rb
@@ -143,9 +143,14 @@ module Tasks
 
       primary_publishing_organisation = primary_publishing_organisations.min { |o| o["lead_ordering"] }
 
+      supporting_organisations = organisations.reject do |organisation|
+        organisation["lead"]
+      end
+
       TagsRevision.new(
         tags: {
           "primary_publishing_organisation" => [primary_publishing_organisation["content_id"]],
+          "organisations" => supporting_organisations.map { |organisation| organisation["content_id"] },
         },
       )
     end

--- a/lib/tasks/whitehall_importer.rb
+++ b/lib/tasks/whitehall_importer.rb
@@ -83,6 +83,7 @@ module Tasks
           tags: {
             "primary_publishing_organisation" => primary_publishing_organisation(whitehall_edition["organisations"]),
             "organisations" => supporting_organisations(whitehall_edition["organisations"]),
+            "role_appointments" => role_appointments(whitehall_edition["role_appointments"]),
           },
         ),
         created_at: whitehall_edition["created_at"],
@@ -155,6 +156,12 @@ module Tasks
       end
 
       supporting_organisations.map { |organisation| organisation["content_id"] }
+    end
+
+    def role_appointments(role_appointments)
+      return [] unless role_appointments
+
+      role_appointments.map { |appointment| appointment["content_id"] }
     end
   end
 

--- a/lib/tasks/whitehall_importer.rb
+++ b/lib/tasks/whitehall_importer.rb
@@ -79,7 +79,7 @@ module Tasks
           update_type: whitehall_edition["minor_change"] ? "minor" : "major",
           change_note: whitehall_edition["change_note"],
         ),
-        tags_revision: TagsRevision.new(tags: {}),
+        tags_revision: tags(whitehall_edition),
         created_at: whitehall_edition["created_at"],
       )
 
@@ -120,6 +120,22 @@ module Tasks
         embed = contacts.select { |x| x["id"] == id }.first["content_id"]
         "[Contact:#{embed}]"
       end
+    end
+
+    def tags(edition)
+      organisations = edition["organisations"]
+
+      primary_publishing_organisations = organisations.select do |organisation|
+        organisation["lead"]
+      end
+
+      primary_publishing_organisation = primary_publishing_organisations.min { |o| o["lead_ordering"] }
+
+      TagsRevision.new(
+        tags: {
+          "primary_publishing_organisation" => [primary_publishing_organisation["content_id"]],
+        },
+      )
     end
   end
 end

--- a/lib/tasks/whitehall_importer.rb
+++ b/lib/tasks/whitehall_importer.rb
@@ -83,7 +83,8 @@ module Tasks
           tags: {
             "primary_publishing_organisation" => primary_publishing_organisation(whitehall_edition["organisations"]),
             "organisations" => supporting_organisations(whitehall_edition["organisations"]),
-            "role_appointments" => role_appointments(whitehall_edition["role_appointments"]),
+            "role_appointments" => tags(whitehall_edition["role_appointments"]),
+            "topical_events" => tags(whitehall_edition["topical_events"]),
           },
         ),
         created_at: whitehall_edition["created_at"],
@@ -158,10 +159,10 @@ module Tasks
       supporting_organisations.map { |organisation| organisation["content_id"] }
     end
 
-    def role_appointments(role_appointments)
-      return [] unless role_appointments
+    def tags(associations)
+      return [] unless associations
 
-      role_appointments.map { |appointment| appointment["content_id"] }
+      associations.map { |association| association["content_id"] }
     end
   end
 

--- a/lib/tasks/whitehall_importer.rb
+++ b/lib/tasks/whitehall_importer.rb
@@ -125,8 +125,20 @@ module Tasks
     def tags(edition)
       organisations = edition["organisations"]
 
+      unless organisations
+        raise AbortImportError, "Must have at least one organisation"
+      end
+
       primary_publishing_organisations = organisations.select do |organisation|
         organisation["lead"]
+      end
+
+      unless primary_publishing_organisations.any?
+        raise AbortImportError, "Lead organisation missing"
+      end
+
+      if primary_publishing_organisations.count > 1
+        raise AbortImportError, "Cannot have more than one lead organisation"
       end
 
       primary_publishing_organisation = primary_publishing_organisations.min { |o| o["lead_ordering"] }
@@ -138,4 +150,6 @@ module Tasks
       )
     end
   end
+
+  class AbortImportError < RuntimeError; end
 end

--- a/spec/tasks/import_spec.rb
+++ b/spec/tasks/import_spec.rb
@@ -28,6 +28,14 @@ RSpec.describe "Import tasks" do
                 "body" => "Body",
               },
             ],
+            "organisations" => [
+              {
+                "id" => 1,
+                "content_id" => SecureRandom.uuid,
+                "lead" => true,
+                "lead_ordering" => 1,
+              },
+            ],
           },
         ],
       }

--- a/spec/tasks/whitehall_importer_spec.rb
+++ b/spec/tasks/whitehall_importer_spec.rb
@@ -31,6 +31,11 @@ RSpec.describe Tasks::WhitehallImporter do
               "lead" => true,
               "lead_ordering" => 1,
             },
+            {
+              "id" => 2,
+              "content_id" => SecureRandom.uuid,
+              "lead" => false,
+            },
           ],
         },
       ],
@@ -160,6 +165,16 @@ RSpec.describe Tasks::WhitehallImporter do
       importer = Tasks::WhitehallImporter.new(123, import_data)
 
       expect { importer.import }.to raise_error(Tasks::AbortImportError)
+    end
+
+    it "sets other supporting organisations" do
+      importer = Tasks::WhitehallImporter.new(123, import_data)
+      importer.import
+
+      imported_organisation = import_data["editions"][0]["organisations"][1]
+      edition = Edition.last
+
+      expect(edition.supporting_organisation_ids.first).to eq(imported_organisation["content_id"])
     end
   end
 

--- a/spec/tasks/whitehall_importer_spec.rb
+++ b/spec/tasks/whitehall_importer_spec.rb
@@ -48,7 +48,13 @@ RSpec.describe Tasks::WhitehallImporter do
               "id" => 1,
               "content_id" => SecureRandom.uuid,
             },
-          ]
+          ],
+          "world_locations" => [
+            {
+              "id" => 1,
+              "content_id" => SecureRandom.uuid,
+            },
+          ],
         },
       ],
     }
@@ -208,6 +214,16 @@ RSpec.describe Tasks::WhitehallImporter do
     edition = Edition.last
 
     expect(edition.tags["topical_events"].first).to eq(imported_topical_events["content_id"])
+  end
+
+  it "sets world locations" do
+    importer = Tasks::WhitehallImporter.new(123, import_data)
+    importer.import
+
+    imported_world_locations = import_data["editions"][0]["world_locations"][0]
+    edition = Edition.last
+
+    expect(edition.tags["world_locations"].first).to eq(imported_world_locations["content_id"])
   end
 
   context "when an imported document has more than one edition" do

--- a/spec/tasks/whitehall_importer_spec.rb
+++ b/spec/tasks/whitehall_importer_spec.rb
@@ -43,6 +43,12 @@ RSpec.describe Tasks::WhitehallImporter do
                "content_id" => SecureRandom.uuid,
              },
            ],
+          "topical_events" => [
+            {
+              "id" => 1,
+              "content_id" => SecureRandom.uuid,
+            },
+          ]
         },
       ],
     }
@@ -192,6 +198,16 @@ RSpec.describe Tasks::WhitehallImporter do
     edition = Edition.last
 
     expect(edition.tags["role_appointments"].first).to eq(imported_role_appointment["content_id"])
+  end
+
+  it "sets topical events" do
+    importer = Tasks::WhitehallImporter.new(123, import_data)
+    importer.import
+
+    imported_topical_events = import_data["editions"][0]["topical_events"][0]
+    edition = Edition.last
+
+    expect(edition.tags["topical_events"].first).to eq(imported_topical_events["content_id"])
   end
 
   context "when an imported document has more than one edition" do

--- a/spec/tasks/whitehall_importer_spec.rb
+++ b/spec/tasks/whitehall_importer_spec.rb
@@ -134,6 +134,33 @@ RSpec.describe Tasks::WhitehallImporter do
 
       expect(edition.primary_publishing_organisation_id).to eq(imported_organisation["content_id"])
     end
+
+    it "rejects the import if there are no organisations" do
+      import_data["editions"][0].delete("organisations")
+      importer = Tasks::WhitehallImporter.new(123, import_data)
+
+      expect { importer.import }.to raise_error(Tasks::AbortImportError)
+    end
+
+    it "rejects the import if there are no lead organisations" do
+      import_data["editions"][0]["organisations"].shift
+      importer = Tasks::WhitehallImporter.new(123, import_data)
+
+      expect { importer.import }.to raise_error(Tasks::AbortImportError)
+    end
+
+    it "rejects the import if there is more than one lead organisation" do
+      import_data["editions"][0]["organisations"].push(
+        "id" => 3,
+        "content_id" => SecureRandom.uuid,
+        "lead" => true,
+        "lead_ordering" => 2,
+      )
+
+      importer = Tasks::WhitehallImporter.new(123, import_data)
+
+      expect { importer.import }.to raise_error(Tasks::AbortImportError)
+    end
   end
 
   context "when an imported document has more than one edition" do

--- a/spec/tasks/whitehall_importer_spec.rb
+++ b/spec/tasks/whitehall_importer_spec.rb
@@ -24,6 +24,14 @@ RSpec.describe Tasks::WhitehallImporter do
               "body" => "Body",
             },
           ],
+          "organisations" => [
+            {
+              "id" => 1,
+              "content_id" => SecureRandom.uuid,
+              "lead" => true,
+              "lead_ordering" => 1,
+            },
+          ],
         },
       ],
     }
@@ -116,6 +124,18 @@ RSpec.describe Tasks::WhitehallImporter do
     expect(Edition.last.contents["body"]).to eq("[Contact:#{content_id}]")
   end
 
+  context "when importing organisation associations" do
+    it "sets a primary_publishing_organisation" do
+      importer = Tasks::WhitehallImporter.new(123, import_data)
+      importer.import
+
+      imported_organisation = import_data["editions"][0]["organisations"][0]
+      edition = Edition.last
+
+      expect(edition.primary_publishing_organisation_id).to eq(imported_organisation["content_id"])
+    end
+  end
+
   context "when an imported document has more than one edition" do
     let(:import_published_then_drafted_data) do
       {
@@ -142,6 +162,14 @@ RSpec.describe Tasks::WhitehallImporter do
                 "body" => "Body",
               },
             ],
+            "organisations" => [
+              {
+                "id" => 1,
+                "content_id" => SecureRandom.uuid,
+                "lead" => true,
+                "lead_ordering" => 1,
+              },
+            ],
           },
           {
             "id" => 2,
@@ -158,6 +186,14 @@ RSpec.describe Tasks::WhitehallImporter do
                 "title" => "Title",
                 "summary" => "Summary",
                 "body" => "Body",
+              },
+            ],
+            "organisations" => [
+              {
+                "id" => 1,
+                "content_id" => SecureRandom.uuid,
+                "lead" => true,
+                "lead_ordering" => 1,
               },
             ],
           },

--- a/spec/tasks/whitehall_importer_spec.rb
+++ b/spec/tasks/whitehall_importer_spec.rb
@@ -37,6 +37,12 @@ RSpec.describe Tasks::WhitehallImporter do
               "lead" => false,
             },
           ],
+          "role_appointments" => [
+             {
+               "id" => 1,
+               "content_id" => SecureRandom.uuid,
+             },
+           ],
         },
       ],
     }
@@ -176,6 +182,16 @@ RSpec.describe Tasks::WhitehallImporter do
 
       expect(edition.supporting_organisation_ids.first).to eq(imported_organisation["content_id"])
     end
+  end
+
+  it "sets role appointments" do
+    importer = Tasks::WhitehallImporter.new(123, import_data)
+    importer.import
+
+    imported_role_appointment = import_data["editions"][0]["role_appointments"][0]
+    edition = Edition.last
+
+    expect(edition.tags["role_appointments"].first).to eq(imported_role_appointment["content_id"])
   end
 
   context "when an imported document has more than one edition" do


### PR DESCRIPTION
Trello: https://trello.com/c/pHYtNC5z

## What's changed
Tags imported documents to:
- their Whitehall publishing organisation
- ministers and government appointments
- topical events
- world locations

Documents that have more than one lead publishing organisation are rejected as the other lead organisations wouldn't be able to update the document once it's been imported to Content Publisher.

## Note for reviewer
The structure of the import from Whitehall is based on: https://github.com/alphagov/whitehall/pull/5093