### PR TITLE
Switch to use document_type_id from MetadataRevisions

### DIFF
--- a/app/models/document.rb
+++ b/app/models/document.rb
@@ -31,6 +31,8 @@ class Document < ApplicationRecord
 
   delegate :topics, to: :document_topics
 
+  self.ignored_columns = %w(document_type_id)
+
   scope :with_current_edition, -> do
     join_tables = { current_edition: %i[revision status] }
     joins(join_tables).includes(join_tables)

--- a/app/models/document.rb
+++ b/app/models/document.rb
@@ -7,7 +7,7 @@
 #
 # This model is mutable
 class Document < ApplicationRecord
-  attr_readonly :content_id, :locale, :document_type_id
+  attr_readonly :content_id, :locale
 
   belongs_to :created_by, class_name: "User", optional: true
 
@@ -57,7 +57,6 @@ class Document < ApplicationRecord
     transaction do
       document = create!(content_id: content_id,
                          locale: locale,
-                         document_type_id: document_type_id,
                          created_by: user)
 
       document.tap do |d|
@@ -81,10 +80,6 @@ class Document < ApplicationRecord
 
   def to_param
     content_id + ":" + locale
-  end
-
-  def document_type
-    DocumentType.find(document_type_id)
   end
 
   def document_topics

--- a/app/models/edition.rb
+++ b/app/models/edition.rb
@@ -48,7 +48,7 @@ class Edition < ApplicationRecord
 
   has_many :internal_notes
 
-  delegate :content_id, :locale, :document_type, :topics, :document_topics, to: :document
+  delegate :content_id, :locale, :topics, :document_topics, to: :document
 
   # delegate each state enum method
   state_methods = Status.states.keys.map { |s| (s + "?").to_sym }
@@ -57,6 +57,7 @@ class Edition < ApplicationRecord
   delegate :title,
            :title_or_fallback,
            :base_path,
+           :document_type,
            :summary,
            :contents,
            :update_type,

--- a/app/models/metadata_revision.rb
+++ b/app/models/metadata_revision.rb
@@ -13,4 +13,8 @@ class MetadataRevision < ApplicationRecord
   def readonly?
     !new_record?
   end
+
+  def document_type
+    DocumentType.find(document_type_id)
+  end
 end

--- a/app/models/revision.rb
+++ b/app/models/revision.rb
@@ -55,6 +55,7 @@ class Revision < ApplicationRecord
            :minor?,
            :proposed_publish_time,
            :backdated_to,
+           :document_type,
            to: :metadata_revision
 
   delegate :tags,

--- a/app/services/path_generator_service.rb
+++ b/app/services/path_generator_service.rb
@@ -8,7 +8,7 @@ class PathGeneratorService < ApplicationService
   end
 
   def call
-    prefix = document.document_type.path_prefix
+    prefix = document.current_edition.document_type.path_prefix
     slug = proposed_title.parameterize
     base_path = create_path(prefix, slug)
     return base_path unless path_in_use?(base_path)

--- a/lib/edition_filter.rb
+++ b/lib/edition_filter.rb
@@ -17,7 +17,7 @@ class EditionFilter
   end
 
   def editions
-    revision_joins = { revision: %i[content_revision tags_revision] }
+    revision_joins = { revision: %i[content_revision tags_revision metadata_revision] }
     scope = Edition.where(current: true)
                    .left_joins(:access_limit)
                    .joins(revision_joins, :status, :document)
@@ -64,7 +64,7 @@ private
                    "%#{sanitize_sql_like(value)}%",
                    "%#{sanitize_sql_like(value)}%")
       when :document_type
-        memo.where("documents.document_type_id": value)
+        memo.where("metadata_revisions.document_type_id": value)
       when :status
         if value == "published"
           memo.where("statuses.state": %w[published published_but_needs_2i])

--- a/lib/requirements/topic_checker.rb
+++ b/lib/requirements/topic_checker.rb
@@ -12,7 +12,7 @@ module Requirements
       issues = CheckerIssues.new
 
       begin
-        if document.document_type.topics && document.topics.none?
+        if document.current_edition.document_type.topics && document.topics.none?
           issues << Issue.new(:topics, :none)
         end
       rescue GdsApi::BaseError => e

