### PR TITLE
Use imported images and attachments

### DIFF
--- a/lib/whitehall_importer/create_revision.rb
+++ b/lib/whitehall_importer/create_revision.rb
@@ -25,6 +25,7 @@ module WhitehallImporter
       document_type_key = DOCUMENT_SUB_TYPES.reject { |t| whitehall_edition[t].nil? }.first
       raise AbortImportError, "Edition has an unsupported document type" unless SUPPORTED_DOCUMENT_TYPES.include?(whitehall_edition[document_type_key])
 
+      image_revisions = create_image_revisions(whitehall_edition["images"])
       Revision.create!(
         document: document,
         number: document.next_revision_number,
@@ -37,6 +38,7 @@ module WhitehallImporter
             body: WhitehallImporter::EmbedBodyReferences.call(
               body: translation["body"],
               contacts: whitehall_edition.fetch("contacts", []),
+              images: image_revisions.map(&:filename),
             ),
           },
         ),
@@ -54,7 +56,7 @@ module WhitehallImporter
             "world_locations" => tags(whitehall_edition["world_locations"]),
           },
         ),
-        image_revisions: create_image_revisions(whitehall_edition["images"]),
+        image_revisions: image_revisions,
         created_at: whitehall_edition["created_at"],
       )
     end

--- a/lib/whitehall_importer/create_revision.rb
+++ b/lib/whitehall_importer/create_revision.rb
@@ -57,6 +57,7 @@ module WhitehallImporter
           },
         ),
         image_revisions: image_revisions,
+        lead_image_revision: image_revisions.first,
         created_at: whitehall_edition["created_at"],
       )
     end

