### PR TITLE
Allow presenting history mode content to Publishing API

### DIFF
--- a/app/models/edition.rb
+++ b/app/models/edition.rb
@@ -74,6 +74,7 @@ class Edition < ApplicationRecord
            :primary_publishing_organisation_id,
            :supporting_organisation_ids,
            :backdated_to,
+           :editor_political,
            to: :revision
 
   scope :find_current, ->(id: nil, document: nil) do

--- a/app/models/edition.rb
+++ b/app/models/edition.rb
@@ -122,6 +122,10 @@ class Edition < ApplicationRecord
     number == 1
   end
 
+  def political?
+    editor_political.nil? ? system_political : editor_political
+  end
+
   def assign_status(state,
                     user,
                     update_last_edited: true,

--- a/app/models/edition.rb
+++ b/app/models/edition.rb
@@ -135,6 +135,12 @@ class Edition < ApplicationRecord
     editor_political.nil? ? system_political : editor_political
   end
 
+  def history_mode?
+    return false unless government
+
+    political? && !government.current?
+  end
+
   def government
     return unless government_id
 

--- a/app/models/edition.rb
+++ b/app/models/edition.rb
@@ -135,6 +135,12 @@ class Edition < ApplicationRecord
     editor_political.nil? ? system_political : editor_political
   end
 
+  def government
+    return unless government_id
+
+    Government.find(government_id)
+  end
+
   def assign_status(state,
                     user,
                     update_last_edited: true,

--- a/app/models/edition.rb
+++ b/app/models/edition.rb
@@ -103,6 +103,15 @@ class Edition < ApplicationRecord
     joins(revision: :metadata_revision).where(sql, political: political)
   end
 
+  scope :history_mode, ->(history_mode = true) do
+    if history_mode
+      political.where.not(government_id: [nil, Government.current.content_id])
+    else
+      political(false)
+        .or(political.where(government_id: [nil, Government.current.content_id]))
+    end
+  end
+
   def self.create_initial(document:, document_type_id:, user: nil, tags: {})
     revision = Revision.create_initial(
       document: document,

--- a/app/models/edition.rb
+++ b/app/models/edition.rb
@@ -94,6 +94,15 @@ class Edition < ApplicationRecord
       .find_by!(find_by)
   end
 
+  scope :political, ->(political = true) do
+    sql = "CASE WHEN metadata_revisions.editor_political IS NULL "\
+          "THEN editions.system_political = :political "\
+          "ELSE metadata_revisions.editor_political = :political "\
+          "END"
+
+    joins(revision: :metadata_revision).where(sql, political: political)
+  end
+
   def self.create_initial(document:, document_type_id:, user: nil, tags: {})
     revision = Revision.create_initial(
       document: document,

--- a/app/models/government.rb
+++ b/app/models/government.rb
@@ -16,6 +16,10 @@ class Government
     for_date(Date.current)
   end
 
+  def self.past
+    all.reject(&:current?)
+  end
+
   def self.all
     @all ||= YAML.load_file(Rails.root.join("config", "governments.yml"))
                  .map { |hash| new(hash) }

--- a/app/models/government.rb
+++ b/app/models/government.rb
@@ -38,4 +38,16 @@ class Government
 
     true
   end
+
+  def current?
+    self == self.class.current
+  end
+
+  def publishing_api_payload
+    {
+      "title" => name,
+      "slug" => slug,
+      "current" => current?,
+    }
+  end
 end

--- a/app/models/government.rb
+++ b/app/models/government.rb
@@ -4,7 +4,8 @@ class Government
   include ActiveModel::Model
 
   def self.find(content_id)
-    all.find { |government| government.content_id == content_id }
+    government = all.find { |g| g.content_id == content_id }
+    government || (raise "Government #{content_id} not found")
   end
 
   def self.for_date(date)

--- a/app/models/government.rb
+++ b/app/models/government.rb
@@ -3,8 +3,8 @@
 class Government
   include ActiveModel::Model
 
-  def self.find(id)
-    all.find { |government| government.id == id }
+  def self.find(content_id)
+    all.find { |government| government.content_id == content_id }
   end
 
   def self.for_date(date)
@@ -20,10 +20,10 @@ class Government
                  .map { |hash| new(hash) }
   end
 
-  attr_accessor :id, :slug, :name, :start_date, :end_date
+  attr_accessor :content_id, :slug, :name, :start_date, :end_date
 
   def ==(other)
-    id == other.id
+    content_id == other.content_id
   end
 
   alias_method :eql?, :==

--- a/app/models/revision.rb
+++ b/app/models/revision.rb
@@ -56,6 +56,7 @@ class Revision < ApplicationRecord
            :proposed_publish_time,
            :backdated_to,
            :document_type,
+           :editor_political,
            to: :metadata_revision
 
   delegate :tags,

--- a/app/services/preview_service/payload.rb
+++ b/app/services/preview_service/payload.rb
@@ -75,7 +75,8 @@ private
   end
 
   def details
-    details = {}
+    details = { "political" => edition.political? }
+    details["government"] = edition.government.publishing_api_payload if edition.government
 
     document_type.contents.each do |field|
       details[field.id] = perform_input_type_specific_transformations(field)

--- a/config/governments.yml
+++ b/config/governments.yml
@@ -1,285 +1,285 @@
 # This list of governments is generated from Whitehall by running the following
 # code in the Rails console:
-# `puts Government.order(start_date: :desc).map { |g| g.as_json(only: %i[id slug name start_date end_date]) }.to_yaml`
+# `puts Government.order(start_date: :desc).map { |g| g.as_json(only: %i[content_id slug name start_date end_date]) }.to_yaml`
 # This is included until government data is in the Publishing API and will
 # need to be updating each time governments change.
-- id: 56
-  slug: 2015-conservative-government
+- slug: 2015-conservative-government
   name: 2015 Conservative government
   start_date: 2015-05-08
   end_date:
-- id: 1
-  slug: 2010-to-2015-conservative-and-liberal-democrat-coalition-government
+  content_id: d4fbc1b9-d47d-4386-af04-ac909f868f92
+- slug: 2010-to-2015-conservative-and-liberal-democrat-coalition-government
   name: 2010 to 2015 Conservative and Liberal Democrat coalition government
   start_date: 2010-05-12
   end_date: 2015-05-08
-- id: 2
-  slug: 2005-to-2010-labour-government
+  content_id: 591c83aa-3b74-437d-a342-612bddd97572
+- slug: 2005-to-2010-labour-government
   name: 2005 to 2010 Labour government
   start_date: 2005-05-06
   end_date: 2010-05-11
-- id: 3
-  slug: 2001-to-2005-labour-government
+  content_id: '09399599-397e-48c7-8bdb-171d6b49d387'
+- slug: 2001-to-2005-labour-government
   name: 2001 to 2005 Labour government
   start_date: 2001-06-08
   end_date: 2005-05-05
-- id: 4
-  slug: 1997-to-2001-labour-government
+  content_id: 52f981c9-c73f-497b-aa91-86bd6092492b
+- slug: 1997-to-2001-labour-government
   name: 1997 to 2001 Labour government
   start_date: 1997-05-02
   end_date: 2001-06-07
-- id: 5
-  slug: 1992-to-1997-conservative-government
+  content_id: ee4de459-0941-40dd-ba36-f23eec0585cb
+- slug: 1992-to-1997-conservative-government
   name: 1992 to 1997 Conservative government
   start_date: 1992-04-10
   end_date: 1997-05-01
-- id: 6
-  slug: 1987-to-1992-conservative-government
+  content_id: a1d4477d-ad05-4e8c-9150-062765c901b8
+- slug: 1987-to-1992-conservative-government
   name: 1987 to 1992 Conservative government
   start_date: 1987-06-12
   end_date: 1992-04-09
-- id: 7
-  slug: 1983-to-1987-conservative-government
+  content_id: 6b79f257-8d65-44fa-a9e4-225a57fe7963
+- slug: 1983-to-1987-conservative-government
   name: 1983 to 1987 Conservative government
   start_date: 1983-06-10
   end_date: 1987-06-11
-- id: 8
-  slug: 1979-to-1983-conservative-government
+  content_id: f4f04740-e945-4be1-951e-ab0dab1ca905
+- slug: 1979-to-1983-conservative-government
   name: 1979 to 1983 Conservative government
   start_date: 1979-05-04
   end_date: 1983-06-09
-- id: 9
-  slug: 1974-to-1979-labour-government
+  content_id: 2d8028c2-a2d1-417a-a115-745196fe17f8
+- slug: 1974-to-1979-labour-government
   name: 1974 to 1979 Labour government
   start_date: 1974-10-11
   end_date: 1979-05-03
-- id: 10
-  slug: 1974-to-1974-labour-minority-government
+  content_id: 2eb3350f-6a54-466b-9a52-07b15f6b3c0c
+- slug: 1974-to-1974-labour-minority-government
   name: 1974 to 1974 Labour (minority) government
   start_date: 1974-03-04
   end_date: 1974-10-10
-- id: 11
-  slug: 1970-to-1974-conservative-government
+  content_id: 88f8bf5b-6be4-4eb4-a2c9-48d1375c7671
+- slug: 1970-to-1974-conservative-government
   name: 1970 to 1974 Conservative government
   start_date: 1970-06-19
   end_date: 1974-03-03
-- id: 12
-  slug: 1966-to-1970-labour-government
+  content_id: f3eaf7f0-00fc-4a04-a895-289e26dd0cff
+- slug: 1966-to-1970-labour-government
   name: 1966 to 1970 Labour government
   start_date: 1966-04-01
   end_date: 1970-06-18
-- id: 13
-  slug: 1964-to-1966-labour-government
+  content_id: bba3f518-4d64-473d-9ff9-6a9f9c3f33c8
+- slug: 1964-to-1966-labour-government
   name: 1964 to 1966 Labour government
   start_date: 1964-10-16
   end_date: 1966-03-31
-- id: 14
-  slug: 1959-to-1964-conservative-government
+  content_id: 8efa5f78-be3f-48cc-8aab-61fbb78c256d
+- slug: 1959-to-1964-conservative-government
   name: 1959 to 1964 Conservative government
   start_date: 1959-10-09
   end_date: 1964-10-15
-- id: 15
-  slug: 1955-to-1959-conservative-government
+  content_id: 5405d71b-c07c-4f92-9dbc-3d0cc36066f4
+- slug: 1955-to-1959-conservative-government
   name: 1955 to 1959 Conservative government
   start_date: 1955-05-27
   end_date: 1959-10-08
-- id: 16
-  slug: 1951-to-1955-conservative-government
+  content_id: 7f62d7bc-a9f5-4073-b042-01537579036f
+- slug: 1951-to-1955-conservative-government
   name: 1951 to 1955 Conservative government
   start_date: 1951-10-26
   end_date: 1955-05-26
-- id: 17
-  slug: 1950-to-1951-labour-government
+  content_id: 603fbd65-1300-49b4-a897-31336dea5297
+- slug: 1950-to-1951-labour-government
   name: 1950 to 1951 Labour government
   start_date: 1950-02-24
   end_date: 1951-10-25
-- id: 18
-  slug: 1945-to-1950-labour-government
+  content_id: '098c877d-1f39-424f-b7cc-c04119b3c91e'
+- slug: 1945-to-1950-labour-government
   name: 1945 to 1950 Labour government
   start_date: 1945-07-27
   end_date: 1950-02-23
-- id: 19
-  slug: 1935-to-1945-national-government
+  content_id: e43512df-4830-45a8-b94d-d27f83ecead9
+- slug: 1935-to-1945-national-government
   name: 1935 to 1945 National government
   start_date: 1935-11-15
   end_date: 1945-07-26
-- id: 20
-  slug: 1931-to-1935-national-government
+  content_id: a05c2130-60c3-4d92-9f30-1cd3fb9d4a00
+- slug: 1931-to-1935-national-government
   name: 1931 to 1935 National government
   start_date: 1931-10-28
   end_date: 1935-11-14
-- id: 21
-  slug: 1929-to-1931-labour-minority-government
+  content_id: 7a893530-a089-4b43-ae14-7472dbe900a2
+- slug: 1929-to-1931-labour-minority-government
   name: 1929 to 1931 Labour (minority) government
   start_date: 1929-06-05
   end_date: 1931-10-27
-- id: 22
-  slug: 1924-to-1929-conservative-government
+  content_id: 18494aed-7b2e-4b3d-adc7-60c41a5df82a
+- slug: 1924-to-1929-conservative-government
   name: 1924 to 1929 Conservative government
   start_date: 1924-10-30
   end_date: 1929-06-04
-- id: 23
-  slug: 1924-to-1924-labour-minority-government
+  content_id: 1c33a365-3d9f-4da2-ac43-cfddb0fbb2d7
+- slug: 1924-to-1924-labour-minority-government
   name: 1924 to 1924 Labour (minority) government
   start_date: 1924-01-22
   end_date: 1924-10-29
-- id: 24
-  slug: 1922-to-1924-conservative-government
+  content_id: 7f7e85d5-487e-4961-ba0f-1b5b455b7d8f
+- slug: 1922-to-1924-conservative-government
   name: 1922 to 1924 Conservative government
   start_date: 1922-11-16
   end_date: 1924-01-21
-- id: 25
-  slug: 1918-to-1922-conservative-and-liberal-coalition-government
+  content_id: be5da979-b7d6-436e-afe4-45d9ea4773c9
+- slug: 1918-to-1922-conservative-and-liberal-coalition-government
   name: 1918 to 1922 Conservative and Liberal coalition government
   start_date: 1918-12-15
   end_date: 1922-11-15
-- id: 26
-  slug: 1910-to-1918-liberal-minority-government
+  content_id: b8c94a77-1842-4d8a-9e1e-92847e2286da
+- slug: 1910-to-1918-liberal-minority-government
   name: 1910 to 1918 Liberal (minority) government
   start_date: 1910-12-19
   end_date: 1918-12-14
-- id: 27
-  slug: 1910-to-1910-liberal-minority-government
+  content_id: 83478dbe-3141-4cb3-83b2-f55c16f478ca
+- slug: 1910-to-1910-liberal-minority-government
   name: 1910 to 1910 Liberal (minority) government
   start_date: 1910-02-10
   end_date: 1910-12-18
-- id: 28
-  slug: 1906-to-1910-liberal-government
+  content_id: cc329b72-09c4-489a-af5c-579a19d71c52
+- slug: 1906-to-1910-liberal-government
   name: 1906 to 1910 Liberal government
   start_date: 1906-02-09
   end_date: 1910-02-09
-- id: 29
-  slug: 1900-to-1906-conservative-government
+  content_id: af30abf2-2cf7-4487-90bd-b629464efa1e
+- slug: 1900-to-1906-conservative-government
   name: 1900 to 1906 Conservative government
   start_date: 1900-10-25
   end_date: 1906-02-08
-- id: 30
-  slug: 1895-to-1900-conservative-government
+  content_id: 4ba70052-dfa8-4d4c-9bb8-fc6904007aa1
+- slug: 1895-to-1900-conservative-government
   name: 1895 to 1900 Conservative government
   start_date: 1895-08-08
   end_date: 1900-10-24
-- id: 31
-  slug: 1892-to-1895-liberal-minority-government
+  content_id: 3cc4a8da-535b-42bb-a861-33ecd98ce773
+- slug: 1892-to-1895-liberal-minority-government
   name: 1892 to 1895 Liberal (minority) government
   start_date: 1892-08-15
   end_date: 1895-08-07
-- id: 32
-  slug: 1886-to-1892-conservative-government
+  content_id: e3372321-5997-4324-a1e7-fedb4a31db30
+- slug: 1886-to-1892-conservative-government
   name: 1886 to 1892 Conservative government
   start_date: 1886-08-25
   end_date: 1892-08-14
-- id: 33
-  slug: 1885-to-1886-liberal-minority-government
+  content_id: c024b258-d9a4-473e-b86e-19ea8ceaea38
+- slug: 1885-to-1886-liberal-minority-government
   name: 1885 to 1886 Liberal (minority) government
   start_date: 1885-12-19
   end_date: 1886-08-24
-- id: 34
-  slug: 1880-to-1885-liberal-government
+  content_id: 41cdb486-3bde-4bcd-aa24-dc0346b1b182
+- slug: 1880-to-1885-liberal-government
   name: 1880 to 1885 Liberal government
   start_date: 1880-04-23
   end_date: 1885-12-18
-- id: 35
-  slug: 1874-to-1880-conservative-government
+  content_id: 55c59c36-75f1-4b09-bb05-2daf0654865f
+- slug: 1874-to-1880-conservative-government
   name: 1874 to 1880 Conservative government
   start_date: 1874-02-18
   end_date: 1880-04-22
-- id: 36
-  slug: 1868-to-1874-liberal-government
+  content_id: dfa0162a-42ed-4948-8537-9e96b037a0e8
+- slug: 1868-to-1874-liberal-government
   name: 1868 to 1874 Liberal government
   start_date: 1868-12-08
   end_date: 1874-02-17
-- id: 37
-  slug: 1865-to-1868-liberal-government
+  content_id: 17eb7b78-f92d-4900-84c7-b1454b996698
+- slug: 1865-to-1868-liberal-government
   name: 1865 to 1868 Liberal government
   start_date: 1865-07-25
   end_date: 1868-12-07
-- id: 38
-  slug: 1859-to-1865-liberal-government
+  content_id: 6e95ac66-19d6-4f70-94a4-bdb2f3411bb8
+- slug: 1859-to-1865-liberal-government
   name: 1859 to 1865 Liberal government
   start_date: 1859-05-19
   end_date: 1865-07-24
-- id: 39
-  slug: 1857-to-1859-whig-government
+  content_id: 3e886b7b-62fd-49f9-9737-ce8b7f942bc2
+- slug: 1857-to-1859-whig-government
   name: 1857 to 1859 Whig government
   start_date: 1857-04-25
   end_date: 1859-05-18
-- id: 40
-  slug: 1852-to-1857-conservative-government
+  content_id: 69b0f69a-2544-4a76-bc73-2d8673cd3423
+- slug: 1852-to-1857-conservative-government
   name: 1852 to 1857 Conservative government
   start_date: 1852-08-01
   end_date: 1857-04-24
-- id: 41
-  slug: 1847-to-1852-whig-government
+  content_id: 36e0cc46-63c9-414c-9540-638d7d1fc6c9
+- slug: 1847-to-1852-whig-government
   name: 1847 to 1852 Whig government
   start_date: 1847-08-27
   end_date: 1852-07-31
-- id: 42
-  slug: 1841-to-1847-conservative-government
+  content_id: a1996829-eb94-469b-92fd-e59b35b20de2
+- slug: 1841-to-1847-conservative-government
   name: 1841 to 1847 Conservative government
   start_date: 1841-07-23
   end_date: 1847-08-26
-- id: 43
-  slug: 1837-to-1841-whig-government
+  content_id: f9630eb9-1a76-45db-8f83-5db13ac00030
+- slug: 1837-to-1841-whig-government
   name: 1837 to 1841 Whig government
   start_date: 1837-08-19
   end_date: 1841-07-22
-- id: 44
-  slug: 1835-to-1837-whig-government
+  content_id: e9b2f798-3679-4c25-8ce6-3d789c886681
+- slug: 1835-to-1837-whig-government
   name: 1835 to 1837 Whig government
   start_date: 1835-04-09
   end_date: 1837-08-18
-- id: 45
-  slug: 1833-to-1835-whig-government
+  content_id: 129ef024-a03b-470e-b7c0-0ead709cdf28
+- slug: 1833-to-1835-whig-government
   name: 1833 to 1835 Whig government
   start_date: 1833-01-29
   end_date: 1835-04-08
-- id: 46
-  slug: 1831-to-1833-whig-government
+  content_id: 4f5d93e2-e5d5-4a17-b376-c8a36ac71a01
+- slug: 1831-to-1833-whig-government
   name: 1831 to 1833 Whig government
   start_date: 1831-06-14
   end_date: 1833-01-28
-- id: 47
-  slug: 1830-to-1831-whig-government
+  content_id: f615471f-3f77-407c-bade-9e0134c56bb7
+- slug: 1830-to-1831-whig-government
   name: 1830 to 1831 Whig government
   start_date: 1830-09-14
   end_date: 1831-06-13
-- id: 48
-  slug: 1826-to-1830-tory-government
+  content_id: a085fb04-564b-4115-a37e-0ef7790093f0
+- slug: 1826-to-1830-tory-government
   name: 1826 to 1830 Tory government
   start_date: 1826-07-25
   end_date: 1830-09-13
-- id: 49
-  slug: 1820-to-1826-tory-government
+  content_id: 35974059-379f-4b38-8ad3-e3b592fed14f
+- slug: 1820-to-1826-tory-government
   name: 1820 to 1826 Tory government
   start_date: 1820-04-21
   end_date: 1826-07-24
-- id: 50
-  slug: 1818-to-1820-tory-government
+  content_id: 0a64be42-43fb-44dd-81b5-ca869aacf5b0
+- slug: 1818-to-1820-tory-government
   name: 1818 to 1820 Tory government
   start_date: 1818-08-04
   end_date: 1820-04-20
-- id: 51
-  slug: 1812-to-1818-tory-government
+  content_id: d1c4eb6e-2551-42fb-8ba1-3b8d5ae659e5
+- slug: 1812-to-1818-tory-government
   name: 1812 to 1818 Tory government
   start_date: 1812-11-24
   end_date: 1818-08-03
-- id: 52
-  slug: 1807-to-1812-tory-government
+  content_id: 9add4800-a469-4d07-91a0-09ca77c1cfe5
+- slug: 1807-to-1812-tory-government
   name: 1807 to 1812 Tory government
   start_date: 1807-06-22
   end_date: 1812-11-23
-- id: 53
-  slug: 1806-to-1807-whig-government
+  content_id: c3a959ae-fed6-4a1a-a085-1006b591d136
+- slug: 1806-to-1807-whig-government
   name: 1806 to 1807 Whig government
   start_date: 1806-12-13
   end_date: 1807-06-21
-- id: 54
-  slug: 1802-to-1806-tory-government
+  content_id: 83d0f35d-0e3e-437c-8fa1-4122326c7aad
+- slug: 1802-to-1806-tory-government
   name: 1802 to 1806 Tory government
   start_date: 1802-08-31
   end_date: 1806-12-12
-- id: 55
-  slug: 1801-to-1802-tory-government
+  content_id: 79148554-b29d-4a85-aa37-a8c3da8346fd
+- slug: 1801-to-1802-tory-government
   name: 1801 to 1802 Tory government
   start_date: 1801-01-22
   end_date: 1802-08-30
+  content_id: 04c65c7c-072d-48ef-8251-9f9dd7dc94cc#

--- a/db/migrate/20191120110949_add_editor_political_to_metadata_revision.rb
+++ b/db/migrate/20191120110949_add_editor_political_to_metadata_revision.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+class AddEditorPoliticalToMetadataRevision < ActiveRecord::Migration[5.2]
+  def change
+    add_column :metadata_revisions, :editor_political, :boolean
+  end
+end

--- a/db/migrate/20191120113230_add_system_political_to_edition.rb
+++ b/db/migrate/20191120113230_add_system_political_to_edition.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+class AddSystemPoliticalToEdition < ActiveRecord::Migration[5.2]
+  def change
+    add_column :editions, :system_political, :boolean, default: false, null: false
+  end
+end

--- a/db/migrate/20191120204541_add_government_id_to_edition.rb
+++ b/db/migrate/20191120204541_add_government_id_to_edition.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+class AddGovernmentIdToEdition < ActiveRecord::Migration[5.2]
+  def change
+    add_column :editions, :government_id, :uuid
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2019_11_20_110949) do
+ActiveRecord::Schema.define(version: 2019_11_20_113230) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -79,6 +79,7 @@ ActiveRecord::Schema.define(version: 2019_11_20_110949) do
     t.bigint "revision_id", null: false
     t.boolean "revision_synced", default: false, null: false
     t.bigint "access_limit_id"
+    t.boolean "system_political", default: false, null: false
     t.index ["access_limit_id"], name: "index_editions_on_access_limit_id"
     t.index ["created_by_id"], name: "index_editions_on_created_by_id"
     t.index ["document_id", "current"], name: "index_editions_on_document_id_and_current", unique: true, where: "(current = true)"

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2019_11_15_103058) do
+ActiveRecord::Schema.define(version: 2019_11_20_110949) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -209,6 +209,7 @@ ActiveRecord::Schema.define(version: 2019_11_15_103058) do
     t.datetime "proposed_publish_time"
     t.datetime "backdated_to"
     t.string "document_type_id", null: false
+    t.boolean "editor_political"
   end
 
   create_table "removals", force: :cascade do |t|

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2019_11_20_113230) do
+ActiveRecord::Schema.define(version: 2019_11_20_204541) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -80,6 +80,7 @@ ActiveRecord::Schema.define(version: 2019_11_20_113230) do
     t.boolean "revision_synced", default: false, null: false
     t.bigint "access_limit_id"
     t.boolean "system_political", default: false, null: false
+    t.uuid "government_id"
     t.index ["access_limit_id"], name: "index_editions_on_access_limit_id"
     t.index ["created_by_id"], name: "index_editions_on_created_by_id"
     t.index ["document_id", "current"], name: "index_editions_on_document_id_and_current", unique: true, where: "(current = true)"

--- a/spec/factories/edition_factory.rb
+++ b/spec/factories/edition_factory.rb
@@ -7,6 +7,7 @@ FactoryBot.define do
     live { false }
     revision_synced { true }
     association :created_by, factory: :user
+    current_government
 
     revision_fields
 
@@ -185,6 +186,14 @@ FactoryBot.define do
 
     trait :not_political do
       system_political { false }
+    end
+
+    trait :current_government do
+      government_id { Government.current.content_id }
+    end
+
+    trait :past_government do
+      government_id { Government.past.first.content_id }
     end
   end
 end

--- a/spec/factories/edition_factory.rb
+++ b/spec/factories/edition_factory.rb
@@ -178,5 +178,13 @@ FactoryBot.define do
         )
       end
     end
