### PR TITLE
Set placeholder alt text for images

### DIFF
--- a/app/views/images/crop.html.erb
+++ b/app/views/images/crop.html.erb
@@ -25,7 +25,7 @@ content_for :title,t(title_key, title: @edition.title_or_fallback)
     src: url_for(@image_revision.blob),
     no_js_src: url_for(@image_revision.crop_variant('960x640')),
     exact_dimensions: @image_revision.at_exact_dimensions?,
-    alt_text: @image_revision.alt_text,
+    alt_text: @image_revision.alt_text || t("images.edit.alt_text_placeholder"),
     crop_x: @image_revision.crop_x,
     crop_y: @image_revision.crop_y,
     crop_width: @image_revision.crop_width,

--- a/app/views/images/edit.html.erb
+++ b/app/views/images/edit.html.erb
@@ -17,7 +17,7 @@ content_for :title, t(title_key, title: @edition.title_or_fallback)
 <%= render "components/image_meta", {
   id: "selected-image",
   src: url_for(@image_revision.thumbnail),
-  alt_text: @image_revision.alt_text,
+  alt_text: @image_revision.alt_text || t("images.edit.alt_text_placeholder"),
   no_border: true
 } %>
 

--- a/config/locales/en/images/edit.yml
+++ b/config/locales/en/images/edit.yml
@@ -3,6 +3,7 @@ en:
     edit:
       title: "Image details for ‘%{title}’"
       title_modal: "Image details"
+      alt_text_placeholder: Your uploaded image
       form_labels:
         alt_text: Alt text
         caption: Image caption


### PR DESCRIPTION
Provide the user with a placeholder alt text for freshly uploaded images.

[Trello card](https://trello.com/c/6idOVWgU)