### PR TITLE
Refactor importing withdrawn status

### DIFF
--- a/lib/whitehall_importer/create_edition.rb
+++ b/lib/whitehall_importer/create_edition.rb
@@ -85,12 +85,15 @@ module WhitehallImporter
     end
 
     def set_withdrawn_status(edition)
-      withdrawn_status = build_status(
-        "withdrawn",
-        build_withdrawal(edition),
+      raise AbortImportError, "Cannot create withdrawn status without an unpublishing" if whitehall_edition["unpublishing"].blank?
+
+      withdrawal = Withdrawal.new(
+        published_status: edition.status,
+        public_explanation: whitehall_edition["unpublishing"]["explanation"],
+        withdrawn_at: whitehall_edition["unpublishing"]["created_at"],
       )
 
-      edition.update!(status: withdrawn_status)
+      edition.update!(status: build_status("withdrawn", withdrawal))
     end
 
     def build_removal
@@ -101,16 +104,6 @@ module WhitehallImporter
         explanatory_note: unpublishing["explanation"],
         alternative_path: unpublishing["alternative_url"],
         redirect: unpublishing["alternative_url"].present?,
-      )
-    end
-
-    def build_withdrawal(edition)
-      raise AbortImportError, "Cannot create withdrawn status without an unpublishing" if whitehall_edition["unpublishing"].blank?
-
-      Withdrawal.new(
-        published_status: edition.status,
-        public_explanation: whitehall_edition["unpublishing"]["explanation"],
-        withdrawn_at: whitehall_edition["unpublishing"]["created_at"],
       )
     end
 

--- a/lib/whitehall_importer/create_edition.rb
+++ b/lib/whitehall_importer/create_edition.rb
@@ -86,7 +86,7 @@ module WhitehallImporter
 
     def set_withdrawn_status(edition)
       withdrawn_status = build_status(
-        MigrateState.call(whitehall_edition["state"], whitehall_edition["force_published"]),
+        "withdrawn",
         build_withdrawal(edition),
       )
 

--- a/lib/whitehall_importer/migrate_state.rb
+++ b/lib/whitehall_importer/migrate_state.rb
@@ -10,7 +10,6 @@ module WhitehallImporter
       rejected
       submitted
       superseded
-      withdrawn
     ).freeze
 
     def self.call(*args)
@@ -30,7 +29,6 @@ module WhitehallImporter
       when "superseded" then "superseded"
       when "published"
         force_published ? "published_but_needs_2i" : "published"
-      when "withdrawn" then "withdrawn"
       else
         "submitted_for_review"
       end


### PR DESCRIPTION
This simplifies how we set the `withdrawn` status. We know that the state will be `withdrawn` so there is no need to call MigrateState.
Since that simplified the `set_withdrawn_status` method we can move the logic of creating Withdrawal there.

We want to use similar pattern for importing scheduled documents.