### PR TITLE
Allow document_type_id to be null on the Document table

### DIFF
--- a/db/migrate/20191106152405_allow_null_on_document_document_type_id.rb
+++ b/db/migrate/20191106152405_allow_null_on_document_document_type_id.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+class AllowNullOnDocumentDocumentTypeId < ActiveRecord::Migration[5.2]
+  def change
+    change_column_null(Document, :document_type_id, true)
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2019_11_06_095154) do
+ActiveRecord::Schema.define(version: 2019_11_06_152405) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -56,7 +56,7 @@ ActiveRecord::Schema.define(version: 2019_11_06_095154) do
   create_table "documents", force: :cascade do |t|
     t.uuid "content_id", null: false
     t.string "locale", null: false
-    t.string "document_type_id", null: false
+    t.string "document_type_id"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.bigint "created_by_id"


### PR DESCRIPTION
Trello - https://trello.com/c/kwnmsIe9/1095-permit-content-publisher-to-have-documents-that-change-type

Content publisher currently sets `document_type_id` on the `Document` and `MetadataRevision` table. Before the `document_type_id` column can be removed from `Document` it needs to be able to be set to nill otherwise code changes that do not set it will fail.

This allows the setting of that column to null in order that changes can be made to the underlying code