### PR TITLE
Rename "history" to "revision_history" in Whitehall import

### DIFF
--- a/lib/tasks/whitehall_importer.rb
+++ b/lib/tasks/whitehall_importer.rb
@@ -63,7 +63,7 @@ module Tasks
 
     def create_or_update_document
       first_edition = whitehall_document["editions"].first
-      first_author = first_edition["history"].select { |h| h["event"] == "create" }.first
+      first_author = first_edition["revision_history"].select { |h| h["event"] == "create" }.first
 
       Document.find_or_create_by!(
         content_id: whitehall_document["content_id"],
@@ -77,8 +77,8 @@ module Tasks
     end
 
     def create_edition(document, translation, whitehall_edition, edition_number)
-      first_author = whitehall_edition["history"].select { |h| h["event"] == "create" }.first
-      last_author = whitehall_edition["history"].last
+      first_author = whitehall_edition["revision_history"].select { |h| h["event"] == "create" }.first
+      last_author = whitehall_edition["revision_history"].last
 
       revision = Revision.create!(
         document: document,

--- a/spec/fixtures/whitehall_export_with_one_edition.json
+++ b/spec/fixtures/whitehall_export_with_one_edition.json
@@ -20,7 +20,7 @@
           "body": "Body"
         }
       ],
-      "history": [
+      "revision_history": [
         {
           "event": "create",
           "state": "draft",

--- a/spec/fixtures/whitehall_export_with_two_editions.json
+++ b/spec/fixtures/whitehall_export_with_two_editions.json
@@ -20,7 +20,7 @@
           "body": "Body"
         }
       ],
-      "history": [
+      "revision_history": [
         {
           "event": "create",
           "state": "draft",
@@ -76,7 +76,7 @@
           "body": "Body"
         }
       ],
-      "history": [
+      "revision_history": [
         {
           "event": "create",
           "state": "draft",


### PR DESCRIPTION
The name of an edition's edit history was changed from `history` to `revision_history` in the Whitehall document export as part of https://github.com/alphagov/whitehall/pull/5093.

This makes the corresponding change in the Content Publisher import code.