### PR TITLE
Some small time consistency tweaks

### DIFF
--- a/app/jobs/scheduled_publishing_job.rb
+++ b/app/jobs/scheduled_publishing_job.rb
@@ -45,7 +45,7 @@ private
 
     scheduling = edition.status.details
 
-    if scheduling.publish_time > Time.zone.now
+    if scheduling.publish_time > Time.current
       Rails.logger.warn("Cannot publish an edition (\##{edition.id}) scheduled in the future")
       return false
     end

--- a/spec/factories/whitehall_export/document_factory.rb
+++ b/spec/factories/whitehall_export/document_factory.rb
@@ -5,8 +5,8 @@ FactoryBot.define do
     skip_create
 
     sequence(:id)
-    created_at { Time.zone.now.rfc3339 }
-    updated_at { Time.zone.now.rfc3339 }
+    created_at { Time.current.rfc3339 }
+    updated_at { Time.current.rfc3339 }
     slug { SecureRandom.alphanumeric(10).parameterize }
     content_id { SecureRandom.uuid }
     editions { [build(:whitehall_export_edition)] }

--- a/spec/factories/whitehall_export/edition_factory.rb
+++ b/spec/factories/whitehall_export/edition_factory.rb
@@ -5,8 +5,8 @@ FactoryBot.define do
     skip_create
 
     sequence(:id)
-    created_at { Time.zone.now.rfc3339 }
-    updated_at { Time.zone.now.rfc3339 }
+    created_at { Time.current.rfc3339 }
+    updated_at { Time.current.rfc3339 }
     access_limited { false }
     change_note { "First published" }
     state { "draft" }
@@ -35,7 +35,7 @@ FactoryBot.define do
       end
 
       created_at { 3.days.ago.rfc3339 }
-      scheduled_publication { Time.zone.now.tomorrow.rfc3339 }
+      scheduled_publication { Time.current.tomorrow.rfc3339 }
       state { "scheduled" }
       revision_history do
         [
@@ -47,7 +47,7 @@ FactoryBot.define do
           build(:revision_history_event,
                 event: "update",
                 state: "scheduled",
-                created_at: Time.zone.now.tomorrow.rfc3339),
+                created_at: Time.current.tomorrow.rfc3339),
         ]
       end
     end

--- a/spec/factories/whitehall_export/image_factory.rb
+++ b/spec/factories/whitehall_export/image_factory.rb
@@ -7,8 +7,8 @@ FactoryBot.define do
     sequence(:id)
     alt_text { "Alt text for image" }
     caption { "This is a caption" }
-    created_at { Time.zone.now.rfc3339 }
-    updated_at { Time.zone.now.rfc3339 }
+    created_at { Time.current.rfc3339 }
+    updated_at { Time.current.rfc3339 }
     variants { {} }
     url { "https://assets.publishing.service.gov.uk/government/uploads/#{filename}" }
 

--- a/spec/factories/whitehall_export/revision_history_event.rb
+++ b/spec/factories/whitehall_export/revision_history_event.rb
@@ -7,7 +7,7 @@ FactoryBot.define do
     event { "create" }
     state { "draft" }
     whodunnit { 1 }
-    created_at { Time.zone.now.rfc3339 }
+    created_at { Time.current.rfc3339 }
 
     initialize_with { attributes.stringify_keys }
   end

--- a/spec/factories/whitehall_export/unpublishing_factory.rb
+++ b/spec/factories/whitehall_export/unpublishing_factory.rb
@@ -5,8 +5,8 @@ FactoryBot.define do
     skip_create
 
     sequence(:id)
-    created_at { Time.zone.now.rfc3339 }
-    updated_at { Time.zone.now.rfc3339 }
+    created_at { Time.current.rfc3339 }
+    updated_at { Time.current.rfc3339 }
     explanation { "User facing explanation" }
     alternative_url { "" }
     redirect { false }

--- a/spec/features/scheduling/clear_proposed_publish_time_spec.rb
+++ b/spec/features/scheduling/clear_proposed_publish_time_spec.rb
@@ -1,8 +1,6 @@
 # frozen_string_literal: true
 
 RSpec.feature "Clear proposed publish time" do
-  include ActiveSupport::Testing::TimeHelpers
-
   around do |example|
     travel_to(Time.zone.parse("2019-06-13 11:00")) { example.run }
   end

