### PR TITLE
Add not null constraint on document_type_id in metadata_revisions

### DIFF
--- a/db/migrate/20191114135544_add_not_null_constraint_on_document_type_id.rb
+++ b/db/migrate/20191114135544_add_not_null_constraint_on_document_type_id.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+class AddNotNullConstraintOnDocumentTypeId < ActiveRecord::Migration[5.2]
+  def change
+    change_column_null(:metadata_revisions, :document_type_id, false)
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2019_11_14_123329) do
+ActiveRecord::Schema.define(version: 2019_11_14_135544) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -209,7 +209,7 @@ ActiveRecord::Schema.define(version: 2019_11_14_123329) do
     t.bigint "created_by_id"
     t.datetime "proposed_publish_time"
     t.datetime "backdated_to"
-    t.string "document_type_id"
+    t.string "document_type_id", null: false
   end
 
   create_table "removals", force: :cascade do |t|

--- a/spec/factories/metadata_revision_factory.rb
+++ b/spec/factories/metadata_revision_factory.rb
@@ -3,6 +3,7 @@
 FactoryBot.define do
   factory :metadata_revision do
     update_type { "major" }
+    document_type_id { build(:document_type, path_prefix: "/prefix").id }
     association :created_by, factory: :user
   end
 end


### PR DESCRIPTION
We are adding "not null" constraint on document_type_id in metadata_revisions table 
to ensure that this value is stored for each metadata_revision. 

We also have to update the metadata revision factory in line with this change.

[Trello card](https://trello.com/c/kwnmsIe9/1095-permit-content-publisher-to-have-documents-that-change-type)