+
+    trait :political do
+      system_political { true }
+    end
+
+    trait :not_political do
+      system_political { false }
+    end
   end
 end

--- a/spec/factories/edition_factory.rb
+++ b/spec/factories/edition_factory.rb
@@ -55,6 +55,7 @@ FactoryBot.define do
           change_note: evaluator.change_note,
           proposed_publish_time: evaluator.proposed_publish_time,
           backdated_to: evaluator.backdated_to,
+          editor_political: evaluator.editor_political,
           lead_image_revision: evaluator.lead_image_revision,
           image_revisions: image_revisions,
           file_attachment_revisions: evaluator.file_attachment_revisions,

--- a/spec/factories/government_factory.rb
+++ b/spec/factories/government_factory.rb
@@ -4,7 +4,7 @@ FactoryBot.define do
   factory :government, class: Government do
     skip_create
 
-    sequence(:id)
+    content_id { SecureRandom.uuid }
     name { SecureRandom.alphanumeric(8) }
     slug { name.parameterize }
     start_date { Date.parse("2015-05-08") }

--- a/spec/factories/revision_factory.rb
+++ b/spec/factories/revision_factory.rb
@@ -19,6 +19,7 @@ FactoryBot.define do
       change_note { "First published." }
       proposed_publish_time { nil }
       backdated_to { nil }
