### PR TITLE
Raise AbortImportError when Whitehall import is unsuccessful

### DIFF
--- a/lib/tasks/whitehall_importer.rb
+++ b/lib/tasks/whitehall_importer.rb
@@ -22,7 +22,7 @@ module Tasks
         whitehall_document["editions"].each_with_index do |edition, edition_number|
           edition["translations"].each do |translation|
             raise AbortImportError, "Edition has an unsupported state" unless SUPPORTED_WHITEHALL_STATES.include?(edition["state"])
-            next unless SUPPORTED_LOCALES.include?(translation["locale"])
+            raise AbortImportError, "Edition has an unsupported locale" unless SUPPORTED_LOCALES.include?(translation["locale"])
 
             create_edition(document, translation, edition, edition_number + 1)
           end

--- a/lib/tasks/whitehall_importer.rb
+++ b/lib/tasks/whitehall_importer.rb
@@ -6,6 +6,14 @@ module Tasks
 
     SUPPORTED_WHITEHALL_STATES = %w(draft published rejected submitted superseded).freeze
     SUPPORTED_LOCALES = %w(en).freeze
+    SUPPORTED_DOCUMENT_TYPES = %w(news_story press_release).freeze
+    DOCUMENT_SUB_TYPES = %w[
+      news_article_type
+      publication_type
+      corporate_information_page_type
+      speech_type
+    ].freeze
+
 
     def initialize(whitehall_document_id, whitehall_document)
       @whitehall_document_id = whitehall_document_id
@@ -68,7 +76,7 @@ module Tasks
       Document.find_or_create_by!(
         content_id: whitehall_document["content_id"],
         locale: "en",
-        document_type_id: "news_story", ## To be updated once Whitehall exports this value
+        document_type_id: "news_story", ## TODO: This is a placeholder, to be removed after document type is moved to revision
         created_at: whitehall_document["created_at"],
         updated_at: whitehall_document["updated_at"],
         created_by_id: user_ids[first_author["whodunnit"]],
@@ -79,6 +87,9 @@ module Tasks
     def create_edition(document, translation, whitehall_edition, edition_number)
       first_author = whitehall_edition["revision_history"].select { |h| h["event"] == "create" }.first
       last_author = whitehall_edition["revision_history"].last
+
+      document_type_key = DOCUMENT_SUB_TYPES.reject { |t| whitehall_edition[t].nil? }.first
+      raise AbortImportError, "Edition has an unsupported document type" unless SUPPORTED_DOCUMENT_TYPES.include?(whitehall_edition[document_type_key])
 
       revision = Revision.create!(
         document: document,
@@ -95,6 +106,7 @@ module Tasks
         metadata_revision: MetadataRevision.new(
           update_type: whitehall_edition["minor_change"] ? "minor" : "major",
           change_note: whitehall_edition["change_note"],
+          #document_type_id: whitehall_edition[document_type_key], # TODO: uncomment when document type is moved to revision
         ),
         tags_revision: TagsRevision.new(
           tags: {

--- a/lib/tasks/whitehall_importer.rb
+++ b/lib/tasks/whitehall_importer.rb
@@ -21,7 +21,7 @@ module Tasks
 
         whitehall_document["editions"].each_with_index do |edition, edition_number|
           edition["translations"].each do |translation|
-            next unless SUPPORTED_WHITEHALL_STATES.include?(edition["state"])
+            raise AbortImportError, "Edition has an unsupported state" unless SUPPORTED_WHITEHALL_STATES.include?(edition["state"])
             next unless SUPPORTED_LOCALES.include?(translation["locale"])
 
             create_edition(document, translation, edition, edition_number + 1)

--- a/spec/fixtures/whitehall_export_with_one_edition.json
+++ b/spec/fixtures/whitehall_export_with_one_edition.json
@@ -11,6 +11,7 @@
       "updated_at": "2019-11-01T12:21:16+00:00",
       "change_note": "First published",
       "state": "draft",
+      "news_article_type": "news_story",
       "translations": [
         {
           "id": 1,

--- a/spec/fixtures/whitehall_export_with_two_editions.json
+++ b/spec/fixtures/whitehall_export_with_two_editions.json
@@ -11,6 +11,7 @@
       "updated_at": "2019-11-01T12:21:16+00:00",
       "change_note": "First published",
       "state": "draft",
+      "news_article_type": "news_story",
       "translations": [
         {
           "id": 1,
@@ -67,6 +68,7 @@
       "summary": "Summary",
       "change_note": "First published",
       "state": "draft",
+      "news_article_type": "news_story",
       "translations": [
         {
           "id": 2,

--- a/spec/tasks/whitehall_importer_spec.rb
+++ b/spec/tasks/whitehall_importer_spec.rb
@@ -247,5 +247,12 @@ RSpec.describe Tasks::WhitehallImporter do
       expect(Edition.second_to_last.last_edited_by_id).to eq(User.second_to_last.id)
       expect(Edition.last.last_edited_by_id).to eq(User.second_to_last.id)
     end
+
+    it "raises AbortImportError when an edition has an unsupported document type" do
+      import_published_then_drafted_data["editions"][0]["news_article_type"] = "unsupported_document"
+      importer = Tasks::WhitehallImporter.new(123, import_published_then_drafted_data)
+
+      expect { importer.import }.to raise_error(Tasks::AbortImportError)
+    end
   end
 end

--- a/spec/tasks/whitehall_importer_spec.rb
+++ b/spec/tasks/whitehall_importer_spec.rb
@@ -118,6 +118,13 @@ RSpec.describe Tasks::WhitehallImporter do
     expect { importer.import }.to raise_error(Tasks::AbortImportError)
   end
 
+  it "raises AbortImportError when edition has an unsupported locale" do
+    import_data["editions"][0]["translations"][0]["locale"] = "zz"
+    importer = Tasks::WhitehallImporter.new(123, import_data)
+
+    expect { importer.import }.to raise_error(Tasks::AbortImportError)
+  end
+
   it "changes the ids of embedded contacts" do
     import_data["editions"][0]["translations"][0]["body"] = "[Contact:123]"
     content_id = SecureRandom.uuid

--- a/spec/tasks/whitehall_importer_spec.rb
+++ b/spec/tasks/whitehall_importer_spec.rb
@@ -111,11 +111,11 @@ RSpec.describe Tasks::WhitehallImporter do
     expect(Edition.last).not_to be_live
   end
 
-  it "skips importing editions with Whitehall states that are not supported" do
+  it "raises AbortImportError when edition has an unsupported state" do
     import_data["editions"][0]["state"] = "not_supported"
     importer = Tasks::WhitehallImporter.new(123, import_data)
 
-    expect { importer.import }.not_to(change { Edition.count })
+    expect { importer.import }.to raise_error(Tasks::AbortImportError)
   end
 
   it "changes the ids of embedded contacts" do


### PR DESCRIPTION
There will sometimes be cases where we cannot fully import a document from Whitehall.  Currently, these documents are still being partially imported but being marked as successful in the database.

This changes the behaviour to abort on the following, and log a relevant message:
- An edition has an unsupported state
- An edition has an unsupported locale
- An edition has an unsupported document type

Note that for the latter, we are currently not storing the document type on import (there is a placeholder in the code) until the `document_type_id` has been fully migrated from `Document` to `RevisionMetadata`.

Trello card: https://trello.com/c/6ChA2UFY