### PR TITLE
Show political status and allow status to be overridden

### DIFF
--- a/app/controllers/political_controller.rb
+++ b/app/controllers/political_controller.rb
@@ -1,0 +1,17 @@
+# frozen_string_literal: true
+
+class PoliticalController < ApplicationController
+  before_action :check_permission
+
+  def edit
+    @edition = Edition.find_current(document: params[:document])
+    assert_edition_state(@edition, &:editable?)
+  end
+
+  def check_permission
+    return if current_user.has_permission?(User::MANAGING_EDITOR_PERMISSION)
+
+    @edition = Edition.find_current(document: params[:document])
+    render :non_managing_editor, status: :forbidden
+  end
+end

--- a/app/controllers/political_controller.rb
+++ b/app/controllers/political_controller.rb
@@ -1,6 +1,7 @@
 # frozen_string_literal: true
 
 class PoliticalController < ApplicationController
+  before_action { authorise_user!(User::PRE_RELEASE_FEATURES_PERMISSION) }
   before_action :check_permission
 
   def edit

--- a/app/controllers/political_controller.rb
+++ b/app/controllers/political_controller.rb
@@ -8,6 +8,11 @@ class PoliticalController < ApplicationController
     assert_edition_state(@edition, &:editable?)
   end
 
+  def update
+    result = Political::UpdateInteractor.call(params: params, user: current_user)
+    redirect_to document_path(result.edition.document)
+  end
+
   def check_permission
     return if current_user.has_permission?(User::MANAGING_EDITOR_PERMISSION)
 

--- a/app/interactors/political/update_interactor.rb
+++ b/app/interactors/political/update_interactor.rb
@@ -1,0 +1,46 @@
+# frozen_string_literal: true
+
+class Political::UpdateInteractor < ApplicationInteractor
+  delegate :params,
+           :user,
+           :edition,
+           :next_revision,
+           to: :context
+
+  def call
+    Edition.transaction do
+      find_and_lock_edition
+      create_next_revision
+      create_timeline_entry
+      update_preview
+    end
+  end
+
+private
+
+  def find_and_lock_edition
+    context.edition = Edition.lock.find_current(document: params[:document])
+    assert_edition_state(edition, &:editable?)
+  end
+
+  def create_next_revision
+    updater = Versioning::RevisionUpdater.new(edition.revision, user)
+
+    updater.assign(editor_political: params[:political] == "yes")
+    EditEditionService.call(edition, user, revision: updater.next_revision)
+    edition.save!
+  end
+
+  def create_timeline_entry
+    TimelineEntry.create_for_revision(
+      entry_type: :political_status_changed,
+      revision: edition.revision,
+      edition: edition,
+      created_by: user,
+    )
+  end
+
+  def update_preview
+    FailsafePreviewService.call(edition)
+  end
+end

--- a/app/models/timeline_entry.rb
+++ b/app/models/timeline_entry.rb
@@ -56,7 +56,8 @@ class TimelineEntry < ApplicationRecord
                      backdate_cleared: "backdate_cleared",
                      access_limit_created: "access_limit_created",
                      access_limit_updated: "access_limit_updated",
-                     access_limit_removed: "access_limit_removed" }
+                     access_limit_removed: "access_limit_removed",
+                     political_status_changed: "political_status_changed" }
 
   def self.create_for_status_change(entry_type:,
                                     status:,

--- a/app/views/documents/show/_content_settings.html.erb
+++ b/app/views/documents/show/_content_settings.html.erb
@@ -36,14 +36,16 @@
   } %>
 <% end %>
 
