### PR TITLE
Resync service

### DIFF
--- a/app/models/government.rb
+++ b/app/models/government.rb
@@ -9,7 +9,7 @@ class Government
   end
 
   def self.for_date(date)
-    all.find { |government| government.covers?(date) }
+    all.find { |government| government.covers?(date) } if date
   end
 
   def self.current

--- a/app/services/edit_edition_service.rb
+++ b/app/services/edit_edition_service.rb
@@ -28,9 +28,6 @@ private
   end
 
   def associate_with_government
-    edition.government_id = if edition.public_first_published_at
-                              government = Government.for_date(edition.public_first_published_at)
-                              government&.content_id
-                            end
+    edition.government_id = Government.for_date(edition.public_first_published_at)&.content_id
   end
 end

--- a/app/services/preview_service.rb
+++ b/app/services/preview_service.rb
@@ -1,9 +1,9 @@
 # frozen_string_literal: true
 
 class PreviewService < ApplicationService
-  def initialize(edition, optional_params = {})
+  def initialize(edition, republish: false)
     @edition = edition
-    @optional_params = optional_params
+    @republish = republish
   end
 
   def call
@@ -16,7 +16,7 @@ class PreviewService < ApplicationService
 
 private
 
-  attr_reader :edition, :optional_params
+  attr_reader :edition, :republish
 
   def put_draft_content
     payload = Payload.new(edition).payload
@@ -28,5 +28,14 @@ private
   def put_draft_assets
     edition.image_revisions.each(&:ensure_assets)
     edition.assets.each { |asset| PreviewAssetService.call(edition, asset) }
+  end
+
+  def optional_params
+    return {} unless republish
+
+    {
+      "update_type" => "republish",
+      "bulk_publishing" => true,
+    }
   end
 end

--- a/app/services/preview_service.rb
+++ b/app/services/preview_service.rb
@@ -19,23 +19,13 @@ private
   attr_reader :edition, :republish
 
   def put_draft_content
-    payload = Payload.new(edition).payload
-    GdsApi.publishing_api_v2.put_content(edition.content_id,
-                                         payload.merge(optional_params))
+    payload = Payload.new(edition, republish: republish).payload
+    GdsApi.publishing_api_v2.put_content(edition.content_id, payload)
     edition.update!(revision_synced: true)
   end
 
   def put_draft_assets
     edition.image_revisions.each(&:ensure_assets)
     edition.assets.each { |asset| PreviewAssetService.call(edition, asset) }
-  end
-
-  def optional_params
-    return {} unless republish
-
-    {
-      "update_type" => "republish",
-      "bulk_publishing" => true,
-    }
   end
 end

--- a/app/services/preview_service.rb
+++ b/app/services/preview_service.rb
@@ -1,8 +1,9 @@
 # frozen_string_literal: true
 
 class PreviewService < ApplicationService
-  def initialize(edition)
+  def initialize(edition, optional_params = {})
     @edition = edition
+    @optional_params = optional_params
   end
 
   def call
@@ -15,11 +16,12 @@ class PreviewService < ApplicationService
 
 private
 
-  attr_reader :edition
+  attr_reader :edition, :optional_params
 
   def put_draft_content
     payload = Payload.new(edition).payload
-    GdsApi.publishing_api_v2.put_content(edition.content_id, payload)
+    GdsApi.publishing_api_v2.put_content(edition.content_id,
+                                         payload.merge(optional_params))
     edition.update!(revision_synced: true)
   end
 

--- a/app/services/preview_service/payload.rb
+++ b/app/services/preview_service/payload.rb
@@ -3,12 +3,13 @@
 class PreviewService::Payload
   PUBLISHING_APP = "content-publisher"
 
-  attr_reader :edition, :document_type, :publishing_metadata
+  attr_reader :edition, :document_type, :publishing_metadata, :republish
 
-  def initialize(edition)
+  def initialize(edition, republish: false)
     @edition = edition
     @document_type = edition.document_type
     @publishing_metadata = document_type.publishing_metadata
+    @republish = republish
   end
 
   def payload
@@ -35,6 +36,11 @@ class PreviewService::Payload
     if edition.backdated_to.present?
       payload["first_published_at"] = edition.backdated_to
       payload["public_updated_at"] = edition.backdated_to if edition.first?
+    end
+
+    if republish
+      payload["update_type"] = "republish"
+      payload["bulk_publishing"] = true
     end
 
     payload

--- a/app/services/resync_service.rb
+++ b/app/services/resync_service.rb
@@ -33,6 +33,8 @@ private
       nil, # Sending update_type is deprecated (now in payload)
       locale: edition.document.locale,
     )
+
+    edition.update!(revision_synced: true)
   end
 
   def update_current_edition(edition)

--- a/app/services/resync_service.rb
+++ b/app/services/resync_service.rb
@@ -20,6 +20,18 @@ private
       system_political: PoliticalEditionIdentifier.new(edition).political?,
       government_id: government_id(edition, document),
     )
+
+    PreviewService.call(
+      edition,
+      update_type: "republish",
+      bulk_publishing: true,
+    )
+
+    GdsApi.publishing_api_v2.publish(
+      edition.document.content_id,
+      nil, # Sending update_type is deprecated (now in payload)
+      locale: edition.document.locale,
+    )
   end
 
   def update_current_edition(edition)

--- a/app/services/resync_service.rb
+++ b/app/services/resync_service.rb
@@ -45,6 +45,7 @@ private
     edition.update!(
       revision_synced: false,
       system_political: PoliticalEditionIdentifier.new(edition).political?,
+      government_id: government_id(edition),
     )
     PreviewService.call(edition)
   end

