### PR TITLE
[Spike] ResyncService

### DIFF
--- a/app/services/resync_service.rb
+++ b/app/services/resync_service.rb
@@ -8,6 +8,8 @@ class ResyncService < ApplicationService
   end
 
   def call
+    reserve_base_path(document.current_edition)
+
     if document.live_edition.present?
       resync(document.live_edition)
       return if document.current_edition == document.live_edition
@@ -20,6 +22,17 @@ class ResyncService < ApplicationService
   end
 
 private
+
+  def reserve_base_path(edition)
+    # Reserves a path for a publishing application, in case it has
+    # been imported from Whitehall. There's no harm in calling
+    # this even if we already own the path.
+    GdsApi.publishing_api_v2.put_path(
+      edition.base_path,
+      publishing_app: "content-publisher",
+      override_existing: true,
+    )
+  end
 
   def resync(edition)
     if edition.withdrawn?

--- a/app/services/resync_service.rb
+++ b/app/services/resync_service.rb
@@ -1,0 +1,63 @@
+# frozen_string_literal: true
+
+class ResyncService < ApplicationService
+  attr_reader :document
+
+  def initialize(document)
+    @document = document
+  end
+
+  def call
+    if document.live_edition.present?
+      republish_live_edition
+      update_draft_edition unless document.live_edition == document.current_edition
+    else
+      update_draft_edition
+    end
+  rescue GdsApi::BaseError => e
+    GovukError.notify(e)
+    raise
+  end
+
+private
+
+  def republish_live_edition
+    # Now we want to promote the content item and assets from
+    # the draft stack to the live stack. We can't use the
+    # PublishService here as it would promote `current_edition`
+    # to `live_edition`. (We just want to resync the two with
+    # Publishing API, not change their states). It also calls
+    # `publish` rather than `republish`.
+    # And we can't use PreviewService for presenting the doc
+    # to publishing API as there is no way of hooking the
+    # `update_type`/`bulk_publishing` into the payload.
+    # (We could - and possibly should - modify the
+    # PreviewService to allow us to pass this override)
+
+    payload = PreviewService::Payload.new(document.live_edition).payload
+
+    # Manually update live edition. Whether the latest edition
+    # is published or draft, this will create a new draft with
+    # an `update_type: "republish"`. We then need to publish it.
+    GdsApi.publishing_api_v2.put_content(
+      document.content_id,
+      payload.merge(update_type: "republish", bulk_publishing: true),
+    )
+
+    # Manually publish assets to live stack before we publish
+    # the document, otherwise we risk referencing assets that
+    # aren't visible yet.
+    PublishAssetService.call(document.live_edition, nil)
+
+    GdsApi.publishing_api_v2.publish(
+      document.content_id,
+      nil, # Sending update_type is deprecated (now in payload)
+      locale: document.locale,
+    )
+  end
+
+  def update_draft_edition
+    # Present to publishing API & Asset Manager draft stack
+    PreviewService.call(document.current_edition)
+  end
+end

--- a/spec/services/resync_service_spec.rb
+++ b/spec/services/resync_service_spec.rb
@@ -1,0 +1,73 @@
+# frozen_string_literal: true
+
+RSpec.describe ResyncService do
+  describe ".call" do
+    before do
+      stub_any_publishing_api_publish
+      stub_any_publishing_api_put_content
+    end
+
+    context "when there is no live edition" do
+      let(:document) { create(:document, :with_current_edition) }
+
+      it "synchronises the current edition, but does not publish" do
+        expect(PreviewService).to receive(:call).with(document.current_edition)
+        expect(GdsApi.publishing_api_v2).not_to receive(:publish)
+        expect(GdsApi.publishing_api_v2).not_to receive(:republish)
+        ResyncService.call(document)
+      end
+
+      # it "retains 2i review status" do
+      #   PublishService.call(edition, user, with_review: false)
+      #   expect(edition).to be_published_but_needs_2i
+      # end
+
+      # it "retains the access limit" do
+      #   edition = create(:edition, :access_limited)
+      #   PublishService.call(edition, user, with_review: true)
+      #   expect(edition.access_limit).to be_present
+      #   expect(edition.access_limit).to be_tagged_organisations
+      # end
+    end
+
+    context "when the current edition is live" do
+      let(:document) { create(:document, :with_live_edition) }
+
+      it "re-publishes the current_edition" do
+        GdsApi.stub_chain(:publishing_api_v2, :put_content)
+        GdsApi.stub_chain(:publishing_api_v2, :publish)
+        expect(GdsApi.publishing_api_v2).to receive(:put_content).once.with(document.content_id, hash_including(update_type: "republish")).ordered
+        expect(GdsApi.publishing_api_v2).to receive(:publish).once.with(document.content_id, nil, hash_including(:locale)).ordered
+        ResyncService.call(document)
+
+        # @TODO - test that PublishAssetService is called
+      end
+
+      # it "retains 2i review status" do
+      #   PublishService.call(edition, user, with_review: false)
+      #   expect(edition).to be_published_but_needs_2i
+      # end
+
+      # it "calls the PublishAssetService" do
+      #   document = create(:document, :with_current_and_live_editions)
+      #   current_edition = document.current_edition
+      #   expect(PublishAssetService).to receive(:call)
+      #   PublishService.call(current_edition, user, with_review: true)
+      # end
+    end
+
+    context "when there are both live and current editions" do
+      let(:document) { create(:document, :with_current_and_live_editions) }
+
+      it "re-publishes the live edition before synchronising the current edition without publishing it" do
+        GdsApi.stub_chain(:publishing_api_v2, :put_content)
+
+        expect(GdsApi.publishing_api_v2).to receive(:put_content).once.with(document.content_id, hash_including(update_type: "republish")).ordered
+        expect(GdsApi.publishing_api_v2).to receive(:publish).once.with(document.content_id, nil, hash_including(:locale)).ordered
+        # @TODO - test that PublishAssetService is called for live edition next
+        expect(PreviewService).to receive(:call).with(document.current_edition).ordered
+        ResyncService.call(document)
+      end
+    end
+  end
+end


