### PR TITLE
Add legends to radios

### DIFF
--- a/app/assets/stylesheets/utilities/_overwrites.scss
+++ b/app/assets/stylesheets/utilities/_overwrites.scss
@@ -100,3 +100,13 @@
     }
   }
 }
+
+.govuk-fieldset {
+  .gem-c-title {
+    margin-bottom: 0;
+  }
+
+  .gem-c-title__text {
+    @extend %govuk-heading-l;
+  }
+}

--- a/app/views/access_limit/edit.html.erb
+++ b/app/views/access_limit/edit.html.erb
@@ -1,4 +1,3 @@
-<% content_for :title, t("access_limit.edit.title") %>
 <% content_for :browser_title, t("access_limit.edit.browser_title") %>
 <% content_for :back_link, render_back_link(href: document_path(@edition.document)) %>
 
@@ -25,16 +24,11 @@
 
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
-    <div class="govuk-body" %>
-      <%= t("access_limit.edit.description") %>
-    </div>
-  </div>
-</div>
-
-<div class="govuk-grid-row">
-  <div class="govuk-grid-column-two-thirds">
     <%= form_tag access_limit_path(@edition.document), data: { gtm: "confirm-access-limit" } do %>
       <%= render "govuk_publishing_components/components/radio", {
+        heading: t("access_limit.edit.title"),
+        is_page_heading: true,
+        description: t("access_limit.edit.description"),
         name: "limit_type",
         error_items: @issues&.items_for(:access_limit),
         items: [

--- a/app/views/documents/edit/_change_notes.html.erb
+++ b/app/views/documents/edit/_change_notes.html.erb
@@ -19,34 +19,30 @@
   title: t("documents.edit.change_note.guidance_title"),
   content: render_govspeak(t("documents.edit.change_note.guidance"))
 } do %>
-  <% legend_text = tag.p(
-    tag.strong(t("documents.edit.update_type.title")),
-    class: "govuk-!-margin-bottom-3")
-  %>
-  <%= render "govuk_publishing_components/components/fieldset", legend_text: legend_text, data: { "contextual-guidance": "change-note-guidance" } do %>
-    <%= render "govuk_publishing_components/components/radio", {
-      name: "revision[update_type]",
-      items: [
-        {
-          value: "major",
-          text: t("documents.edit.update_type.major_name"),
-          conditional: textarea,
-          checked: @revision.major?,
-          data_attributes: {
-            gtm: "choose-update-type",
-            "gtm-value": t("documents.edit.update_type.major_name")
-          }
-        },
-        {
-          value: "minor",
-          text: t("documents.edit.update_type.minor_name"),
-          checked: @revision.minor?,
-          data_attributes: {
-            gtm: "choose-update-type",
-            "gtm-value": t("documents.edit.update_type.minor_name")
-          }
+  <%= render "govuk_publishing_components/components/radio", {
+    name: "revision[update_type]",
+    heading: t("documents.edit.update_type.title"),
+    heading_size: "s",
+    items: [
+      {
+        value: "major",
+        text: t("documents.edit.update_type.major_name"),
+        conditional: textarea,
+        checked: @revision.major?,
+        data_attributes: {
+          gtm: "choose-update-type",
+          "gtm-value": t("documents.edit.update_type.major_name")
         }
-      ]
-    } %>
-  <% end %>
+      },
+      {
+        value: "minor",
+        text: t("documents.edit.update_type.minor_name"),
+        checked: @revision.minor?,
+        data_attributes: {
+          gtm: "choose-update-type",
+          "gtm-value": t("documents.edit.update_type.minor_name")
+        }
+      }
+    ]
+  } %>
 <% end %>

--- a/app/views/new_document/choose_document_type.html.erb
+++ b/app/views/new_document/choose_document_type.html.erb
@@ -1,10 +1,12 @@
+<% content_for :browser_title, @supertype.label %>
 <% content_for :back_link, render_back_link(href: new_document_path) %>
-<% content_for :title, @supertype.label %>
 
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
     <%= form_tag create_document_path, data: { gtm: "confirm-document-type" } do %>
       <%= render "govuk_publishing_components/components/radio", {
+        heading: @supertype.label,
+        is_page_heading: true,
         name: "document_type",
         error_items: @issues&.items_for(:document_type),
         items: @supertype.document_types.map { |document_type|

--- a/app/views/new_document/choose_supertype.html.erb
+++ b/app/views/new_document/choose_supertype.html.erb
@@ -1,5 +1,5 @@
+<% content_for :browser_title, t("new_document.choose_supertype.title") %>
 <% content_for :back_link, render_back_link(href: root_path) %>
-<% content_for :title, t("new_document.choose_supertype.title") %>
 
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
@@ -8,6 +8,8 @@
                  enforce_utf8: false,
                  data: { gtm: "confirm-supertype" }) do %>
       <%= render "govuk_publishing_components/components/radio", {
+        heading: t("new_document.choose_supertype.title"),
+        is_page_heading: true,
         name: "supertype",
         error_items: @issues&.items_for(:supertype),
         items: Supertype.all.map do |supertype|

--- a/app/views/publish/confirmation.html.erb
+++ b/app/views/publish/confirmation.html.erb
@@ -1,10 +1,12 @@
+<% content_for :browser_title, t("publish.confirmation.title") %>
 <% content_for :back_link, render_back_link(href: document_path(@edition.document)) %>
-<% content_for :title, t("publish.confirmation.title") %>
 
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
     <%= form_tag publish_confirmation_path(@edition.document), data: { gtm: "confirm-publish" } do %>
       <%= render "govuk_publishing_components/components/radio", {
+        heading: t("publish.confirmation.title"),
+        is_page_heading: true,
         name: "review_status",
         error_items: @issues&.items_for(:review_status),
         items: [

--- a/app/views/schedule/new.html.erb
+++ b/app/views/schedule/new.html.erb
@@ -1,10 +1,10 @@
+<% content_for :browser_title, t("schedule.new.title") %>
+
 <% if params[:wizard] == "schedule" %>
   <% content_for :back_link, render_back_link(href: schedule_proposal_path(@edition.document, wizard: "schedule")) %>
 <% else %>
   <% content_for :back_link, render_back_link(href: document_path(@edition.document)) %>
 <% end %>
-
-<% content_for :title, t("schedule.new.title") %>
 
 <% datetime = @edition.proposed_publish_time %>
 <% time = format_time(datetime) %>
@@ -13,8 +13,10 @@
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
     <%= form_tag create_schedule_path(@edition.document), data: { gtm: "confirm-schedule" } do %>
-      <%= render_govspeak(t("schedule.new.hint_text", time: time, date: date)) %>
       <%= render "govuk_publishing_components/components/radio", {
+        heading: t("schedule.new.title"),
+        is_page_heading: true,
+        description: render_govspeak(t("schedule.new.hint_text", time: time, date: date)),
         name: "review_status",
         error_items: @issues&.items,
         items: [


### PR DESCRIPTION
This PR updates the markup generated for the radios across the application ensuring that each instance has a legend. It doesn't contain any visual changes.

An example of using the main page heading as legend below:

### Before
```
<h1 class="govuk-heading-l">What is the content for?</h1>
...
<fieldset class="govuk-fieldset">
  <div class="govuk-radios" data-module="govuk-radios">
    <div class="gem-c-radio govuk-radios__item">
      <input type="radio" name="supertype" id="radio-0802af77-0" value="news" class="govuk-radios__input" aria-describedby="label-hint-20c762ca" data-gtm="choose-supertype" data-gtm-value="News" aria-controls="conditional-ced84d75" aria-expanded="false">
      <label for="radio-0802af77-0" class="gem-c-label govuk-label govuk-label--s govuk-radios__label">News</label>
    </div>
    ...
  </div>
</fieldset>
```

### After
```
<fieldset class="govuk-fieldset">
  <legend class="govuk-fieldset__legend govuk-fieldset__legend--xl gem-c-title">
    <h1 class="gem-c-title__text">What is the content for?</h1>
  </legend>
  <div class="govuk-radios" data-module="govuk-radios">
    <div class="gem-c-radio govuk-radios__item">
      <input type="radio" name="supertype" id="radio-0802af77-0" value="news" class="govuk-radios__input" aria-describedby="label-hint-20c762ca" data-gtm="choose-supertype" data-gtm-value="News" aria-controls="conditional-ced84d75" aria-expanded="false">
      <label for="radio-0802af77-0" class="gem-c-label govuk-label govuk-label--s govuk-radios__label">News</label>
    </div>
    ...
  </div>
</fieldset>
```

This problem is related to the fact that [the radio component](https://components.publishing.service.gov.uk/component-guide/radio) doesn't require a legend in the first place – I captured this as [an issue in govuk_publishing_components](https://github.com/alphagov/govuk_publishing_components/issues/1215) and will to address it separately. 

[Trello card](https://trello.com/c/QCUNqBIw)