--- a/app/services/resync_service.rb
+++ b/app/services/resync_service.rb
@@ -8,14 +8,14 @@ class ResyncService < ApplicationService
   end
 
   def call
-    update_live_edition(document.live_edition) if document.live_edition
-    update_current_edition(document.current_edition) unless
-      document.current_edition == document.live_edition
+    sync_live_edition if document.live_edition
+    sync_draft_edition if document.current_edition != document.live_edition
   end
 
 private
 
-  def update_live_edition(edition)
+  def sync_live_edition
+    edition = document.live_edition
     edition.update!(
       revision_synced: false,
       system_political: PoliticalEditionIdentifier.new(edition).political?,
@@ -40,7 +40,8 @@ private
     edition.update!(revision_synced: true)
   end
 
-  def update_current_edition(edition)
+  def sync_draft_edition
+    edition = document.current_edition
     edition.update!(
       revision_synced: false,
       system_political: PoliticalEditionIdentifier.new(edition).political?,

--- a/app/services/resync_service.rb
+++ b/app/services/resync_service.rb
@@ -30,8 +30,6 @@ private
     else
       publish
     end
-
-    live_edition.update!(revision_synced: true)
   end
 
   def sync_draft_edition

--- a/app/services/resync_service.rb
+++ b/app/services/resync_service.rb
@@ -1,0 +1,13 @@
+# frozen_string_literal: true
+
+class ResyncService < ApplicationService
+  attr_reader :document
+
+  def initialize(document)
+    @document = document
+  end
+
+  def call
+    # TODO
+  end
+end

--- a/app/services/resync_service.rb
+++ b/app/services/resync_service.rb
@@ -9,7 +9,8 @@ class ResyncService < ApplicationService
 
   def call
     update_live_edition(document.live_edition) if document.live_edition
-    update_current_edition(document.current_edition)
+    update_current_edition(document.current_edition) unless
+      document.current_edition == document.live_edition
   end
 
 private

--- a/app/services/resync_service.rb
+++ b/app/services/resync_service.rb
@@ -70,7 +70,7 @@ private
     removal = edition.status.details
     GdsApi.publishing_api_v2.unpublish(
       edition.content_id,
-      type: "redirect",
+      type: removal.redirect? ? "redirect" : "gone",
       explanation: removal.explanatory_note,
       alternative_path: removal.alternative_path,
       locale: edition.locale,

--- a/app/services/resync_service.rb
+++ b/app/services/resync_service.rb
@@ -27,6 +27,7 @@ private
       revision_synced: false,
       system_political: PoliticalEditionIdentifier.new(edition).political?,
     )
+    PreviewService.call(edition)
   end
 
   def government_id(edition, document)

--- a/app/services/resync_service.rb
+++ b/app/services/resync_service.rb
@@ -28,6 +28,8 @@ private
       bulk_publishing: true,
     )
 
+    PublishAssetService.call(edition, nil)
+
     GdsApi.publishing_api_v2.publish(
       edition.document.content_id,
       nil, # Sending update_type is deprecated (now in payload)

--- a/app/services/resync_service.rb
+++ b/app/services/resync_service.rb
@@ -12,6 +12,16 @@ class ResyncService < ApplicationService
     edition.update!(
       revision_synced: false,
       system_political: PoliticalEditionIdentifier.new(edition).political?,
+      government_id: government_id(edition, document),
     )
+  end
+
+private
+
+  def government_id(edition, document)
+    date = edition.backdated_to || document.first_published_at
+    return unless date
+
+    Government.for_date(date)&.content_id
   end
 end

--- a/app/services/resync_service.rb
+++ b/app/services/resync_service.rb
@@ -32,6 +32,8 @@ private
 
     if edition.withdrawn?
       withdraw(edition)
+    elsif edition.removed?
+      redirect_or_remove(edition)
     else
       publish(edition)
     end
@@ -60,6 +62,17 @@ private
       edition.document.content_id,
       type: "withdrawal",
       explanation: GovspeakDocument.new(edition.status.details, edition).payload_html,
+      locale: edition.locale,
+    )
+  end
+
+  def redirect_or_remove(edition)
+    removal = edition.status.details
+    GdsApi.publishing_api_v2.unpublish(
+      edition.content_id,
+      type: "redirect",
+      explanation: removal.explanatory_note,
+      alternative_path: removal.alternative_path,
       locale: edition.locale,
     )
   end

--- a/app/services/resync_service.rb
+++ b/app/services/resync_service.rb
@@ -23,6 +23,7 @@ private
   def sync_live_edition
     live_edition.lock!
     set_political_and_government(live_edition)
+    reserve_path(live_edition.base_path)
     PreviewService.call(live_edition, republish: true)
     PublishAssetService.call(live_edition, nil)
 
@@ -38,6 +39,7 @@ private
   def sync_draft_edition
     current_edition.lock!
     set_political_and_government(current_edition)
+    reserve_path(current_edition.base_path)
     PreviewService.call(current_edition)
   end
 
@@ -46,6 +48,14 @@ private
       revision_synced: false,
       system_political: PoliticalEditionIdentifier.new(edition).political?,
       government_id: Government.for_date(edition.public_first_published_at)&.content_id,
+    )
+  end
+
+  def reserve_path(base_path)
+    GdsApi.publishing_api_v2.put_path(
+      base_path,
+      publishing_app: "content-publisher",
+      override_existing: true,
     )
   end
 

--- a/app/services/resync_service.rb
+++ b/app/services/resync_service.rb
@@ -24,8 +24,7 @@ private
 
     PreviewService.call(
       edition,
-      update_type: "republish",
-      bulk_publishing: true,
+      republish: true,
     )
 
     PublishAssetService.call(edition, nil)

