### PR TITLE
Remove document_type_id from Document

### DIFF
--- a/db/migrate/20191115103058_remove_document_type_id_from_documents.rb
+++ b/db/migrate/20191115103058_remove_document_type_id_from_documents.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+class RemoveDocumentTypeIdFromDocuments < ActiveRecord::Migration[5.2]
+  def change
+    remove_column :documents, :document_type_id, :string
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2019_11_14_135544) do
+ActiveRecord::Schema.define(version: 2019_11_15_103058) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -56,7 +56,6 @@ ActiveRecord::Schema.define(version: 2019_11_14_135544) do
   create_table "documents", force: :cascade do |t|
     t.uuid "content_id", null: false
     t.string "locale", null: false
-    t.string "document_type_id"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.bigint "created_by_id"


### PR DESCRIPTION
Trello - https://trello.com/c/kwnmsIe9/1095-permit-content-publisher-to-have-documents-that-change-type

This is among the last pieces of work in a stream set to move document_type_id from Documents to MetadataRevisions. It will allow us to change document types on documents within content-publisher. This PR removes document_type_id from Documents now that all of its functionality has been moves to MetadataRevisions.