--- a/lib/whitehall_importer/create_revision.rb
+++ b/lib/whitehall_importer/create_revision.rb
@@ -34,7 +34,10 @@ module WhitehallImporter
           base_path: translation["base_path"],
           summary: translation["summary"],
           contents: {
-            body: embed_contacts(translation["body"], whitehall_edition.fetch("contacts", [])),
+            body: WhitehallImporter::EmbedBodyReferences.call(
+              body: translation["body"],
+              contacts: whitehall_edition.fetch("contacts", []),
+            ),
           },
         ),
         metadata_revision: MetadataRevision.new(
@@ -100,14 +103,6 @@ module WhitehallImporter
       return [] unless associations
 
       associations.map { |association| association["content_id"] }
-    end
-
-    def embed_contacts(body, contacts)
-      body&.gsub(/\[Contact:\s*(\d*)\s*\]/) do
-        id = Regexp.last_match[1].to_i
-        embed = contacts.select { |x| x["id"] == id }.first["content_id"]
-        "[Contact:#{embed}]"
-      end
     end
 
     def create_image_revisions(images)

--- a/lib/whitehall_importer/embed_body_references.rb
+++ b/lib/whitehall_importer/embed_body_references.rb
@@ -37,7 +37,7 @@ module WhitehallImporter
       body&.gsub(/!!(\d+)/) do
         whitehall_image_index = Regexp.last_match[1].to_i
         image_name = images[whitehall_image_index - 1]
-        "[Image:#{image_name}]"
+        image_name.present? ? "[Image:#{image_name}]" : ""
       end
     end
 

--- a/lib/whitehall_importer/embed_body_references.rb
+++ b/lib/whitehall_importer/embed_body_references.rb
@@ -2,19 +2,22 @@
 
 module WhitehallImporter
   class EmbedBodyReferences
-    attr_reader :body, :contacts
+    attr_reader :body, :contacts, :images
 
     def self.call(*args)
       new(*args).call
     end
 
-    def initialize(body:, contacts: [])
+    def initialize(body:, contacts: [], images: [])
       @body = body
       @contacts = contacts
+      @images = images
     end
 
     def call
-      embed_contacts(body, contacts)
+      body_with_embeds = embed_contacts(body, contacts)
+      body_with_embeds = embed_images(body_with_embeds, images)
+      body_with_embeds
     end
 
   private
@@ -24,6 +27,14 @@ module WhitehallImporter
         id = Regexp.last_match[1].to_i
         embed = contacts.select { |x| x["id"] == id }.first["content_id"]
         "[Contact:#{embed}]"
+      end
+    end
+
+    def embed_images(body, images)
+      body&.gsub(/!!(\d+)/) do
+        whitehall_image_index = Regexp.last_match[1].to_i
+        image_name = images[whitehall_image_index - 1]
+        "[Image:#{image_name}]"
       end
     end
   end

--- a/lib/whitehall_importer/embed_body_references.rb
+++ b/lib/whitehall_importer/embed_body_references.rb
@@ -45,7 +45,7 @@ module WhitehallImporter
       body&.gsub(/!@(\d+)/) do
         whitehall_attachment_index = Regexp.last_match[1].to_i
         attachment_name = attachments[whitehall_attachment_index - 1]
-        "[Attachment:#{attachment_name}]"
+        attachment_name.present? ? "[Attachment:#{attachment_name}]" : ""
       end
     end
 
@@ -53,7 +53,7 @@ module WhitehallImporter
       body&.gsub(/\[InlineAttachment:(\d+)\s*\]/) do
         whitehall_attachment_index = Regexp.last_match[1].to_i
         attachment_name = attachments[whitehall_attachment_index - 1]
-        "[AttachmentLink:#{attachment_name}]"
+        attachment_name.present? ? "[AttachmentLink:#{attachment_name}]" : ""
       end
     end
   end

--- a/lib/whitehall_importer/embed_body_references.rb
+++ b/lib/whitehall_importer/embed_body_references.rb
@@ -19,6 +19,7 @@ module WhitehallImporter
       body_with_embeds = embed_contacts(body, contacts)
       body_with_embeds = embed_images(body_with_embeds, images)
       body_with_embeds = embed_attachments(body_with_embeds, attachments)
+      body_with_embeds = embed_inline_attachments(body_with_embeds, attachments)
       body_with_embeds
     end
 
@@ -45,6 +46,14 @@ module WhitehallImporter
         whitehall_attachment_index = Regexp.last_match[1].to_i
         attachment_name = attachments[whitehall_attachment_index - 1]
         "[Attachment:#{attachment_name}]"
+      end
+    end
+
+    def embed_inline_attachments(body, attachments)
+      body&.gsub(/\[InlineAttachment:(\d+)\s*\]/) do
+        whitehall_attachment_index = Regexp.last_match[1].to_i
+        attachment_name = attachments[whitehall_attachment_index - 1]
+        "[AttachmentLink:#{attachment_name}]"
       end
     end
   end

--- a/lib/whitehall_importer/embed_body_references.rb
+++ b/lib/whitehall_importer/embed_body_references.rb
@@ -2,21 +2,23 @@
 
 module WhitehallImporter
   class EmbedBodyReferences
-    attr_reader :body, :contacts, :images
+    attr_reader :body, :contacts, :images, :attachments
 
     def self.call(*args)
       new(*args).call
     end
 
-    def initialize(body:, contacts: [], images: [])
+    def initialize(body:, contacts: [], images: [], attachments: [])
       @body = body
       @contacts = contacts
       @images = images
+      @attachments = attachments
     end
 
     def call
       body_with_embeds = embed_contacts(body, contacts)
       body_with_embeds = embed_images(body_with_embeds, images)
+      body_with_embeds = embed_attachments(body_with_embeds, attachments)
       body_with_embeds
     end
 
@@ -35,6 +37,14 @@ module WhitehallImporter
         whitehall_image_index = Regexp.last_match[1].to_i
         image_name = images[whitehall_image_index - 1]
         "[Image:#{image_name}]"
+      end
+    end
+
+    def embed_attachments(body, attachments)
+      body&.gsub(/!@(\d+)/) do
+        whitehall_attachment_index = Regexp.last_match[1].to_i
+        attachment_name = attachments[whitehall_attachment_index - 1]
+        "[Attachment:#{attachment_name}]"
       end
     end
   end

--- a/lib/whitehall_importer/embed_body_references.rb
+++ b/lib/whitehall_importer/embed_body_references.rb
@@ -1,0 +1,30 @@
+# frozen_string_literal: true
+
+module WhitehallImporter
+  class EmbedBodyReferences
+    attr_reader :body, :contacts
+
+    def self.call(*args)
+      new(*args).call
+    end
+
+    def initialize(body:, contacts: [])
+      @body = body
+      @contacts = contacts
+    end
+
+    def call
+      embed_contacts(body, contacts)
+    end
+
+  private
+
+    def embed_contacts(body, contacts)
+      body&.gsub(/\[Contact:\s*(\d*)\s*\]/) do
+        id = Regexp.last_match[1].to_i
+        embed = contacts.select { |x| x["id"] == id }.first["content_id"]
+        "[Contact:#{embed}]"
+      end
+    end
+  end
+end

--- a/spec/lib/whitehall_importer/create_revision_spec.rb
+++ b/spec/lib/whitehall_importer/create_revision_spec.rb
@@ -63,10 +63,12 @@ RSpec.describe WhitehallImporter::CreateRevision do
       whitehall_edition = build(
         :whitehall_export_edition,
         translations: [build(:whitehall_export_translation, body: body)],
+        images: [build(:whitehall_export_image, filename: "foo.jpg")],
       )
       expect(WhitehallImporter::EmbedBodyReferences).to receive(:call).with(
         body: "Foo Bar",
         contacts: [],
+        images: ["foo.jpg"],
       )
       described_class.call(document, whitehall_edition)
     end

--- a/spec/lib/whitehall_importer/create_revision_spec.rb
+++ b/spec/lib/whitehall_importer/create_revision_spec.rb
@@ -56,6 +56,19 @@ RSpec.describe WhitehallImporter::CreateRevision do
         expect(revision.image_revisions.first.blob_revision.filename).to eq("image.jpg")
         expect(revision.image_revisions.last.blob_revision.filename).to eq("image-1.jpg")
       end
+
+      it "uses the first image as the lead image" do
+        whitehall_edition = build(
+          :whitehall_export_edition,
+          images: [
+            build(:whitehall_export_image, filename: "first.jpg"),
+            build(:whitehall_export_image, filename: "second.jpg"),
+          ],
+        )
+        revision = described_class.call(document, whitehall_edition)
+
+        expect(revision.lead_image_revision.filename).to eq("first.jpg")
+      end
     end
 
     it "passes body through the EmbedBodyReferences service" do

--- a/spec/lib/whitehall_importer/create_revision_spec.rb
+++ b/spec/lib/whitehall_importer/create_revision_spec.rb
@@ -58,18 +58,17 @@ RSpec.describe WhitehallImporter::CreateRevision do
       end
     end
 
-    it "changes the ids of embedded contacts" do
-      translation = build(:whitehall_export_translation,
-                          body: "[Contact:123]")
-      content_id = SecureRandom.uuid
+    it "passes body through the EmbedBodyReferences service" do
+      body = "Foo Bar"
       whitehall_edition = build(
         :whitehall_export_edition,
-        translations: [translation],
-        contacts: [{ "id" => 123, "content_id" => content_id }],
+        translations: [build(:whitehall_export_translation, body: body)],
       )
-      revision = described_class.call(document, whitehall_edition)
-
-      expect(revision.contents["body"]).to eq("[Contact:#{content_id}]")
+      expect(WhitehallImporter::EmbedBodyReferences).to receive(:call).with(
+        body: "Foo Bar",
+        contacts: [],
+      )
+      described_class.call(document, whitehall_edition)
     end
 
     it "aborts when a translation isn't available for the documents locale" do

--- a/spec/lib/whitehall_importer/embed_body_references_spec.rb
+++ b/spec/lib/whitehall_importer/embed_body_references_spec.rb
@@ -11,5 +11,14 @@ RSpec.describe WhitehallImporter::EmbedBodyReferences do
 
       expect(govspeak_body).to eq("[Contact:#{content_id}]")
     end
+
+    it "converts Whitehall image syntax to Content Publisher syntax" do
+      govspeak_body = described_class.call(
+        body: "!!1 test !!2",
+        images: ["foo.png", "bar.jpg"],
+      )
+
+      expect(govspeak_body).to eq("[Image:foo.png] test [Image:bar.jpg]")
+    end
   end
 end

--- a/spec/lib/whitehall_importer/embed_body_references_spec.rb
+++ b/spec/lib/whitehall_importer/embed_body_references_spec.rb
@@ -21,6 +21,15 @@ RSpec.describe WhitehallImporter::EmbedBodyReferences do
       expect(govspeak_body).to eq("[Image:foo.png] test [Image:bar.jpg]")
     end
 
+    it "removes any image markdown that doesn't resolve to an image" do
+      govspeak_body = described_class.call(
+        body: "Bar !!2 Baz",
+        images: ["foo.png"],
+      )
+
+      expect(govspeak_body).to eq("Bar  Baz")
+    end
+
     it "converts Whitehall attachment syntax to Content Publisher syntax" do
       govspeak_body = described_class.call(
         body: "!@1 test !@2",

--- a/spec/lib/whitehall_importer/embed_body_references_spec.rb
+++ b/spec/lib/whitehall_importer/embed_body_references_spec.rb
@@ -20,5 +20,14 @@ RSpec.describe WhitehallImporter::EmbedBodyReferences do
 
       expect(govspeak_body).to eq("[Image:foo.png] test [Image:bar.jpg]")
     end
+
+    it "converts Whitehall attachment syntax to Content Publisher syntax" do
+      govspeak_body = described_class.call(
+        body: "!@1 test !@2",
+        attachments: ["file.pdf", "download.csv"],
+      )
+
+      expect(govspeak_body).to eq("[Attachment:file.pdf] test [Attachment:download.csv]")
+    end
   end
 end

--- a/spec/lib/whitehall_importer/embed_body_references_spec.rb
+++ b/spec/lib/whitehall_importer/embed_body_references_spec.rb
@@ -47,5 +47,14 @@ RSpec.describe WhitehallImporter::EmbedBodyReferences do
 
       expect(govspeak_body).to eq("[AttachmentLink:file.pdf] test [AttachmentLink:download.csv]")
     end
+
+    it "removes any attachment markdown that doesn't resolve to an attachment" do
+      govspeak_body = described_class.call(
+        body: "Bar !@2 Baz [InlineAttachment:3] << removed, but !@1 continues to work",
+        attachments: ["foo.pdf"],
+      )
+
+      expect(govspeak_body).to eq("Bar  Baz  << removed, but [Attachment:foo.pdf] continues to work")
+    end
   end
 end

--- a/spec/lib/whitehall_importer/embed_body_references_spec.rb
+++ b/spec/lib/whitehall_importer/embed_body_references_spec.rb
@@ -1,0 +1,15 @@
+# frozen_string_literal: true
+
+RSpec.describe WhitehallImporter::EmbedBodyReferences do
+  describe ".call" do
+    it "changes the ids of embedded contacts" do
+      content_id = SecureRandom.uuid
+      govspeak_body = described_class.call(
+        body: "[Contact:123]",
+        contacts: [{ "id" => 123, "content_id" => content_id }],
+      )
+
+      expect(govspeak_body).to eq("[Contact:#{content_id}]")
+    end
+  end
+end

--- a/spec/lib/whitehall_importer/embed_body_references_spec.rb
+++ b/spec/lib/whitehall_importer/embed_body_references_spec.rb
@@ -29,5 +29,14 @@ RSpec.describe WhitehallImporter::EmbedBodyReferences do
 
       expect(govspeak_body).to eq("[Attachment:file.pdf] test [Attachment:download.csv]")
     end
+
+    it "converts Whitehall inline attachment syntax to Content Publisher syntax" do
+      govspeak_body = described_class.call(
+        body: "[InlineAttachment:1] test [InlineAttachment:2]",
+        attachments: ["file.pdf", "download.csv"],
+      )
+
+      expect(govspeak_body).to eq("[AttachmentLink:file.pdf] test [AttachmentLink:download.csv]")
+    end
   end
 end


### PR DESCRIPTION
Trello card: https://trello.com/c/ubTM9ylI/1176-use-imported-images-and-attachments-in-content-publisher

- [x] Converts Whitehall image syntax to Content Publisher image syntax
- [x] Converts Whitehall attachment syntax to Content Publisher attachment syntax
- [x] Converts Whitehall inline attachment syntax to Content Publisher inline attachment syntax
- [x] Passes `images` to EmbedBodyReferences
- [x] Used first image as the lead image
- [x] ~Passes `attachments` to EmbedBodyReferences~ This will be done in [another Trello card](https://trello.com/c/4FF2oprK/1182-import-attachments-into-content-publisher) and is out of scope for this PR.
