### PR TITLE
Pass document_type_id through to metadata_revisions

### DIFF
--- a/app/models/document.rb
+++ b/app/models/document.rb
@@ -58,7 +58,14 @@ class Document < ApplicationRecord
                          document_type_id: document_type_id,
                          created_by: user)
 
-      document.tap { |d| Edition.create_initial(d, user, tags) }
+      document.tap do |d|
+        Edition.create_initial(
+          document: d,
+          user: user,
+          tags: tags,
+          document_type_id: document_type_id,
+        )
+      end
     end
   end
 

--- a/app/models/edition.rb
+++ b/app/models/edition.rb
@@ -92,8 +92,13 @@ class Edition < ApplicationRecord
       .find_by!(find_by)
   end
 
-  def self.create_initial(document, user = nil, tags = {})
-    revision = Revision.create_initial(document, user, tags)
+  def self.create_initial(document:, document_type_id:, user: nil, tags: {})
+    revision = Revision.create_initial(
+      document: document,
+      user: user,
+      tags: tags,
+      document_type_id: document_type_id,
+    )
     status = Status.create!(created_by: user,
                             revision_at_creation: revision,
                             state: :draft)

--- a/app/models/revision.rb
+++ b/app/models/revision.rb
@@ -62,7 +62,7 @@ class Revision < ApplicationRecord
            :supporting_organisation_ids,
            to: :tags_revision
 
-  def self.create_initial(document, user = nil, tags = {})
+  def self.create_initial(document:, document_type_id:, user: nil, tags: {})
     Revision.create!(
       created_by: user,
       document: document,
@@ -72,6 +72,7 @@ class Revision < ApplicationRecord
         change_note: "First published.",
         update_type: "major",
         created_by: user,
+        document_type_id: document_type_id,
       ),
       tags_revision: TagsRevision.new(tags: tags, created_by: user),
     )

--- a/spec/models/document_spec.rb
+++ b/spec/models/document_spec.rb
@@ -17,6 +17,7 @@ RSpec.describe Document do
       expect(doc.content_id).to eq(content_id)
       expect(doc.current_edition).to be_a(Edition)
       expect(doc.current_edition.created_by).to eq(user)
+      expect(doc.editions.first.revisions.first.metadata_revision.document_type_id).to eq(document_type.id)
     end
   end
 

--- a/spec/models/document_spec.rb
+++ b/spec/models/document_spec.rb
@@ -2,21 +2,25 @@
 
 RSpec.describe Document do
   describe ".create_initial" do
-    it "creates a document with a current edition" do
-      content_id = SecureRandom.uuid
-      document_type = build(:document_type)
-      user = build(:user)
-
-      doc = Document.create_initial(
+    let(:content_id) { SecureRandom.uuid }
+    let(:document_type) { build(:document_type) }
+    let(:user) { build(:user) }
+    let(:doc) {
+      Document.create_initial(
         content_id: content_id,
         document_type_id: document_type.id,
         user: user,
       )
+    }
 
+    it "creates a document with a current edition" do
       expect(doc).to be_a(Document)
       expect(doc.content_id).to eq(content_id)
       expect(doc.current_edition).to be_a(Edition)
       expect(doc.current_edition.created_by).to eq(user)
+    end
+
+    it "passes on the `document_type_id` to the relevant metadata_revision" do
       expect(doc.editions.first.revisions.first.metadata_revision.document_type_id).to eq(document_type.id)
     end
   end

--- a/spec/models/edition_spec.rb
+++ b/spec/models/edition_spec.rb
@@ -30,7 +30,11 @@ RSpec.describe Edition do
     let(:user) { build(:user) }
 
     it "creates a current edition" do
-      edition = Edition.create_initial(document, user)
+      edition = Edition.create_initial(
+        document: document,
+        document_type_id: document.document_type_id,
+        user: user,
+      )
 
       expect(edition).to be_a(Edition)
       expect(edition.created_by).to eq(user)
@@ -39,14 +43,22 @@ RSpec.describe Edition do
     end
 
     it "has a revision" do
-      edition = Edition.create_initial(document, user)
+      edition = Edition.create_initial(
+        document: document,
+        document_type_id: document.document_type_id,
+        user: user,
+      )
 
       expect(edition.revision).to be_a(Revision)
       expect(edition.created_by).to eq(user)
     end
 
     it "has a status which is draft" do
-      edition = Edition.create_initial(document, user)
+      edition = Edition.create_initial(
+        document: document,
+        document_type_id: document.document_type_id,
+        user: user,
+      )
 
       expect(edition.status).to be_a(Status)
       expect(edition.status).to be_draft

--- a/spec/models/revision_spec.rb
+++ b/spec/models/revision_spec.rb
@@ -7,7 +7,10 @@ RSpec.describe Revision do
     let(:document) { build(:document) }
 
     it "creates an empty revision for the document" do
-      revision = Revision.create_initial(document)
+      revision = Revision.create_initial(
+        document: document,
+        document_type_id: document.document_type_id,
+      )
 
       expect(revision).to be_a(Revision)
       expect(revision).not_to be_new_record
@@ -16,7 +19,10 @@ RSpec.describe Revision do
     end
 
     it "sets default change note and update type" do
-      revision = Revision.create_initial(document)
+      revision = Revision.create_initial(
+        document: document,
+        document_type_id: document.document_type_id,
+      )
 
       expect(revision.change_note).to eq("First published.")
       expect(revision.update_type).to eq("major")
@@ -24,7 +30,11 @@ RSpec.describe Revision do
 
     it "can associate records with a user" do
       user = build(:user)
-      revision = Revision.create_initial(document, user)
+      revision = Revision.create_initial(
+        document: document,
+        document_type_id: document.document_type_id,
+        user: user,
+      )
 
       expect(revision.created_by).to eq(user)
       expect(revision.content_revision.created_by).to eq(user)
@@ -34,7 +44,12 @@ RSpec.describe Revision do
 
     it "can set tags" do
       tags = { "type" => %w[value1 value2] }
-      revision = Revision.create_initial(document, nil, tags)
+      revision = Revision.create_initial(
+        document: document,
+        document_type_id: document.document_type_id,
+        user: nil,
+        tags: tags,
+      )
 
       expect(revision.tags).to eq(tags)
     end


### PR DESCRIPTION
As part of allowing content publisher to change the document types of documents we need to have the document type id saved in metadata revisions. This duplicates thatf information across metadata revisions and document. This will be removed from Document after later schema changes.

Relies on - https://github.com/alphagov/content-publisher/pull/1419/files
Trello - https://trello.com/b/mn2MqH3M/publishing-workflow-doing-q4-2019-to

Co-authored-by: Aga Dufrat <agnieszka.dufrat@digital.cabinet-office.gov.uk>