### PR TITLE
Improve tag selection

### DIFF
--- a/app/assets/stylesheets/components/_autocomplete.scss
+++ b/app/assets/stylesheets/components/_autocomplete.scss
@@ -1,7 +1,6 @@
 @import url(asset-path("accessible-autocomplete/dist/accessible-autocomplete.min.css"));
 
-// TODO: Replace with $govuk-focus-colour when the new colour scheme is released
-$app-focus-colour: #ffdd00;
+$app-focus-colour: $govuk-focus-colour;
 
 .app-c-autocomplete {
   margin-bottom: govuk-spacing(6);
@@ -26,6 +25,13 @@ $app-focus-colour: #ffdd00;
   @include govuk-font(19);
   z-index: 1;
   color: $govuk-text-colour;
+}
+
+.autocomplete__input:focus,
+.autocomplete__input--focused {
+  outline: $govuk-focus-width solid $govuk-focus-colour;
+  outline-offset: $govuk-border-width-form-element;
+  box-shadow: $govuk-input-border-colour 0 0 0 $govuk-border-width-form-element;
 }
 
 .autocomplete__hint {
@@ -71,6 +77,7 @@ $app-focus-colour: #ffdd00;
 
   .autocomplete__remove-option {
     @include govuk-font(16);
+    @extend %govuk-link;
   }
 }
 

--- a/app/assets/stylesheets/components/_autocomplete.scss
+++ b/app/assets/stylesheets/components/_autocomplete.scss
@@ -3,6 +3,14 @@
 // TODO: Replace with $govuk-focus-colour when the new colour scheme is released
 $app-focus-colour: #ffdd00;
 
+.app-c-autocomplete {
+  margin-bottom: govuk-spacing(6);
+
+  @include govuk-media-query($from: tablet) {
+    margin-bottom: govuk-spacing(4);
+  }
+}
+
 .app-c-autocomplete--search {
   .autocomplete__input {
     // scss-lint:disable PlaceholderInExtend

--- a/app/assets/stylesheets/components/_autocomplete.scss
+++ b/app/assets/stylesheets/components/_autocomplete.scss
@@ -38,8 +38,7 @@ $app-focus-colour: #ffdd00;
   z-index: 0;
 }
 
-.autocomplete__option,
-.autocomplete__selected-option {
+.autocomplete__option {
   @include govuk-font(19);
   color: $govuk-text-colour;
 
@@ -50,22 +49,29 @@ $app-focus-colour: #ffdd00;
 }
 
 .autocomplete__list {
-  margin-top: govuk-spacing(3);
-}
+  margin-top: 0;
 
-.autocomplete__list .autocomplete__option,
-.autocomplete__list .autocomplete__option:hover {
-  padding: 5px 6px;
+  .autocomplete__option,
+  .autocomplete__option:hover {
+    padding: 5px 6px;
 
-  &:before {
-    position: relative;
-    top: 3px;
-    padding-top: 2px;
+    &:before {
+      position: relative;
+      top: 3px;
+      padding-top: 2px;
+    }
   }
-}
 
-.autocomplete__list .autocomplete__remove-option {
-  @include govuk-font(16);
+  .autocomplete__selected-option,
+  .autocomplete__selected-option:hover {
+    @include govuk-font(19);
+    margin: govuk-spacing(2) 0 0;
+    color: $govuk-text-colour;
+  }
+
+  .autocomplete__remove-option {
+    @include govuk-font(16);
+  }
 }
 
 .autocomplete__option-hint {


### PR DESCRIPTION
### What
Improve tag selection on small devices.
Update the focus state styles to align them with `govuk-frontend` 3.x.

### Why
On mobile, the page is quite dense and elements are close together, making it hard to scan and read.
Focus state was using the old styles (most probably the only component that wasn't updated yet).

### Visual changes
<table>
<tr><th>Before</th><th>After</th></tr>
<tr><td>

![content-publisher integration publishing service gov uk_documents_0ca4cd1b-cbc7-4dfb-92a2-500f97d09219_en_tags](https://user-images.githubusercontent.com/788096/68474669-f838ca80-021d-11ea-93a0-f66a41d42e32.png)

</td><td>

![content-publisher dev gov uk_documents_05e1b607-b9f5-48d8-bb88-44c2f6571b03_en_tags](https://user-images.githubusercontent.com/788096/68474681-ff5fd880-021d-11ea-97da-442846bde3f4.png)

</td></tr>
<tr><td>

<img width="673" alt="Screen Shot 2019-11-08 at 11 42 12" src="https://user-images.githubusercontent.com/788096/68474709-11417b80-021e-11ea-9364-3517c5cc4796.png">

</td><td>

<img width="672" alt="Screen Shot 2019-11-08 at 11 41 37" src="https://user-images.githubusercontent.com/788096/68474724-1ef70100-021e-11ea-8494-9851277c9729.png">


</td></tr>
<tr><td>

<img width="665" alt="Screen Shot 2019-11-08 at 11 42 19" src="https://user-images.githubusercontent.com/788096/68474719-16062f80-021e-11ea-978b-261886bfced4.png">

</td><td>

<img width="668" alt="Screen Shot 2019-11-08 at 11 41 48" src="https://user-images.githubusercontent.com/788096/68474728-21f1f180-021e-11ea-9e34-9f2aaf3df858.png">


</td></tr>

</table>

[Trello card](https://trello.com/c/4T9XiLh7)