### PR TITLE
Prevent tags page movement

### DIFF
--- a/app/assets/stylesheets/components/_autocomplete.scss
+++ b/app/assets/stylesheets/components/_autocomplete.scss
@@ -105,6 +105,12 @@ $app-focus-colour: $govuk-focus-colour;
 }
 
 .js-enabled {
+  .app-c-autocomplete {
+    .govuk-select[multiple] {
+      height: 40px;
+    }
+  }
+
   .app-c-autocomplete__multiselect-instructions {
     display: none;
   }


### PR DESCRIPTION
When JavaScript is enabled a `select[multiple]` element part of the autocomplete will be enhanced via JavaScript. Between the page load and the JavaScript load the `select[multiple]` switches from the default height (which shows a few options) to the enhanced autocomplete (which shows a basic input). This causes quick page movements that are confusing users. We now set the `select[multiple]` element to the default input height of 40px when JavaScript is enabled to prevent this from happening.

Live preview [before](https://content-publisher.integration.publishing.service.gov.uk/component-guide/autocomplete/select_multiple) and [after](https://content-publisher-revi-pr-1436.herokuapp.com/component-guide/autocomplete/select_multiple).

<details>
<summary>Before</summary>

![2019-11-08 at 13 22 03](https://user-images.githubusercontent.com/788096/68479818-28d33100-022b-11ea-8df2-074e51ede26a.gif)

</details>


<details>
<summary>After</summary>

![2019-11-08 at 13 22 46](https://user-images.githubusercontent.com/788096/68479830-35578980-022b-11ea-9759-453c7a36e7ee.gif)

</details>
