### PR TITLE
Use base path supplied by Whitehall when importing

### DIFF
--- a/lib/tasks/whitehall_importer.rb
+++ b/lib/tasks/whitehall_importer.rb
@@ -101,7 +101,7 @@ module Tasks
         imported: true,
         content_revision: ContentRevision.new(
           title: translation["title"],
-          base_path: "/government/news/" + whitehall_document["slug"],
+          base_path: translation["base_path"],
           summary: translation["summary"],
           contents: {
             body: embed_contacts(translation["body"], whitehall_edition.fetch("contacts", [])),

--- a/spec/fixtures/whitehall_export_with_one_edition.json
+++ b/spec/fixtures/whitehall_export_with_one_edition.json
@@ -18,7 +18,8 @@
           "locale": "en",
           "title": "Title",
           "summary": "Summary",
-          "body": "Body"
+          "body": "Body",
+          "base_path": "/government/news/document-slug"
         }
       ],
       "revision_history": [

--- a/spec/fixtures/whitehall_export_with_one_withdrawn_edition.json
+++ b/spec/fixtures/whitehall_export_with_one_withdrawn_edition.json
@@ -18,7 +18,8 @@
           "locale": "en",
           "title": "Title",
           "summary": "Summary",
-          "body": "Body"
+          "body": "Body",
+          "base_path": "/government/news/document-slug"
         }
       ],
       "revision_history": [

--- a/spec/fixtures/whitehall_export_with_two_editions.json
+++ b/spec/fixtures/whitehall_export_with_two_editions.json
@@ -18,7 +18,8 @@
           "locale": "en",
           "title": "Title",
           "summary": "Summary",
-          "body": "Body"
+          "body": "Body",
+          "base_path": "/government/news/document-slug"
         }
       ],
       "revision_history": [
@@ -75,7 +76,8 @@
           "locale": "en",
           "title": "Title",
           "summary": "Summary",
-          "body": "Body"
+          "body": "Body",
+          "base_path": "/government/news/document-slug"
         }
       ],
       "revision_history": [

--- a/spec/tasks/whitehall_importer_spec.rb
+++ b/spec/tasks/whitehall_importer_spec.rb
@@ -16,6 +16,8 @@ RSpec.describe Tasks::WhitehallImporter do
     expect(edition.summary)
       .to eq(imported_edition["translations"][0]["summary"])
 
+    expect(edition.base_path).to eq(imported_edition["translations"][0]["base_path"])
+
     expect(edition.number).to eql(1)
     expect(edition.status).to be_draft
     expect(edition.update_type).to eq("major")


### PR DESCRIPTION
We were previously hard-coding the first part of the base path, then adding the document's slug when importing from Whitehall.  This change assigns the correct base path to each revision, based on the information provided in the Whitehall export.

Trello card: https://trello.com/c/IKL78lqj