### PR TITLE
Set political status and government when an edition is updated

### DIFF
--- a/app/interactors/editions/create_interactor.rb
+++ b/app/interactors/editions/create_interactor.rb
@@ -15,6 +15,7 @@ class Editions::CreateInteractor < ApplicationInteractor
       create_next_revision
       create_next_edition
       create_timeline_entry
+      preview_next_edition
     end
   end
 
@@ -63,5 +64,9 @@ private
       TimelineEntry.create_for_status_change(entry_type: :new_edition,
                                              status: next_edition.status)
     end
+  end
+
+  def preview_next_edition
+    FailsafePreviewService.call(next_edition)
   end
 end

--- a/app/services/failsafe_preview_service.rb
+++ b/app/services/failsafe_preview_service.rb
@@ -7,6 +7,7 @@ class FailsafePreviewService < ApplicationService
 
   def call
     if has_issues?
+      PoliticalAssociationService.call(edition)
       edition.update!(revision_synced: false)
     else
       PreviewService.call(edition)

--- a/app/services/political_association_service.rb
+++ b/app/services/political_association_service.rb
@@ -1,0 +1,26 @@
+# frozen_string_literal: true
+
+class PoliticalAssociationService < ApplicationService
+  def initialize(edition, fallback_government: nil)
+    @edition = edition
+    @fallback_government = fallback_government
+  end
+
+  def call
+    edition.assign_attributes(
+      government_id: government&.content_id,
+      system_political: PoliticalEditionIdentifier.new(edition).political?,
+    )
+
+    edition.update!(revision_synced: false) if edition.changed?
+  end
+
+private
+
+  attr_reader :edition, :fallback_government
+
+  def government
+    date = edition.backdated_to || edition.document.first_published_at
+    date ? Government.for_date(date) : fallback_government
+  end
+end

--- a/app/services/preview_service.rb
+++ b/app/services/preview_service.rb
@@ -6,6 +6,7 @@ class PreviewService < ApplicationService
   end
 
   def call
+    PoliticalAssociationService.call(edition)
     put_draft_assets
     put_draft_content
   rescue GdsApi::BaseError

--- a/spec/factories/edition_factory.rb
+++ b/spec/factories/edition_factory.rb
@@ -7,7 +7,6 @@ FactoryBot.define do
     live { false }
     revision_synced { true }
     association :created_by, factory: :user
-    current_government
 
     revision_fields
 

--- a/spec/features/scheduling/scheduled_publishing_spec.rb
+++ b/spec/features/scheduling/scheduled_publishing_spec.rb
@@ -66,6 +66,7 @@ RSpec.feature "Scheduled publishing" do
 
   def when_the_publishing_job_runs
     travel_to(Time.zone.parse("2019-6-22 9:00"))
+    stub_any_publishing_api_put_content
     @publish_request = stub_publishing_api_publish(@edition.content_id,
                                                    update_type: nil,
                                                    locale: @edition.locale)

--- a/spec/features/scheduling/scheduled_publishing_without_review_spec.rb
+++ b/spec/features/scheduling/scheduled_publishing_without_review_spec.rb
@@ -50,6 +50,7 @@ RSpec.feature "Scheduled publishing without review" do
 
   def when_the_publishing_job_runs
     travel_to(Time.zone.parse("2019-8-10 12:00"))
+    stub_any_publishing_api_put_content
     @publish_request = stub_publishing_api_publish(@edition.content_id,
                                                    update_type: nil,
                                                    locale: @edition.locale)

--- a/spec/features/workflow/delete_draft_after_publishing_spec.rb
+++ b/spec/features/workflow/delete_draft_after_publishing_spec.rb
@@ -24,6 +24,7 @@ RSpec.feature "Delete draft after publishing" do
   end
 
   def and_i_publish_the_edition
+    stub_any_publishing_api_put_content
     stub_any_publishing_api_publish
     click_on "Publish"
     choose I18n.t!("publish.confirmation.should_be_reviewed")

--- a/spec/features/workflow/publish_asset_manager_down_spec.rb
+++ b/spec/features/workflow/publish_asset_manager_down_spec.rb
@@ -20,6 +20,7 @@ RSpec.feature "Publishing an edition when Asset Manager is down" do
 
   def and_asset_manager_is_down
     stub_asset_manager_isnt_available
