### PR TITLE
New service to re-sync documents with publishing-api

### DIFF
--- a/app/models/government.rb
+++ b/app/models/government.rb
@@ -9,7 +9,7 @@ class Government
   end
 
   def self.for_date(date)
-    all.find { |government| government.covers?(date) }
+    all.find { |government| government.covers?(date) } if date
   end
 
   def self.current

--- a/app/services/edit_edition_service.rb
+++ b/app/services/edit_edition_service.rb
@@ -28,9 +28,6 @@ private
   end
 
   def associate_with_government
-    edition.government_id = if edition.public_first_published_at
-                              government = Government.for_date(edition.public_first_published_at)
-                              government&.content_id
-                            end
+    edition.government_id = Government.for_date(edition.public_first_published_at)&.content_id
   end
 end

--- a/app/services/preview_service.rb
+++ b/app/services/preview_service.rb
@@ -1,8 +1,9 @@
 # frozen_string_literal: true
 
 class PreviewService < ApplicationService
-  def initialize(edition)
+  def initialize(edition, republish: false)
     @edition = edition
+    @republish = republish
   end
 
   def call
@@ -15,10 +16,10 @@ class PreviewService < ApplicationService
 
 private
 
-  attr_reader :edition
+  attr_reader :edition, :republish
 
   def put_draft_content
-    payload = Payload.new(edition).payload
+    payload = Payload.new(edition, republish: republish).payload
     GdsApi.publishing_api_v2.put_content(edition.content_id, payload)
     edition.update!(revision_synced: true)
   end

--- a/app/services/preview_service/payload.rb
+++ b/app/services/preview_service/payload.rb
@@ -3,12 +3,13 @@
 class PreviewService::Payload
   PUBLISHING_APP = "content-publisher"
 
-  attr_reader :edition, :document_type, :publishing_metadata
+  attr_reader :edition, :document_type, :publishing_metadata, :republish
 
-  def initialize(edition)
+  def initialize(edition, republish: false)
     @edition = edition
     @document_type = edition.document_type
     @publishing_metadata = document_type.publishing_metadata
+    @republish = republish
   end
 
   def payload
@@ -35,6 +36,11 @@ class PreviewService::Payload
     if edition.backdated_to.present?
       payload["first_published_at"] = edition.backdated_to
       payload["public_updated_at"] = edition.backdated_to if edition.first?
+    end
+
+    if republish
+      payload["update_type"] = "republish"
+      payload["bulk_publishing"] = true
     end
 
     payload

--- a/app/services/resync_service.rb
+++ b/app/services/resync_service.rb
@@ -23,6 +23,7 @@ private
   def sync_live_edition
     live_edition.lock!
     set_political_and_government(live_edition)
+    reserve_path(live_edition.base_path)
     PreviewService.call(live_edition, republish: true)
     PublishAssetService.call(live_edition, nil)
 
@@ -38,6 +39,7 @@ private
   def sync_draft_edition
     current_edition.lock!
     set_political_and_government(current_edition)
+    reserve_path(current_edition.base_path)
     FailsafePreviewService.call(current_edition)
 
     schedule if current_edition.scheduled?
@@ -48,6 +50,14 @@ private
       revision_synced: false,
       system_political: PoliticalEditionIdentifier.new(edition).political?,
       government_id: Government.for_date(edition.public_first_published_at)&.content_id,
+    )
+  end
+
+  def reserve_path(base_path)
+    GdsApi.publishing_api_v2.put_path(
+      base_path,
+      publishing_app: "content-publisher",
+      override_existing: true,
     )
   end
 

--- a/app/services/resync_service.rb
+++ b/app/services/resync_service.rb
@@ -37,6 +37,8 @@ private
   def sync_draft_edition
     current_edition.lock!
     FailsafePreviewService.call(current_edition)
+
+    schedule if current_edition.scheduled?
   end
 
   def publish
@@ -72,5 +74,14 @@ private
       unpublished_at: removal.created_at,
       allow_draft: true,
     )
+  end
+
+  def schedule
+    payload = ScheduleService::Payload.new(current_edition).intent_payload
+    GdsApi.publishing_api.put_intent(current_edition.base_path, payload)
+
+    scheduling = current_edition.status.details
+    ScheduledPublishingJob.set(wait_until: scheduling.publish_time)
+                          .perform_later(current_edition.id)
   end
 end

--- a/app/services/resync_service.rb
+++ b/app/services/resync_service.rb
@@ -27,6 +27,8 @@ private
 
     if live_edition.withdrawn?
       withdraw