+      editor_political { nil }
     end
   end
 
@@ -53,6 +54,7 @@ FactoryBot.define do
           proposed_publish_time: evaluator.proposed_publish_time,
           backdated_to: evaluator.backdated_to,
           document_type_id: evaluator.document_type_id,
+          editor_political: evaluator.editor_political,
         )
       end
 

--- a/spec/models/edition_spec.rb
+++ b/spec/models/edition_spec.rb
@@ -25,6 +25,23 @@ RSpec.describe Edition do
     end
   end
 
+  describe ".political" do
+    let!(:editor_political) { create(:edition, editor_political: true) }
+    let!(:editor_not_political) { create(:edition, editor_political: false) }
+    let!(:system_political) { create(:edition, system_political: true) }
+    let!(:system_not_political) { create(:edition, system_political: false) }
+
+    it "defaults to scoping to only political editions" do
+      expect(Edition.political)
+        .to contain_exactly(editor_political, system_political)
+    end
+
+    it "can be passed false to scope to non political editions" do
+      expect(Edition.political(false))
+        .to contain_exactly(editor_not_political, system_not_political)
+    end
+  end
+
   describe ".create_initial" do
     let(:document) { build(:document) }
     let(:document_type_id) { build(:document_type, path_prefix: "/prefix").id }

