### PR TITLE
Update miller-columns-element to 1.2.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
     "cropperjs": "^1.5.1",
     "es5-polyfill": "^0.0.6",
     "markdown-toolbar-element": "^0.2.0",
-    "miller-columns-element": "^1.1.0",
+    "miller-columns-element": "^1.2.0",
     "paste-html-to-govspeak": "^0.2.3",
     "raven-js": "^3.27.0",
     "url-polyfill": "^1.1.3",

--- a/yarn.lock
+++ b/yarn.lock
@@ -832,10 +832,10 @@ markdown-toolbar-element@^0.2.0:
   resolved "https://registry.yarnpkg.com/markdown-toolbar-element/-/markdown-toolbar-element-0.2.0.tgz#df9f1bc347e1f3174ddc4d69e4e6f5fe2c32285a"
   integrity sha512-0QJfZmS7JE6JNtax2U1qdTQSFCO3dtQBlVYzTMO8nKuOktbR1xJVk7mneMBTVj9j2GTnq+dquDqk2Hb+fDKhFg==
 
-miller-columns-element@^1.1.0:
-  version "1.1.0"
-  resolved "https://registry.yarnpkg.com/miller-columns-element/-/miller-columns-element-1.1.0.tgz#eb7429a23976f4f531e2c62089215e1b03ba8375"
-  integrity sha512-ZDAybFjoUkOw/uZjY5jMP9MdYo6ubeZeL9OP94PIvph9mwUJcjFKyh6NPsf3W8JSq2kzQRwj7GXCHMxFJ1JeUA==
+miller-columns-element@^1.2.0:
+  version "1.2.0"
+  resolved "https://registry.yarnpkg.com/miller-columns-element/-/miller-columns-element-1.2.0.tgz#415ae776a64eb20eaa5c8ead42a708c9aa415a86"
+  integrity sha512-WtjVzab2J+bgd0L/S1jWr1bq6p/jGMiWjPHgNoPjzS9IXHe99Y/CQU1bJcwDka4oWGnGrGxU82nP3voGbQ03KQ==
 
 mimic-fn@^1.0.0:
   version "1.2.0"


### PR DESCRIPTION
Update `miller-columns-element` to [1.2.0](https://github.com/alphagov/miller-columns-element/pull/26).

[Trello card](https://trello.com/c/ApHlPUDQ/1146-improve-topic-selection-on-small-screens-and-when-used-with-magnifying-tools)