--- a/spec/features/scheduling/propose_publish_time_and_schedule_spec.rb
+++ b/spec/features/scheduling/propose_publish_time_and_schedule_spec.rb
@@ -1,8 +1,6 @@
 # frozen_string_literal: true
 
 RSpec.feature "Propose publish time and schedule" do
-  include ActiveSupport::Testing::TimeHelpers
-
   around do |example|
     travel_to(Time.zone.parse("2019-06-17")) { example.run }
   end

--- a/spec/features/scheduling/propose_publish_time_spec.rb
+++ b/spec/features/scheduling/propose_publish_time_spec.rb
@@ -1,8 +1,6 @@
 # frozen_string_literal: true
 
 RSpec.feature "Propose publish time" do
-  include ActiveSupport::Testing::TimeHelpers
-
   around do |example|
     travel_to(Time.zone.parse("2019-06-13")) { example.run }
   end

--- a/spec/features/scheduling/scheduled_publishing_failed_spec.rb
+++ b/spec/features/scheduling/scheduled_publishing_failed_spec.rb
@@ -1,8 +1,6 @@
 # frozen_string_literal: true
 
 RSpec.feature "Scheduled publishing failed" do
-  include ActiveSupport::Testing::TimeHelpers
-
   around do |example|
     Sidekiq::Testing.fake! do
       travel_to(Time.zone.parse("2019-06-19"))

--- a/spec/features/scheduling/scheduled_publishing_spec.rb
+++ b/spec/features/scheduling/scheduled_publishing_spec.rb
@@ -1,8 +1,6 @@
 # frozen_string_literal: true
 
 RSpec.feature "Scheduled publishing" do
-  include ActiveSupport::Testing::TimeHelpers
-
   around do |example|
     Sidekiq::Testing.fake! do
       travel_to(Time.zone.parse("2019-06-21"))

--- a/spec/features/scheduling/scheduled_publishing_without_review_spec.rb
+++ b/spec/features/scheduling/scheduled_publishing_without_review_spec.rb
@@ -1,8 +1,6 @@
 # frozen_string_literal: true
 
 RSpec.feature "Scheduled publishing without review" do
-  include ActiveSupport::Testing::TimeHelpers
-
   around do |example|
     Sidekiq::Testing.fake! do
       travel_to(Time.zone.parse("2019-06-20"))

--- a/spec/features/scheduling/unschedule_spec.rb
+++ b/spec/features/scheduling/unschedule_spec.rb
@@ -1,8 +1,6 @@
 # frozen_string_literal: true
 
 RSpec.feature "Unschedule" do
-  include ActiveSupport::Testing::TimeHelpers
-
   around do |example|
     travel_to(Time.zone.parse("2019-06-13")) { example.run }
   end

--- a/spec/features/scheduling/update_proposed_publish_time_spec.rb
+++ b/spec/features/scheduling/update_proposed_publish_time_spec.rb
@@ -1,8 +1,6 @@
 # frozen_string_literal: true
 
 RSpec.feature "Update proposed publish time" do
-  include ActiveSupport::Testing::TimeHelpers
-
   around do |example|
     travel_to(Time.zone.parse("2019-06-13")) { example.run }
   end

--- a/spec/features/scheduling/update_publish_time_spec.rb
+++ b/spec/features/scheduling/update_publish_time_spec.rb
@@ -2,7 +2,6 @@
 
 RSpec.feature "Update publish time" do
   include ActiveJob::TestHelper
-  include ActiveSupport::Testing::TimeHelpers
 
   around do |example|
     Sidekiq::Testing.fake! do

--- a/spec/features/workflow/publish_spec.rb
+++ b/spec/features/workflow/publish_spec.rb
@@ -1,8 +1,6 @@
 # frozen_string_literal: true
 
 RSpec.feature "Publishing an edition" do
-  include ActiveSupport::Testing::TimeHelpers
-
   scenario do
     given_there_is_an_edition_in_draft
     when_i_visit_the_summary_page

--- a/spec/features/workflow/publish_without_review_spec.rb
+++ b/spec/features/workflow/publish_without_review_spec.rb
@@ -1,8 +1,6 @@
 # frozen_string_literal: true
 
 RSpec.feature "Publish without review" do
-  include ActiveSupport::Testing::TimeHelpers
-
   scenario do
     given_there_is_an_edition
     when_i_visit_the_summary_page

--- a/spec/lib/requirements/publish_time_checker_spec.rb
+++ b/spec/lib/requirements/publish_time_checker_spec.rb
@@ -1,8 +1,6 @@
 # frozen_string_literal: true
 
 RSpec.describe Requirements::PublishTimeChecker do
