### PR TITLE
Import documents a withdrawn status into Content Publisher

### DIFF
--- a/lib/tasks/whitehall_importer.rb
+++ b/lib/tasks/whitehall_importer.rb
@@ -165,6 +165,10 @@ module Tasks
 
       raise AbortImportError, "Cannot set a withdrawn status without a revision history event" unless revision_history_event
 
+      if whitehall_edition["unpublishing"].blank?
+        raise AbortImportError, "Cannot create withdrawn status without an unpublishing"
+      end
+
       edition.status = Status.new(
         state: whitehall_edition["state"],
         revision_at_creation: edition.revision,

--- a/lib/tasks/whitehall_importer.rb
+++ b/lib/tasks/whitehall_importer.rb
@@ -168,7 +168,11 @@ module Tasks
         revision_at_creation: edition.revision,
         created_by_id: user_ids[event["whodunnit"]],
         created_at: event["created_at"],
-        details: state_details(whitehall_edition, edition),
+        details: Withdrawal.new(
+          published_status: edition.status,
+          public_explanation: whitehall_edition["unpublishing"]["explanation"],
+          withdrawn_at: whitehall_edition["unpublishing"]["created_at"],
+        ),
       )
 
       edition.save!
@@ -189,16 +193,6 @@ module Tasks
       raise AbortImportError, "Edition is missing a #{state} event" unless event
 
       event
-    end
-
-    def state_details(whitehall_edition, edition)
-      return unless whitehall_edition["state"] == "withdrawn"
-
-      Withdrawal.new(
-        published_status: edition.status,
-        public_explanation: whitehall_edition["unpublishing"]["explanation"],
-        withdrawn_at: whitehall_edition["unpublishing"]["created_at"],
-      )
     end
 
     def state(whitehall_edition)

--- a/lib/tasks/whitehall_importer.rb
+++ b/lib/tasks/whitehall_importer.rb
@@ -256,7 +256,11 @@ module Tasks
 
       associations.map { |association| association["content_id"] }
     end
-  end
 
-  class AbortImportError < RuntimeError; end
+    class AbortImportError < RuntimeError
+      def initialize(message)
+        super(message)
+      end
+    end
+  end
 end

--- a/lib/tasks/whitehall_importer.rb
+++ b/lib/tasks/whitehall_importer.rb
@@ -156,6 +156,7 @@ module Tasks
         state: state(whitehall_edition),
         revision_at_creation: revision,
         created_by_id: user_ids[revision_history_event["whodunnit"]],
+        created_at: revision_history_event["created_at"],
       )
     end
 
@@ -168,6 +169,7 @@ module Tasks
         state: whitehall_edition["state"],
         revision_at_creation: edition.revision,
         created_by_id: user_ids[revision_history_event["whodunnit"]],
+        created_at: revision_history_event["created_at"],
       )
 
       edition.save!

--- a/lib/tasks/whitehall_importer.rb
+++ b/lib/tasks/whitehall_importer.rb
@@ -150,6 +150,8 @@ module Tasks
                                  current_author_history_event(whitehall_edition)
                                end
 
