### PR TITLE
Import user attribution from Whitehall

### DIFF
--- a/lib/tasks/whitehall_importer.rb
+++ b/lib/tasks/whitehall_importer.rb
@@ -2,7 +2,7 @@
 
 module Tasks
   class WhitehallImporter
-    attr_reader :whitehall_document_id, :whitehall_document, :whitehall_import
+    attr_reader :whitehall_document_id, :whitehall_document, :whitehall_import, :user_ids
 
     SUPPORTED_WHITEHALL_STATES = %w(draft published rejected submitted superseded).freeze
     SUPPORTED_LOCALES = %w(en).freeze
@@ -11,6 +11,7 @@ module Tasks
       @whitehall_document_id = whitehall_document_id
       @whitehall_document = whitehall_document
       @whitehall_import = store_json_blob
+      @user_ids = {}
     end
 
     def import
@@ -50,10 +51,9 @@ module Tasks
 
     def create_users(users)
       users.each do |user|
-        next if User.exists?(uid: user["uid"])
-
         user_keys = %w[uid name email organisation_slug organisation_content_id]
-        User.create!(user.slice(*user_keys).merge("permissions" => []))
+        content_publisher_user = User.create_with(user.slice(*user_keys).merge("permissions" => [])).find_or_create_by!(uid: user["uid"])
+        user_ids[user["id"]] = content_publisher_user["id"]
       end
     end
 

--- a/lib/tasks/whitehall_importer.rb
+++ b/lib/tasks/whitehall_importer.rb
@@ -78,6 +78,7 @@ module Tasks
 
     def create_edition(document, translation, whitehall_edition, edition_number)
       first_author = whitehall_edition["history"].select { |h| h["event"] == "create" }.first
+      last_author = whitehall_edition["history"].last
 
       revision = Revision.create!(
         document: document,
@@ -121,6 +122,7 @@ module Tasks
         created_at: whitehall_edition["created_at"],
         updated_at: whitehall_edition["updated_at"],
         created_by_id: user_ids[first_author["whodunnit"]],
+        last_edited_by_id: user_ids[last_author["whodunnit"]],
       )
     end
 

--- a/lib/tasks/whitehall_importer.rb
+++ b/lib/tasks/whitehall_importer.rb
@@ -77,6 +77,8 @@ module Tasks
     end
 
     def create_edition(document, translation, whitehall_edition, edition_number)
+      first_author = whitehall_edition["history"].select { |h| h["event"] == "create" }.first
+
       revision = Revision.create!(
         document: document,
         number: document.next_revision_number,
@@ -118,6 +120,7 @@ module Tasks
         live: live?(whitehall_edition),
         created_at: whitehall_edition["created_at"],
         updated_at: whitehall_edition["updated_at"],
+        created_by_id: user_ids[first_author["whodunnit"]],
       )
     end
 

--- a/spec/fixtures/whitehall_export_with_one_edition.json
+++ b/spec/fixtures/whitehall_export_with_one_edition.json
@@ -20,6 +20,13 @@
           "body": "Body"
         }
       ],
+      "history": [
+        {
+          "event": "create",
+          "state": "draft",
+          "whodunnit": 1
+        }
+      ],
       "organisations": [
         {
           "id": 1,

--- a/spec/fixtures/whitehall_export_with_two_editions.json
+++ b/spec/fixtures/whitehall_export_with_two_editions.json
@@ -20,6 +20,13 @@
           "body": "Body"
         }
       ],
+      "history": [
+        {
+          "event": "create",
+          "state": "draft",
+          "whodunnit": 1
+        }
+      ],
       "organisations": [
         {
           "id": 1,
@@ -67,6 +74,13 @@
           "title": "Title",
           "summary": "Summary",
           "body": "Body"
+        }
+      ],
+      "history": [
+        {
+          "event": "create",
+          "state": "draft",
+          "whodunnit": 1
         }
       ],
       "organisations": [

--- a/spec/fixtures/whitehall_export_with_two_editions.json
+++ b/spec/fixtures/whitehall_export_with_two_editions.json
@@ -81,7 +81,13 @@
           "event": "create",
           "state": "draft",
           "whodunnit": 2
+        },
+        {
+          "event": "update",
+          "state": "draft",
+          "whodunnit": 1
         }