+    stub_any_publishing_api_put_content
     stub_any_publishing_api_publish
   end
 

--- a/spec/features/workflow/publish_publishing_api_down_spec.rb
+++ b/spec/features/workflow/publish_publishing_api_down_spec.rb
@@ -16,8 +16,8 @@ RSpec.feature "Publishing an edition when the Publishing API is down" do
   end
 
   def and_the_publishing_api_is_down
-    @request = stub_publishing_api_publish(@edition.content_id, {})
-    publishing_api_isnt_available
+    stub_any_publishing_api_put_content
+    @request = stub_publishing_api_publish(@edition.content_id, {}, status: 503)
   end
 
   def when_i_try_to_publish_the_edition

--- a/spec/features/workflow/publish_spec.rb
+++ b/spec/features/workflow/publish_spec.rb
@@ -44,6 +44,7 @@ RSpec.feature "Publishing an edition" do
     travel_to(@publish_date = Time.current) do
       click_on "Publish"
       choose I18n.t!("publish.confirmation.has_been_reviewed")
+      stub_any_publishing_api_put_content
       @content_request = stub_publishing_api_publish(@edition.content_id, update_type: nil, locale: @edition.locale)
       click_on "Confirm publish"
     end

--- a/spec/features/workflow/publish_without_review_spec.rb
+++ b/spec/features/workflow/publish_without_review_spec.rb
@@ -40,6 +40,7 @@ RSpec.feature "Publish without review" do
     travel_to(@publish_date = Time.current) do
       click_on "Publish"
       choose I18n.t!("publish.confirmation.should_be_reviewed")
+      stub_any_publishing_api_put_content
       stub_any_publishing_api_publish
       click_on "Confirm publish"
     end

--- a/spec/services/failsafe_preview_service_spec.rb
+++ b/spec/services/failsafe_preview_service_spec.rb
@@ -4,6 +4,7 @@ RSpec.describe FailsafePreviewService do
   before do
     allow(PreviewService).to receive(:call)
     allow(AssetCleanupJob).to receive(:perform_later)
+    allow(PoliticalAssociationService).to receive(:call)
   end
 
   describe ".call" do
@@ -28,6 +29,11 @@ RSpec.describe FailsafePreviewService do
       it "sets revision_synced to false on the edition" do
         FailsafePreviewService.call(edition)
         expect(edition.revision_synced).to be(false)
+      end
+
+      it "updates the political association of the content" do
+        expect(PoliticalAssociationService).to receive(:call).with(edition)
+        FailsafePreviewService.call(edition)
       end
 
       it "doesn't send to the Publishing API" do

