### PR TITLE
Abort import task if import fails

### DIFF
--- a/lib/tasks/import.rake
+++ b/lib/tasks/import.rake
@@ -13,6 +13,12 @@ namespace :import do
     client = GdsApi::JsonClient.new(options)
     response = client.get_json(endpoint)
     whitehall_export = response.to_hash
-    WhitehallImporter.import(whitehall_export)
+    import = WhitehallImporter.import(whitehall_export)
+
+    if import.failed?
+      puts "Import failed"
+      puts "Error: #{import.error_log}"
+      abort
+    end
   end
 end

--- a/spec/lib/tasks/import_spec.rb
+++ b/spec/lib/tasks/import_spec.rb
@@ -5,6 +5,7 @@ RSpec.describe "Import tasks" do
     let(:whitehall_host) { Plek.new.external_url_for("whitehall-admin") }
 
     before do
+      allow($stdout).to receive(:puts)
       Rake::Task["import:whitehall"].reenable
       stub_request(:get, "#{whitehall_host}/government/admin/export/document/123")
         .to_return(status: 200, body: build(:whitehall_export_document).to_json)
@@ -12,6 +13,15 @@ RSpec.describe "Import tasks" do
 
     it "creates a document" do
       expect { Rake::Task["import:whitehall"].invoke("123") }.to change { Document.count }.by(1)
+    end
+
+    it "aborts if the import fails" do
+      expect(WhitehallImporter::Import).to receive(:call).and_raise("Error importing")
+
+      expect($stdout).to receive(:puts).with("Import failed")
+      expect($stdout).to receive(:puts).with("Error: Error importing")
+      expect { Rake::Task["import:whitehall"].invoke("123") }
+        .to raise_error(SystemExit)
     end
   end
 end


### PR DESCRIPTION
This ensures we get an exit code of 1 to indicate an error and outputs
text to explain why it failed.