### PR TITLE
Use edition links to governments

### DIFF
--- a/app/services/preview_service/payload.rb
+++ b/app/services/preview_service/payload.rb
@@ -62,6 +62,7 @@ private
       .except("role_appointments")
       .merge(roles_and_people(role_appointments))
       .merge("organisations" => links.uniq)
+      .merge("government" => [edition.government&.content_id].compact)
   end
 
   def image

--- a/spec/factories/edition_factory.rb
+++ b/spec/factories/edition_factory.rb
@@ -7,7 +7,6 @@ FactoryBot.define do
     live { false }
     revision_synced { true }
     association :created_by, factory: :user
-    current_government
 
     revision_fields
 

--- a/spec/features/workflow/create_document_spec.rb
+++ b/spec/features/workflow/create_document_spec.rb
@@ -56,10 +56,10 @@ RSpec.feature "Create a document" do
 
   def content_body
     {
-      "links" => {
+      "links" => hash_including(
         "organisations" => [current_user.organisation_content_id],
         "primary_publishing_organisation" => [current_user.organisation_content_id],
-      },
+      ),
       "title" => "A title",
       "document_type" => @document_type.id,
       "description" => "A summary",

--- a/spec/formats/news_story_spec.rb
+++ b/spec/formats/news_story_spec.rb
@@ -65,14 +65,14 @@ RSpec.feature "Create a news story", format: true do
 
   def content_body
     {
-      "links" => {
+      "links" => hash_including(
         "topical_events" => [linkable["content_id"]],
         "world_locations" => [linkable["content_id"]],
         "organisations" => [linkable["content_id"]],
         "primary_publishing_organisation" => [linkable["content_id"]],
         "roles" => role_appointment_links["links"]["role"],
         "people" => role_appointment_links["links"]["person"],
-      },
+      ),
       "title" => "A great title",
       "document_type" => "news_story",
       "description" => "A great summary",

--- a/spec/formats/press_release_spec.rb
+++ b/spec/formats/press_release_spec.rb
@@ -65,14 +65,14 @@ RSpec.feature "Create a press release", format: true do
 
   def content_body
     {
-      "links" => {
+      "links" => hash_including(
         "topical_events" => [linkable["content_id"]],
         "world_locations" => [linkable["content_id"]],
         "organisations" => [linkable["content_id"]],
         "primary_publishing_organisation" => [linkable["content_id"]],
         "roles" => role_appointment_links["links"]["role"],
         "people" => role_appointment_links["links"]["person"],
-      },
+      ),
       "title" => "A great title",
       "document_type" => "press_release",
       "description" => "A great summary",

--- a/spec/services/preview_service/payload_spec.rb
+++ b/spec/services/preview_service/payload_spec.rb
@@ -16,7 +16,7 @@ RSpec.describe PreviewService::Payload do
         "base_path" => "/foo/bar/baz",
         "description" => "document summary",
         "document_type" => document_type.id,
-        "links" => { "organisations" => [] },
+        "links" => { "government" => [], "organisations" => [] },
         "locale" => edition.locale,
         "publishing_app" => "content-publisher",
         "rendering_app" => nil,
@@ -52,13 +52,10 @@ RSpec.describe PreviewService::Payload do
 
       payload = PreviewService::Payload.new(edition).payload
 
-      payload_hash = {
-        "links" => {
-          "primary_publishing_organisation" => %w[my-org-id],
-          "organisations" => %w[my-org-id other-org-id],
-        },
-      }
-      expect(payload).to match a_hash_including(payload_hash)
+      expect(payload["links"]).to match a_hash_including(
+        "primary_publishing_organisation" => %w[my-org-id],
+        "organisations" => %w[my-org-id other-org-id],
+      )
     end
 
     it "ensures the organisation links are unique" do
@@ -71,13 +68,7 @@ RSpec.describe PreviewService::Payload do
 
       payload = PreviewService::Payload.new(edition).payload
 
-      payload_hash = {
-        "links" => {
-          "primary_publishing_organisation" => %w[my-org-id],
-          "organisations" => %w[my-org-id],
-        },
-      }
-      expect(payload).to match a_hash_including(payload_hash)
+      expect(payload["links"]["organisations"]).to eq %w[my-org-id]
     end
 
     it "converts role appointment links to role and person links" do
@@ -162,6 +153,8 @@ RSpec.describe PreviewService::Payload do
         "slug" => current_government.slug,
         "current" => true,
       )
+
+      expect(payload["links"]["government"]).to eq [current_government.content_id]
     end
 
     it "includes a change note if the update type is 'major'" do


### PR DESCRIPTION
Platform Health (well mostly @cbaines) have been doing work to represent governments in the Publishing API (see: https://github.com/alphagov/whitehall/pull/5178 and https://github.com/alphagov/govuk-content-schemas/pull/936) this work is leading towards the frontend apps to consider what content a government is linked to rather than the [government data in the details](https://github.com/alphagov/content-publisher/blob/62306c4f15edf9795631d5e2389334e5e0c12b86/app/services/preview_service/payload.rb#L79)

So that Content Publisher can be compatible with this change we will include links to government as well as government data in the details. Once Platform Health complete this change we can then remove the government data from our details hash.