+      raise AbortImportError, "Cannot create an initial status without a revision history event" unless revision_history_event
+
       Status.new(
         state: state(whitehall_edition),
         revision_at_creation: revision,
@@ -159,6 +161,8 @@ module Tasks
 
     def set_withdrawn_status(whitehall_edition, edition)
       revision_history_event = current_author_history_event(whitehall_edition)
+
+      raise AbortImportError, "Cannot set a withdrawn status without a revision history event" unless revision_history_event
 
       edition.status = Status.new(
         state: whitehall_edition["state"],

--- a/lib/tasks/whitehall_importer.rb
+++ b/lib/tasks/whitehall_importer.rb
@@ -131,16 +131,20 @@ module Tasks
         number: edition_number,
         revision_synced: true,
         revision: revision,
-        status: Status.new(
-          state: state(whitehall_edition),
-          revision_at_creation: revision,
-        ),
+        status: initial_status(whitehall_edition, revision),
         current: whitehall_edition["id"] == most_recent_edition["id"],
         live: live?(whitehall_edition),
         created_at: whitehall_edition["created_at"],
         updated_at: whitehall_edition["updated_at"],
         created_by_id: user_ids[first_author["whodunnit"]],
         last_edited_by_id: user_ids[last_author["whodunnit"]],
+      )
+    end
+
+    def initial_status(whitehall_edition, revision)
+      Status.new(
+        state: state(whitehall_edition),
+        revision_at_creation: revision,
       )
     end
 

--- a/lib/tasks/whitehall_importer.rb
+++ b/lib/tasks/whitehall_importer.rb
@@ -147,7 +147,7 @@ module Tasks
       revision_history_event = if whitehall_edition["state"] == "withdrawn"
                                  published_author_history_event(whitehall_edition)
                                else
-                                 whitehall_edition["revision_history"].last
+                                 current_author_history_event(whitehall_edition)
                                end
 
       Status.new(
@@ -158,7 +158,7 @@ module Tasks
     end
 
     def set_withdrawn_status(whitehall_edition, edition)
-      revision_history_event = whitehall_edition["revision_history"].last
+      revision_history_event = current_author_history_event(whitehall_edition)
 
       edition.status = Status.new(
         state: whitehall_edition["state"],
@@ -167,6 +167,10 @@ module Tasks
       )
 
       edition.save!
+    end
+
+    def current_author_history_event(whitehall_edition)
+      whitehall_edition["revision_history"].select { |h| h["state"] == whitehall_edition["state"] }.last
     end
 
     def published_author_history_event(whitehall_edition)

--- a/lib/tasks/whitehall_importer.rb
+++ b/lib/tasks/whitehall_importer.rb
@@ -4,7 +4,14 @@ module Tasks
   class WhitehallImporter
     attr_reader :whitehall_document_id, :whitehall_document, :whitehall_import, :user_ids
 
-    SUPPORTED_WHITEHALL_STATES = %w(draft published rejected submitted superseded).freeze
+    SUPPORTED_WHITEHALL_STATES = %w(
+      draft
+      published
+      rejected
+      submitted
+      superseded
+      withdrawn
+    ).freeze
     SUPPORTED_LOCALES = %w(en).freeze
     SUPPORTED_DOCUMENT_TYPES = %w(news_story press_release).freeze
     DOCUMENT_SUB_TYPES = %w[
@@ -143,6 +150,7 @@ module Tasks
       when "superseded" then "superseded"
       when "published"
         whitehall_edition["force_published"] ? "published_but_needs_2i" : "published"
+      when "withdrawn" then "withdrawn"
       else
         "submitted_for_review"
       end

--- a/lib/tasks/whitehall_importer.rb
+++ b/lib/tasks/whitehall_importer.rb
@@ -174,6 +174,7 @@ module Tasks
         revision_at_creation: edition.revision,
         created_by_id: user_ids[revision_history_event["whodunnit"]],
         created_at: revision_history_event["created_at"],
+        details: state_details(whitehall_edition, edition),
       )
 
       edition.save!
@@ -185,6 +186,16 @@ module Tasks
 
     def published_author_history_event(whitehall_edition)
       whitehall_edition["revision_history"].select { |h| h["state"] == "published" }.last
+    end
+
+    def state_details(whitehall_edition, edition)
+      return unless whitehall_edition["state"] == "withdrawn"
+
+      Withdrawal.new(
+        published_status: edition.status,
+        public_explanation: whitehall_edition["unpublishing"]["explanation"],
+        withdrawn_at: whitehall_edition["unpublishing"]["created_at"],
+      )
     end
 
     def state(whitehall_edition)

--- a/lib/tasks/whitehall_importer.rb
+++ b/lib/tasks/whitehall_importer.rb
@@ -210,7 +210,7 @@ module Tasks
     end
 
     def live?(whitehall_edition)
-      whitehall_edition["state"] == "published"
+      whitehall_edition["state"].in?(%w(published withdrawn))
     end
 
     def embed_contacts(body, contacts)

--- a/spec/fixtures/whitehall_export_with_one_withdrawn_edition.json
+++ b/spec/fixtures/whitehall_export_with_one_withdrawn_edition.json
@@ -1,0 +1,112 @@
+{
+  "id": 1,
+  "created_at": "2019-11-01T12:21:16+00:00",
+  "updated_at": "2019-11-01T12:21:16+00:00",
+  "slug": "some-news-document",
+  "content_id": "b98b768d-5393-4088-8a12-3f4a26cc20cc",
+  "editions": [
+    {
+      "id": 1,
+      "created_at": "2019-11-01T12:21:16+00:00",
+      "updated_at": "2019-11-03T12:21:16+00:00",
+      "change_note": "First published",
+      "state": "withdrawn",
+      "news_article_type": "news_story",
+      "translations": [
+        {
+          "id": 1,
+          "locale": "en",
+          "title": "Title",
+          "summary": "Summary",
+          "body": "Body"
+        }
+      ],
+      "revision_history": [
+        {
+          "event": "create",
+          "state": "draft",
+          "whodunnit": 1,
+          "created_at": "2019-11-01T12:21:16+00:00"
+        },
+        {
+          "event": "update",
+          "state": "published",
+          "whodunnit": 2,
+          "created_at": "2019-11-02T12:21:16+00:00"
+        },
+        {
+          "event": "update",
+          "state": "withdrawn",
+          "whodunnit": 3,
+          "created_at": "2019-11-03T12:21:16+00:00"
+        }
+      ],
+      "organisations": [
+        {
+          "id": 1,
+          "content_id": "424ba2bd-9d2e-4167-b05a-b9fb55d08a6f",
+          "lead": true,
+          "lead_ordering": 1
+        },
+        {
+          "id": 2,
+          "content_id": "bf88b646-9ef0-4303-8a17-5a529afa5274",
+          "lead": false
+        }
+      ],
+      "role_appointments": [
+        {
+          "id": 1,
+          "content_id": "a12d02cc-a753-451a-be23-d7089fc17bac"
+        }
+      ],
+      "topical_events": [
+        {
+          "id": 1,
+          "content_id": "22b08ca1-26cd-4565-bb47-f4c0b224970c"
+        }
+      ],
+      "world_locations": [
+        {
+          "id": 1,
+          "content_id": "9e80a56d-f9ee-4a15-8792-66e98be3dcd2"
+        }
+      ],
+      "unpublishing": {
+        "id": 1,
+        "explanation": "User facing explanation",
+        "alternative_url": "",
+        "created_at": "2019-11-07T16:12:52.000+00:00",
+        "updated_at": "2019-11-07T16:12:52.000+00:00",
+        "redirect": false,
+        "unpublishing_reason": "No longer current government policy/activity"
+      }
+    }
+  ],
+  "users": [
+    {
+      "id": 1,
+      "name": "A Person",
+      "uid": "36d5154e-d3b7-4e3e-aad8-32a50fc9430e",
+      "email": "a-publisher@department.gov.uk",
+      "organisation_slug": "a-government-department",
+      "organisation_content_id": "01892f23-b069-43f5-8404-d082f8dffcb9"
+    },
+    {
+      "id": 2,
+      "name": "Another Person",
+      "uid": "b4a2ba47-5990-4456-b952-0a1d24b82c18",
+      "email": "another-publisher@department.gov.uk",
+      "organisation_slug": "a-government-department",
+      "organisation_content_id": "01892f23-b069-43f5-8404-d082f8dffcb9"
+    },
+    {
+      "id": 3,
+      "name": "An extra Person",
+      "uid": "2e1d3a3d-c44d-4a7e-a38a-ff62de3e4001",
+      "email": "an-extra-publisher@department.gov.uk",
+      "organisation_slug": "a-government-department",
+      "organisation_content_id": "01892f23-b069-43f5-8404-d082f8dffcb9"
+    }
+  ]
+}

--- a/spec/support/fixtures_helper.rb
+++ b/spec/support/fixtures_helper.rb
@@ -12,4 +12,8 @@ module FixturesHelper
   def whitehall_export_with_two_editions
     JSON.parse(File.read(fixtures_path + "/whitehall_export_with_two_editions.json"))
   end
+
+  def whitehall_export_with_one_withdrawn_edition
+    JSON.parse(File.read(fixtures_path + "/whitehall_export_with_one_withdrawn_edition.json"))
+  end
 end

--- a/spec/tasks/whitehall_importer_spec.rb
+++ b/spec/tasks/whitehall_importer_spec.rb
@@ -138,6 +138,13 @@ RSpec.describe Tasks::WhitehallImporter do
     expect { importer.import }.to raise_error(Tasks::AbortImportError)
   end
 
+  it "raises AbortImportError when revision history is missing for state" do
+    import_data["editions"][0]["state"] = "published"
+    importer = Tasks::WhitehallImporter.new(123, import_data)
+
+    expect { importer.import }.to raise_error(Tasks::AbortImportError)
+  end
+
   it "raises AbortImportError when edition has an unsupported locale" do
     import_data["editions"][0]["translations"][0]["locale"] = "zz"
     importer = Tasks::WhitehallImporter.new(123, import_data)
@@ -307,6 +314,13 @@ RSpec.describe Tasks::WhitehallImporter do
 
       expect(Status.first.created_by_id).to eq(User.second_to_last.id)
       expect(Edition.last.status.created_by_id).to eq(User.last.id)
+    end
+
+    it "raises AbortImportError when revision history cannot be found for state" do
+      import_data_for_withdrawn_edition["editions"][0]["revision_history"].delete_at(1)
+      importer = Tasks::WhitehallImporter.new(123, import_data_for_withdrawn_edition)
+
+      expect { importer.import }.to raise_error(Tasks::AbortImportError)
     end
   end
 end

--- a/spec/tasks/whitehall_importer_spec.rb
+++ b/spec/tasks/whitehall_importer_spec.rb
@@ -67,6 +67,11 @@ RSpec.describe Tasks::WhitehallImporter do
 
   it "sets the correct states when Whitehall document state is 'published'" do
     import_data["editions"][0]["state"] = "published"
+    import_data["editions"][0]["revision_history"] << {
+      "event" => "update",
+      "state" => "published",
+      "whodunnit" => 1,
+    }
     importer = Tasks::WhitehallImporter.new(123, import_data)
     importer.import
 
@@ -86,6 +91,11 @@ RSpec.describe Tasks::WhitehallImporter do
   it "sets the correct states when Whitehall document is force published" do
     import_data["editions"][0]["state"] = "published"
     import_data["editions"][0]["force_published"] = true
+    import_data["editions"][0]["revision_history"] << {
+      "event" => "update",
+      "state" => "published",
+      "whodunnit" => 1,
+    }
     importer = Tasks::WhitehallImporter.new(123, import_data)
     importer.import
 
@@ -95,6 +105,11 @@ RSpec.describe Tasks::WhitehallImporter do
 
   it "sets the correct states when Whitehall document state is 'rejected'" do
     import_data["editions"][0]["state"] = "rejected"
+    import_data["editions"][0]["revision_history"] << {
+      "event" => "update",
+      "state" => "rejected",
+      "whodunnit" => 1,
+    }
     importer = Tasks::WhitehallImporter.new(123, import_data)
     importer.import
 
@@ -104,6 +119,11 @@ RSpec.describe Tasks::WhitehallImporter do
 
   it "sets the correct states when Whitehall document state is 'submitted'" do
     import_data["editions"][0]["state"] = "submitted"
+    import_data["editions"][0]["revision_history"] << {
+      "event" => "update",
+      "state" => "submitted",
+      "whodunnit" => 1,
+    }
     importer = Tasks::WhitehallImporter.new(123, import_data)
     importer.import
 

--- a/spec/tasks/whitehall_importer_spec.rb
+++ b/spec/tasks/whitehall_importer_spec.rb
@@ -343,5 +343,12 @@ RSpec.describe Tasks::WhitehallImporter do
       expect(Status.first.created_at).to eq(import_revision_history[1]["created_at"])
       expect(Edition.last.status.created_at).to eq(import_revision_history[2]["created_at"])
     end
+
+    it "raises AbortImportError when document is withdrawn but has no unpublishing details" do
+      import_data_for_withdrawn_edition["editions"][0]["unpublishing"] = nil
+      importer = Tasks::WhitehallImporter.new(123, import_data_for_withdrawn_edition)
+
+      expect { importer.import }.to raise_error(Tasks::AbortImportError)
+    end
   end
 end

--- a/spec/tasks/whitehall_importer_spec.rb
+++ b/spec/tasks/whitehall_importer_spec.rb
@@ -259,10 +259,24 @@ RSpec.describe Tasks::WhitehallImporter do
   context "when importing a withdrawn document" do
     let(:import_data_for_withdrawn_edition) { whitehall_export_with_one_withdrawn_edition }
 
-    it "sets the correct state when Whitehall document state is withdrawn" do
+    it "sets the correct states when Whitehall document state is withdrawn" do
       importer = Tasks::WhitehallImporter.new(123, import_data_for_withdrawn_edition)
       importer.import
 
+      expect(Status.count).to eq(2)
+      expect(Status.first.state).to eq("published")
+      expect(Edition.last.status).to be_withdrawn
+      expect(Edition.last).not_to be_live
+    end
+
+    it "sets the correct states when Whitehall document state is withdrawn and was force_published" do
+      import_data_for_withdrawn_edition["editions"][0]["force_published"] = true
+
+      importer = Tasks::WhitehallImporter.new(123, import_data_for_withdrawn_edition)
+      importer.import
+
+      expect(Status.count).to eq(2)
+      expect(Status.first.state).to eq("published_but_needs_2i")
       expect(Edition.last.status).to be_withdrawn
       expect(Edition.last).not_to be_live
     end

--- a/spec/tasks/whitehall_importer_spec.rb
+++ b/spec/tasks/whitehall_importer_spec.rb
@@ -280,5 +280,13 @@ RSpec.describe Tasks::WhitehallImporter do
       expect(Edition.last.status).to be_withdrawn
       expect(Edition.last).not_to be_live
     end
+
+    it "sets the created_by_id of each status if more than one state needs to be recorded" do
+      importer = Tasks::WhitehallImporter.new(123, import_data_for_withdrawn_edition)
+      importer.import
+
+      expect(Status.first.created_by_id).to eq(User.second_to_last.id)
+      expect(Edition.last.status.created_by_id).to eq(User.last.id)
+    end
   end
 end

--- a/spec/tasks/whitehall_importer_spec.rb
+++ b/spec/tasks/whitehall_importer_spec.rb
@@ -304,7 +304,7 @@ RSpec.describe Tasks::WhitehallImporter do
       expect(Status.count).to eq(2)
       expect(Status.first.state).to eq("published")
       expect(Edition.last.status).to be_withdrawn
-      expect(Edition.last).not_to be_live
+      expect(Edition.last).to be_live
     end
 
     it "sets the correct states when Whitehall document state is withdrawn and was force_published" do
@@ -316,7 +316,7 @@ RSpec.describe Tasks::WhitehallImporter do
       expect(Status.count).to eq(2)
       expect(Status.first.state).to eq("published_but_needs_2i")
       expect(Edition.last.status).to be_withdrawn
-      expect(Edition.last).not_to be_live
+      expect(Edition.last).to be_live
     end
 
     it "sets the created_by_id of each status if more than one state needs to be recorded" do

--- a/spec/tasks/whitehall_importer_spec.rb
+++ b/spec/tasks/whitehall_importer_spec.rb
@@ -135,14 +135,14 @@ RSpec.describe Tasks::WhitehallImporter do
     import_data["editions"][0]["state"] = "not_supported"
     importer = Tasks::WhitehallImporter.new(123, import_data)
 
-    expect { importer.import }.to raise_error(Tasks::AbortImportError)
+    expect { importer.import }.to raise_error(Tasks::WhitehallImporter::AbortImportError)
   end
 
   it "raises AbortImportError when revision history is missing for state" do
     import_data["editions"][0]["state"] = "published"
     importer = Tasks::WhitehallImporter.new(123, import_data)
 
-    expect { importer.import }.to raise_error(Tasks::AbortImportError)
+    expect { importer.import }.to raise_error(Tasks::WhitehallImporter::AbortImportError)
   end
 
   it "sets the created_at datetime of the document state" do
@@ -160,7 +160,7 @@ RSpec.describe Tasks::WhitehallImporter do
     import_data["editions"][0]["translations"][0]["locale"] = "zz"
     importer = Tasks::WhitehallImporter.new(123, import_data)
 
-    expect { importer.import }.to raise_error(Tasks::AbortImportError)
+    expect { importer.import }.to raise_error(Tasks::WhitehallImporter::AbortImportError)
   end
 
   it "changes the ids of embedded contacts" do
@@ -188,14 +188,14 @@ RSpec.describe Tasks::WhitehallImporter do
       import_data["editions"][0].delete("organisations")
       importer = Tasks::WhitehallImporter.new(123, import_data)
 
-      expect { importer.import }.to raise_error(Tasks::AbortImportError)
+      expect { importer.import }.to raise_error(Tasks::WhitehallImporter::AbortImportError)
     end
 
     it "rejects the import if there are no lead organisations" do
       import_data["editions"][0]["organisations"].shift
       importer = Tasks::WhitehallImporter.new(123, import_data)
 
-      expect { importer.import }.to raise_error(Tasks::AbortImportError)
+      expect { importer.import }.to raise_error(Tasks::WhitehallImporter::AbortImportError)
     end
 
     it "rejects the import if there is more than one lead organisation" do
@@ -208,7 +208,7 @@ RSpec.describe Tasks::WhitehallImporter do
 
       importer = Tasks::WhitehallImporter.new(123, import_data)
 
-      expect { importer.import }.to raise_error(Tasks::AbortImportError)
+      expect { importer.import }.to raise_error(Tasks::WhitehallImporter::AbortImportError)
     end
 
     it "sets other supporting organisations" do
@@ -290,7 +290,7 @@ RSpec.describe Tasks::WhitehallImporter do
       import_published_then_drafted_data["editions"][0]["news_article_type"] = "unsupported_document"
       importer = Tasks::WhitehallImporter.new(123, import_published_then_drafted_data)
 
-      expect { importer.import }.to raise_error(Tasks::AbortImportError)
+      expect { importer.import }.to raise_error(Tasks::WhitehallImporter::AbortImportError)
     end
   end
 
@@ -331,7 +331,7 @@ RSpec.describe Tasks::WhitehallImporter do
       import_data_for_withdrawn_edition["editions"][0]["revision_history"].delete_at(1)
       importer = Tasks::WhitehallImporter.new(123, import_data_for_withdrawn_edition)
 
-      expect { importer.import }.to raise_error(Tasks::AbortImportError)
+      expect { importer.import }.to raise_error(Tasks::WhitehallImporter::AbortImportError)
     end
 
     it "sets the created_at datetime of the initial and current document states" do
@@ -348,7 +348,7 @@ RSpec.describe Tasks::WhitehallImporter do
       import_data_for_withdrawn_edition["editions"][0]["unpublishing"] = nil
       importer = Tasks::WhitehallImporter.new(123, import_data_for_withdrawn_edition)
 
-      expect { importer.import }.to raise_error(Tasks::AbortImportError)
+      expect { importer.import }.to raise_error(Tasks::WhitehallImporter::AbortImportError)
     end
 
     it "sets the Withdrawal details for a withdrawn document" do

--- a/spec/tasks/whitehall_importer_spec.rb
+++ b/spec/tasks/whitehall_importer_spec.rb
@@ -350,5 +350,17 @@ RSpec.describe Tasks::WhitehallImporter do
 
       expect { importer.import }.to raise_error(Tasks::AbortImportError)
     end
+
+    it "sets the Withdrawal details for a withdrawn document" do
+      importer = Tasks::WhitehallImporter.new(123, import_data_for_withdrawn_edition)
+      importer.import
+
+      import_unpublishing_data = import_data_for_withdrawn_edition["editions"][0]["unpublishing"]
+      details = Edition.last.status.details
+
+      expect(details.published_status_id).to eq(Status.first.id)
+      expect(details.public_explanation).to eq(import_unpublishing_data["explanation"])
+      expect(details.withdrawn_at).to eq(import_unpublishing_data["created_at"])
+    end
   end
 end

--- a/spec/tasks/whitehall_importer_spec.rb
+++ b/spec/tasks/whitehall_importer_spec.rb
@@ -255,4 +255,16 @@ RSpec.describe Tasks::WhitehallImporter do
       expect { importer.import }.to raise_error(Tasks::AbortImportError)
     end
   end
+
+  context "when importing a withdrawn document" do
+    let(:import_data_for_withdrawn_edition) { whitehall_export_with_one_withdrawn_edition }
+
+    it "sets the correct state when Whitehall document state is withdrawn" do
+      importer = Tasks::WhitehallImporter.new(123, import_data_for_withdrawn_edition)
+      importer.import
+
+      expect(Edition.last.status).to be_withdrawn
+      expect(Edition.last).not_to be_live
+    end
+  end
 end


### PR DESCRIPTION
Trello: https://trello.com/c/8U7JPIHT

## What's changed and why?

Update `WhitehallImporter` to support documents that have a status of `withdrawn`.

The public explanation and the internal reason why the document was withdrawn have also been imported.

As Content Publisher supports undoing a withdrawal of content which involves using the published status to determine what to revert the content to (published or published_but_needs_2i_review), the published status details for the document have also been imported.

## Results from testing on integration

[Link to Whitehall export data](https://whitehall-admin.integration.publishing.service.gov.uk/government/admin/export/document/353919)

### Imported document in Content Publisher

```
#<Document id: 623, content_id: "2817f9a0-7c4a-4b48-a272-3c28251e79fe", locale: "en", document_type_id: "news_story", created_at: "2017-03-13 17:39:03", updated_at: "2019-10-29 10:28:38", created_by_id: 86, first_published_at: nil, imported_from: "whitehall">

#<Edition id: 886, number: 1, last_edited_at: "2019-11-11 12:55:48", created_at: "2017-03-13 17:39:03", updated_at: "2019-11-11 12:55:48", document_id: 623, created_by_id: 86, current: true, live: false, last_edited_by_id: 126, status_id: 2677, revision_id: 5332, revision_synced: true, access_limit_id: nil>

#<Revision id: 5332, created_by_id: nil, created_at: "2017-03-13 17:39:03", document_id: 623, lead_image_revision_id: nil, content_revision_id: 2970, metadata_revision_id: 1458, tags_revision_id: 819, preceded_by_id: nil, number: 1, imported: true>

Status.where(revision_at_creation_id: 5332)
=> #<ActiveRecord::Relation [#<Status id: 2677, state: "withdrawn", revision_at_creation_id: 5332, edition_id: 886, created_by_id: 126, created_at: "2019-10-29 10:28:38", updated_at: "2019-11-11 12:55:48", details_type: "Withdrawal", details_id: 3>, #<Status id: 2676, state: "published", revision_at_creation_id: 5332, edition_id: 886, created_by_id: 86, created_at: "2017-03-14 08:41:56", updated_at: "2019-11-11 12:55:48", details_type: nil, details_id: nil>]>

#<Withdrawal id: 3, public_explanation: "The [Dundee to London flight route was extended fo...", created_at: "2019-11-11 12:55:48", published_status_id: 2676, withdrawn_at: "2019-10-29 10:28:38">
```

![Screenshot 2019-11-13 at 17 16 09](https://user-images.githubusercontent.com/5793815/68787380-53612780-0639-11ea-9d10-9e62b71cbb41.png)