--- a/spec/models/edition_spec.rb
+++ b/spec/models/edition_spec.rb
@@ -107,6 +107,26 @@ RSpec.describe Edition do
     end
   end
 
+  describe "#government" do
+    before { allow(Government).to receive(:all).and_return([government]) }
+    let(:government) { build(:government) }
+
+    it "returns nil when government_id isn't set" do
+      edition = build(:edition, government_id: nil)
+      expect(edition.government).to be_nil
+    end
+
+    it "returns a government when one matches the id" do
+      edition = build(:edition, government_id: government.content_id)
+      expect(edition.government).to eq(government)
+    end
+
+    it "raises an error when no government matches the id" do
+      edition = build(:edition, government_id: SecureRandom.uuid)
+      expect { edition.government }.to raise_error(RuntimeError)
+    end
+  end
+
   describe "#assign_as_edit" do
     let(:edition) { build(:edition) }
     let(:user) { build(:user) }

--- a/spec/models/edition_spec.rb
+++ b/spec/models/edition_spec.rb
@@ -42,6 +42,23 @@ RSpec.describe Edition do
     end
   end
 
+  describe ".history_mode" do
+    let!(:political_past_government) { create(:edition, :political, :past_government) }
+    let!(:political_current_government) { create(:edition, :political, :current_government) }
+    let!(:political_no_government) { create(:edition, :political, government_id: nil) }
+    let!(:not_political) { create(:edition, :not_political) }
+
+    it "defaults to scoping to only history mode editions" do
+      expect(Edition.history_mode)
+        .to contain_exactly(political_past_government)
+    end
+
+    it "can be passed false to scope to non history mode editions" do
+      expect(Edition.history_mode(false))
+        .to contain_exactly(political_current_government, political_no_government, not_political)
+    end
+  end
+
   describe ".create_initial" do
     let(:document) { build(:document) }
     let(:document_type_id) { build(:document_type, path_prefix: "/prefix").id }

