### PR TITLE
Import unpublishing

### DIFF
--- a/lib/tasks/whitehall_importer.rb
+++ b/lib/tasks/whitehall_importer.rb
@@ -187,9 +187,12 @@ module Tasks
     end
 
     def status(whitehall_edition, revision)
+      author_id = whitehall_edition["revision_history"].last["whodunnit"]
+
       Status.new(
         state: state(whitehall_edition),
         revision_at_creation: revision,
+        created_by_id: user_ids[author_id],
         details: details(whitehall_edition),
       )
     end

--- a/lib/tasks/whitehall_importer.rb
+++ b/lib/tasks/whitehall_importer.rb
@@ -176,10 +176,7 @@ module Tasks
         number: edition_number,
         revision_synced: true,
         revision: revision,
-        status: Status.new(
-          state: state(whitehall_edition),
-          revision_at_creation: revision,
-        ),
+        status: status(whitehall_edition, revision),
         current: whitehall_edition["revision_history"].last == most_recent_edition["revision_history"].last,
         live: live?(whitehall_edition),
         created_at: whitehall_edition["created_at"],
@@ -187,6 +184,26 @@ module Tasks
         created_by_id: user_ids[first_author["whodunnit"]],
         last_edited_by_id: user_ids[last_author["whodunnit"]],
       )
+    end
+
+    def status(whitehall_edition, revision)
+      Status.new(
+        state: state(whitehall_edition),
+        revision_at_creation: revision,
+        details: details(whitehall_edition),
+      )
+    end
+
+    def details(whitehall_edition)
+      if whitehall_edition["state"] == "removed"
+        unpublishing = whitehall_edition["unpublishing"]
+
+        Removal.new(
+          explanatory_note: unpublishing["explanation"],
+          alternative_path: unpublishing["alternative_url"],
+          redirect: unpublishing["alternative_url"].present?,
+        )
+      end
     end
 
     def state(whitehall_edition)

--- a/spec/fixtures/whitehall_export_with_one_edition.json
+++ b/spec/fixtures/whitehall_export_with_one_edition.json
@@ -25,6 +25,7 @@
         {
           "event": "create",
           "state": "draft",
+          "created_at": "2019-11-01T12:21:16+00:00",
           "whodunnit": 1
         }
       ],

--- a/spec/fixtures/whitehall_export_with_unpublished_edition.json
+++ b/spec/fixtures/whitehall_export_with_unpublished_edition.json
@@ -1,0 +1,79 @@
+{
+  "id": 1,
+  "created_at": "2019-11-01T12:21:16+00:00",
+  "updated_at": "2019-11-01T12:21:16+00:00",
+  "slug": "some-news-document",
+  "content_id": "b98b768d-5393-4088-8a12-3f4a26cc20cc",
+  "editions": [
+    {
+      "id": 1,
+      "created_at": "2019-11-05T16:12:52.000+00:00",
+      "updated_at": "2019-11-08T11:12:52.000+00:00",
+      "change_note": "First published",
+      "state": "draft",
+      "news_article_type": "news_story",
+      "unpublishing": {
+        "id": 43917,
+        "explanation": "Brexit is being delayed again",
+        "alternative_url": "https://www.gov.uk/flextension",
+        "created_at": "2019-11-05T16:12:52.000+00:00",
+        "updated_at": "2019-11-08T16:12:52.000+00:00",
+        "redirect": false,
+        "unpublishing_reason": "Consolidated into another GOV.UK page"
+      },
+      "translations": [
+        {
+          "id": 1,
+          "locale": "en",
+          "title": "Title",
+          "summary": "Summary",
+          "body": "Body"
+        }
+      ],
+      "revision_history": [
+        {
+          "event": "create",
+          "state": "draft",
+          "created_at": "2019-11-05T16:12:52.000+00:00",
+          "whodunnit": 1
+        },
+        { "event": "update",
+          "state": "draft",
+          "created_at": "2019-11-05T17:12:52.000+00:00",
+          "whodunnit": 1
+        },
+        {
+          "event": "update",
+          "state": "published",
+          "created_at": "2019-11-07T16:12:52.000+00:00",
+          "whodunnit": 1
+        },
+        {
+          "event": "update",
+          "state": "draft",
+          "created_at": "2019-11-08T11:12:52.000+00:00",
+          "whodunnit": 1
+        }
+      ],
+      "organisations": [
+        {
+          "id": 1,
+          "content_id": "424ba2bd-9d2e-4167-b05a-b9fb55d08a6f",
+          "lead": true,
+          "lead_ordering": 1
+        }
+      ]
+    }
+  ],
+
+  "users": [
+    {
+      "id": 1,
+      "name": "A Person",
+      "uid": "36d5154e-d3b7-4e3e-aad8-32a50fc9430e",
+      "email": "a-publisher@department.gov.uk",
+      "organisation_slug": "a-government-department",
+      "organisation_content_id": "01892f23-b069-43f5-8404-d082f8dffcb9"
+    }
+  ]
+}

--- a/spec/support/fixtures_helper.rb
+++ b/spec/support/fixtures_helper.rb
@@ -12,4 +12,8 @@ module FixturesHelper
   def whitehall_export_with_two_editions
     JSON.parse(File.read(fixtures_path + "/whitehall_export_with_two_editions.json"))
   end
+
+  def whitehall_export_with_unpublished_edition
+    JSON.parse(File.read(fixtures_path + "/whitehall_export_with_unpublished_edition.json"))
+  end
 end

