### PR TITLE
Add rake task for creating CSVs of political status by organisation

### DIFF
--- a/lib/tasks/csv_report.rake
+++ b/lib/tasks/csv_report.rake
@@ -5,6 +5,8 @@ require "csv"
 namespace :csv_report do
   desc "A CSV report of political documents published by organisations"
   task political_status_by_organisation: :environment do
+    raise "csv_report:political_status_by_organisation rake task should be removed" unless Time.zone.today < Date.new(2020, 1, 1)
+
     live_editions = Edition.where(live: true).joins(revision: :tags_revision)
     org_content_ids = live_editions.pluck(Arel.sql("tags_revisions.tags->'primary_publishing_organisation'->0")).uniq
     links = Linkables.new("organisation")

--- a/lib/tasks/csv_report.rake
+++ b/lib/tasks/csv_report.rake
@@ -1,0 +1,36 @@
+# frozen_string_literal: true
+
+require "csv"
+
+namespace :csv_report do
+  desc "A CSV report of political documents published by organisations"
+  task political_status_by_organisation: :environment do
+    live_editions = Edition.where(live: true).joins(revision: :tags_revision)
+    org_content_ids = live_editions.pluck(Arel.sql("tags_revisions.tags->'primary_publishing_organisation'->0")).uniq
+    links = Linkables.new("organisation")
+
+    organisations = org_content_ids.map { |id| links.by_content_id(id) }.compact
+
+    organisations.each do |organisation|
+      path = Rails.root.join("tmp", "#{organisation['internal_name'].parameterize}-political-status.csv")
+      csv_headers = ["Public URL", "Admin URL", "Title", "Document type", "Political", "Summary"]
+
+      CSV.open(path, "w", headers: csv_headers, write_headers: true) do |csv|
+        editions_published_by_organisation = live_editions.merge(TagsRevision.primary_organisation_is(organisation["content_id"]))
+
+        editions_published_by_organisation.each do |edition|
+          csv << [
+            "https://gov.uk#{edition.base_path}",
+            "https://content-publisher.publishing.service.gov.uk/documents/#{edition.content_id}:#{edition.locale}",
+            edition.title,
+            edition.document_type.id.humanize,
+            PoliticalEditionIdentifier.new(edition).political? ? "Yes" : "No",
+            edition.summary,
+          ]
+        end
+      end
+
+      puts "Report available at #{path}"
+    end
+  end
+end

--- a/spec/lib/tasks/csv_report_spec.rb
+++ b/spec/lib/tasks/csv_report_spec.rb
@@ -1,0 +1,67 @@
+# frozen_string_literal: true
+
+RSpec.describe "Political documents tasks" do
+  describe "political_status_by_organisation" do
+    let(:organisation1) { { "content_id" => SecureRandom.uuid, "internal_name" => "Org 1" } }
+    let(:organisation2) { { "content_id" => SecureRandom.uuid, "internal_name" => "Org 2" } }
+    let(:csv_headers) { ["Public URL", "Admin URL", "Title", "Document type", "Political", "Summary"] }
+
+    before :each do
+      Rake::Task["csv_report:political_status_by_organisation"].reenable
+      stub_publishing_api_has_linkables([organisation1, organisation2], document_type: "organisation")
+    end
+
+    it "can output political status" do
+      create(:edition, :published, tags: { primary_publishing_organisation: [organisation1["content_id"]] })
+
+      csv_file = StringIO.new
+      expected_content = [
+        "https://gov.uk#{Edition.first.base_path}",
+        "https://content-publisher.publishing.service.gov.uk/documents/#{Edition.first.content_id}:#{Edition.first.locale}",
+        Edition.first.title,
+        Edition.first.document_type.id.humanize,
+        "No",
+        Edition.first.summary,
+      ]
+
+      expect(CSV).to receive(:open).with(
+        Rails.root.join("tmp", "org-1-political-status.csv"), "w",
+        headers: csv_headers,
+        write_headers: true
+      ).and_yield(csv_file)
+
+      expect(csv_file).to receive(:<<).with(expected_content)
+      expect($stdout).to receive(:puts).with("Report available at #{Rails.root}/tmp/#{organisation1['internal_name'].parameterize}-political-status.csv")
+
+      Rake::Task["csv_report:political_status_by_organisation"].invoke
+    end
+
+    it "creates a CSV per organisation" do
+      create(:edition, :published, tags: { primary_publishing_organisation: [organisation1["content_id"]] })
+      create(:edition, :published, tags: { primary_publishing_organisation: [organisation2["content_id"]] })
+
+      expect(CSV).to receive(:open).with(
+        Rails.root.join("tmp", "org-1-political-status.csv"), "w",
+        headers: csv_headers,
+        write_headers: true
+      )
+      expect(CSV).to receive(:open).with(
+        Rails.root.join("tmp", "org-2-political-status.csv"), "w",
+        headers: csv_headers,
+        write_headers: true
+      )
+      expect($stdout).to receive(:puts).with("Report available at #{Rails.root}/tmp/#{organisation1['internal_name'].parameterize}-political-status.csv")
+      expect($stdout).to receive(:puts).with("Report available at #{Rails.root}/tmp/#{organisation2['internal_name'].parameterize}-political-status.csv")
+
+      Rake::Task["csv_report:political_status_by_organisation"].invoke
+    end
+
+    it "ignores draft content" do
+      create(:edition, tags: { primary_publishing_organisation: [organisation1["content_id"]] })
+
+      expect(CSV).not_to receive(:open)
+
+      Rake::Task["csv_report:political_status_by_organisation"].invoke
+    end
+  end
+end


### PR DESCRIPTION
Several published documents on Content Publisher will go into history mode when a government falls.  We need to let managing editors know which documents are politically sensitive and will go into history mode so they can audit their documents and identify exceptions.

This rake task produces a CSV files with a list of live documents with their political status for each organisation.

It is intended to be removed once the history mode is implemented in the user interface. We will raise an exception as a prompt.

_Tested in integration_

[Trello card](https://trello.com/c/JP693RnO/1188-work-out-which-docs-are-political)