### PR DESCRIPTION
Trello: https://trello.com/c/kLriQCoa/1195-create-service-to-re-publish-content-to-publishing-api

## TODO

Create a rake task for this too. Can be done in the 'real' card; this is still a spike.

## Aside

Looks like we’re aborting on `scheduled` status at the moment: https://github.com/alphagov/content-publisher/blob/300c54d5fbf6319c9139a1535b1212694b236172/lib/whitehall_importer/migrate_state.rb. Some work will need to be done on the ResyncService if/when schedule support is added.

## Local testing

In one terminal:

```sh
cd ~/govuk/publishing-api
govuk-docker-up
```

In the other:

```
curl http://publishing-api.dev.gov.uk/v2/content/cdaebb8f-02ae-48ef-be0a-b718b49f9a24 \
  -H "Content-Type: application/json" --request PUT \
  --data '{ "base_path": "/foo/bar/baz", "document_type": "press_release", "publishing_app": "content-publisher", "rendering_app": "government-frontend", "routes": [ { "path": "/foo/bar/baz", "type": "exact" } ], "schema_name": "news_article", "title": "test", "update_type": "major", "details": { "body": "this is a body" } }'
```

Can then `curl http://publishing-api.dev.gov.uk/v2/content/cdaebb8f-02ae-48ef-be0a-b718b49f9a24` to retrieve the content.

In another terminal, can `govuk-docker-run bundle exec rails console` in `publishing-api` and run `Document.last` to see the document (`Document.last.editions` to see its contents).

Publish: `curl http://publishing-api.dev.gov.uk/v2/content/cdaebb8f-02ae-48ef-be0a-b718b49f9a24/publish -H "Content-Type: application/json" --request POST --data '{}'`

In the Rails console, `Document.last` has a `stale_lock_version`, currently at `1`. On `Document.last.editions`, we have one edition with a `user_facing_version: 1`.

Re-run the original PUT command (perhaps with an updated `body`) and we now have two editions. The `Document.last.stale_lock_version` is now on 2, and the draft edition has `user_facing_version: 2`, but the published one is still `1`. We can use this value (presumably) as the optional `previous_version` parameter in our requests.

### Testing the republish

As above, I created a local document in publishing API, that had two editions [first: published, second: draft].

I sent a request to `PUT /v2/content/:content_id` with the original payload of the first edition, and a `"update_type": "republish"` merged into that.

My expectation was that it would create a new, live edition, so that we would now have [first: published, second: draft, third: published-with-update_type:"republish"].

What it actually did was overwrite the draft edition so that we have [first: published, second: draft-with-update_type:"republish"]. If we then were to 'sync' the second edition, we'd overwrite again to [first: published, second: draft]. In other words, only the draft edition ever gets synced, the live version remains untouched.

I then tried a `PUT /v2/content/:content_id` (with `"update_type": "republish"`) on a document whose **latest edition is 'published'**. I expected it to remain `published` but with an update_type of `republish`. In fact, it created a new draft. So we need an additional step.

```
when syncing a live edition:
  PUT  /v2/content/:content_id (with update_type: republish)
  # this is not published, it's only overwritten a draft edition, so need to publish
  POST /v2/content/:content_id/publish

when syncing a draft edition:
  PUT  /v2/content/:content_id (with no specific update_type)
```

### Testing migration

Creating a Whitehall document:

```
curl http://publishing-api.dev.gov.uk/v2/content/cdaebb8f-02ae-48ef-be0a-b718b49f9a26 \
  -H "Content-Type: application/json" --request PUT \
  --data '{ "base_path": "/bar", "document_type": "press_release", "publishing_app": "whitehall", "rendering_app": "whitehall-frontend", "routes": [ { "path": "/bar", "type": "exact" } ], "schema_name": "news_article", "title": "test", "update_type": "major", "details": { "body": "Whitehall content" } }' 
```

Publish it:

`curl http://publishing-api.dev.gov.uk/v2/content/cdaebb8f-02ae-48ef-be0a-b718b49f9a26/publish -H "Content-Type: application/json" --request POST --data '{}'`

Reserve the path (from Content Publisher script):

`curl http://publishing-api.dev.gov.uk/paths/bar -H "Content-Type: application/json" --request PUT --data '{ "publishing_app": "content-publisher", "override_existing": true }'`

Sync Content Publisher version (note we've changed the publishing_app and rendering_app):

```
curl http://publishing-api.dev.gov.uk/v2/content/cdaebb8f-02ae-48ef-be0a-b718b49f9a26 \
  -H "Content-Type: application/json" --request PUT \
  --data '{ "base_path": "/bar", "document_type": "press_release", "publishing_app": "content-publisher", "rendering_app": "government-frontend", "routes": [ { "path": "/bar", "type": "exact" } ], "schema_name": "news_article", "title": "test", "update_type": "major", "details": { "body": "Whitehall content" } }' 
```

Publish it:

`curl http://publishing-api.dev.gov.uk/v2/content/cdaebb8f-02ae-48ef-be0a-b718b49f9a26/publish -H "Content-Type: application/json" --request POST --data '{}'`

A new edition is created, with the new publishing/rendering apps. The previous editions remain intact.