### PR TITLE
Update Whitehall import task for new export format

### DIFF
--- a/lib/tasks/whitehall_importer.rb
+++ b/lib/tasks/whitehall_importer.rb
@@ -72,7 +72,7 @@ module Tasks
           base_path: "/government/news/" + whitehall_document["slug"],
           summary: translation["summary"],
           contents: {
-            body: embed_contacts(translation["body"], whitehall_edition.fetch("depended_upon_contacts", [])),
+            body: embed_contacts(translation["body"], whitehall_edition.fetch("contacts", [])),
           },
         ),
         metadata_revision: MetadataRevision.new(

--- a/lib/tasks/whitehall_importer.rb
+++ b/lib/tasks/whitehall_importer.rb
@@ -18,8 +18,8 @@ module Tasks
         document = create_or_update_document
 
         whitehall_document["editions"].each_with_index do |edition, edition_number|
-          edition["associations"]["translations"].each do |translation|
-            next unless SUPPORTED_WHITEHALL_STATES.include?(edition["edition"]["state"])
+          edition["translations"].each do |translation|
+            next unless SUPPORTED_WHITEHALL_STATES.include?(edition["state"])
             next unless SUPPORTED_LOCALES.include?(translation["locale"])
 
             create_edition(document, translation, edition, edition_number + 1)
@@ -32,7 +32,7 @@ module Tasks
       WhitehallImport.create(
         whitehall_document_id: whitehall_document_id,
         payload: whitehall_document,
-        content_id: whitehall_document["document"]["content_id"],
+        content_id: whitehall_document["content_id"],
         state: "importing",
       )
     end
@@ -48,16 +48,16 @@ module Tasks
   private
 
     def most_recent_edition
-      whitehall_document["editions"].max_by { |e| e["edition"]["created_at"] }
+      whitehall_document["editions"].max_by { |e| e["created_at"] }
     end
 
     def create_or_update_document
       Document.find_or_create_by(
-        content_id: whitehall_document["document"]["content_id"],
+        content_id: whitehall_document["content_id"],
         locale: "en",
         document_type_id: "news_story", ## To be updated once Whitehall exports this value
-        created_at: whitehall_document["document"]["created_at"],
-        updated_at: whitehall_document["document"]["updated_at"],
+        created_at: whitehall_document["created_at"],
+        updated_at: whitehall_document["updated_at"],
         imported_from: "whitehall",
       )
     end
@@ -69,18 +69,18 @@ module Tasks
         imported: true,
         content_revision: ContentRevision.new(
           title: translation["title"],
-          base_path: "/government/news/" + whitehall_document["document"]["slug"],
+          base_path: "/government/news/" + whitehall_document["slug"],
           summary: translation["summary"],
           contents: {
-            body: embed_contacts(translation["body"], whitehall_edition["associations"].fetch("depended_upon_contacts", [])),
+            body: embed_contacts(translation["body"], whitehall_edition.fetch("depended_upon_contacts", [])),
           },
         ),
         metadata_revision: MetadataRevision.new(
-          update_type: whitehall_edition["edition"]["minor_change"] ? "minor" : "major",
-          change_note: whitehall_edition["edition"]["change_note"],
+          update_type: whitehall_edition["minor_change"] ? "minor" : "major",
+          change_note: whitehall_edition["change_note"],
         ),
         tags_revision: TagsRevision.new(tags: {}),
-        created_at: whitehall_edition["edition"]["created_at"],
+        created_at: whitehall_edition["created_at"],
       )
 
       Edition.create!(
@@ -92,26 +92,26 @@ module Tasks
           state: state(whitehall_edition),
           revision_at_creation: revision,
         ),
-        current: whitehall_edition["edition"]["id"] == most_recent_edition["edition"]["id"],
+        current: whitehall_edition["id"] == most_recent_edition["id"],
         live: live?(whitehall_edition),
-        created_at: whitehall_edition["edition"]["created_at"],
-        updated_at: whitehall_edition["edition"]["updated_at"],
+        created_at: whitehall_edition["created_at"],
+        updated_at: whitehall_edition["updated_at"],
       )
     end
 
     def state(whitehall_edition)
-      case whitehall_edition["edition"]["state"]
+      case whitehall_edition["state"]
       when "draft" then "draft"
       when "superseded" then "superseded"
       when "published"
-        whitehall_edition["edition"]["force_published"] ? "published_but_needs_2i" : "published"
+        whitehall_edition["force_published"] ? "published_but_needs_2i" : "published"
       else
         "submitted_for_review"
       end
     end
 
     def live?(whitehall_edition)
-      whitehall_edition["edition"]["state"] == "published"
+      whitehall_edition["state"] == "published"
     end
 
     def embed_contacts(body, contacts)

--- a/spec/tasks/import_spec.rb
+++ b/spec/tasks/import_spec.rb
@@ -5,35 +5,29 @@ RSpec.describe "Import tasks" do
     let(:whitehall_host) { Plek.new.external_url_for("whitehall-admin") }
     let(:import_data) do
       {
-        "document" => {
-          "id" => 1,
-          "created_at" => Time.current,
-          "updated_at" => Time.current,
-          "slug" => "some-news-document",
-          "content_id" => SecureRandom.uuid,
-        },
+        "id" => 1,
+        "created_at" => Time.current,
+        "updated_at" => Time.current,
+        "slug" => "some-news-document",
+        "content_id" => SecureRandom.uuid,
         "editions" => [
           {
-            "edition" => {
-              "id" => 1,
-              "created_at" => Time.current,
-              "updated_at" => Time.current,
-              "title" => "Title",
-              "summary" => "Summary",
-              "change_note" => "First published",
-              "state" => "draft",
-            },
-            "associations" => {
-              "translations" => [
-                {
-                  "id" => 1,
-                  "locale" => "en",
-                  "title" => "Title",
-                  "summary" => "Summary",
-                  "body" => "Body",
-                },
-              ],
-            },
+            "id" => 1,
+            "created_at" => Time.current,
+            "updated_at" => Time.current,
+            "title" => "Title",
+            "summary" => "Summary",
+            "change_note" => "First published",
+            "state" => "draft",
+            "translations" => [
+              {
+                "id" => 1,
+                "locale" => "en",
+                "title" => "Title",
+                "summary" => "Summary",
+                "body" => "Body",
+              },
+            ],
           },
         ],
       }

--- a/spec/tasks/whitehall_importer_spec.rb
+++ b/spec/tasks/whitehall_importer_spec.rb
@@ -109,7 +109,7 @@ RSpec.describe Tasks::WhitehallImporter do
   it "changes the ids of embedded contacts" do
     import_data["editions"][0]["translations"][0]["body"] = "[Contact:123]"
     content_id = SecureRandom.uuid
-    import_data["editions"][0]["depended_upon_contacts"] = [{ "id" => 123, "content_id" => content_id }]
+    import_data["editions"][0]["contacts"] = [{ "id" => 123, "content_id" => content_id }]
     importer = Tasks::WhitehallImporter.new(123, import_data)
     importer.import
 


### PR DESCRIPTION
The format of the Whitehall document export was changed in https://trello.com/c/at9jVJVu.  This updates the import task to reflect these changes in the format.