### PR TITLE
Fix Content Publisher returning 500 on document 404s

### DIFF
--- a/app/controllers/errors_controller.rb
+++ b/app/controllers/errors_controller.rb
@@ -2,6 +2,7 @@
 
 class ErrorsController < ApplicationController
   skip_before_action :verify_authenticity_token
+  skip_before_action :check_user_access
 
   def bad_request
     render status: :bad_request, formats: :html

--- a/config/environments/test.rb
+++ b/config/environments/test.rb
@@ -22,8 +22,8 @@ Rails.application.configure do
   config.consider_all_requests_local       = true
   config.action_controller.perform_caching = false
 
-  # Raise exceptions instead of rendering exception templates.
-  config.action_dispatch.show_exceptions = false
+  # Handle exceptions ourselves and return HTTP status instead of raising exceptions.
+  config.action_dispatch.show_exceptions = true
 
   # Disable request forgery protection in test environment.
   config.action_controller.allow_forgery_protection = false

--- a/spec/requests/errors_spec.rb
+++ b/spec/requests/errors_spec.rb
@@ -32,4 +32,12 @@ RSpec.describe "Errors" do
       expect(response.body).to include(I18n.t!("errors.internal_server_error.title"))
     end
   end
+
+  describe "bypassing user access checks" do
+    it "returns a not found response when a document doesn't exist" do
+      get document_path("document-that-does-not-exist")
+
+      expect(response).to have_http_status(:not_found)
+    end
+  end
 end


### PR DESCRIPTION
Content Publisher currently returns an [unstyled 500 error](https://github.com/rails/rails/blob/98a57aa5f610bc66af31af409c72173cdeeb3c9e/actionpack/lib/action_dispatch/middleware/show_exceptions.rb#L20-L24) when a 404 page
is encountered. This happens because an exception loop occurs during the
rendering of an error response. The problem occurs because `check_user_access`
before action runs before all actions (including error actions). So if a
document is going to 404, the `ActiveRecord::RecordNotFound` is raised once
before the requested action and then again in the ErrorsController.

To avoid this we are using skip_before_action callback in ErrorsController so
the `check_user_access` action only runs once.

We are setting `config.action_dispatch.show_exceptions` to `true` in the test
environment so exceptions are rescued and Rails returns a corresponding HTTP
status code instead of returning `ActiveRecord::RecordNotFound` exeption.

We are also testing if 404 is returned if a Document doesn’t have an edition,
which is the case when access limited documents are copied from production.

**Before**
<img width="843" alt="page_before" src="https://user-images.githubusercontent.com/38078064/69260546-fa087380-0bb7-11ea-968e-2b9100ec89ff.png">

**After**
<img width="1167" alt="page_after" src="https://user-images.githubusercontent.com/38078064/69260558-0096eb00-0bb8-11ea-9434-c1b9d4b72a33.png">

[Trello card](https://trello.com/c/uNKKMrpa/1169-fix-content-publisher-returning-500-on-document-404s) 