### PR TITLE
Post document.document_type_id removal cleanup

### DIFF
--- a/app/models/document.rb
+++ b/app/models/document.rb
@@ -31,8 +31,6 @@ class Document < ApplicationRecord
 
   delegate :topics, to: :document_topics
 
-  self.ignored_columns = %w(document_type_id)
-
   scope :with_current_edition, -> do
     join_tables = { current_edition: %i[revision status] }
     joins(join_tables).includes(join_tables)


### PR DESCRIPTION
There was a small amount of code that was left over after the movement of document_type_id from Documents to MetadataRevisions. This removes code that refers to a table column that is no longer extant.