-<% items << {
-  field: t("documents.show.content_settings.political.title"),
-  value: @edition.political? ? t("documents.show.content_settings.political.true_label") : t("documents.show.content_settings.political.false_label"),
-  edit: {
-    href: political_path,
-    data_attributes: { gtm: "edit-political" }
-  }
-} %>
+<% if current_user.has_permission?(User::PRE_RELEASE_FEATURES_PERMISSION) %>
+  <% items << {
+    field: t("documents.show.content_settings.political.title"),
+    value: @edition.political? ? t("documents.show.content_settings.political.true_label") : t("documents.show.content_settings.political.false_label"),
+    edit: {
+      href: political_path,
+      data_attributes: { gtm: "edit-political" }
+    }
+  } %>
+<% end %>
 
 <%= render "govuk_publishing_components/components/summary_list", {
   id: "content_settings",

--- a/app/views/documents/show/_content_settings.html.erb
+++ b/app/views/documents/show/_content_settings.html.erb
@@ -36,6 +36,15 @@
   } %>
 <% end %>
 
+<% items << {
+  field: t("documents.show.content_settings.political.title"),
+  value: @edition.political? ? t("documents.show.content_settings.political.true_label") : t("documents.show.content_settings.political.false_label"),
+  edit: {
+    href: "placeholder",
+    data_attributes: { gtm: "edit-political" }
+  }
+} %>
+
 <%= render "govuk_publishing_components/components/summary_list", {
   id: "content_settings",
   title: t("documents.show.content_settings.title"),

--- a/app/views/documents/show/_content_settings.html.erb
+++ b/app/views/documents/show/_content_settings.html.erb
@@ -40,7 +40,7 @@
   field: t("documents.show.content_settings.political.title"),
   value: @edition.political? ? t("documents.show.content_settings.political.true_label") : t("documents.show.content_settings.political.false_label"),
   edit: {
-    href: "placeholder",
+    href: political_path,
     data_attributes: { gtm: "edit-political" }
   }
 } %>

--- a/app/views/political/edit.html.erb
+++ b/app/views/political/edit.html.erb
@@ -1,0 +1,44 @@
+<% content_for :title, t("political.edit.title", document_type: @edition.document_type.label.downcase) %>
+<% content_for :back_link, render_back_link(href: document_path(@edition.document)) %>
+
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-two-thirds">
+    <div class="govuk-body" %>
+      <%= t("political.edit.description") %>
+    </div>
+  </div>
+</div>
+
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-two-thirds">
+    <%= form_tag political_path(@edition.document), data: { gtm: "confirm-political" } do %>
+      <%= render "govuk_publishing_components/components/radio", {
+        name: "political",
+        error_items: @issues&.items_for(:political),
+        items: [
+          {
+            value: "yes",
+            text: t("political.edit.labels.political"),
+            checked: @edition.political?,
+            data_attributes: {
+              gtm: "choose-political",
+              "gtm-value": t("political.edit.labels.political")
+            }
+          },
+          {
+            value: "no",
+            text: t("political.edit.labels.not_political"),
+            checked: @edition.political? == false,
+            data_attributes: {
+              gtm: "choose-political",
+              "gtm-value": t("political.edit.labels.not_political")
+            }
+          }
+        ]
+      } %>
+
+      <%= render "govuk_publishing_components/components/button", { text: "Save", margin_bottom: true } %>
+      <%= render_govspeak(t("political.edit.guidance_link_govspeak")) %>
+    <% end %>
+  </div>
+</div>

--- a/app/views/political/non_managing_editor.html.erb
+++ b/app/views/political/non_managing_editor.html.erb
@@ -1,0 +1,2 @@
+<% content_for :back_link, render_back_link(href: document_path(@edition.document)) %>
+<%= render partial: "errors/error", locals: { title: t("political.no_managing_editor_permission.title", title: @edition.title), body_govspeak: t("political.no_managing_editor_permission.body_govspeak") } %>

--- a/config/locales/en/documents/history.yml
+++ b/config/locales/en/documents/history.yml
@@ -37,5 +37,6 @@ en:
         access_limit_created: "Access limit created"
         access_limit_updated: "Access limit updated"
         access_limit_removed: "Access limit removed"
+        political_status_changed: "History mode criteria updated"
       entry_content:
         backdated: "First published date backdated to %{date}"

