### PR TITLE
Add document_type_id column to Metadata Revisions table

### DIFF
--- a/db/migrate/20191104131759_add_document_type_id_to_metadata_revisions.rb
+++ b/db/migrate/20191104131759_add_document_type_id_to_metadata_revisions.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+class AddDocumentTypeIdToMetadataRevisions < ActiveRecord::Migration[5.2]
+  def change
+    add_column :metadata_revisions, :document_type_id, :string
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2019_10_30_093601) do
+ActiveRecord::Schema.define(version: 2019_11_04_131759) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -209,6 +209,7 @@ ActiveRecord::Schema.define(version: 2019_10_30_093601) do
     t.bigint "created_by_id"
     t.datetime "proposed_publish_time"
     t.datetime "backdated_to"
+    t.string "document_type_id"
   end
 
   create_table "removals", force: :cascade do |t|


### PR DESCRIPTION
In order to support documents that can change type, the document_type_id has to
be moved from the Document to Metadata Revisions table. 

Further work will be completed in separate PRs.
[Trello card](https://trello.com/c/kwnmsIe9/1095-permit-content-publisher-to-have-documents-that-change-type)

Co-authored-by: Jon Hallam <jonathan.hallam@digital.cabinet-office.gov.uk>

