### PR TITLE
Fix topics search markup

### DIFF
--- a/app/assets/javascripts/components/autocomplete.js
+++ b/app/assets/javascripts/components/autocomplete.js
@@ -150,7 +150,7 @@ window.GOVUK.Modules = window.GOVUK.Modules || {};
       }
     })
 
-    $input.parentNode.parentNode.removeChild($input.parentNode)
+    $input.parentNode.removeChild($input)
   }
 
   Autocomplete.prototype.initAutoCompleteSelect = function ($select) {

--- a/app/assets/stylesheets/components/_autocomplete.scss
+++ b/app/assets/stylesheets/components/_autocomplete.scss
@@ -114,4 +114,10 @@ $app-focus-colour: $govuk-focus-colour;
   .app-c-autocomplete__multiselect-instructions {
     display: none;
   }
+
+  .app-c-autocomplete--search {
+    .govuk-label {
+      @include govuk-visually-hidden;
+    }
+  }
 }

--- a/app/views/components/_autocomplete.html.erb
+++ b/app/views/components/_autocomplete.html.erb
@@ -17,50 +17,47 @@
   root_classes << "govuk-form-group--error" if error_items.any?
 %>
 
-<%= tag.div class: root_classes,
-            data: data_attributes.merge(module: "autocomplete", "autocomplete-type": type) do %>
-  <%= tag.fieldset class: "govuk-fieldset", "aria-describedby": aria do %>
-    <%= render "govuk_publishing_components/components/label", {
-      html_for: id
-    }.merge(label.symbolize_keys) %>
+<%= tag.div class: root_classes, data: data_attributes.merge(module: "autocomplete", "autocomplete-type": type) do %>
+  <%= render "govuk_publishing_components/components/label", {
+    html_for: id
+  }.merge(label.symbolize_keys) %>
 
-    <% if error_items.any? %>
-      <%= render "govuk_publishing_components/components/error_message", {
-        id: error_id,
-        items: error_items,
-      } %>
+  <% if error_items.any? %>
+    <%= render "govuk_publishing_components/components/error_message", {
+      id: error_id,
+      items: error_items,
+    } %>
+  <% end %>
+
+  <%= tag.span hint, class: "govuk-hint" if hint %>
+
+  <% if select.any? %>
+    <% if select[:multiple] %>
+      <%= tag.span "To select multiple items in a list, hold down Ctrl (PC) or Command (Mac) key.",
+                   class: "govuk-hint app-c-autocomplete__multiselect-instructions" %>
     <% end %>
 
-    <%= tag.span hint, class: "govuk-hint" if hint %>
+    <%= select_tag name,
+      options_for_select(select[:options], select[:selected]),
+      id: id,
+      class: "govuk-select",
+      size: select[:size],
+      multiple: select[:multiple]
+    %>
+  <% else %>
+    <% options = Array(input[:options]) %>
 
-    <% if select.any? %>
-      <% if select[:multiple] %>
-        <%= tag.span "To select multiple items in a list, hold down Ctrl (PC) or Command (Mac) key.",
-                     class: "govuk-hint app-c-autocomplete__multiselect-instructions" %>
-      <% end %>
+    <%= tag.input name: name,
+                  value: input[:value],
+                  class: "govuk-input",
+                  id: id,
+                  list: options.any? ? "#{id}-list" : nil,
+                  type: search ? "search" : "text" %>
 
-      <%= select_tag name,
-        options_for_select(select[:options], select[:selected]),
-        id: id,
-        class: "govuk-select",
-        size: select[:size],
-        multiple: select[:multiple]
-      %>
-    <% else %>
-      <% options = Array(input[:options]) %>
-
-      <%= tag.input name: name,
-                    value: input[:value],
-                    class: "govuk-input",
-                    id: id,
-                    list: options.any? ? "#{id}-list" : nil,
-                    type: search ? "search" : "text" %>
-
-      <% if options.any? %>
-        <%= tag.datalist id: "#{id}-list" do %>
-          <% options.each do |option| %>
-            <%= tag.option(value: option) %>
-          <% end %>
+    <% if options.any? %>
+      <%= tag.datalist id: "#{id}-list" do %>
+        <% options.each do |option| %>
+          <%= tag.option(value: option) %>
         <% end %>
       <% end %>
     <% end %>


### PR DESCRIPTION
This PR updates the markup that's generated by the autocomplete component and then updated by the autocomplete script to meet web standards.

### Before
Initial (non-enhanced) markup
```
<div class="app-c-autocomplete app-c-autocomplete--search" data-module="autocomplete">
  <fieldset class="govuk-fieldset">
    <label for="autocomplete-search" class="gem-c-label govuk-label">Search</label>
    <input name="autocomplete-search" class="govuk-input" id="autocomplete-search" list="autocomplete-search-list" type="search">
  </fieldset>
</div>
```

JavaScript enhanced markup
```
<div class="app-c-autocomplete app-c-autocomplete--search" data-module="autocomplete">
  <div class="autocomplete__wrapper" role="combobox" aria-expanded="false">
    <input aria-owns="autocomplete-search__listbox" autocomplete="off" class="autocomplete__input autocomplete__input--default" id="autocomplete-search" name="autocomplete-search" placeholder="" type="text" role="textbox">
    <ul class="autocomplete__menu autocomplete__menu--inline autocomplete__menu--hidden" id="autocomplete-search__listbox" role="listbox"></ul>
  </div>
</div>
```

### After
Initial (non-enhanced) markup
```
<div class="app-c-autocomplete app-c-autocomplete--search" data-module="autocomplete">
  <label for="autocomplete-search" class="gem-c-label govuk-label">Search</label>
  <input name="autocomplete-search" class="govuk-input" id="autocomplete-search" list="autocomplete-search-list" type="search">
</div>
```

JavaScript enhanced markup
```
<div class="app-c-autocomplete app-c-autocomplete--search" data-module="autocomplete">
  <label for="autocomplete-search" class="gem-c-label govuk-label">Search</label>
  <div class="autocomplete__wrapper" role="combobox" aria-expanded="false">
    <input aria-owns="autocomplete-search__listbox" class="autocomplete__input autocomplete__input--default" id="autocomplete-search" name="autocomplete-search" placeholder="" type="text" role="textbox">
    <ul class="autocomplete__menu autocomplete__menu--inline autocomplete__menu--hidden" id="autocomplete-search__listbox" role="listbox"></ul>
  </div>
</div>
```

[Trello card](https://trello.com/c/Ej2MvVVN)