--- a/app/services/resync_service.rb
+++ b/app/services/resync_service.rb
@@ -45,7 +45,7 @@ private
     edition.update!(
       revision_synced: false,
       system_political: PoliticalEditionIdentifier.new(edition).political?,
-      government_id: government_id(edition),
+      government_id: Government.for_date(edition.public_first_published_at)&.content_id,
     )
   end
 
@@ -75,14 +75,5 @@ private
       alternative_path: removal.alternative_path,
       locale: live_edition.locale,
     )
-  end
-
-  def government_id(edition)
-    government = if edition.public_first_published_at
-                   Government.for_date(edition.public_first_published_at)
-                 else
-                   Government.current
-                 end
-    government.content_id
   end
 end

--- a/app/services/resync_service.rb
+++ b/app/services/resync_service.rb
@@ -8,6 +8,10 @@ class ResyncService < ApplicationService
   end
 
   def call
-    # TODO
+    edition = document.current_edition
+    edition.update!(
+      revision_synced: false,
+      system_political: PoliticalEditionIdentifier.new(edition).political?,
+    )
   end
 end

--- a/app/services/resync_service.rb
+++ b/app/services/resync_service.rb
@@ -8,7 +8,13 @@ class ResyncService < ApplicationService
   end
 
   def call
-    edition = document.current_edition
+    update_live_edition(document.live_edition) if document.live_edition
+    update_current_edition(document.current_edition)
+  end
+
+private
+
+  def update_live_edition(edition)
     edition.update!(
       revision_synced: false,
       system_political: PoliticalEditionIdentifier.new(edition).political?,
@@ -16,7 +22,12 @@ class ResyncService < ApplicationService
     )
   end
 
-private
+  def update_current_edition(edition)
+    edition.update!(
+      revision_synced: false,
+      system_political: PoliticalEditionIdentifier.new(edition).political?,
+    )
+  end
 
   def government_id(edition, document)
     date = edition.backdated_to || document.first_published_at

--- a/app/services/resync_service.rb
+++ b/app/services/resync_service.rb
@@ -19,7 +19,7 @@ private
     edition.update!(
       revision_synced: false,
       system_political: PoliticalEditionIdentifier.new(edition).political?,
-      government_id: government_id(edition, document),
+      government_id: government_id(edition),
     )
 
     PreviewService.call(
@@ -77,10 +77,12 @@ private
     )
   end
 
-  def government_id(edition, document)
-    date = edition.backdated_to || document.first_published_at
-    return unless date
-
-    Government.for_date(date)&.content_id
+  def government_id(edition)
+    government = if edition.public_first_published_at
+                   Government.for_date(edition.public_first_published_at)
+                 else
+                   Government.current
+                 end
+    government.content_id
   end
 end

--- a/lib/tasks/resync.rake
+++ b/lib/tasks/resync.rake
@@ -1,0 +1,21 @@
+# frozen_string_literal: true
+
+namespace :resync do
+  desc "Resync a document with the publishing-api e.g. resync:document['a-content-id:en']"
+  task :document, [:content_id_and_locale] => :environment do |_, args|
+    raise "Missing content_id and locale parameter" unless args.content_id_and_locale
+
+    document = Document.find_by_param(args.content_id_and_locale)
+
+    raise "No document exists for #{content_id_and_locale}" unless document
+
+    ResyncService.call(document)
+  end
+
+  desc "Resync all documents with the publishing-api e.g. resync:all"
+  task all: :environment do
+    Document.all.each do |document|
+      ResyncService.call(document)
+    end
+  end
+end

--- a/spec/factories/document_factory.rb
+++ b/spec/factories/document_factory.rb
@@ -5,11 +5,8 @@ FactoryBot.define do
     content_id { SecureRandom.uuid }
     locale { I18n.available_locales.sample }
     association :created_by, factory: :user
-    first_published_at { nil }
 
     trait :with_live_edition do