--- a/spec/models/edition_spec.rb
+++ b/spec/models/edition_spec.rb
@@ -66,6 +66,30 @@ RSpec.describe Edition do
     end
   end
 
+  describe "#political?" do
+    it "returns editor political when that is set" do
+      political_edition = build(:edition,
+                                editor_political: true,
+                                system_political: true)
+      not_political_edition = build(:edition,
+                                    editor_political: false,
+                                    system_political: true)
+      expect(political_edition).to be_political
+      expect(not_political_edition).not_to be_political
+    end
+
+    it "returns system political when editor political isn't set" do
+      political_edition = build(:edition,
+                                editor_political: nil,
+                                system_political: true)
+      not_political_edition = build(:edition,
+                                    editor_political: nil,
+                                    system_political: false)
+      expect(political_edition).to be_political
+      expect(not_political_edition).not_to be_political
+    end
+  end
+
   describe "#assign_as_edit" do
     let(:edition) { build(:edition) }
     let(:user) { build(:user) }

--- a/spec/models/edition_spec.rb
+++ b/spec/models/edition_spec.rb
@@ -107,6 +107,28 @@ RSpec.describe Edition do
     end
   end
 
+  describe "#history_mode?" do
+    it "returns true when political and associated with a previous government" do
+      edition = build(:edition, :political, :past_government)
+      expect(edition.history_mode?).to be(true)
+    end
+
+    it "returns false when the edition isn't political" do
+      edition = build(:edition, :not_political)
+      expect(edition.history_mode?).to be(false)
+    end
+
+    it "returns false when the edition isn't associated with a government" do
+      edition = build(:edition, :political, government_id: nil)
+      expect(edition.history_mode?).to be(false)
+    end
+
+    it "returns false when the edition is political and associated with the current government" do
+      edition = build(:edition, :political, :current_government)
+      expect(edition.history_mode?).to be(false)
+    end
+  end
+
   describe "#government" do
     before { allow(Government).to receive(:all).and_return([government]) }
     let(:government) { build(:government) }