--- a/spec/services/political_association_service_spec.rb
+++ b/spec/services/political_association_service_spec.rb
@@ -1,0 +1,115 @@
+# frozen_string_literal: true
+
+RSpec.describe PoliticalAssociationService do
+  include ActiveSupport::Testing::TimeHelpers
+
+  describe ".call" do
+    describe "associates an edition with a government" do
+      it "sets the government for a backdated edition" do
+        backdate = Time.zone.parse("2018-01-01")
+        government = build(:government)
+        edition = create(:edition, backdated_to: backdate)
+        allow(Government).to receive(:for_date).with(edition.backdated_to)
+                         .and_return(government)
+
+        expect { PoliticalAssociationService.call(edition) }
+          .to change { edition.reload.government_id }
+          .to(government.content_id)
+      end
+
+      it "sets the government for an edition of a published document" do
+        publish_date = Time.zone.parse("2019-11-01")
+        government = build(:government)
+        allow(Government).to receive(:for_date).with(publish_date)
+                         .and_return(government)
+        edition = create(:edition, :published, first_published_at: publish_date)
+
+        expect { PoliticalAssociationService.call(edition) }
+          .to change { edition.reload.government_id }
+          .to(government.content_id)
+      end
+
+      it "sets the government to nil when an edition isn't backdated or the document published" do
+        edition = create(:edition)
+
+        expect { PoliticalAssociationService.call(edition) }
+          .not_to change { edition.reload.government_id }
+          .from(nil)
+      end
+
+      it "can set the government to a provided one when an edition isn't backdated or the document published" do
+        edition = create(:edition)
+        government = build(:government)
+
+        expect { PoliticalAssociationService.call(edition, fallback_government: government) }
+          .to change { edition.reload.government_id }
+          .to(government.content_id)
+      end
+
+      it "doesn't use the fallback government when no government exists for the date" do
+        backdate = Time.zone.parse("2018-01-01")
+        edition = create(:edition, backdated_to: backdate)
+        fallback_government = build(:government)
+        allow(Government).to receive(:for_date).with(edition.backdated_to)
+                         .and_return(nil)
+
+        expect { PoliticalAssociationService.call(edition, fallback_government: fallback_government) }
+          .not_to change { edition.reload.government_id }
+          .from(nil)
+      end
+    end
+
+    describe "marks an edition as political" do
+      it "sets system_political to true when the edition is identified as political" do
+        edition = create(:edition, system_political: false)
+        allow(PoliticalEditionIdentifier)
+          .to receive(:new)
+          .with(edition)
+          .and_return(instance_double(PoliticalEditionIdentifier, political?: true))
+
+        expect { PoliticalAssociationService.call(edition) }
+          .to change { edition.reload.system_political }
+          .to(true)
+      end
+
+      it "sets system_political to false when the edition is not identified as political" do
+        edition = create(:edition, system_political: true)
+        allow(PoliticalEditionIdentifier)
+          .to receive(:new)
+          .with(edition)
+          .and_return(instance_double(PoliticalEditionIdentifier, political?: false))
+
+        expect { PoliticalAssociationService.call(edition) }
+          .to change { edition.reload.system_political }
+          .to(false)
+      end
+    end
+
+    describe "updating revision_synced value" do
+      before do
+        allow(PoliticalEditionIdentifier)
+          .to receive(:new)
+          .and_return(instance_double(PoliticalEditionIdentifier, political?: true))
+      end
+
+      it "sets revision_synced to false when values change" do
+        edition = create(:edition,
+                         system_political: false,
+                         revision_synced: true)
+
+        expect { PoliticalAssociationService.call(edition) }
+          .to change { edition.reload.revision_synced }
+          .to(false)
+      end
+
+      it "doesn't update revision_synced when the edition is not modified" do
+        edition = create(:edition,
+                         system_political: true,
+                         revision_synced: true)
+
+        expect { PoliticalAssociationService.call(edition) }
+          .not_to(change { edition.reload.revision_synced })
+      end
+    end
+  end
+end

--- a/spec/services/preview_service_spec.rb
+++ b/spec/services/preview_service_spec.rb
@@ -4,9 +4,16 @@ RSpec.describe PreviewService do
   before do
     stub_any_publishing_api_put_content
     allow(PreviewAssetService).to receive(:call)
+    allow(PoliticalAssociationService).to receive(:call)
   end
 
   describe ".call" do
+    it "updates the political status of the edition" do
+      edition = create(:edition)
+      expect(PoliticalAssociationService).to receive(:call).with(edition)
+      PreviewService.call(edition)
+    end
+
     it "updates the Publishing API" do
       edition = create(:edition)
       request = stub_publishing_api_put_content(edition.content_id, {})


### PR DESCRIPTION
Trello: https://trello.com/c/KxlsWBzq/1207-automatically-determine-political-status-and-government-at-the-point-of-editing

This builds on https://github.com/alphagov/content-publisher/pull/1466 and should be reviewed once that is merged in.

This code is used to set the political status and government each time content is updating the Publishing API. This uses the PreviewService and PublishService as places to call this logic. 

It also adds this check into the FailsafePreviewService so that content with issues can still reflect up-to-date political and government statuses.

I wasn't too sure about where to place this code. It feels quite natural to be placed within PreviewService and PublishService since it is data that we're concerned about the value at syncing. However it didn't feel such a natural place on a FailsafePreviewService. Alternatives to this however seemed rather complex and unappealing (lots of duplicated code or callbacks), so I think that maybe in time we'll end up renaming FailsafePreviewService if it acquires other similar concerns.

A late change I made to this was deciding to only set the government when content is published or backdated, previously this used the current time to set the government. I decided against using the current time as it meant that drafts would show incorrect governments whenever the government changed until they were then updated. I opted instead for no government at that point on the basis that no data was better than potentially incorrect data. A consequence of this change is that we need a manual way of setting a government at the point of publishing which is where the concept of a fallback_government comes from.