--- a/config/locales/en/documents/show.yml
+++ b/config/locales/en/documents/show.yml
@@ -47,6 +47,10 @@ en:
           type:
             tagged_organisations: Only publishers in tagged organistions have access
             primary_organisation: Only publishers in the primary organisation have access
+        political:
+          title: Gets history mode
+          true_label: "Yes"
+          false_label: "No"
       metadata:
         status: Status
         updated_at: Last updated

--- a/config/locales/en/political/edit.yml
+++ b/config/locales/en/political/edit.yml
@@ -1,0 +1,10 @@
+en:
+  political:
+    edit:
+      title: Do you want to tag this %{document_type} to history mode?
+      description: When the government ends, content tagged to history mode can only be edited by GDS and has a banner showing it is associated with a previous government.
+      labels:
+        political: "Yes"
+        not_political: "No"
+      guidance_link_govspeak: |
+        Read the [guidance about content from previous governments](https://www.gov.uk/guidance/content-design/gov-uk-content-retention-and-withdrawal-archiving-policy){:target="_blank"} (link opens in a new window).

--- a/config/locales/en/political/political.yml
+++ b/config/locales/en/political/political.yml
@@ -1,0 +1,10 @@
+en:
+  political:
+    no_managing_editor_permission:
+      title: Change the history mode tag for ‘%{title}’
+      body_govspeak: |
+        Only a managing editor can change the political status of a page. You do not have permission to do this.
+
+        If you think the history mode tag of this content is wrong, you need to ask the managing editor for your organisation.
+
+        Read the [guidance about content from previous governments](https://www.gov.uk/guidance/content-design/gov-uk-content-retention-and-withdrawal-archiving-policy){:target="_blank"} (link opens in a new window).

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -76,6 +76,8 @@ Rails.application.routes.draw do
     get "/access-limit" => "access_limit#edit", as: :access_limit
     post "/access-limit" => "access_limit#update"
 
+    get "/political" => "political#edit", as: :political
+
     post "/editions" => "editions#create", as: :create_edition
 
     get "/contact-embed" => "contact_embed#new"

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -77,6 +77,7 @@ Rails.application.routes.draw do
     post "/access-limit" => "access_limit#update"
 
     get "/political" => "political#edit", as: :political
+    post "/political" => "political#update"
 
     post "/editions" => "editions#create", as: :create_edition
 

--- a/spec/features/editing_content_settings/political_spec.rb
+++ b/spec/features/editing_content_settings/political_spec.rb
@@ -1,0 +1,41 @@
+# frozen_string_literal: true
+
+RSpec.feature "History mode" do
+  scenario "not political document" do
+    given_there_is_a_not_political_document
+    when_i_visit_the_summary_page
+    then_i_see_that_the_content_is_not_political
+  end
+
+  scenario "political document" do
+    given_there_is_a_political_document
+    when_i_visit_the_summary_page
+    then_i_see_that_the_content_is_political
+  end
+
+  def given_there_is_a_political_document
+    @edition = create(:edition, :political)
+  end
+
+  def given_there_is_a_not_political_document
+    @edition = create(:edition, :not_political)
+  end
+
+  def when_i_visit_the_summary_page
+    visit document_path(@edition.document)
+  end
+
+  def then_i_see_that_the_content_is_not_political
+    row = page.find(".govuk-summary-list__row", text: I18n.t!("documents.show.content_settings.political.title"))
+    expect(row).to have_content(
+      I18n.t!("documents.show.content_settings.political.false_label"),
+    )
+  end
+
+  def then_i_see_that_the_content_is_political
+    row = page.find(".govuk-summary-list__row", text: I18n.t!("documents.show.content_settings.political.title"))
+    expect(row).to have_content(
+      I18n.t!("documents.show.content_settings.political.true_label"),
+    )
+  end
+end

--- a/spec/features/editing_content_settings/political_spec.rb
+++ b/spec/features/editing_content_settings/political_spec.rb
@@ -6,10 +6,15 @@ RSpec.feature "History mode" do
     and_i_am_a_managing_editor
     when_i_visit_the_summary_page
     then_i_see_that_the_content_is_not_political
+    and_i_do_not_see_the_history_mode_banner
     when_i_click_to_change_the_status
     then_i_enable_political_status
     and_i_see_that_the_content_is_political
     and_i_see_the_timeline_entry
+    and_i_do_not_see_the_history_mode_banner
+    when_i_click_to_backdate_the_content
+    and_i_enter_a_date_to_backdate_the_content_to
+    and_i_see_the_history_mode_banner
   end
 
   def given_there_is_a_not_political_document
@@ -56,5 +61,29 @@ RSpec.feature "History mode" do
     within("#document-history") do
       expect(page).to have_content(I18n.t!("documents.history.entry_types.political_status_changed"))
     end
+  end
+
+  def when_i_click_to_backdate_the_content
+    click_on "Change Backdate"
+  end
+
+  def and_i_enter_a_date_to_backdate_the_content_to
+    @request = stub_publishing_api_put_content(@edition.content_id, {})
+    fill_in "backdate[date][day]", with: "1"
+    fill_in "backdate[date][month]", with: "1"
+    fill_in "backdate[date][year]", with: "1999"
+    click_on "Save"
+  end
+
+  def and_i_do_not_see_the_history_mode_banner
+    expect(page).not_to have_content(
+      I18n.t!("documents.show.historical.title", document_type: @edition.document_type.label.downcase),
+    )
+  end
+
+  def and_i_see_the_history_mode_banner
+    expect(page).to have_content(
+      I18n.t!("documents.show.historical.title", document_type: @edition.document_type.label.downcase),
+    )
   end
 end

--- a/spec/features/editing_content_settings/political_spec.rb
+++ b/spec/features/editing_content_settings/political_spec.rb
@@ -1,24 +1,23 @@
 # frozen_string_literal: true
 
 RSpec.feature "History mode" do
-  scenario "not political document" do
+  scenario do
     given_there_is_a_not_political_document
+    and_i_am_a_managing_editor
     when_i_visit_the_summary_page
     then_i_see_that_the_content_is_not_political
-  end
-
-  scenario "political document" do
-    given_there_is_a_political_document
-    when_i_visit_the_summary_page
-    then_i_see_that_the_content_is_political
-  end
-
-  def given_there_is_a_political_document
-    @edition = create(:edition, :political)
+    when_i_click_to_change_the_status
+    then_i_enable_political_status
+    and_i_see_that_the_content_is_political
+    and_i_see_the_timeline_entry
   end
 
   def given_there_is_a_not_political_document
     @edition = create(:edition, :not_political)
+  end
+
+  def and_i_am_a_managing_editor
+    login_as(create(:user, managing_editor: true))
   end
 
   def when_i_visit_the_summary_page
@@ -32,10 +31,30 @@ RSpec.feature "History mode" do
     )
   end
 
+  alias_method :and_i_see_that_the_content_is_not_political, :then_i_see_that_the_content_is_not_political
+
   def then_i_see_that_the_content_is_political
     row = page.find(".govuk-summary-list__row", text: I18n.t!("documents.show.content_settings.political.title"))
     expect(row).to have_content(
       I18n.t!("documents.show.content_settings.political.true_label"),
     )
+  end
+
+  alias_method :and_i_see_that_the_content_is_political, :then_i_see_that_the_content_is_political
+
+  def when_i_click_to_change_the_status
+    click_on "Change Gets history mode"
+  end
+
+  def then_i_enable_political_status
+    @request = stub_publishing_api_put_content(@edition.content_id, {})
+    choose(I18n.t!("political.edit.labels.political"))
+    click_on "Save"
+  end
+
+  def and_i_see_the_timeline_entry
+    within("#document-history") do
+      expect(page).to have_content(I18n.t!("documents.history.entry_types.political_status_changed"))
+    end
   end
 end

--- a/spec/interactors/political/update_interactor_spec.rb
+++ b/spec/interactors/political/update_interactor_spec.rb
@@ -1,0 +1,47 @@
+# frozen_string_literal: true
+
+RSpec.describe Political::UpdateInteractor do
+  describe ".call" do
+    let(:user) { create(:user, managing_editor: true) }
+    let(:edition) { create(:edition, :not_political) }
+    let(:args) do
+      {
+        params: {
+          document: edition.document.to_param,
+          political: "yes",
+        },
+        user: user,
+      }
+    end
+
+    before { stub_any_publishing_api_put_content }
+
+    it "sets the edition to political" do
+      Political::UpdateInteractor.call(**args)
+      edition.reload
+
+      expect(edition.political?).to be true
+    end
+
+    it "sets the edition to not political" do
+      args[:params][:political] = "no"
+      Political::UpdateInteractor.call(**args)
+      edition.reload
+
+      expect(edition.political?).to be false
+    end
+
+    it "creates a timeline entry" do
+      Political::UpdateInteractor.call(**args)
+      edition.reload
+
+      expect(edition.timeline_entries.last.entry_type).to eq("political_status_changed")
+    end
+
+    it "sends a preview of the new edition to the Publishing API" do
+      expect(FailsafePreviewService).to receive(:call)
+
+      Political::UpdateInteractor.call(**args)
+    end
+  end
+end

--- a/spec/requests/documents_spec.rb
+++ b/spec/requests/documents_spec.rb
@@ -28,4 +28,20 @@ RSpec.describe "Documents" do
       end
     end
   end
+
+  describe "GET /documents/:document/political" do
+    it "returns a forbidden status for user without managing editor permission" do
+      @edition = create(:edition)
+      login_as(create(:user))
+      get political_path(@edition.document)
+      expect(response.status).to eq(403)
+    end
+
+    it "does not return a forbidden status for user with managing editor permission" do
+      @edition = create(:edition)
+      login_as(create(:user, managing_editor: true))
+      get political_path(@edition.document)
+      expect(response.status).to_not eq(403)
+    end
+  end
 end

--- a/spec/requests/documents_spec.rb
+++ b/spec/requests/documents_spec.rb
@@ -35,12 +35,30 @@ RSpec.describe "Documents" do
       login_as(create(:user))
       get political_path(@edition.document)
       expect(response.status).to eq(403)
+      expect(response.body).to include(I18n.t!("political.no_managing_editor_permission.title", title: @edition.title))
     end
 
     it "does not return a forbidden status for user with managing editor permission" do
       @edition = create(:edition)
       login_as(create(:user, managing_editor: true))
       get political_path(@edition.document)
+      expect(response.status).to_not eq(403)
+    end
+  end
+
+  describe "POST /documents/:document/political" do
+    it "returns a forbidden status for user without managing editor permission" do
+      @edition = create(:edition)
+      login_as(create(:user))
+      post political_path(@edition.document)
+      expect(response.status).to eq(403)
+      expect(response.body).to include(I18n.t!("political.no_managing_editor_permission.title", title: @edition.title))
+    end
+
+    it "does not return a forbidden status for user with managing editor permission" do
+      @edition = create(:edition)
+      login_as(create(:user, managing_editor: true))
+      post political_path(@edition.document)
       expect(response.status).to_not eq(403)
     end
   end


### PR DESCRIPTION
Publishers need to be able to see the political status of their documents.  Managing editors need to be able to override the automatically determined political status for their documents.

To this end, this PR adds a "Political content" value to the "Content settings" section of the document summary page.  This also has a link to change the political status, which can only be done when the edition is editable (i.e. it is draft).  Non-managing editors will see a message asking them to contact their managing editor, whilst managing editors will see a form with radio buttons.  Once the status has been overridden, a timeline history entry is added and the preview updated (in case the document has been backdated and a history mode banner needs to be shown).

This sits behind a pre-release feature flag until history mode is fully released.

Trello card: https://trello.com/c/ambyZ2ia