+
       ],
       "organisations": [
         {

--- a/spec/fixtures/whitehall_export_with_two_editions.json
+++ b/spec/fixtures/whitehall_export_with_two_editions.json
@@ -80,7 +80,7 @@
         {
           "event": "create",
           "state": "draft",
-          "whodunnit": 1
+          "whodunnit": 2
         }
       ],
       "organisations": [
@@ -122,6 +122,14 @@
       "name": "A Person",
       "uid": "36d5154e-d3b7-4e3e-aad8-32a50fc9430e",
       "email": "a-publisher@department.gov.uk",
+      "organisation_slug": "a-government-department",
+      "organisation_content_id": "01892f23-b069-43f5-8404-d082f8dffcb9"
+    },
+    {
+      "id": 2,
+      "name": "A Second Person",
+      "uid": "52303743-6d34-4974-93c3-914bdf92d645",
+      "email": "a-second-publisher@department.gov.uk",
       "organisation_slug": "a-government-department",
       "organisation_content_id": "01892f23-b069-43f5-8404-d082f8dffcb9"
     }

--- a/spec/tasks/whitehall_importer_spec.rb
+++ b/spec/tasks/whitehall_importer_spec.rb
@@ -224,5 +224,13 @@ RSpec.describe Tasks::WhitehallImporter do
 
       expect(Revision.last.imported).to be true
     end
+
+    it "sets created_by_id on each edition as the original edition author" do
+      importer = Tasks::WhitehallImporter.new(123, import_published_then_drafted_data)
+      importer.import
+
+      expect(Edition.second_to_last.created_by_id).to eq(User.second_to_last.id)
+      expect(Edition.last.created_by_id).to eq(User.last.id)
+    end
   end
 end

--- a/spec/tasks/whitehall_importer_spec.rb
+++ b/spec/tasks/whitehall_importer_spec.rb
@@ -50,6 +50,13 @@ RSpec.describe Tasks::WhitehallImporter do
     expect(importer.user_ids).to eq(expected_user_ids)
   end
 
+  it "sets created_by_id as the original author" do
+    importer = Tasks::WhitehallImporter.new(123, import_data)
+    importer.import
+
+    expect(Document.last.created_by_id).to eq(User.last.id)
+  end
+
   it "sets import_from as Whitehall" do
     importer = Tasks::WhitehallImporter.new(123, import_data)
     importer.import

--- a/spec/tasks/whitehall_importer_spec.rb
+++ b/spec/tasks/whitehall_importer_spec.rb
@@ -232,5 +232,13 @@ RSpec.describe Tasks::WhitehallImporter do
       expect(Edition.second_to_last.created_by_id).to eq(User.second_to_last.id)
       expect(Edition.last.created_by_id).to eq(User.last.id)
     end
+
+    it "sets last_edited_by_id on each edition as the most recent author" do
+      importer = Tasks::WhitehallImporter.new(123, import_published_then_drafted_data)
+      importer.import
+
+      expect(Edition.second_to_last.last_edited_by_id).to eq(User.second_to_last.id)
+      expect(Edition.last.last_edited_by_id).to eq(User.second_to_last.id)
+    end
   end
 end

--- a/spec/tasks/whitehall_importer_spec.rb
+++ b/spec/tasks/whitehall_importer_spec.rb
@@ -39,6 +39,17 @@ RSpec.describe Tasks::WhitehallImporter do
     expect { importer.import }.not_to(change { User.count })
   end
 
+  it "creates a user map" do
+    importer = Tasks::WhitehallImporter.new(123, import_data)
+    importer.import
+
+    expected_user_ids = {
+      1 => User.last.id,
+    }
+
+    expect(importer.user_ids).to eq(expected_user_ids)
+  end
+
   it "sets import_from as Whitehall" do
     importer = Tasks::WhitehallImporter.new(123, import_data)
     importer.import


### PR DESCRIPTION
So far, we have imported users and documents from Whitehall, but not linked the users to the documents they have edited.  When importing a document from Whitehall, we now attribute the following to Content Publisher users:
- document creator
- edition creator
- edition last editor

Trello card: https://trello.com/c/jOaNlx3c