### PR TITLE
Fix URL preview spec due to lack of blur event

### DIFF
--- a/spec/features/editing_content/url_preview_spec.rb
+++ b/spec/features/editing_content/url_preview_spec.rb
@@ -44,7 +44,7 @@ RSpec.feature "Shows a preview of the URL", js: true do
 
   def and_i_fill_in_the_title
     fill_in("revision[title]", with: "A great title")
-    page.find("body").click
+    page.find("body").native.send_keys :tab
   end
 
   def then_i_see_a_preview_of_the_url_on_govuk


### PR DESCRIPTION
Previously we tested the URL preview of a title by clicking the 'body'
field as a way to generate a blur event. This replaces the click method
with an explicit 'tab', as the former doesn't seem to work anymore.