--- a/spec/models/government_spec.rb
+++ b/spec/models/government_spec.rb
@@ -9,15 +9,16 @@ RSpec.describe Government do
   end
 
   describe ".find" do
-    let(:government) { build(:government, id: 1) }
+    let(:content_id) { SecureRandom.uuid }
+    let(:government) { build(:government, content_id: content_id) }
     before { allow(Government).to receive(:all).and_return([government]) }
 
-    it "finds a government by id" do
-      expect(Government.find(1)).to be government
+    it "finds a government by content id" do
+      expect(Government.find(content_id)).to be government
     end
 
     it "returns nil if there isn't a government for the id" do
-      expect(Government.find(2)).to be_nil
+      expect(Government.find(SecureRandom.uuid)).to be_nil
     end
   end
 

--- a/spec/models/government_spec.rb
+++ b/spec/models/government_spec.rb
@@ -17,8 +17,10 @@ RSpec.describe Government do
       expect(Government.find(content_id)).to be government
     end
 
-    it "returns nil if there isn't a government for the id" do
-      expect(Government.find(SecureRandom.uuid)).to be_nil
+    it "raises an error if there isn't a government for the id" do
+      missing_content_id = SecureRandom.uuid
+      expect { Government.find(missing_content_id) }
+        .to raise_error(RuntimeError, "Government #{missing_content_id} not found")
     end
   end
 