-  include ActiveSupport::Testing::TimeHelpers
-
   describe "#issues" do
     it "returns no issues if there are none" do
       issues = Requirements::PublishTimeChecker.new(1.day.from_now).issues

--- a/spec/lib/whitehall_importer/create_edition_spec.rb
+++ b/spec/lib/whitehall_importer/create_edition_spec.rb
@@ -117,8 +117,8 @@ RSpec.describe WhitehallImporter::CreateEdition do
     end
 
     context "when an unpublished edition has not been edited" do
-      let(:created_at) { Time.zone.now.yesterday.rfc3339 }
-      let(:updated_at) { Time.zone.now.rfc3339 }
+      let(:created_at) { Time.current.yesterday.rfc3339 }
+      let(:updated_at) { Time.current.rfc3339 }
       let(:whitehall_edition) do
         build(:whitehall_export_edition,
               revision_history: [
@@ -156,7 +156,7 @@ RSpec.describe WhitehallImporter::CreateEdition do
     end
 
     context "when an unpublished edition has been edited" do
-      let(:created_at) { Time.zone.now.rfc3339 }
+      let(:created_at) { Time.current.rfc3339 }
       let(:whitehall_edition) do
         build(:whitehall_export_edition,
               revision_history: [

--- a/spec/lib/whitehall_importer/import_spec.rb
+++ b/spec/lib/whitehall_importer/import_spec.rb
@@ -60,7 +60,7 @@ RSpec.describe WhitehallImporter::Import do
     it "sets current boolean on whether edition is current or not" do
       past_edition = build(
         :whitehall_export_edition,
-        created_at: Time.zone.now.yesterday.rfc3339,
+        created_at: Time.current.yesterday.rfc3339,
         revision_history: [build(:revision_history_event, whodunnit: whitehall_user["id"])],
       )
       current_edition = build(

--- a/spec/models/edition_spec.rb
+++ b/spec/models/edition_spec.rb
@@ -1,8 +1,6 @@
 # frozen_string_literal: true
 
 RSpec.describe Edition do
-  include ActiveSupport::Testing::TimeHelpers
-
   describe ".find_current" do
     it "finds an edition by id" do
       edition = create(:edition)

--- a/spec/services/assign_edition_status_service_spec.rb
+++ b/spec/services/assign_edition_status_service_spec.rb
@@ -1,8 +1,6 @@
 # frozen_string_literal: true
 
 RSpec.describe AssignEditionStatusService do
-  include ActiveSupport::Testing::TimeHelpers
-
   describe ".call" do
     let(:edition) { build(:edition) }
     let(:user) { build(:user) }

--- a/spec/services/edit_edition_service_spec.rb
+++ b/spec/services/edit_edition_service_spec.rb
@@ -1,8 +1,6 @@
 # frozen_string_literal: true
 
 RSpec.describe EditEditionService do
-  include ActiveSupport::Testing::TimeHelpers
-
   describe ".call" do
     let(:edition) { build(:edition) }
     let(:user) { build(:user) }

--- a/spec/services/publish_service_spec.rb
+++ b/spec/services/publish_service_spec.rb
@@ -1,8 +1,6 @@
 # frozen_string_literal: true
 
 RSpec.describe PublishService do
-  include ActiveSupport::Testing::TimeHelpers
-
   describe ".call" do
     let(:user) { create(:user) }
 

--- a/spec/services/withdraw_service_spec.rb
+++ b/spec/services/withdraw_service_spec.rb
@@ -1,8 +1,6 @@
 # frozen_string_literal: true
 
 RSpec.describe WithdrawService do
-  include ActiveSupport::Testing::TimeHelpers
-
   describe "#call" do
     let(:edition) { create(:edition, :published) }
     let(:user) { create(:user) }

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -29,6 +29,7 @@ RSpec.configure do |config|
   config.expose_dsl_globally = false
   config.infer_spec_type_from_file_location!
   config.use_transactional_fixtures = true
+  config.include ActiveSupport::Testing::TimeHelpers
   config.include FactoryBot::Syntax::Methods
   config.include GdsApi::TestHelpers::PublishingApi
   config.include GdsApi::TestHelpers::PublishingApiV2


### PR DESCRIPTION
This changes our use of Time.zone.now to Time.current for consistency across the app as we have a preference for Time.current.

It also moves the TimeHelpers include to the spec_helper.rb so this no longer needs to be included manually - since we hit including this file in a fair number of files.