-      first_published_at { Time.current }
-
       after(:build) do |document, evaluator|
         document.live_edition = evaluator.association(
           :edition,
@@ -32,8 +29,6 @@ FactoryBot.define do
     end
 
     trait :with_current_and_live_editions do
-      first_published_at { Time.current }
-
       after(:build) do |document, evaluator|
         document.live_edition = evaluator.association(
           :edition,

--- a/spec/factories/document_factory.rb
+++ b/spec/factories/document_factory.rb
@@ -5,8 +5,11 @@ FactoryBot.define do
     content_id { SecureRandom.uuid }
     locale { I18n.available_locales.sample }
     association :created_by, factory: :user
+    first_published_at { nil }
 
     trait :with_live_edition do
+      first_published_at { Time.current }
+
       after(:build) do |document, evaluator|
         document.live_edition = evaluator.association(
           :edition,
@@ -29,6 +32,8 @@ FactoryBot.define do
     end
 
     trait :with_current_and_live_editions do
+      first_published_at { Time.current }
+
       after(:build) do |document, evaluator|
         document.live_edition = evaluator.association(
           :edition,

--- a/spec/factories/edition_factory.rb
+++ b/spec/factories/edition_factory.rb
@@ -119,6 +119,27 @@ FactoryBot.define do
       end
     end
 
+    trait :removed do
+      live { true }
+
+      transient do
+        removal { nil }
+        redirect { true }
+        alternative_path { "/foo/bar" }
+        explanatory_note { "Explanation" }
+      end
+
+      after(:build) do |edition, evaluator|
+        edition.status = evaluator.association(
+          :status,
+          :removed,
+          created_by: edition.created_by,
+          state: :removed,
+          removal: evaluator.removal,
+        )
+      end
+    end
+
     trait :schedulable do
       publishable
       proposed_publish_time { Time.current.advance(days: 2) }

--- a/spec/factories/edition_factory.rb
+++ b/spec/factories/edition_factory.rb
@@ -107,13 +107,11 @@ FactoryBot.define do
       end
 
       after(:build) do |edition, evaluator|
-        edition.revision = evaluator.association(:revision)
         edition.status = evaluator.association(
           :status,
           :withdrawn,
           created_by: edition.created_by,
           state: :withdrawn,
-          revision_at_creation: edition.revision,
           withdrawal: evaluator.withdrawal,
         )
       end

--- a/spec/factories/edition_factory.rb
+++ b/spec/factories/edition_factory.rb
@@ -107,11 +107,13 @@ FactoryBot.define do
       end
 
       after(:build) do |edition, evaluator|
+        edition.revision = evaluator.association(:revision)
         edition.status = evaluator.association(
           :status,
           :withdrawn,
           created_by: edition.created_by,
           state: :withdrawn,
+          revision_at_creation: edition.revision,
           withdrawal: evaluator.withdrawal,
         )
       end

--- a/spec/factories/edition_factory.rb
+++ b/spec/factories/edition_factory.rb
@@ -124,17 +124,15 @@ FactoryBot.define do
 
       transient do
         removal { nil }
-        redirect { true }
-        alternative_path { "/foo/bar" }
-        explanatory_note { "Explanation" }
       end
 
       after(:build) do |edition, evaluator|
+        edition.revision = evaluator.association(:revision)
         edition.status = evaluator.association(
           :status,
           :removed,
           created_by: edition.created_by,
-          state: :removed,
+          revision_at_creation: edition.revision,
           removal: evaluator.removal,
         )
       end

--- a/spec/factories/status_factory.rb
+++ b/spec/factories/status_factory.rb
@@ -26,6 +26,18 @@ FactoryBot.define do
       state { :published_but_needs_2i }
     end
 
+    trait :removed do
+      state { :removed }
+
+      transient do
+        removal { nil }
+      end
+
+      after(:build) do |status, evaluator|
+        status.details = evaluator.removal || evaluator.association(:removal)
+      end
+    end
+
     trait :scheduled do
       state { :scheduled }
 

--- a/spec/lib/tasks/resync_spec.rb
+++ b/spec/lib/tasks/resync_spec.rb
@@ -1,0 +1,29 @@
+# frozen_string_literal: true
+
+RSpec.describe "Resync tasks" do
+  describe "resync:document" do
+    it "resyncs a document" do
+      document = create(:document)
+
+      expect(ResyncService)
+        .to receive(:call)
+        .once
+        .with(document)
+
+      Rake::Task["resync:document"].invoke("#{document.content_id}:#{document.locale}")
+    end
+  end
+
+  describe "resync:all" do
+    it "resyncs all documentss" do
+      create(:document)
+      create(:document)
+
+      expect(ResyncService)
+        .to receive(:call)
+        .twice
+
+      Rake::Task["resync:all"].invoke
+    end
+  end
+end

--- a/spec/models/government_spec.rb
+++ b/spec/models/government_spec.rb
@@ -53,6 +53,10 @@ RSpec.describe Government do
     it "opts for the more recent government when there is a date conflict" do
       expect(Government.for_date(Date.parse("2018-12-01"))).to eq current_government
     end
+
+    it "accepts a nil date" do
+      expect(Government.for_date(nil)).to be_nil
+    end
   end
 
   describe ".current" do

--- a/spec/services/preview_service/payload_spec.rb
+++ b/spec/services/preview_service/payload_spec.rb
@@ -192,5 +192,15 @@ RSpec.describe PreviewService::Payload do
 
       expect(payload).to match a_hash_including("public_updated_at" => date)
     end
+
+    it "includes bulk_publishing and sets the update to republish if the edition is being republished" do
+      edition = build(:edition)
+      payload = PreviewService::Payload.new(edition, republish: true).payload
+
+      expect(payload).to match a_hash_including(
+        "update_type" => "republish",
+        "bulk_publishing" => true,
+      )
+    end
   end
 end

--- a/spec/services/preview_service_spec.rb
+++ b/spec/services/preview_service_spec.rb
@@ -34,6 +34,16 @@ RSpec.describe PreviewService do
       PreviewService.call(edition)
     end
 
+    it "accepts parameter to merge arbitrary things into the payload" do
+      edition = create(:edition)
+      extra_params = { "bulk_publishing" => true }
+      GdsApi.stub_chain(:publishing_api_v2, :put_content)
+
+      expect(GdsApi.publishing_api_v2).to receive(:put_content).once.
+        with(edition.content_id, hash_including(extra_params))
+      PreviewService.call(edition, extra_params)
+    end
+
     context "when Publishing API is down" do
       before do
         stub_publishing_api_isnt_available

--- a/spec/services/preview_service_spec.rb
+++ b/spec/services/preview_service_spec.rb
@@ -34,22 +34,15 @@ RSpec.describe PreviewService do
       PreviewService.call(edition)
     end
 
-    it "republishes the edition" do
+    it "sets an update type of republish" do
       edition = create(:edition)
 
-      allow(PreviewService::Payload)
+      expect(PreviewService::Payload)
         .to receive(:new)
-        .with(edition)
-        .and_return(instance_double(PreviewService::Payload, payload: {}))
-
-      expected_params = {
-        "update_type" => "republish",
-        "bulk_publishing" => true,
-      }
+        .with(edition, republish: true)
+        .and_call_original
 
       PreviewService.call(edition, republish: true)
-
-      assert_publishing_api_put_content(edition.content_id, expected_params, 1)
     end
 
     context "when Publishing API is down" do

--- a/spec/services/resync_service_spec.rb
+++ b/spec/services/resync_service_spec.rb
@@ -6,18 +6,28 @@ RSpec.describe ResyncService do
       PoliticalEditionIdentifier.stub_chain(:new, :political?).and_return(true)
     end
 
-    it "updates the system_political value associated with the current edition" do
-      document = create(:document, :with_current_edition)
-      expect(document.current_edition.system_political).to be false
-      ResyncService.call(document)
-      expect(document.current_edition.system_political).to be true
-    end
+    context "when there are both live and current editions" do
+      let(:document) { create(:document, :with_current_and_live_editions) }
 
-    it "updates the government_id associated with the live edition" do
-      document = create(:document, :with_live_edition)
-      expect(document.live_edition.government_id).to be nil
-      ResyncService.call(document)
-      expect(document.live_edition.government_id).to eq "d4fbc1b9-d47d-4386-af04-ac909f868f92"
+      it "updates the system_political value associated with both editions" do
+        expect(document.live_edition.system_political).to be false
+        expect(document.current_edition.system_political).to be false
+        ResyncService.call(document)
+        expect(document.live_edition.system_political).to be true
+        expect(document.current_edition.system_political).to be true
+      end
+
+      it "updates the government_id associated with the live edition" do
+        expect(document.live_edition.government_id).to be nil
+        ResyncService.call(document)
+        expect(document.live_edition.government_id).to eq "d4fbc1b9-d47d-4386-af04-ac909f868f92"
+      end
+
+      it "does not set the government_id associated with the current edition" do
+        expect(document.current_edition.government_id).to be nil
+        ResyncService.call(document)
+        expect(document.current_edition.government_id).to be nil
+      end
     end
   end
 end

--- a/spec/services/resync_service_spec.rb
+++ b/spec/services/resync_service_spec.rb
@@ -13,11 +13,10 @@ RSpec.describe ResyncService do
     context "when there is no live edition" do
       let(:document) { create(:document, :with_current_edition) }
 
-      it "synchronises the current edition, but does not publish" do
-        expect(PreviewService).to receive(:call).with(document.current_edition).and_call_original
+      it "it does not publish the edition" do
+        expect(PreviewService).to receive(:call).with(document.current_edition)
         expect(GdsApi.publishing_api_v2).not_to receive(:publish)
         ResyncService.call(document)
-        expect(document.current_edition.revision_synced).to be true
       end
     end
 
@@ -36,6 +35,7 @@ RSpec.describe ResyncService do
             document.current_edition,
             republish: true,
           )
+          .and_call_original
 
         ResyncService.call(document)
 

--- a/spec/services/resync_service_spec.rb
+++ b/spec/services/resync_service_spec.rb
@@ -40,7 +40,6 @@ RSpec.describe ResyncService do
         ResyncService.call(document)
 
         assert_publishing_api_publish(document.content_id)
-        expect(document.current_edition.revision_synced).to be true
       end
 
       it "publishes assets to the live stack" do

--- a/spec/services/resync_service_spec.rb
+++ b/spec/services/resync_service_spec.rb
@@ -128,25 +128,28 @@ RSpec.describe ResyncService do
 
     context "when there are both live and current editions" do
       let(:document) { create(:document, :with_current_and_live_editions) }
+      let(:government) { build(:government) }
+
+      before do
+        allow(Government).to receive(:all).and_return([government])
+      end
 
       it "updates the system_political value associated with both editions" do
-        expect(document.live_edition.system_political).to be false
-        expect(document.current_edition.system_political).to be false
-        ResyncService.call(document)
-        expect(document.live_edition.system_political).to be true
-        expect(document.current_edition.system_political).to be true
+        expect { ResyncService.call(document) }
+          .to change { document.live_edition.system_political }.to(true)
+          .and change { document.current_edition.system_political }.to(true)
       end
 
       it "updates the government_id associated with the live edition" do
         expect(document.live_edition.government_id).to be nil
         ResyncService.call(document)
-        expect(document.live_edition.government_id).to eq "d4fbc1b9-d47d-4386-af04-ac909f868f92"
+        expect(document.live_edition.government_id).to eq government.content_id
       end
 
       it "updates the government_id associated with the current edition" do
         expect(document.current_edition.government_id).to be nil
         ResyncService.call(document)
-        expect(document.current_edition.government_id).to eq "d4fbc1b9-d47d-4386-af04-ac909f868f92"
+        expect(document.current_edition.government_id).to eq government.content_id
       end
     end
   end

--- a/spec/services/resync_service_spec.rb
+++ b/spec/services/resync_service_spec.rb
@@ -88,40 +88,32 @@ RSpec.describe ResyncService do
           )
         end
 
-        before do
-          document.current_edition.stub(:removed?).and_return(true)
-          document.current_edition.status.stub(:details).and_return(removal)
-        end
+        let(:edition) { create(:edition, :removed, removal: removal) }
 
         it "unpublishes the edition as redirected" do
           unpublish_params = {
             "type" => "redirect",
             "explanation" => explanation,
             "alternative_path" => removal.alternative_path,
-            "locale" => document.current_edition.locale,
+            "locale" => edition.locale,
           }
 
-          ResyncService.call(document)
-          assert_publishing_api_unpublish(document.content_id, unpublish_params, 1)
+          ResyncService.call(edition.document)
+          assert_publishing_api_unpublish(edition.content_id, unpublish_params, 1)
         end
       end
 
       context "when the live edition is unpublished without a redirect" do
-        let(:removal) { build(:removal) }
-
-        before do
-          document.current_edition.stub(:removed?).and_return(true)
-          document.current_edition.status.stub(:details).and_return(removal)
-        end
+        let(:edition) { create(:edition, :removed) }
 
         it "unpublishes the edition as redirected" do
           unpublish_params = {
             "type" => "gone",
-            "locale" => document.current_edition.locale,
+            "locale" => edition.locale,
           }
 
-          ResyncService.call(document)
-          assert_publishing_api_unpublish(document.content_id, unpublish_params, 1)
+          ResyncService.call(edition.document)
+          assert_publishing_api_unpublish(edition.content_id, unpublish_params, 1)
         end
       end
     end

--- a/spec/services/resync_service_spec.rb
+++ b/spec/services/resync_service_spec.rb
@@ -22,6 +22,11 @@ RSpec.describe ResyncService do
     context "when the current edition is live" do
       let(:document) { create(:document, :with_live_edition) }
 
+      it "avoids synchronising the edition twice" do
+        expect(PreviewService).to receive(:call).once
+        ResyncService.call(document)
+      end
+
       it "re-publishes the live edition" do
         GdsApi.stub_chain(:publishing_api_v2, :put_content)
         GdsApi.stub_chain(:publishing_api_v2, :publish)

--- a/spec/services/resync_service_spec.rb
+++ b/spec/services/resync_service_spec.rb
@@ -56,6 +56,8 @@ RSpec.describe ResyncService do
 
       before do
         stub_any_publishing_api_unpublish
+        allow(PreviewAssetService).to receive(:call)
+        allow(PublishAssetService).to receive(:call)
         allow(GovspeakDocument)
           .to receive(:new)
           .and_return(instance_double(GovspeakDocument, payload_html: explanation))

--- a/spec/services/resync_service_spec.rb
+++ b/spec/services/resync_service_spec.rb
@@ -2,13 +2,22 @@
 
 RSpec.describe ResyncService do
   describe ".call" do
+    before do
+      PoliticalEditionIdentifier.stub_chain(:new, :political?).and_return(true)
+    end
+
     it "updates the system_political value associated with the current edition" do
       document = create(:document, :with_current_edition)
-      PoliticalEditionIdentifier.stub_chain(:new, :political?).and_return(true)
-
       expect(document.current_edition.system_political).to be false
       ResyncService.call(document)
       expect(document.current_edition.system_political).to be true
+    end
+
+    it "updates the government_id associated with the live edition" do
+      document = create(:document, :with_live_edition)
+      expect(document.live_edition.government_id).to be nil
+      ResyncService.call(document)
+      expect(document.live_edition.government_id).to eq "d4fbc1b9-d47d-4386-af04-ac909f868f92"
     end
   end
 end

--- a/spec/services/resync_service_spec.rb
+++ b/spec/services/resync_service_spec.rb
@@ -5,6 +5,7 @@ RSpec.describe ResyncService do
     before do
       stub_any_publishing_api_publish
       stub_any_publishing_api_put_content
+      stub_default_publishing_api_path_reservation
     end
 
     context "when there is no live edition" do
@@ -147,6 +148,26 @@ RSpec.describe ResyncService do
           .to change { document.live_edition.government_id }.to(government.content_id)
           .and change { document.current_edition.government_id }.to(government.content_id)
       end
+    end
+
+    it "reserves the path of the edition" do
+      edition = create(:edition)
+      reserve_path_params = {
+        publishing_app: "content-publisher",
+        override_existing: true,
+      }
+
+      request = stub_publishing_api_path_reservation(edition.base_path, reserve_path_params)
+      ResyncService.call(edition.document)
+
+      expect(request).to have_been_requested
+    end
+
+    def stub_publishing_api_path_reservation(base_path, params)
+      endpoint = GdsApi::TestHelpers::PublishingApi::PUBLISHING_API_ENDPOINT
+      url = endpoint + "/paths#{base_path}"
+
+      stub_request(:put, url).with(body: params)
     end
   end
 end

--- a/spec/services/resync_service_spec.rb
+++ b/spec/services/resync_service_spec.rb
@@ -132,10 +132,10 @@ RSpec.describe ResyncService do
         expect(document.live_edition.government_id).to eq "d4fbc1b9-d47d-4386-af04-ac909f868f92"
       end
 
-      it "does not set the government_id associated with the current edition" do
+      it "updates the government_id associated with the current edition" do
         expect(document.current_edition.government_id).to be nil
         ResyncService.call(document)
-        expect(document.current_edition.government_id).to be nil
+        expect(document.current_edition.government_id).to eq "d4fbc1b9-d47d-4386-af04-ac909f868f92"
       end
     end
   end

--- a/spec/services/resync_service_spec.rb
+++ b/spec/services/resync_service_spec.rb
@@ -5,9 +5,6 @@ RSpec.describe ResyncService do
     before do
       stub_any_publishing_api_publish
       stub_any_publishing_api_put_content
-      allow(PoliticalEditionIdentifier)
-        .to receive(:new)
-        .and_return(instance_double(PoliticalEditionIdentifier, political?: true))
     end
 
     context "when there is no live edition" do
@@ -128,6 +125,9 @@ RSpec.describe ResyncService do
 
       before do
         allow(Government).to receive(:all).and_return([government])
+        allow(PoliticalEditionIdentifier)
+          .to receive(:new)
+          .and_return(instance_double(PoliticalEditionIdentifier, political?: true))
       end
 
       it "updates the system_political value associated with both editions" do
@@ -136,16 +136,10 @@ RSpec.describe ResyncService do
           .and change { document.current_edition.system_political }.to(true)
       end
 
-      it "updates the government_id associated with the live edition" do
-        expect(document.live_edition.government_id).to be nil
-        ResyncService.call(document)
-        expect(document.live_edition.government_id).to eq government.content_id
-      end
-
-      it "updates the government_id associated with the current edition" do
-        expect(document.current_edition.government_id).to be nil
-        ResyncService.call(document)
-        expect(document.current_edition.government_id).to eq government.content_id
+      it "updates the government_id associated with with both editions" do
+        expect { ResyncService.call(document) }
+          .to change { document.live_edition.government_id }.to(government.content_id)
+          .and change { document.current_edition.government_id }.to(government.content_id)
       end
     end
   end

--- a/spec/services/resync_service_spec.rb
+++ b/spec/services/resync_service_spec.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+RSpec.describe ResyncService do
+  describe ".call" do
+    # TODO
+  end
+end

--- a/spec/services/resync_service_spec.rb
+++ b/spec/services/resync_service_spec.rb
@@ -37,6 +37,12 @@ RSpec.describe ResyncService do
         ResyncService.call(document)
         expect(document.current_edition.revision_synced).to be true
       end
+
+      it "publishes assets to the live stack" do
+        expect(PublishAssetService).to receive(:call).once.
+          with(document.live_edition, nil)
+        ResyncService.call(document)
+      end
     end
 
     context "when there are both live and current editions" do

--- a/spec/services/resync_service_spec.rb
+++ b/spec/services/resync_service_spec.rb
@@ -35,6 +35,7 @@ RSpec.describe ResyncService do
         expect(GdsApi.publishing_api_v2).to receive(:publish).once.
           with(document.content_id, nil, hash_including(:locale)).ordered
         ResyncService.call(document)
+        expect(document.current_edition.revision_synced).to be true
       end
     end
 

--- a/spec/services/resync_service_spec.rb
+++ b/spec/services/resync_service_spec.rb
@@ -2,6 +2,13 @@
 
 RSpec.describe ResyncService do
   describe ".call" do
-    # TODO
+    it "updates the system_political value associated with the current edition" do
+      document = create(:document, :with_current_edition)
+      PoliticalEditionIdentifier.stub_chain(:new, :political?).and_return(true)
+
+      expect(document.current_edition.system_political).to be false
+      ResyncService.call(document)
+      expect(document.current_edition.system_political).to be true
+    end
   end
 end

--- a/spec/services/resync_service_spec.rb
+++ b/spec/services/resync_service_spec.rb
@@ -117,7 +117,7 @@ RSpec.describe ResyncService do
     end
 
     context "when there are both live and current editions" do
-      let(:document) { create(:document, :with_current_and_live_editions) }
+      let(:document) { create(:document, :with_current_and_live_editions, first_published_at: Time.current) }
       let(:government) { build(:government) }
 
       before do

--- a/spec/services/resync_service_spec.rb
+++ b/spec/services/resync_service_spec.rb
@@ -62,19 +62,17 @@ RSpec.describe ResyncService do
       end
 
       context "when the live edition is withdrawn" do
-        before do
-          document.current_edition.stub(:withdrawn?).and_return(true)
-        end
+        let(:edition) { create(:edition, :withdrawn) }
 
         it "unpublishes the edition as withdrawn" do
           unpublish_params = {
             "type" => "withdrawal",
             "explanation" => explanation,
-            "locale" => document.current_edition.locale,
+            "locale" => edition.locale,
           }
 
-          ResyncService.call(document)
-          assert_publishing_api_unpublish(document.content_id, unpublish_params, 1)
+          ResyncService.call(edition.document)
+          assert_publishing_api_unpublish(edition.content_id, unpublish_params, 1)
         end
       end
 

--- a/spec/services/resync_service_spec.rb
+++ b/spec/services/resync_service_spec.rb
@@ -45,76 +45,73 @@ RSpec.describe ResyncService do
       end
     end
 
-    context "when the current edition is withdrawn" do
+    context "when the live edition has been unpublished" do
       let(:document) { create(:document, :with_live_edition) }
 
       before do
-        document.current_edition.stub(:withdrawn?).and_return(true)
         GdsApi.stub_chain(:publishing_api_v2, :put_content)
         GdsApi.stub_chain(:publishing_api_v2, :unpublish)
       end
 
-      it "unpublishes the edition as withdrawn" do
-        unpublish_params = hash_including(
-          type: "withdrawal",
-          locale: document.current_edition.locale,
-        )
-        expect(GdsApi.publishing_api_v2).to receive(:put_content).once.ordered
-        expect(GdsApi.publishing_api_v2).to receive(:unpublish).once.
-          with(document.content_id, unpublish_params).ordered
-        ResyncService.call(document)
-      end
-    end
+      context "when the live edition is withdrawn" do
+        before do
+          document.current_edition.stub(:withdrawn?).and_return(true)
+        end
 
-    context "when the current edition is unpublished with redirect" do
-      let(:document) { create(:document, :with_live_edition) }
-
-      before do
-        document.current_edition.stub(:removed?).and_return(true)
-        document.current_edition.status.details.stub(:redirect?).and_return(true)
-        document.current_edition.status.details.stub(:alternative_path).and_return("/foo/bar")
-        document.current_edition.status.details.stub(:explanatory_note).and_return("Explanation")
-        GdsApi.stub_chain(:publishing_api_v2, :put_content)
-        GdsApi.stub_chain(:publishing_api_v2, :unpublish)
+        it "unpublishes the edition as withdrawn" do
+          unpublish_params = hash_including(
+            type: "withdrawal",
+            locale: document.current_edition.locale,
+          )
+          expect(GdsApi.publishing_api_v2).to receive(:put_content).once.ordered
+          expect(GdsApi.publishing_api_v2).to receive(:unpublish).once.
+            with(document.content_id, unpublish_params).ordered
+          ResyncService.call(document)
+        end
       end
 
-      it "unpublishes the edition as redirected" do
-        unpublish_params = hash_including(
-          type: "redirect",
-          locale: document.current_edition.locale,
-          alternative_path: "/foo/bar",
-          explanation: "Explanation",
-        )
-        expect(GdsApi.publishing_api_v2).to receive(:put_content).once.ordered
-        expect(GdsApi.publishing_api_v2).to receive(:unpublish).once.
-          with(document.content_id, unpublish_params).ordered
-        ResyncService.call(document)
-      end
-    end
+      context "when the live edition is unpublished with redirect" do
+        before do
+          document.current_edition.stub(:removed?).and_return(true)
+          document.current_edition.status.details.stub(:redirect?).and_return(true)
+          document.current_edition.status.details.stub(:alternative_path).and_return("/foo/bar")
+          document.current_edition.status.details.stub(:explanatory_note).and_return("Explanation")
+        end
 
-    context "when the current edition is unpublished without a redirect" do
-      let(:document) { create(:document, :with_live_edition) }
-
-      before do
-        document.current_edition.stub(:removed?).and_return(true)
-        document.current_edition.status.details.stub(:redirect?).and_return(false)
-        document.current_edition.status.details.stub(:alternative_path).and_return("")
-        document.current_edition.status.details.stub(:explanatory_note).and_return("")
-        GdsApi.stub_chain(:publishing_api_v2, :put_content)
-        GdsApi.stub_chain(:publishing_api_v2, :unpublish)
+        it "unpublishes the edition as redirected" do
+          unpublish_params = hash_including(
+            type: "redirect",
+            locale: document.current_edition.locale,
+            alternative_path: "/foo/bar",
+            explanation: "Explanation",
+          )
+          expect(GdsApi.publishing_api_v2).to receive(:put_content).once.ordered
+          expect(GdsApi.publishing_api_v2).to receive(:unpublish).once.
+            with(document.content_id, unpublish_params).ordered
+          ResyncService.call(document)
+        end
       end
 
-      it "unpublishes the edition as redirected" do
-        unpublish_params = hash_including(
-          type: "gone",
-          locale: document.current_edition.locale,
-          alternative_path: "",
-          explanation: "",
-        )
-        expect(GdsApi.publishing_api_v2).to receive(:put_content).once.ordered
-        expect(GdsApi.publishing_api_v2).to receive(:unpublish).once.
-          with(document.content_id, unpublish_params).ordered
-        ResyncService.call(document)
+      context "when the live edition is unpublished without a redirect" do
+        before do
+          document.current_edition.stub(:removed?).and_return(true)
+          document.current_edition.status.details.stub(:redirect?).and_return(false)
+          document.current_edition.status.details.stub(:alternative_path).and_return("")
+          document.current_edition.status.details.stub(:explanatory_note).and_return("")
+        end
+
+        it "unpublishes the edition as redirected" do
+          unpublish_params = hash_including(
+            type: "gone",
+            locale: document.current_edition.locale,
+            alternative_path: "",
+            explanation: "",
+          )
+          expect(GdsApi.publishing_api_v2).to receive(:put_content).once.ordered
+          expect(GdsApi.publishing_api_v2).to receive(:unpublish).once.
+            with(document.content_id, unpublish_params).ordered
+          ResyncService.call(document)
+        end
       end
     end
 

--- a/spec/services/resync_service_spec.rb
+++ b/spec/services/resync_service_spec.rb
@@ -92,6 +92,32 @@ RSpec.describe ResyncService do
       end
     end
 
+    context "when the current edition is unpublished without a redirect" do
+      let(:document) { create(:document, :with_live_edition) }
+
+      before do
+        document.current_edition.stub(:removed?).and_return(true)
+        document.current_edition.status.details.stub(:redirect?).and_return(false)
+        document.current_edition.status.details.stub(:alternative_path).and_return("")
+        document.current_edition.status.details.stub(:explanatory_note).and_return("")
+        GdsApi.stub_chain(:publishing_api_v2, :put_content)
+        GdsApi.stub_chain(:publishing_api_v2, :unpublish)
+      end
+
+      it "unpublishes the edition as redirected" do
+        unpublish_params = hash_including(
+          type: "gone",
+          locale: document.current_edition.locale,
+          alternative_path: "",
+          explanation: "",
+        )
+        expect(GdsApi.publishing_api_v2).to receive(:put_content).once.ordered
+        expect(GdsApi.publishing_api_v2).to receive(:unpublish).once.
+          with(document.content_id, unpublish_params).ordered
+        ResyncService.call(document)
+      end
+    end
+
     context "when there are both live and current editions" do
       let(:document) { create(:document, :with_current_and_live_editions) }
 

--- a/spec/services/resync_service_spec.rb
+++ b/spec/services/resync_service_spec.rb
@@ -57,20 +57,25 @@ RSpec.describe ResyncService do
         stub_any_publishing_api_unpublish
         allow(PreviewAssetService).to receive(:call)
         allow(PublishAssetService).to receive(:call)
-        allow(GovspeakDocument)
-          .to receive(:new)
-          .and_return(instance_double(GovspeakDocument, payload_html: explanation))
       end
 
       context "when the live edition is withdrawn" do
         let(:edition) { create(:edition, :withdrawn) }
 
         it "unpublishes the edition as withdrawn" do
+          allow(GovspeakDocument)
+            .to receive(:new)
+            .and_return(instance_double(GovspeakDocument, payload_html: explanation))
+
           unpublish_params = {
             "type" => "withdrawal",
             "explanation" => explanation,
             "locale" => edition.locale,
           }
+
+          expect(GovspeakDocument)
+            .to receive(:new)
+            .with(edition.status.details, edition)
 
           ResyncService.call(edition.document)
           assert_publishing_api_unpublish(edition.content_id, unpublish_params, 1)


### PR DESCRIPTION
Adds a Resync service for use in syncing Whitehall-imported documents, or mass-updating documents that need to be put into history mode.

Trello card: https://trello.com/c/cT9yYO4X/1214-create-a-resyncservice