+    elsif live_edition.removed?
+      redirect_or_remove
     else
       publish
     end
@@ -55,6 +57,19 @@ private
       explanation: explanation_html,
       locale: live_edition.locale,
       unpublished_at: withdrawal.withdrawn_at,
+      allow_draft: true,
+    )
+  end
+
+  def redirect_or_remove
+    removal = live_edition.status.details
+    GdsApi.publishing_api_v2.unpublish(
+      live_edition.content_id,
+      type: removal.redirect? ? "redirect" : "gone",
+      explanation: removal.explanatory_note,
+      alternative_path: removal.alternative_path,
+      locale: live_edition.locale,
+      unpublished_at: removal.created_at,
       allow_draft: true,
     )
   end

--- a/app/services/resync_service.rb
+++ b/app/services/resync_service.rb
@@ -29,7 +29,7 @@ private
 
   def sync_draft_edition
     current_edition.lock!
-    PreviewService.call(current_edition)
+    FailsafePreviewService.call(current_edition)
   end
 
   def publish

--- a/app/services/resync_service.rb
+++ b/app/services/resync_service.rb
@@ -1,0 +1,42 @@
+# frozen_string_literal: true
+
+class ResyncService < ApplicationService
+  attr_reader :document
+
+  delegate :live_edition,
+           :current_edition,
+           to: :document
+
+  def initialize(document)
+    @document = document
+  end
+
+  def call
+    Edition.transaction do
+      sync_live_edition if live_edition
+      sync_draft_edition if current_edition != live_edition
+    end
+  end
+
+private
+
+  def sync_live_edition
+    live_edition.lock!
+    PreviewService.call(live_edition, republish: true)
+    PublishAssetService.call(live_edition, nil)
+    publish
+  end
+
+  def sync_draft_edition
+    current_edition.lock!
+    PreviewService.call(current_edition)
+  end
+
+  def publish
+    GdsApi.publishing_api_v2.publish(
+      live_edition.document.content_id,
+      nil, # Sending update_type is deprecated (now in payload)
+      locale: live_edition.document.locale,
+    )
+  end
+end

--- a/lib/tasks/resync.rake
+++ b/lib/tasks/resync.rake
@@ -1,0 +1,21 @@
+# frozen_string_literal: true
+
+namespace :resync do
+  desc "Resync a document with the publishing-api e.g. resync:document['a-content-id:en']"
+  task :document, [:content_id_and_locale] => :environment do |_, args|
+    raise "Missing content_id and locale parameter" unless args.content_id_and_locale
+
+    document = Document.find_by_param(args.content_id_and_locale)
+
+    raise "No document exists for #{content_id_and_locale}" unless document
+
+    ResyncService.call(document)
+  end
+
+  desc "Resync all documents with the publishing-api e.g. resync:all"
+  task all: :environment do
+    Document.find_each do |document|
+      ResyncService.call(document)
+    end
+  end
+end

--- a/spec/factories/edition_factory.rb
+++ b/spec/factories/edition_factory.rb
@@ -138,7 +138,7 @@ FactoryBot.define do
 
     trait :schedulable do
       publishable
-      proposed_publish_time { Time.current.advance(days: 2) }
+      proposed_publish_time { Date.tomorrow.noon }
     end
 
     trait :scheduled do
@@ -146,7 +146,7 @@ FactoryBot.define do
 
       transient do
         scheduling { nil }
-        publish_time { Time.current.advance(days: 2) }
+        publish_time { Date.tomorrow.noon }
       end
 
       after(:build) do |edition, evaluator|

--- a/spec/factories/edition_factory.rb
+++ b/spec/factories/edition_factory.rb
@@ -118,6 +118,24 @@ FactoryBot.define do
       end
     end
 
+    trait :removed do
+      live { true }
+
+      transient do
+        removal { nil }
+      end
+
+      after(:build) do |edition, evaluator|
+        edition.status = evaluator.association(
+          :status,
+          :removed,
+          created_by: edition.created_by,
+          revision_at_creation: edition.revision,
+          removal: evaluator.removal,
+        )
+      end
+    end
+
     trait :schedulable do
       publishable
       proposed_publish_time { Time.current.advance(days: 2) }

--- a/spec/factories/edition_factory.rb
+++ b/spec/factories/edition_factory.rb
@@ -107,7 +107,6 @@ FactoryBot.define do
       end
 
       after(:build) do |edition, evaluator|