--- a/lib/tasks/whitehall_importer.rb
+++ b/lib/tasks/whitehall_importer.rb
@@ -76,7 +76,6 @@ module Tasks
       Document.find_or_create_by!(
         content_id: whitehall_document["content_id"],
         locale: "en",
-        document_type_id: "news_story", ## TODO: This is a placeholder, to be removed after document type is moved to revision
         created_at: whitehall_document["created_at"],
         updated_at: whitehall_document["updated_at"],
         created_by_id: user_ids[first_author["whodunnit"]],
@@ -106,7 +105,7 @@ module Tasks
         metadata_revision: MetadataRevision.new(
           update_type: whitehall_edition["minor_change"] ? "minor" : "major",
           change_note: whitehall_edition["change_note"],
-          #document_type_id: whitehall_edition[document_type_key], # TODO: uncomment when document type is moved to revision
+          document_type_id: whitehall_edition[document_type_key],
         ),
         tags_revision: TagsRevision.new(
           tags: {

--- a/spec/factories/document_factory.rb
+++ b/spec/factories/document_factory.rb
@@ -4,7 +4,6 @@ FactoryBot.define do
   factory :document do
     content_id { SecureRandom.uuid }
     locale { I18n.available_locales.sample }
-    document_type_id { build(:document_type, path_prefix: "/prefix").id }
     association :created_by, factory: :user
 
     trait :with_live_edition do

--- a/spec/factories/edition_factory.rb
+++ b/spec/factories/edition_factory.rb
@@ -28,7 +28,6 @@ FactoryBot.define do
           created_by: edition.created_by,
           content_id: evaluator.content_id,
           locale: evaluator.locale,
-          document_type_id: evaluator.document_type_id,
           first_published_at: evaluator.first_published_at,
         )
       end
@@ -46,6 +45,7 @@ FactoryBot.define do
           :revision,
           created_by: edition.created_by,
           document: edition.document,
+          document_type_id: evaluator.document_type_id,
           title: evaluator.title,
           summary: evaluator.summary,
           base_path: evaluator.base_path,

--- a/spec/factories/revision_factory.rb
+++ b/spec/factories/revision_factory.rb
@@ -5,6 +5,7 @@ FactoryBot.define do
     transient do
       title { SecureRandom.alphanumeric(10) }
       base_path { title ? "/prefix/#{title.parameterize}" : nil }
+      document_type_id { build(:document_type, path_prefix: "/prefix").id }
       summary { nil }
       contents { {} }
       tags do
@@ -51,6 +52,7 @@ FactoryBot.define do
           created_by: revision.created_by,
           proposed_publish_time: evaluator.proposed_publish_time,
           backdated_to: evaluator.backdated_to,
+          document_type_id: evaluator.document_type_id,
         )
       end
 

--- a/spec/features/workflow/withdraw_spec.rb
+++ b/spec/features/workflow/withdraw_spec.rb
@@ -42,7 +42,7 @@ RSpec.feature "Withdraw a document" do
   def then_i_see_the_document_has_been_withdrawn
     status = @edition.reload.status
     withdrawal = status.details
-    document_type = @edition.document.document_type.label.downcase
+    document_type = @edition.document_type.label.downcase
 
     expect(page).to have_content(I18n.t!("user_facing_states.withdrawn.name"))
     expect(page).to have_content(I18n.t!("documents.show.withdrawn.title",

--- a/spec/formats/news_story_spec.rb
+++ b/spec/formats/news_story_spec.rb
@@ -29,7 +29,7 @@ RSpec.feature "Create a news story", format: true do
     fill_in "revision[summary]", with: "A great summary"
 
     document = Document.first
-    base_path = document.document_type.path_prefix + "/a-great-title"
+    base_path = Edition.last.document_type.path_prefix + "/a-great-title"
     stub_publishing_api_has_lookups(base_path => document.content_id)
 
     click_on "Save"
@@ -39,7 +39,7 @@ RSpec.feature "Create a news story", format: true do
   def and_i_add_some_tags
     stub_publishing_api_has_links(role_appointment_links)
 
-    expect(Document.last.document_type.tags.count).to eq(5)
+    expect(Edition.last.document_type.tags.count).to eq(5)
     stub_publishing_api_has_linkables([linkable], document_type: "topical_event")
     stub_publishing_api_has_linkables([linkable], document_type: "world_location")
     stub_publishing_api_has_linkables([linkable], document_type: "organisation")

--- a/spec/formats/press_release_spec.rb
+++ b/spec/formats/press_release_spec.rb
@@ -29,7 +29,7 @@ RSpec.feature "Create a press release", format: true do
     fill_in "revision[summary]", with: "A great summary"
 
     document = Document.first
-    base_path = document.document_type.path_prefix + "/a-great-title"
+    base_path = Edition.last.document_type.path_prefix + "/a-great-title"
     stub_publishing_api_has_lookups(base_path => document.content_id)
 
     click_on "Save"
@@ -39,7 +39,7 @@ RSpec.feature "Create a press release", format: true do
   def and_i_add_some_tags
     stub_publishing_api_has_links(role_appointment_links)
 
-    expect(Document.last.document_type.tags.count).to eq(5)
+    expect(Edition.last.document_type.tags.count).to eq(5)
     stub_publishing_api_has_linkables([linkable], document_type: "topical_event")
     stub_publishing_api_has_linkables([linkable], document_type: "world_location")
     stub_publishing_api_has_linkables([linkable], document_type: "organisation")

--- a/spec/lib/requirements/topic_checker_spec.rb
+++ b/spec/lib/requirements/topic_checker_spec.rb
@@ -12,7 +12,7 @@ RSpec.describe Requirements::TopicChecker do
 
     context "when the Publishing API is available" do
       let(:document_type) { build :document_type, topics: true }
-      let(:document) { build :document, document_type_id: document_type.id }
+      let(:document) { build :document }
 
       before do
         stub_publishing_api_has_links(
@@ -32,7 +32,7 @@ RSpec.describe Requirements::TopicChecker do
 
     context "when the Publishing API is down" do
       let(:document_type) { build :document_type, topics: true }
-      let(:document) { build :document, document_type_id: document_type.id }
+      let(:document) { build :document }
 
       before do
         stub_publishing_api_isnt_available

--- a/spec/lib/requirements/topic_checker_spec.rb
+++ b/spec/lib/requirements/topic_checker_spec.rb
@@ -4,19 +4,21 @@ RSpec.describe Requirements::TopicChecker do
   include TopicsHelper
 
   describe "#pre_publish_issues" do
+    let(:document_type) { create :document_type, topics: true }
+    let(:metadata_revision) { create :metadata_revision, document_type_id: document_type.id }
+    let(:revision) { create :revision, metadata_revision: metadata_revision }
+    let(:edition) { create :edition, revision: revision }
+
     it "returns no issues if there are none" do
-      edition = build :edition, :publishable
+      edition = create :edition, :publishable
       issues = Requirements::TopicChecker.new(edition.document).pre_publish_issues
       expect(issues).to be_empty
     end
 
     context "when the Publishing API is available" do
-      let(:document_type) { build :document_type, topics: true }
-      let(:document) { build :document }
-
       before do
         stub_publishing_api_has_links(
-          "content_id" => document.content_id,
+          "content_id" => edition.content_id,
           "links" => {},
           "version" => 3,
         )
@@ -25,26 +27,23 @@ RSpec.describe Requirements::TopicChecker do
       end
 
       it "returns an issue if there are no topics" do
-        issues = Requirements::TopicChecker.new(document).pre_publish_issues
+        issues = Requirements::TopicChecker.new(edition.document).pre_publish_issues
         expect(issues).to have_issue(:topics, :none, styles: %i[form summary])
       end
     end
 
     context "when the Publishing API is down" do
-      let(:document_type) { build :document_type, topics: true }
-      let(:document) { build :document }
-
       before do
         stub_publishing_api_isnt_available
       end
 
       it "returns no issues by default (ignore exception)" do
-        issues = Requirements::TopicChecker.new(document).pre_publish_issues
+        issues = Requirements::TopicChecker.new(edition.document).pre_publish_issues
         expect(issues.items_for(:topics)).to be_empty
       end
 
       it "raises an exception if we specify it should" do
-        expect { Requirements::TopicChecker.new(document).pre_publish_issues(rescue_api_errors: false) }
+        expect { Requirements::TopicChecker.new(edition.document).pre_publish_issues(rescue_api_errors: false) }
           .to raise_error GdsApi::BaseError
       end
     end

--- a/spec/models/edition_spec.rb
+++ b/spec/models/edition_spec.rb
@@ -27,12 +27,13 @@ RSpec.describe Edition do
 
   describe ".create_initial" do
     let(:document) { build(:document) }
+    let(:document_type_id) { build(:document_type, path_prefix: "/prefix").id }
     let(:user) { build(:user) }
 
     it "creates a current edition" do
       edition = Edition.create_initial(
         document: document,
-        document_type_id: document.document_type_id,
+        document_type_id: document_type_id,
         user: user,
       )
 
@@ -45,7 +46,7 @@ RSpec.describe Edition do
     it "has a revision" do
       edition = Edition.create_initial(
         document: document,
-        document_type_id: document.document_type_id,
+        document_type_id: document_type_id,
         user: user,
       )
 
@@ -56,7 +57,7 @@ RSpec.describe Edition do
     it "has a status which is draft" do
       edition = Edition.create_initial(
         document: document,
-        document_type_id: document.document_type_id,
+        document_type_id: document_type_id,
         user: user,
       )
 

--- a/spec/models/revision_spec.rb
+++ b/spec/models/revision_spec.rb
@@ -5,11 +5,12 @@ RSpec.describe Revision do
 
   describe ".create_initial" do
     let(:document) { build(:document) }
+    let(:document_type_id) { build(:document_type, path_prefix: "/prefix").id }
 
     it "creates an empty revision for the document" do
       revision = Revision.create_initial(
         document: document,
-        document_type_id: document.document_type_id,
+        document_type_id: document_type_id,
       )
 
       expect(revision).to be_a(Revision)
@@ -21,7 +22,7 @@ RSpec.describe Revision do
     it "sets default change note and update type" do
       revision = Revision.create_initial(
         document: document,
-        document_type_id: document.document_type_id,
+        document_type_id: document_type_id,
       )
 
       expect(revision.change_note).to eq("First published.")
@@ -32,7 +33,7 @@ RSpec.describe Revision do
       user = build(:user)
       revision = Revision.create_initial(
         document: document,
-        document_type_id: document.document_type_id,
+        document_type_id: document_type_id,
         user: user,
       )
 
@@ -46,7 +47,7 @@ RSpec.describe Revision do
       tags = { "type" => %w[value1 value2] }
       revision = Revision.create_initial(
         document: document,
-        document_type_id: document.document_type_id,
+        document_type_id: document_type_id,
         user: nil,
         tags: tags,
       )

--- a/spec/services/path_generator_service_spec.rb
+++ b/spec/services/path_generator_service_spec.rb
@@ -5,7 +5,7 @@ RSpec.describe PathGeneratorService do
     let(:document) { create(:document, :with_current_edition) }
 
     it "generates a base path which is unique to our database" do
-      new_document = build(:document, document_type_id: document.document_type_id)
+      new_document = build(:document, :with_current_edition)
       stub_publishing_api_has_lookups("#{document.current_edition.base_path}": nil)
 
       expect(PathGeneratorService.call(new_document, document.current_edition.title))
@@ -13,7 +13,7 @@ RSpec.describe PathGeneratorService do
     end
 
     it "raises an error when many variations of that path are in use" do
-      prefix = document.document_type.path_prefix
+      prefix = document.current_edition.document_type.path_prefix
       existing_paths = ["#{prefix}/a-title", "#{prefix}/a-title-1", "#{prefix}/a-title-2"]
       existing_paths.each { |path| create(:edition, base_path: path) }
 


### PR DESCRIPTION
We are moving document_type_id column from Documents table to MetadataRevisions table so we can change the type of the documents.

This switches the app to use data from the new column in the MetadataRevisions table.
In this PR we:
- Move `document_type` method from Document to MetadataRevision
- Edition delegates document_type_id to Revisions and further to MetadataRevision
- Update factories
- Update tests that rely on document type id
- Update WhitehallImporter
- Ignore `document_type_id` in Document model 

[Trello card](https://trello.com/c/kwnmsIe9/1095-permit-content-publisher-to-have-documents-that-change-type)

Co-authored by @JonathanHallam, with help from @leenagupte 