### PR TITLE
Import scheduled Whitehall documents

### DIFF
--- a/lib/whitehall_importer/create_edition.rb
+++ b/lib/whitehall_importer/create_edition.rb
@@ -87,7 +87,9 @@ module WhitehallImporter
     end
 
     def set_withdrawn_status(edition)
-      raise AbortImportError, "Cannot create withdrawn status without an unpublishing" if whitehall_edition["unpublishing"].blank?
+      unless whitehall_edition["unpublishing"]
+        raise AbortImportError, "Cannot create withdrawn status without an unpublishing"
+      end
 
       withdrawal = Withdrawal.new(
         published_status: edition.status,
@@ -99,7 +101,9 @@ module WhitehallImporter
     end
 
     def create_scheduled_edition
-      raise AbortImportError, "Cannot create scheduled status without scheduled_publication" if whitehall_edition["scheduled_publication"].blank?
+      unless whitehall_edition["scheduled_publication"]
+        raise AbortImportError, "Cannot create scheduled status without scheduled_publication"
+      end
 
       pre_scheduled_state = history.state_event("submitted") ? "submitted_for_review" : "draft"
       edition = create_edition(status: build_status(pre_scheduled_state),
@@ -114,7 +118,9 @@ module WhitehallImporter
 
     def build_removal
       unpublishing = whitehall_edition["unpublishing"]
-      raise AbortImportError, "Cannot create removal status without an unpublishing" if unpublishing.blank?
+      unless unpublishing
+        raise AbortImportError, "Cannot create removal status without an unpublishing"
+      end
 
       Removal.new(
         explanatory_note: unpublishing["explanation"],

--- a/lib/whitehall_importer/create_edition.rb
+++ b/lib/whitehall_importer/create_edition.rb
@@ -101,7 +101,8 @@ module WhitehallImporter
     def create_scheduled_edition
       raise AbortImportError, "Cannot create scheduled status without scheduled_publication" if whitehall_edition["scheduled_publication"].blank?
 
-      edition = create_edition(status: build_status("submitted_for_review"),
+      pre_scheduled_state = history.state_event("submitted") ? "submitted_for_review" : "draft"
+      edition = create_edition(status: build_status(pre_scheduled_state),
                                current: current,
                                edition_number: edition_number)
       scheduling = Scheduling.new(pre_scheduled_status: edition.status,

--- a/lib/whitehall_importer/create_edition.rb
+++ b/lib/whitehall_importer/create_edition.rb
@@ -99,6 +99,8 @@ module WhitehallImporter
     end
 
     def create_scheduled_edition
+      raise AbortImportError, "Cannot create scheduled status without scheduled_publication" if whitehall_edition["scheduled_publication"].blank?
+
       edition = create_edition(status: build_status("submitted_for_review"),
                                current: current,
                                edition_number: edition_number)

--- a/lib/whitehall_importer/create_edition.rb
+++ b/lib/whitehall_importer/create_edition.rb
@@ -51,7 +51,7 @@ module WhitehallImporter
     end
 
     def split_unpublished_edition
-      unpublishing_event = history.last_unpublishing_event
+      unpublishing_event = history.last_unpublishing_event!
       create_edition(
         status: build_status("removed", build_removal),
         current: false,
@@ -63,7 +63,7 @@ module WhitehallImporter
         status: build_status(MigrateState.call(whitehall_edition["state"], whitehall_edition["force_published"])),
         edition_number: edition_number + 1,
         current: true,
-        create_event: history.next_event(unpublishing_event),
+        create_event: history.next_event!(unpublishing_event),
       )
     end
 
@@ -136,7 +136,7 @@ module WhitehallImporter
     end
 
     def create_edition(status:, edition_number:, current:, create_event: nil, last_event: nil)
-      create_event ||= history.create_event
+      create_event ||= history.create_event!
       last_event ||= whitehall_edition["revision_history"].last
 
       Edition.create!(

--- a/lib/whitehall_importer/create_edition.rb
+++ b/lib/whitehall_importer/create_edition.rb
@@ -123,7 +123,7 @@ module WhitehallImporter
     end
 
     def build_status(state, details = nil)
-      state_event = history.state_event(whitehall_edition["state"])
+      state_event = history.state_event!(whitehall_edition["state"])
 
       Status.new(
         state: state,

--- a/lib/whitehall_importer/edition_history.rb
+++ b/lib/whitehall_importer/edition_history.rb
@@ -6,7 +6,7 @@ module WhitehallImporter
       @revision_history = revision_history
     end
 
-    def state_event(state)
+    def state_event!(state)
       event = revision_history.select { |h| h["state"] == state }.last
 
       raise AbortImportError, "Edition is missing a #{state} event" unless event

--- a/lib/whitehall_importer/edition_history.rb
+++ b/lib/whitehall_importer/edition_history.rb
@@ -14,6 +14,10 @@ module WhitehallImporter
       event
     end
 
+    def state_event(state)
+      revision_history.select { |h| h["state"] == state }.last
+    end
+
     def create_event
       event = revision_history.select { |h| h["event"] == "create" }.first
 

--- a/lib/whitehall_importer/edition_history.rb
+++ b/lib/whitehall_importer/edition_history.rb
@@ -14,12 +14,23 @@ module WhitehallImporter
       state_event(state) || raise(AbortImportError, "Edition is missing a #{state} event")
     end
 
+    def next_event(event)
+      index = revision_history.index(event)
+      return unless index
+
+      revision_history[index + 1]
+    end
+
+    def next_event!(event)
+      next_event(event) || (raise AbortImportError, "Edition is missing next event for #{event}")
+    end
+
     def create_event
-      event = revision_history.select { |h| h["event"] == "create" }.first
+      revision_history.select { |h| h["event"] == "create" }.first
+    end
 
-      raise AbortImportError, "Edition is missing a create event" unless event
-
-      event
+    def create_event!
+      create_event || (raise AbortImportError, "Edition is missing a create event")
     end
 
     def last_unpublishing_event
@@ -31,23 +42,18 @@ module WhitehallImporter
         previous_entry && previous_entry["state"] == "published"
       end
 
-      raise AbortImportError, "Edition is missing unpublishing event" if unpublishing_events.blank?
-
       unpublishing_events.last
     end
 
-    def next_event(event)
-      next_event_index = revision_history.index(event) + 1
-
-      raise AbortImportError, "Edition is missing next event for #{event}" unless revision_history[next_event_index]
-
-      revision_history[next_event_index]
+    def last_unpublishing_event!
+      last_unpublishing_event || (raise AbortImportError, "Edition is missing unpublishing event")
     end
 
     def edited_after_unpublishing?
-      return false unless revision_history.second_to_last
+      unpublishing_event = last_unpublishing_event
+      return false unless unpublishing_event
 
-      revision_history.second_to_last["state"] != "published"
+      revision_history.last != unpublishing_event
     end
 
   private

--- a/lib/whitehall_importer/edition_history.rb
+++ b/lib/whitehall_importer/edition_history.rb
@@ -6,16 +6,12 @@ module WhitehallImporter
       @revision_history = revision_history
     end
 
-    def state_event!(state)
-      event = revision_history.select { |h| h["state"] == state }.last
-
-      raise AbortImportError, "Edition is missing a #{state} event" unless event
-
-      event
-    end
-
     def state_event(state)
       revision_history.select { |h| h["state"] == state }.last
+    end
+
+    def state_event!(state)
+      state_event(state) || raise(AbortImportError, "Edition is missing a #{state} event")
     end
 
     def create_event

--- a/spec/factories/whitehall_export/edition_factory.rb
+++ b/spec/factories/whitehall_export/edition_factory.rb
@@ -28,5 +28,24 @@ FactoryBot.define do
     unpublishing { nil }
 
     initialize_with { attributes.stringify_keys }
+
+    trait :scheduled do
+      created_at { 3.days.ago.rfc3339 }
+      scheduled_publication { Time.zone.now.tomorrow.rfc3339 }
+      state { "scheduled" }
+      revision_history do
+        [
+          build(:revision_history_event, created_at: created_at),
+          build(:revision_history_event,
+                event: "update",
+                created_at: 2.days.ago.rfc3339,
+                state: "submitted"),
+          build(:revision_history_event,
+                event: "update",
+                state: "scheduled",
+                created_at: Time.zone.now.tomorrow.rfc3339),
+        ]
+      end
+    end
   end
 end

--- a/spec/factories/whitehall_export/edition_factory.rb
+++ b/spec/factories/whitehall_export/edition_factory.rb
@@ -30,6 +30,10 @@ FactoryBot.define do
     initialize_with { attributes.stringify_keys }
 
     trait :scheduled do
+      transient do
+        previous_state { "submitted" }
+      end
+
       created_at { 3.days.ago.rfc3339 }
       scheduled_publication { Time.zone.now.tomorrow.rfc3339 }
       state { "scheduled" }
@@ -39,7 +43,7 @@ FactoryBot.define do
           build(:revision_history_event,
                 event: "update",
                 created_at: 2.days.ago.rfc3339,
-                state: "submitted"),
+                state: previous_state),
           build(:revision_history_event,
                 event: "update",
                 state: "scheduled",

--- a/spec/lib/whitehall_importer/create_edition_spec.rb
+++ b/spec/lib/whitehall_importer/create_edition_spec.rb
@@ -162,7 +162,7 @@ RSpec.describe WhitehallImporter::CreateEdition do
               revision_history: [
                 build(:revision_history_event),
                 build(:revision_history_event, event: "update", state: "published"),
-                build(:revision_history_event, event: "update", state: "draft"),
+                build(:revision_history_event, event: "update", state: "draft", created_at: 5.minutes.ago.rfc3339),
                 build(:revision_history_event, event: "update", state: "draft", created_at: created_at),
               ],
               unpublishing: build(:whitehall_export_unpublishing,

--- a/spec/lib/whitehall_importer/create_edition_spec.rb
+++ b/spec/lib/whitehall_importer/create_edition_spec.rb
@@ -241,13 +241,27 @@ RSpec.describe WhitehallImporter::CreateEdition do
     end
 
     it "sets a previous submitted_for_review status when the whitehall edition was submitted" do
-      whitehall_edition = build(:whitehall_export_edition, :scheduled)
+      whitehall_edition = build(:whitehall_export_edition,
+                                :scheduled,
+                                previous_state: "submitted")
       edition = described_class.call(document: document,
                                      whitehall_edition: whitehall_edition)
 
       statuses = edition.statuses.map(&:state)
       expect(statuses).to eq(%w[submitted_for_review scheduled])
       expect(edition.status.details.pre_scheduled_status).to be_submitted_for_review
+    end
+
+    it "sets a previous submitted_for_review status when the whitehall edition was a draft" do
+      whitehall_edition = build(:whitehall_export_edition,
+                                :scheduled,
+                                previous_state: "draft")
+      edition = described_class.call(document: document,
+                                     whitehall_edition: whitehall_edition)
+
+      statuses = edition.statuses.map(&:state)
+      expect(statuses).to eq(%w[draft scheduled])
+      expect(edition.status.details.pre_scheduled_status).to be_draft
     end
 
     it "marks a non force published whitehall edition as reviewed" do

--- a/spec/lib/whitehall_importer/create_edition_spec.rb
+++ b/spec/lib/whitehall_importer/create_edition_spec.rb
@@ -267,5 +267,18 @@ RSpec.describe WhitehallImporter::CreateEdition do
                                      whitehall_edition: whitehall_edition)
       expect(edition.status.details.reviewed).to be false
     end
+
+    it "aborts when there is no scheduled publication date" do
+      whitehall_edition = build(:whitehall_export_edition,
+                                :scheduled,
+                                scheduled_publication: nil)
+
+      expect {
+        described_class.call(document: document, whitehall_edition: whitehall_edition)
+      }.to raise_error(
+        WhitehallImporter::AbortImportError,
+        "Cannot create scheduled status without scheduled_publication",
+      )
+    end
   end
 end

--- a/spec/lib/whitehall_importer/create_edition_spec.rb
+++ b/spec/lib/whitehall_importer/create_edition_spec.rb
@@ -224,4 +224,48 @@ RSpec.describe WhitehallImporter::CreateEdition do
       }.to raise_error(WhitehallImporter::AbortImportError)
     end
   end
+
+  context "when the document is scheduled" do
+    let(:document) { create(:document, imported_from: "whitehall", locale: "en") }
+
+    it "sets the edition as scheduled" do
+      publish_time = Date.tomorrow.beginning_of_day
+      whitehall_edition = build(:whitehall_export_edition,
+                                :scheduled,
+                                scheduled_publication: publish_time.rfc3339)
+      edition = described_class.call(document: document,
+                                     whitehall_edition: whitehall_edition)
+
+      expect(edition).to be_scheduled
+      expect(edition.status.details.publish_time).to eq(publish_time)
+    end
+
+    it "sets a previous submitted_for_review status when the whitehall edition was submitted" do
+      whitehall_edition = build(:whitehall_export_edition, :scheduled)
+      edition = described_class.call(document: document,
+                                     whitehall_edition: whitehall_edition)
+
+      statuses = edition.statuses.map(&:state)
+      expect(statuses).to eq(%w[submitted_for_review scheduled])
+      expect(edition.status.details.pre_scheduled_status).to be_submitted_for_review
+    end
+
+    it "marks a non force published whitehall edition as reviewed" do
+      whitehall_edition = build(:whitehall_export_edition,
+                                :scheduled,
+                                force_published: false)
+      edition = described_class.call(document: document,
+                                     whitehall_edition: whitehall_edition)
+      expect(edition.status.details.reviewed).to be true
+    end
+
+    it "marks a force published whitehall edition as needing review" do
+      whitehall_edition = build(:whitehall_export_edition,
+                                :scheduled,
+                                force_published: true)
+      edition = described_class.call(document: document,
+                                     whitehall_edition: whitehall_edition)
+      expect(edition.status.details.reviewed).to be false
+    end
+  end
 end

--- a/spec/lib/whitehall_importer/edition_history_spec.rb
+++ b/spec/lib/whitehall_importer/edition_history_spec.rb
@@ -17,6 +17,21 @@ RSpec.describe WhitehallImporter::EditionHistory do
     end
   end
 
+  describe "#state_event" do
+    it "returns the event associated with the state" do
+      revision_history = [build(:revision_history_event)]
+      event = described_class.new(revision_history).state_event("draft")
+
+      expect(event).to eq(revision_history.first)
+    end
+
+    it "returns nil if the edition is missing a state event" do
+      revision_history = [build(:revision_history_event)]
+
+      expect(described_class.new(revision_history).state_event("published")).to eq nil
+    end
+  end
+
   describe "#create_event" do
     it "returns the create event of the edition" do
       revision_history = [build(:revision_history_event)]

--- a/spec/lib/whitehall_importer/edition_history_spec.rb
+++ b/spec/lib/whitehall_importer/edition_history_spec.rb
@@ -1,119 +1,136 @@
 # frozen_string_literal: true
 
 RSpec.describe WhitehallImporter::EditionHistory do
-  describe "#state_event!" do
-    it "returns the event associated with the state" do
-      revision_history = [build(:revision_history_event)]
-      event = described_class.new(revision_history).state_event!("draft")
+  shared_examples "an event bang method" do |method, args = []|
+    let(:instance) { described_class.new([]) }
+    let(:bang_method) { "#{method}!".to_sym }
 
-      expect(event).to eq(revision_history.first)
+    it "delegates to ##{method}" do
+      event = build(:revision_history_event)
+      expect(instance).to receive(method).and_return(event)
+      expect(instance.public_send(bang_method, *args)).to be(event)
     end
 
-    it "aborts if the edition is missing a state event" do
-      revision_history = [build(:revision_history_event)]
-
-      expect { described_class.new(revision_history).state_event!("published") }
+    it "raises an AbortImportError if the event is not found" do
+      expect(instance).to receive(method).and_return(nil)
+      expect { instance.public_send(bang_method, *args) }
         .to raise_error(WhitehallImporter::AbortImportError)
     end
   end
 
   describe "#state_event" do
-    it "returns the event associated with the state" do
-      revision_history = [build(:revision_history_event)]
-      event = described_class.new(revision_history).state_event("draft")
+    it "returns the last event associated with the state" do
+      first_draft_event = build(:revision_history_event, state: "draft")
+      last_draft_event = build(:revision_history_event, state: "draft")
+      instance = described_class.new([first_draft_event, last_draft_event])
 
-      expect(event).to eq(revision_history.first)
+      expect(instance.state_event("draft")).to be(last_draft_event)
     end
 
     it "returns nil if the edition is missing a state event" do
-      revision_history = [build(:revision_history_event)]
-
-      expect(described_class.new(revision_history).state_event("published")).to eq nil
+      draft_event = build(:revision_history_event, state: "draft")
+      expect(described_class.new([draft_event]).state_event("published"))
+        .to be_nil
     end
   end
 
-  describe "#create_event" do
-    it "returns the create event of the edition" do
-      revision_history = [build(:revision_history_event)]
-      event = described_class.new(revision_history).create_event
-
-      expect(event).to eq(revision_history.first)
-    end
-
-    it "aborts if the edition is missing the create event" do
-      revision_history = []
-
-      expect { described_class.new(revision_history).create_event }
-        .to raise_error(WhitehallImporter::AbortImportError)
-    end
-  end
-
-  describe "#last_unpublishing_event" do
-    it "returns the last publishing event of the edition" do
-      revision_history = [
-        build(:revision_history_event),
-        build(:revision_history_event, event: "update", state: "published"),
-        build(:revision_history_event, event: "update", state: "draft"),
-      ]
-      event = described_class.new(revision_history).last_unpublishing_event
-
-      expect(event).to eq(revision_history.last)
-    end
-
-    it "aborts if the edition is missing the unpublishing event" do
-      revision_history = []
-
-      expect { described_class.new(revision_history).last_unpublishing_event }
-        .to raise_error(WhitehallImporter::AbortImportError)
-    end
+  describe "#state_event!" do
+    it_behaves_like "an event bang method", :state_event, %w[draft]
   end
 
   describe "#next_event" do
-    it "returns the next event" do
-      revision_history = [
-        build(:revision_history_event),
-        build(:revision_history_event, event: "update", state: "published"),
-      ]
-      event = described_class.new(revision_history).next_event(revision_history.first)
+    it "returns the event associated with the state" do
+      first_event = build(:revision_history_event)
+      next_event = build(:revision_history_event)
+      instance = described_class.new([first_event, next_event])
 
-      expect(event).to eq(revision_history.last)
+      expect(instance.next_event(first_event)).to be(next_event)
     end
 
-    it "aborts if the edition is missing a next event" do
-      revision_history = [build(:revision_history_event)]
-
-      expect { described_class.new(revision_history).next_event(revision_history.first) }
-        .to raise_error(WhitehallImporter::AbortImportError)
+    it "returns nil when a next event is not found" do
+      event = build(:revision_history_event)
+      expect(described_class.new([]).next_event(event)).to be_nil
     end
   end
 
+  describe "#next_event!" do
+    it_behaves_like "an event bang method",
+                    :next_event,
+                    [FactoryBot.build(:revision_history_event)]
+  end
+
+  describe "#create_event" do
+    it "returns the first create event associated" do
+      first_event = build(:revision_history_event, event: "update")
+      first_create_event = build(:revision_history_event, event: "create")
+      last_create_event = build(:revision_history_event, event: "create")
+      instance = described_class.new([first_event, first_create_event, last_create_event])
+
+      expect(instance.create_event).to be(first_create_event)
+    end
+
+    it "returns nil if the edition is missing a create event" do
+      event = build(:revision_history_event, event: "update")
+      expect(described_class.new([event]).create_event).to be_nil
+    end
+  end
+
+  describe "#create_event!" do
+    it_behaves_like "an event bang method", :create_event
+  end
+
+  describe "#last_unpublishing_event" do
+    it "returns the draft that follows a published event" do
+      first_publishing_event = build(:revision_history_event, state: "published")
+      first_unpublishing_event = build(:revision_history_event, state: "draft")
+      last_publishing_event = build(:revision_history_event, state: "published")
+      last_unpublishing_event = build(:revision_history_event, state: "draft")
+      instance = described_class.new([first_publishing_event,
+                                      first_unpublishing_event,
+                                      last_publishing_event,
+                                      last_unpublishing_event])
+
+      expect(instance.last_unpublishing_event).to eq(last_unpublishing_event)
+    end
+
+    it "returns nil if there is not a draft update that follows a published event" do
+      publishing_event = build(:revision_history_event, state: "published")
+      next_event = build(:revision_history_event, state: "withdrawn")
+      instance = described_class.new([publishing_event, next_event])
+
+      expect(instance.last_unpublishing_event).to be_nil
+    end
+  end
+
+  describe "#last_unpublishing_event!" do
+    it_behaves_like "an event bang method", :last_unpublishing_event
+  end
+
   describe "#edited_after_unpublishing?" do
-    it "returns true if second to last event isn't published" do
-      revision_history = [
-        build(:revision_history_event),
-        build(:revision_history_event),
-      ]
-      edited_boolean = described_class.new(revision_history).edited_after_unpublishing?
+    it "returns true if there are events after the unpublishing" do
+      publishing_event = build(:revision_history_event, state: "published")
+      unpublishing_event = build(:revision_history_event, state: "draft")
+      edit_event = build(:revision_history_event,
+                         state: "draft",
+                         created_at: 5.minutes.from_now.rfc3339)
+      instance = described_class.new([publishing_event,
+                                      unpublishing_event,
+                                      edit_event])
 
-      expect(edited_boolean).to be_truthy
+      expect(instance.edited_after_unpublishing?).to be(true)
     end
 
-    it "returns false if second to last event doesn't exist" do
-      revision_history = [build(:revision_history_event)]
-      edited_boolean = described_class.new(revision_history).edited_after_unpublishing?
+    it "returns false if there aren't edits after unpublishing" do
+      publishing_event = build(:revision_history_event, state: "published")
+      unpublishing_event = build(:revision_history_event, state: "draft")
+      instance = described_class.new([publishing_event, unpublishing_event])
 
-      expect(edited_boolean).to be_falsey
+      expect(instance.edited_after_unpublishing?).to be(false)
     end
 
-    it "returns false if second to last event is published" do
-      revision_history = [
-        build(:revision_history_event),
-        build(:revision_history_event, event: "update", state: "published"),
-        build(:revision_history_event, event: "update", state: "draft"),
-      ]
-      edited_boolean = described_class.new(revision_history).edited_after_unpublishing?
-
-      expect(edited_boolean).to be_falsey
+    it "returns false if the edition doesn't appear unpublished" do
+      instance = described_class.new([])
+      expect(instance.edited_after_unpublishing?).to be(false)
     end
   end
 end

--- a/spec/lib/whitehall_importer/edition_history_spec.rb
+++ b/spec/lib/whitehall_importer/edition_history_spec.rb
@@ -1,10 +1,10 @@
 # frozen_string_literal: true
 
 RSpec.describe WhitehallImporter::EditionHistory do
-  describe "#state_event" do
+  describe "#state_event!" do
     it "returns the event associated with the state" do
       revision_history = [build(:revision_history_event)]
-      event = described_class.new(revision_history).state_event("draft")
+      event = described_class.new(revision_history).state_event!("draft")
 
       expect(event).to eq(revision_history.first)
     end
@@ -12,7 +12,7 @@ RSpec.describe WhitehallImporter::EditionHistory do
     it "aborts if the edition is missing a state event" do
       revision_history = [build(:revision_history_event)]
 
-      expect { described_class.new(revision_history).state_event("published") }
+      expect { described_class.new(revision_history).state_event!("published") }
         .to raise_error(WhitehallImporter::AbortImportError)
     end
   end


### PR DESCRIPTION
We want to have the ability to import a document that is scheduled for publication.

In Whitehall you can determine that an edition is scheduled as it has a state of “scheduled” and a field of `scheduled_publication` with the time.
In Content Publisher the scheduled publishing is represented by a status of “scheduled” with a Scheduling object that knows:
- who created the scheduling. This is handled in the existing `build_status` method
- whether the content was reviewed before scheduling. This is set based on the value of `force_published` on the `whitehall_edition`. If this is true, reviewed should is false otherwise this is true.
- the status prior to the scheduling to allow rolling back to that. We determine the status using whitehall document's `revision_history` by checking if the previous one is "submitted". If it isn't we the pre scheduled status is "draft".
- publish time

<img width="724" alt="importing_scheduled" src="https://user-images.githubusercontent.com/38078064/69974090-7a19cc00-151c-11ea-8b92-e391d93cdcd4.png">

- **After unscheduling**

<img width="973" alt="submitted_unshceduled" src="https://user-images.githubusercontent.com/38078064/69974111-800fad00-151c-11ea-82a5-da82bf85f09b.png">
<img width="970" alt="draft_unscheduled" src="https://user-images.githubusercontent.com/38078064/69974122-869e2480-151c-11ea-95a6-ab79048ff985.png">

[Trello card](https://trello.com/c/nsm9dRgz/1192-import-a-scheduled-whitehall-document-into-content-publisher)