-        edition.revision = evaluator.association(:revision)
         edition.status = evaluator.association(
           :status,
           :withdrawn,

--- a/spec/factories/removal_factory.rb
+++ b/spec/factories/removal_factory.rb
@@ -3,5 +3,6 @@
 FactoryBot.define do
   factory :removal do
     redirect { false }
+    created_at { Date.yesterday.noon }
   end
 end

--- a/spec/factories/scheduling_factory.rb
+++ b/spec/factories/scheduling_factory.rb
@@ -3,11 +3,11 @@
 FactoryBot.define do
   factory :scheduling do
     reviewed { false }
-    publish_time { Time.current.advance(days: 2) }
+    publish_time { Date.tomorrow.noon }
     association :pre_scheduled_status, factory: :status
 
     trait :failed do
-      publish_time { Time.current.advance(hour: -1) }
+      publish_time { Date.yesterday.noon }
     end
   end
 end

--- a/spec/factories/status_factory.rb
+++ b/spec/factories/status_factory.rb
@@ -43,7 +43,7 @@ FactoryBot.define do
 
       transient do
         scheduling { nil }
-        publish_time { Time.current.advance(days: 2) }
+        publish_time { Date.tomorrow.noon }
       end
 
       after(:build) do |status, evaluator|

--- a/spec/factories/status_factory.rb
+++ b/spec/factories/status_factory.rb
@@ -26,6 +26,18 @@ FactoryBot.define do
       state { :published_but_needs_2i }
     end
 
+    trait :removed do
+      state { :removed }
+
+      transient do
+        removal { nil }
+      end
+
+      after(:build) do |status, evaluator|
+        status.details = evaluator.removal || evaluator.association(:removal)
+      end
+    end
+
     trait :scheduled do
       state { :scheduled }
 

--- a/spec/factories/withdrawal_factory.rb
+++ b/spec/factories/withdrawal_factory.rb
@@ -3,7 +3,7 @@
 FactoryBot.define do
   factory :withdrawal do
     public_explanation { SecureRandom.alphanumeric }
-    withdrawn_at { Time.current }
+    withdrawn_at { Date.yesterday.noon }
 
     association :published_status, :published, factory: :status
   end

--- a/spec/features/scheduling/schedule_requirements_spec.rb
+++ b/spec/features/scheduling/schedule_requirements_spec.rb
@@ -26,7 +26,7 @@ RSpec.feature "Schedule an edition with requirements issues" do
   end
 
   def given_there_is_an_edition_with_publish_issues
-    @edition = create(:edition, proposed_publish_time: Time.current.advance(days: 2))
+    @edition = create(:edition, proposed_publish_time: Date.tomorrow.noon)
   end
 
   def given_there_is_an_edition_to_publish_too_soon

--- a/spec/lib/tasks/resync_spec.rb
+++ b/spec/lib/tasks/resync_spec.rb
@@ -1,0 +1,28 @@
+# frozen_string_literal: true
+
+RSpec.describe "Resync tasks" do
+  describe "resync:document" do
+    it "resyncs a document" do
+      document = create(:document)
+
+      expect(ResyncService)
+        .to receive(:call)
+        .once
+        .with(document)
+
+      Rake::Task["resync:document"].invoke("#{document.content_id}:#{document.locale}")
+    end
+  end
+
+  describe "resync:all" do
+    it "resyncs all documents" do
+      create_list(:document, 2)
+
+      expect(ResyncService)
+        .to receive(:call)
+        .twice
+
+      Rake::Task["resync:all"].invoke
+    end
+  end
+end

--- a/spec/models/government_spec.rb
+++ b/spec/models/government_spec.rb
@@ -53,6 +53,10 @@ RSpec.describe Government do
     it "opts for the more recent government when there is a date conflict" do
       expect(Government.for_date(Date.parse("2018-12-01"))).to eq current_government
     end
+
+    it "accepts a nil date" do
+      expect(Government.for_date(nil)).to be_nil
+    end
   end
 
   describe ".current" do

--- a/spec/services/preview_service/payload_spec.rb
+++ b/spec/services/preview_service/payload_spec.rb
@@ -192,5 +192,15 @@ RSpec.describe PreviewService::Payload do
 
       expect(payload).to match a_hash_including("public_updated_at" => date)
     end
+
+    it "includes bulk_publishing and sets the update to republish if the edition is being republished" do
+      edition = build(:edition)
+      payload = PreviewService::Payload.new(edition, republish: true).payload
+
+      expect(payload).to match a_hash_including(
+        "update_type" => "republish",
+        "bulk_publishing" => true,
+      )
+    end
   end
 end

--- a/spec/services/preview_service_spec.rb
+++ b/spec/services/preview_service_spec.rb
@@ -34,6 +34,17 @@ RSpec.describe PreviewService do
       PreviewService.call(edition)
     end
 
+    it "sets an update type of republish" do
+      edition = create(:edition)
+
+      expect(PreviewService::Payload)
+        .to receive(:new)
+        .with(edition, republish: true)
+        .and_call_original
+
+      PreviewService.call(edition, republish: true)
+    end
+
     context "when Publishing API is down" do
       before do
         stub_publishing_api_isnt_available

--- a/spec/services/resync_service_spec.rb
+++ b/spec/services/resync_service_spec.rb
@@ -11,7 +11,7 @@ RSpec.describe ResyncService do
       let(:document) { create(:document, :with_current_edition) }
 
       it "it does not publish the edition" do
-        expect(PreviewService).to receive(:call).with(document.current_edition)
+        expect(FailsafePreviewService).to receive(:call).with(document.current_edition)
         expect(GdsApi.publishing_api_v2).not_to receive(:publish)
         ResyncService.call(document)
       end

--- a/spec/services/resync_service_spec.rb
+++ b/spec/services/resync_service_spec.rb
@@ -1,0 +1,54 @@
+# frozen_string_literal: true
+
+RSpec.describe ResyncService do
+  describe ".call" do
+    before do
+      stub_any_publishing_api_publish
+      stub_any_publishing_api_put_content
+    end
+
+    context "when there is no live edition" do
+      let(:document) { create(:document, :with_current_edition) }
+
+      it "it does not publish the edition" do
+        expect(PreviewService).to receive(:call).with(document.current_edition)
+        expect(GdsApi.publishing_api_v2).not_to receive(:publish)
+        ResyncService.call(document)
+      end
+    end
+
+    context "when the current edition is live" do
+      let(:document) { create(:document, :with_live_edition) }
+
+      it "avoids synchronising the edition twice" do
+        expect(PreviewService).to receive(:call).once
+        ResyncService.call(document)
+      end
+
+      it "re-publishes the live edition" do
+        expect(PreviewService)
+          .to receive(:call)
+          .with(
+            document.current_edition,
+            republish: true,
+          )
+          .and_call_original
+
+        request = stub_publishing_api_publish(
+          document.content_id,
+          update_type: nil,
+          locale: document.locale,
+        )
+        ResyncService.call(document)
+
+        expect(request).to have_been_requested
+      end
+
+      it "publishes assets to the live stack" do
+        expect(PublishAssetService).to receive(:call).once.
+          with(document.live_edition, nil)
+        ResyncService.call(document)
+      end
+    end
+  end
+end

--- a/spec/services/resync_service_spec.rb
+++ b/spec/services/resync_service_spec.rb
@@ -166,5 +166,29 @@ RSpec.describe ResyncService do
         end
       end
     end
+
+    context "when there are both live and current editions" do
+      let(:document) { create(:document, :with_current_and_live_editions, first_published_at: Time.current) }
+      let(:government) { build(:government) }
+
+      before do
+        allow(Government).to receive(:all).and_return([government])
+        allow(PoliticalEditionIdentifier)
+          .to receive(:new)
+          .and_return(instance_double(PoliticalEditionIdentifier, political?: true))
+      end
+
+      it "updates the system_political value associated with both editions" do
+        expect { ResyncService.call(document) }
+          .to change { document.live_edition.system_political }.to(true)
+          .and change { document.current_edition.system_political }.to(true)
+      end
+
+      it "updates the government_id associated with with both editions" do
+        expect { ResyncService.call(document) }
+          .to change { document.live_edition.government_id }.to(government.content_id)
+          .and change { document.current_edition.government_id }.to(government.content_id)
+      end
+    end
   end
 end


### PR DESCRIPTION
Trello: https://trello.com/c/cT9yYO4X
Replaces PR #1487 

## What's changed and why?
Adds a service to re-sync a document with publishing-api. This will mainly be used in two scenarios:

1. Documents imported from Whitehall will need to be re-presented to publishing-api and have their base_path reservation moved from Whitehall to Content Publisher.

2. All documents will need to be represented to publishing-api to associate them with the correct government, so that if there is a new government, they can successfully transition into history mode.

co-authored with @ChrisBAshton 