### PR TITLE
Add in history mode status banner

### DIFF
--- a/app/views/documents/show/_historical_notice.html.erb
+++ b/app/views/documents/show/_historical_notice.html.erb
@@ -1,0 +1,12 @@
+<%= render "govuk_publishing_components/components/notice",
+  {
+    title: I18n.t(
+      "documents.show.historical.title",
+      document_type: @edition.document_type.label.downcase
+    ),
+    description_text: I18n.t(
+      "documents.show.historical.description",
+      government_name: @edition.government.name
+    ),
+  }
+%>

--- a/app/views/documents/show/_summary_tab.html.erb
+++ b/app/views/documents/show/_summary_tab.html.erb
@@ -4,6 +4,10 @@
       <%= render "documents/show/submitted_for_review" %>
     <% end %>
 
+    <% if @edition.history_mode? && current_user.has_permission?(User::PRE_RELEASE_FEATURES_PERMISSION) %>
+      <%= render "documents/show/historical_notice" %>
+    <% end %>
+
     <% if @edition.withdrawn? %>
       <%= render "documents/show/withdrawn_notice" %>
     <% end %>

--- a/config/locales/en/documents/show.yml
+++ b/config/locales/en/documents/show.yml
@@ -6,6 +6,9 @@ en:
         history: Document history
       withdrawn:
         title: "This %{document_type} was withdrawn on %{withdrawn_date}"
+      historical:
+        title: "This %{document_type} is in history mode"
+        description: "It was created under the %{government_name}"
       unwithdraw:
         title: Are you sure you want to undo withdraw?
         description: This will remove the withdrawn banner and republish the content immediately. It will not send an email alert to users.

--- a/spec/requests/historical_banner_spec.rb
+++ b/spec/requests/historical_banner_spec.rb
@@ -1,0 +1,31 @@
+# frozen_string_literal: true
+
+RSpec.describe "Documents" do
+  describe "GET /documents/:document" do
+    describe "history mode banner" do
+      context "when in history mode" do
+        it "shows the history mode banner" do
+          @edition = create(:edition, :political, :past_government)
+          get document_path(@edition.document)
+          expect(response.body).to include(I18n.t!("documents.show.historical.title", document_type: @edition.document_type.label.downcase))
+          expect(response.body).to include(I18n.t!("documents.show.historical.description", government_name: @edition.government.name))
+        end
+
+        it "won't show the history mode banner when the edition was created under the current government" do
+          @edition = create(:edition, :political, :current_government)
+          get document_path(@edition.document)
+          expect(response.body).not_to include(I18n.t!("documents.show.historical.title", document_type: @edition.document_type.label.downcase))
+          expect(response.body).not_to include(I18n.t!("documents.show.historical.description", government_name: @edition.government.name))
+        end
+      end
+
+      context "when not in history_mode" do
+        it "won't show the history mode banner" do
+          @edition = create(:edition, :not_political)
+          get document_path(@edition.document)
+          expect(response.body).not_to include(I18n.t!("documents.show.historical.title", document_type: @edition.document_type.label.downcase))
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
As part of the work to introduce history mode to content publisher we need to let publishers know when a document is in history mode. This introduces a notice that warns publishers when a political document is marked as being from a previous government. This feature is not yet ready for release and as such is hidden behind a feature flag. This will be removed at a later date.

## Before

![Screenshot 2019-12-04 at 12 13 29](https://user-images.githubusercontent.com/24547207/70141790-abff6f80-168f-11ea-89bf-2dad8ba1b4b2.png)

## After

![Screenshot 2019-12-04 at 12 13 57](https://user-images.githubusercontent.com/24547207/70141800-b3bf1400-168f-11ea-9446-a61c6302cec7.png)

Trello - https://trello.com/c/rhEtuy5V/1208-show-history-mode-status-on-summary-view

Co-authored-by: Bruce Bolt <bruce.bolt@digital.cabinet-office.gov.uk>