--- a/spec/tasks/whitehall_importer_spec.rb
+++ b/spec/tasks/whitehall_importer_spec.rb
@@ -262,7 +262,10 @@ RSpec.describe Tasks::WhitehallImporter do
     end
 
     it "creates an edition with a status of removed" do
+      status = Edition.first.status
+
       expect(Edition.last.removed?).to be_truthy
+      expect(status.created_by_id).to eq(User.last.id)
     end
 
     it "creates a removal record" do
@@ -297,7 +300,10 @@ RSpec.describe Tasks::WhitehallImporter do
     end
 
     it "creates an edition with a status of removed" do
+      status = Edition.first.status
+
       expect(Edition.first.removed?).to be_truthy
+      expect(status.created_by_id).to eq(User.last.id)
     end
 
     it "creates a removal record" do
@@ -310,8 +316,11 @@ RSpec.describe Tasks::WhitehallImporter do
     end
 
     it "creates a draft edition and assigns as current" do
+      status = Edition.first.status
+
       expect(Edition.last.draft?).to be_truthy
       expect(Edition.last.current).to be_truthy
+      expect(status.created_by_id).to eq(User.last.id)
     end
   end
 
@@ -338,7 +347,10 @@ RSpec.describe Tasks::WhitehallImporter do
     end
 
     it "creates an edition with a status of removed" do
+      status = Edition.first.status
+
       expect(Edition.first.removed?).to be_truthy
+      expect(status.created_by_id).to eq(User.last.id)
     end
 
     it "creates a removal record" do
@@ -351,8 +363,11 @@ RSpec.describe Tasks::WhitehallImporter do
     end
 
     it "creates a draft edition and assigns as current" do
+      status = Edition.last.status
+
       expect(Edition.last.submitted_for_review?).to be_truthy
       expect(Edition.last.current).to be_truthy
+      expect(status.created_by_id).to eq(User.last.id)
     end
   end
 end

--- a/spec/tasks/whitehall_importer_spec.rb
+++ b/spec/tasks/whitehall_importer_spec.rb
@@ -264,6 +264,15 @@ RSpec.describe Tasks::WhitehallImporter do
     it "creates an edition with a status of removed" do
       expect(Edition.last.removed?).to be_truthy
     end
+
+    it "creates a removal record" do
+      removal = Edition.last.status.details
+      unpublishing_data = whitehall_export_with_unpublished_edition["editions"].first["unpublishing"]
+
+      expect(removal.explanatory_note).to eq(unpublishing_data["explanation"])
+      expect(removal.alternative_path).to eq(unpublishing_data["alternative_url"])
+      expect(removal.redirect).to be_truthy
+    end
   end
 
   context "when a unpublished edition has been edited" do
@@ -289,6 +298,15 @@ RSpec.describe Tasks::WhitehallImporter do
 
     it "creates an edition with a status of removed" do
       expect(Edition.first.removed?).to be_truthy
+    end
+
+    it "creates a removal record" do
+      removal = Edition.first.status.details
+      unpublishing_data = whitehall_export_with_unpublished_edition["editions"].first["unpublishing"]
+
+      expect(removal.explanatory_note).to eq(unpublishing_data["explanation"])
+      expect(removal.alternative_path).to eq(unpublishing_data["alternative_url"])
+      expect(removal.redirect).to be_truthy
     end
 
     it "creates a draft edition and assigns as current" do
@@ -321,6 +339,15 @@ RSpec.describe Tasks::WhitehallImporter do
 
     it "creates an edition with a status of removed" do
       expect(Edition.first.removed?).to be_truthy
+    end
+
+    it "creates a removal record" do
+      removal = Edition.first.status.details
+      unpublishing_data = whitehall_export_with_unpublished_edition["editions"].first["unpublishing"]
+
+      expect(removal.explanatory_note).to eq(unpublishing_data["explanation"])
+      expect(removal.alternative_path).to eq(unpublishing_data["alternative_url"])
+      expect(removal.redirect).to be_truthy
     end
 
     it "creates a draft edition and assigns as current" do


### PR DESCRIPTION
We want to have the ability to import a document that has been removed from GOV.UK. A complication of this is that Whitehall sets unpublished documents to a draft status. So we need to determine whether a user has modified the draft at all for us to know whether it should be an edition with "removed", "draft" or "submitted_for_2i" status.

There is also some quite bad data rot in whitehall to watch out for, like there is a case where a published edition has got an unpublished object attached to it. Some withdrawn documents have got the wrong unpublishing reason attached due to the unpublishing reason ids changing in the code at some point. Also there are some recent documents that are superseded but have an unpublishing object (don't know how you do this through the UI) 😢. 

More info within the commits ->

Trello:
https://trello.com/c/nDK6MZLW/1172-import-an-unpublished-status-into-content-publisher

Importer ran with different scenarios below:

## Removed unpublishing

<img width="1098" alt="Screen Shot 2019-11-12 at 12 23 30" src="https://user-images.githubusercontent.com/24479188/68672101-d0f93a80-0548-11ea-9027-083372e3febf.png">
<img width="714" alt="Screen Shot 2019-11-12 at 12 23 16" src="https://user-images.githubusercontent.com/24479188/68672108-d6568500-0548-11ea-95d9-48c0771467ba.png">

## Removed and edited unpublishing

<img width="1066" alt="Screen Shot 2019-11-12 at 12 33 42" src="https://user-images.githubusercontent.com/24479188/68672146-e8d0be80-0548-11ea-9f25-4b23d1dc9cb8.png">
<img width="716" alt="Screen Shot 2019-11-12 at 12 34 42" src="https://user-images.githubusercontent.com/24479188/68672163-eff7cc80-0548-11ea-8287-6b53eb519f8f.png">