--- a/spec/models/government_spec.rb
+++ b/spec/models/government_spec.rb
@@ -78,6 +78,15 @@ RSpec.describe Government do
     end
   end
 
+  describe ".past" do
+    it "returns the past governments" do
+      past = Government.past
+      expect(past).not_to be_empty
+      expect(past).to all be_a(Government)
+      expect(past).not_to include(Government.current)
+    end
+  end
+
   describe "#covers?" do
     let(:government) do
       build(:government, start_date: start_date, end_date: end_date)

--- a/spec/models/government_spec.rb
+++ b/spec/models/government_spec.rb
@@ -126,4 +126,31 @@ RSpec.describe Government do
       end
     end
   end
+
+  describe "#current?" do
+    let(:government) { build(:government) }
+
+    it "returns true when the government is the current one" do
+      allow(Government).to receive(:current).and_return(government)
+      expect(government.current?).to be true
+    end
+
+    it "returns false when the government is not the current one" do
+      expect(government.current?).to be false
+    end
+  end
+
+  describe "#publishing_api_payload" do
+    it "returns the fields needed for presenting to Publishing API" do
+      government = build(:government,
+                         name: "Past Government",
+                         slug: "past-government")
+
+      expect(government.publishing_api_payload).to eq(
+        "title" => "Past Government",
+        "slug" => "past-government",
+        "current" => false,
+      )
+    end
+  end
 end

