### PR TITLE
Filter index page based on political and history mode status

### DIFF
--- a/app/controllers/documents_controller.rb
+++ b/app/controllers/documents_controller.rb
@@ -67,7 +67,7 @@ private
 
   def filter_params
     {
-      filters: params.slice(:title_or_url, :document_type, :status, :organisation).permit!,
+      filters: params.slice(:title_or_url, :document_type, :status, :organisation, :political).permit!,
       sort: params[:sort],
       page: params[:page],
       per_page: 50,

--- a/app/controllers/documents_controller.rb
+++ b/app/controllers/documents_controller.rb
@@ -67,7 +67,7 @@ private
 
   def filter_params
     {
-      filters: params.slice(:title_or_url, :document_type, :status, :organisation, :political).permit!,
+      filters: params.slice(:title_or_url, :document_type, :status, :organisation, :political, :history_mode).permit!,
       sort: params[:sort],
       page: params[:page],
       per_page: 50,

--- a/app/views/documents/index/_filters.html.erb
+++ b/app/views/documents/index/_filters.html.erb
@@ -120,6 +120,26 @@
     %>
   </div>
 
+  <div class="govuk-form-group">
+    <%= render "govuk_publishing_components/components/label", {
+      text: t("documents.index.filter.history_mode"),
+      html_for: "history_mode-filter",
+      bold: true
+    } %>
+
+    <%= select_tag "history_mode",
+      options_for_select([["Yes", "yes"], ["No", "no"]], [params[:history_mode]]),
+      include_blank: true,
+      id: "history_mode-filter",
+      class: "govuk-select",
+      data: {
+        gtm: "select-history_mode",
+        "gtm-visibility-tracking": params[:history_mode].present? || nil,
+        "gtm-value": params[:history_mode]
+      }
+    %>
+  </div>
+
   <%= hidden_field_tag "sort", @sort %>
 
   <%= render "govuk_publishing_components/components/button", {

--- a/app/views/documents/index/_filters.html.erb
+++ b/app/views/documents/index/_filters.html.erb
@@ -100,45 +100,47 @@
     %>
   </div>
 
-  <div class="govuk-form-group">
-    <%= render "govuk_publishing_components/components/label", {
-      text: t("documents.index.filter.political"),
-      html_for: "political-filter",
-      bold: true
-    } %>
+  <% if current_user.has_permission?(User::PRE_RELEASE_FEATURES_PERMISSION) %>
+    <div class="govuk-form-group">
+      <%= render "govuk_publishing_components/components/label", {
+        text: t("documents.index.filter.political"),
+        html_for: "political-filter",
+        bold: true
+      } %>
 
-    <%= select_tag "political",
-      options_for_select([["Yes", "yes"], ["No", "no"]], [params[:political]]),
-      include_blank: true,
-      id: "political-filter",
-      class: "govuk-select",
-      data: {
-        gtm: "select-political",
-        "gtm-visibility-tracking": params[:political].present? || nil,
-        "gtm-value": params[:political]
-      }
-    %>
-  </div>
+      <%= select_tag "political",
+        options_for_select([["Yes", "yes"], ["No", "no"]], [params[:political]]),
+        include_blank: true,
+        id: "political-filter",
+        class: "govuk-select",
+        data: {
+          gtm: "select-political",
+          "gtm-visibility-tracking": params[:political].present? || nil,
+          "gtm-value": params[:political]
+        }
+      %>
+    </div>
 
-  <div class="govuk-form-group">
-    <%= render "govuk_publishing_components/components/label", {
-      text: t("documents.index.filter.history_mode"),
-      html_for: "history_mode-filter",
-      bold: true
-    } %>
+    <div class="govuk-form-group">
+      <%= render "govuk_publishing_components/components/label", {
+        text: t("documents.index.filter.history_mode"),
+        html_for: "history_mode-filter",
+        bold: true
+      } %>
 
-    <%= select_tag "history_mode",
-      options_for_select([["Yes", "yes"], ["No", "no"]], [params[:history_mode]]),
-      include_blank: true,
-      id: "history_mode-filter",
-      class: "govuk-select",
-      data: {
-        gtm: "select-history_mode",
-        "gtm-visibility-tracking": params[:history_mode].present? || nil,
-        "gtm-value": params[:history_mode]
-      }
-    %>
-  </div>
+      <%= select_tag "history_mode",
+        options_for_select([["Yes", "yes"], ["No", "no"]], [params[:history_mode]]),
+        include_blank: true,
+        id: "history_mode-filter",
+        class: "govuk-select",
+        data: {
+          gtm: "select-history_mode",
+          "gtm-visibility-tracking": params[:history_mode].present? || nil,
+          "gtm-value": params[:history_mode]
+        }
+      %>
+    </div>
+  <% end %>
 
   <%= hidden_field_tag "sort", @sort %>
 

--- a/app/views/documents/index/_filters.html.erb
+++ b/app/views/documents/index/_filters.html.erb
@@ -100,6 +100,26 @@
     %>
   </div>
 
+  <div class="govuk-form-group">
+    <%= render "govuk_publishing_components/components/label", {
+      text: t("documents.index.filter.political"),
+      html_for: "political-filter",
+      bold: true
+    } %>
+
+    <%= select_tag "political",
+      options_for_select([["Yes", "yes"], ["No", "no"]], [params[:political]]),
+      include_blank: true,
+      id: "political-filter",
+      class: "govuk-select",
+      data: {
+        gtm: "select-political",
+        "gtm-visibility-tracking": params[:political].present? || nil,
+        "gtm-value": params[:political]
+      }
+    %>
+  </div>
+
   <%= hidden_field_tag "sort", @sort %>
 
   <%= render "govuk_publishing_components/components/button", {

--- a/config/locales/en/documents/index.yml
+++ b/config/locales/en/documents/index.yml
@@ -25,3 +25,4 @@ en:
         document_type: Document type
         state: Status
         organisation: Organisation
+        political: Marked as political

--- a/config/locales/en/documents/index.yml
+++ b/config/locales/en/documents/index.yml
@@ -26,3 +26,4 @@ en:
         state: Status
         organisation: Organisation
         political: Marked as political
+        history_mode: In history mode

--- a/lib/edition_filter.rb
+++ b/lib/edition_filter.rb
@@ -73,6 +73,8 @@ private
         end
       when :organisation
         memo.merge(TagsRevision.tagged_organisations_include(value))
+      when :political
+        memo.political(value == "yes")
       else
         memo
       end

--- a/lib/edition_filter.rb
+++ b/lib/edition_filter.rb
@@ -75,6 +75,8 @@ private
         memo.merge(TagsRevision.tagged_organisations_include(value))
       when :political
         memo.political(value == "yes")
+      when :history_mode
+        memo.history_mode(value == "yes")
       else
         memo
       end

--- a/spec/features/finding/index_filtering_spec.rb
+++ b/spec/features/finding/index_filtering_spec.rb
@@ -24,6 +24,10 @@ RSpec.feature "Index filtering" do
     and_i_filter_by_organisation
     then_i_see_just_the_ones_that_match
 
+    when_i_clear_the_filters
+    and_i_filter_by_political_status
+    then_i_see_just_the_ones_that_match
+
     when_i_filter_too_much
     then_i_see_there_are_no_results
   end
@@ -35,6 +39,7 @@ RSpec.feature "Index filtering" do
                             "internal_name" => "Organisation 2" }
 
     @relevant_edition = create(:edition,
+                               :political,
                                title: "Super relevant",
                                tags: {
                                  primary_publishing_organisation: [@primary_organisation["content_id"]],
@@ -102,6 +107,11 @@ RSpec.feature "Index filtering" do
 
   def and_i_filter_by_organisation
     select @other_organisation["internal_name"], from: "organisation"
+    click_on "Filter"
+  end
+
+  def and_i_filter_by_political_status
+    select "Yes", from: "political"
     click_on "Filter"
   end
 

--- a/spec/features/finding/index_filtering_spec.rb
+++ b/spec/features/finding/index_filtering_spec.rb
@@ -28,6 +28,10 @@ RSpec.feature "Index filtering" do
     and_i_filter_by_political_status
     then_i_see_just_the_ones_that_match
 
+    when_i_clear_the_filters
+    and_i_filter_by_history_mode
+    then_i_see_just_the_ones_that_match
+
     when_i_filter_too_much
     then_i_see_there_are_no_results
   end
@@ -40,6 +44,7 @@ RSpec.feature "Index filtering" do
 
     @relevant_edition = create(:edition,
                                :political,
+                               :past_government,
                                title: "Super relevant",
                                tags: {
                                  primary_publishing_organisation: [@primary_organisation["content_id"]],
@@ -112,6 +117,11 @@ RSpec.feature "Index filtering" do
 
   def and_i_filter_by_political_status
     select "Yes", from: "political"
+    click_on "Filter"
+  end
+
+  def and_i_filter_by_history_mode
+    select "Yes", from: "history_mode"
     click_on "Filter"
   end
 

--- a/spec/lib/edition_filter_spec.rb
+++ b/spec/lib/edition_filter_spec.rb
@@ -83,6 +83,17 @@ RSpec.describe EditionFilter do
       expect(editions).to match_array([edition1, edition2])
     end
 
+    it "filters the editions by political status" do
+      edition1 = create(:edition, :not_political)
+      edition2 = create(:edition, :political)
+
+      editions = EditionFilter.new(user, filters: { political: "yes" }).editions
+      expect(editions).to match_array([edition2])
+
+      editions = EditionFilter.new(user, filters: { political: "no" }).editions
+      expect(editions).to match_array([edition1])
+    end
+
     it "ignores other kinds of filter" do
       edition1 = create(:edition)
 

--- a/spec/lib/edition_filter_spec.rb
+++ b/spec/lib/edition_filter_spec.rb
@@ -94,6 +94,17 @@ RSpec.describe EditionFilter do
       expect(editions).to match_array([edition1])
     end
 
+    it "filters the editions by history mode" do
+      edition1 = create(:edition, :political, :current_government)
+      edition2 = create(:edition, :political, :past_government)
+
+      editions = EditionFilter.new(user, filters: { history_mode: "yes" }).editions
+      expect(editions).to match_array([edition2])
+
+      editions = EditionFilter.new(user, filters: { history_mode: "no" }).editions
+      expect(editions).to match_array([edition1])
+    end
+
     it "ignores other kinds of filter" do
       edition1 = create(:edition)
 


### PR DESCRIPTION
Adds two new filters to the index page:

- `Marked as political` => "", "Yes", "No"
- `In history mode` => "", "Yes", "No"

We did consider having labels for the latter as "Yes - past government", "No - current government", but these don't fully explain what constitutes history mode (e.g. a document published by a past government is not in history mode if it is not classed as political content).

Screenshot:

![](https://user-images.githubusercontent.com/5111927/70321098-5c02e300-181e-11ea-8151-560c335e34b8.png)


Trello card: https://trello.com/c/7ZtSXVFx/1211-filter-index-page-based-on-political-and-history-mode-status