### PR TITLE
Edition method for public first published time

### DIFF
--- a/app/models/edition.rb
+++ b/app/models/edition.rb
@@ -156,6 +156,10 @@ class Edition < ApplicationRecord
     Government.find(government_id)
   end
 
+  def public_first_published_at
+    backdated_to || document.first_published_at
+  end
+
   def editors
     user_ids = statuses.pluck(:created_by_id) + revisions.pluck(:created_by_id)
     User.where(id: user_ids.uniq)

--- a/app/services/edit_edition_service.rb
+++ b/app/services/edit_edition_service.rb
@@ -28,10 +28,8 @@ private
   end
 
   def associate_with_government
-    date = edition.backdated_to || edition.document.first_published_at
-
-    edition.government_id = if date
-                              government = Government.for_date(date)
+    edition.government_id = if edition.public_first_published_at
+                              government = Government.for_date(edition.public_first_published_at)
                               government&.content_id
                             end
   end

--- a/app/services/publish_service.rb
+++ b/app/services/publish_service.rb
@@ -33,8 +33,11 @@ private
   def associate_with_government
     return if edition.government
 
-    date = edition.backdated_to || edition.document.first_published_at || Time.current
-    government = Government.for_date(date)
+    government = if edition.public_first_published_at
+                   Government.for_date(edition.public_first_published_at)
+                 else
+                   Government.current
+                 end
     edition.assign_attributes(government_id: government&.content_id)
 
     # We need to update the Publishing API if we're changing the government

--- a/spec/models/edition_spec.rb
+++ b/spec/models/edition_spec.rb
@@ -166,6 +166,27 @@ RSpec.describe Edition do
     end
   end
 
+  describe "#public_first_published_at" do
+    it "it returns backdate when that is set" do
+      freeze_time do
+        edition = build(:edition, backdated_to: 1.year.ago, first_published_at: 1.week.ago)
+        expect(edition.public_first_published_at).to eq(1.year.ago)
+      end
+    end
+
+    it "it returns first published date when backdate isn't set" do
+      freeze_time do
+        edition = build(:edition, backdated_to: nil, first_published_at: 1.week.ago)
+        expect(edition.public_first_published_at).to eq(1.week.ago)
+      end
+    end
+
+    it "returns nil when it is not backdated or first published" do
+      edition = build(:edition, backdated_to: nil, first_published_at: nil)
+      expect(edition.public_first_published_at).to be_nil
+    end
+  end
+
   describe "#access_limit_organisation_ids" do
     context "when the limit is to primary orgs" do
       let(:edition) do

--- a/spec/services/edit_edition_service_spec.rb
+++ b/spec/services/edit_edition_service_spec.rb
@@ -64,24 +64,12 @@ RSpec.describe EditEditionService do
     end
 
     describe "associates the edition with a government" do
-      it "sets the government for a backdated edition" do
-        backdate = Time.zone.parse("2018-01-01")
+      it "sets the government when there is a public first published at time" do
+        time = Time.zone.parse("2018-01-01")
         government = build(:government)
-        edition = create(:edition, backdated_to: backdate)
-        allow(Government).to receive(:for_date).with(edition.backdated_to)
-                         .and_return(government)
-
-        expect { EditEditionService.call(edition, user) }
-          .to change { edition.government_id }
-          .to(government.content_id)
-      end
-
-      it "sets the government for an edition of a published document" do
-        publish_date = Time.zone.parse("2019-11-01")
-        government = build(:government)
-        allow(Government).to receive(:for_date).with(publish_date)
-                         .and_return(government)
-        edition = build(:edition, first_published_at: publish_date)
+        edition = create(:edition)
+        allow(edition).to receive(:public_first_published_at).and_return(time)
+        allow(Government).to receive(:for_date).with(time).and_return(government)
 
         expect { EditEditionService.call(edition, user) }
           .to change { edition.government_id }


### PR DESCRIPTION
Trello: https://trello.com/c/KxlsWBzq/1207-automatically-determine-political-status-and-government-at-the-point-of-editing

This is a method that returns the date that is shown on GOV.UK to show
the first published at time on an edition. It is intended to be used to
calculate the government at a particular time.