### PR TITLE
Populate document_type_id in metadata_revisions

### DIFF
--- a/db/migrate/20191106095154_populate_document_type_id_in_metadata_revisions.rb
+++ b/db/migrate/20191106095154_populate_document_type_id_in_metadata_revisions.rb
@@ -1,0 +1,12 @@
+# frozen_string_literal: true
+
+class PopulateDocumentTypeIdInMetadataRevisions < ActiveRecord::Migration[5.2]
+  def up
+    type_doc_ids_hash = Document.group(:document_type_id).pluck(:document_type_id, "ARRAY_AGG(id)").to_h
+
+    type_doc_ids_hash.each do |type, ids|
+      MetadataRevision.joins("INNER JOIN revisions ON metadata_revisions.id = revisions.id")
+        .where("revisions.document_id": ids).update_all(document_type_id: type)
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2019_11_04_131759) do
+ActiveRecord::Schema.define(version: 2019_11_06_095154) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"


### PR DESCRIPTION
Populate `document_type_id` in `metadata_revisions` table with the data from the `documents` table as a part of work to allow Content Publisher to change document types. 

In the next step we will switch the application to use data from the new column.

[Trello card](https://trello.com/c/kwnmsIe9/1095-permit-content-publisher-to-have-documents-that-change-type)