### PR TITLE
Re-populate document_type_id for MetadataRevision

### DIFF
--- a/db/migrate/20191114123329_repopulate_document_id_in_metadata_revisions.rb
+++ b/db/migrate/20191114123329_repopulate_document_id_in_metadata_revisions.rb
@@ -1,0 +1,12 @@
+# frozen_string_literal: true
+
+class RepopulateDocumentIdInMetadataRevisions < ActiveRecord::Migration[5.2]
+  def up
+    type_doc_ids_hash = Document.group(:document_type_id).pluck(:document_type_id, "ARRAY_AGG(id)").to_h
+
+    type_doc_ids_hash.each do |type, ids|
+      MetadataRevision.joins("INNER JOIN revisions ON metadata_revisions.id = revisions.metadata_revision_id")
+        .where("revisions.document_id": ids).update_all(document_type_id: type)
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2019_11_06_152405) do
+ActiveRecord::Schema.define(version: 2019_11_14_123329) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"


### PR DESCRIPTION
This fixes forward the migration introduced in [06c03c5][] which updated
the document_type_id's incorrectly.

This problem was identified by comparing the backfilled data:

```
irb(main):001:0> Document.joins(current_edition: { revision: :metadata_revision }).where("documents.document_type_id != metadata_revisions.document_type_id").count
   (19.7ms)  SELECT COUNT(*) FROM "documents" INNER JOIN "editions" ON "editions"."document_id" = "documents"."id" AND "editions"."current" = $1 INNER JOIN "revisions" ON "revisions"."id" = "editions"."revision_id" INNER JOIN "metadata_revisions" ON "metadata_revisions"."id" = "revisions"."metadata_revision_id" WHERE (documents.document_type_id != metadata_revisions.document_type_id)  [["current", true]]
=> 97
```

After running this migration here these are corrected:

```
irb(main):001:0> Document.joins(current_edition: { revision: :metadata_revision }).where("documents.document_type_id != metadata_revisions.document_type_id").count
   (9.1ms)  SELECT COUNT(*) FROM "documents" INNER JOIN "editions" ON "editions"."document_id" = "documents"."id" AND "editions"."current" = $1 INNER JOIN "revisions" ON "revisions"."id" = "editions"."revision_id" INNER JOIN "metadata_revisions" ON "metadata_revisions"."id" = "revisions"."metadata_revision_id" WHERE (documents.document_type_id != metadata_revisions.document_type_id)  [["current", true]]
=> 0
```

[06c03c5]: https://github.com/alphagov/content-publisher/commit/06c03c5fb2ebead0c4a775530065193684fb5481