### PR TITLE
Import AccessLimit from Whitehall

### DIFF
--- a/lib/tasks/whitehall_importer.rb
+++ b/lib/tasks/whitehall_importer.rb
@@ -138,6 +138,7 @@ module Tasks
         last_edited_by_id: user_ids[last_event["whodunnit"]],
       )
 
+      set_access_limit(whitehall_edition["created_at"], edition, revision) if whitehall_edition["access_limited"]
       set_withdrawn_status(whitehall_edition, edition) if whitehall_edition["state"] == "withdrawn"
     end
 
@@ -252,6 +253,17 @@ module Tasks
       return [] unless associations
 
       associations.map { |association| association["content_id"] }
+    end
+
+    def set_access_limit(created_at, edition, revision)
+      edition.access_limit = AccessLimit.new(
+        created_at: created_at,
+        edition: edition,
+        revision_at_creation: revision,
+        limit_type: "tagged_organisations",
+      )
+
+      edition.save!
     end
 
     class AbortImportError < RuntimeError

--- a/spec/tasks/whitehall_importer_spec.rb
+++ b/spec/tasks/whitehall_importer_spec.rb
@@ -131,6 +131,21 @@ RSpec.describe Tasks::WhitehallImporter do
     expect(Edition.last).not_to be_live
   end
 
+  it "creates AccessLimit" do
+    import_data["editions"][0]["access_limited"] = true
+    import_data["editions"][0]["revision_history"][0].merge!("created_at" => 3.days.ago)
+
+    importer = Tasks::WhitehallImporter.new(123, import_data)
+    importer.import
+
+    expect(Edition.last.access_limit).to eq(AccessLimit.last)
+    expect(AccessLimit.last.created_at).to eq(Edition.last.created_at)
+    expect(AccessLimit.last.created_by_id).to be nil
+    expect(AccessLimit.last.edition_id).to eq(Edition.last.id)
+    expect(AccessLimit.last.revision_at_creation_id).to eq(Revision.last.id)
+    expect(AccessLimit.last.limit_type).to eq("tagged_organisations")
+  end
+
   it "raises AbortImportError when edition has an unsupported state" do
     import_data["editions"][0]["state"] = "not_supported"
     importer = Tasks::WhitehallImporter.new(123, import_data)


### PR DESCRIPTION
Whitehall sets access limiting by setting `access_limited: true` on Edition. Whereas in Content Publisher, we have AccessLimit model which points to an edition.

When importing AccessLimit:
- created_at is set to the time the edition was last edited
- revision is the last one for this content
- there is no user attribution
- limit_type is set to "tagged_organisations" as this is the only option in Whitehall

The only statuses considered for access_limit are draft, rejected, submitted. In both apps access_limit is cleared once the document is published ([Content Publisher](https://github.com/alphagov/content-publisher/blob/master/app/services/publish_service.rb#L50 ), [Whitehall](https://github.com/alphagov/whitehall/blob/13ccb069d3df45371c7c7390c292968d052c7ea5/app/services/edition_publisher.rb#L32))

[Trello card](https://trello.com/b/mn2MqH3M/publishing-workflow-doing-q4-2019-to)