--- a/spec/services/preview_service/payload_spec.rb
+++ b/spec/services/preview_service/payload_spec.rb
@@ -165,18 +165,18 @@ RSpec.describe PreviewService::Payload do
     end
 
     it "includes a change note if the update type is 'major'" do
-      edition = create(:edition,
-                       update_type: "major",
-                       change_note: "A change note")
+      edition = build(:edition,
+                      update_type: "major",
+                      change_note: "A change note")
       payload = PreviewService::Payload.new(edition).payload
 
       expect(payload).to match a_hash_including("change_note" => "A change note")
     end
 
     it "does not include a change note if the update type is 'minor'" do
-      edition = create(:edition,
-                       update_type: "minor",
-                       change_note: "A change note")
+      edition = build(:edition,
+                      update_type: "minor",
+                      change_note: "A change note")
       payload = PreviewService::Payload.new(edition).payload
 
       expect(payload).not_to match a_hash_including("change_note" => "A change note")
@@ -185,7 +185,7 @@ RSpec.describe PreviewService::Payload do
     it "includes first_published_at if the edition has a backdated_to value" do
       date = Time.current.yesterday
       revision = build(:revision, backdated_to: date)
-      edition = create(:edition, revision: revision)
+      edition = build(:edition, revision: revision)
       payload = PreviewService::Payload.new(edition).payload
 
       expect(payload).to match a_hash_including("first_published_at" => date)
@@ -194,7 +194,7 @@ RSpec.describe PreviewService::Payload do
     it "include public_updated_at if the edition has backdated_to and is a first edition" do
       date = Time.current.yesterday
       revision = build(:revision, backdated_to: date)
-      edition = create(:edition, revision: revision, number: 1)
+      edition = build(:edition, revision: revision, number: 1)
       payload = PreviewService::Payload.new(edition).payload
 
       expect(payload).to match a_hash_including("public_updated_at" => date)

--- a/spec/services/preview_service/payload_spec.rb
+++ b/spec/services/preview_service/payload_spec.rb
@@ -141,6 +141,29 @@ RSpec.describe PreviewService::Payload do
       expect(payload["details"]["image"]).to match a_hash_including(payload_hash)
     end
 
+    it "includes the political status of the edition" do
+      political_edition = build(:edition, :political)
+      payload = PreviewService::Payload.new(political_edition).payload
+      expect(payload["details"]["political"]).to be true
+
+      not_political_edition = build(:edition, :not_political)
+      payload = PreviewService::Payload.new(not_political_edition).payload
+      expect(payload["details"]["political"]).to be false
+    end
+
+    it "includes government when one is present" do
+      current_government = Government.current
+      edition = build(:edition, government_id: current_government.content_id)
+
+      payload = PreviewService::Payload.new(edition).payload
+
+      expect(payload["details"]["government"]).to eq(
+        "title" => current_government.name,
+        "slug" => current_government.slug,
+        "current" => true,
+      )
+    end
+
     it "includes a change note if the update type is 'major'" do
       edition = create(:edition,
                        update_type: "major",


### PR DESCRIPTION
Trello: https://trello.com/c/WKUoYhxb/1189-spike-into-defining-the-history-mode-feature

This PR adds the database changes and associated methods for an Edition to know whether it is in history mode. This data can then be included in data sent to the Publishing API.

The approach taken here is to have two fields on Edition that can be set each time the content is updated or published which represent the government and the automatically determined political status. This data can be worked out on the fly but is stored to allow filtering and to make everything simpler. These are represented as `government_id` and `system_political` fields.

A user can override political status which is represented by a boolean field in a metadata_revision of `editor_political`. A nil value for this indicates `system_political` should be used otherwise it overrides `editor_political` to determine an editions `political?` state.

This updates the Publishing API payload data to include political and government information.

There is more info in the individual commits.