### PR TITLE
History mode permissions

### DIFF
--- a/app/controllers/editions_controller.rb
+++ b/app/controllers/editions_controller.rb
@@ -1,8 +1,19 @@
 # frozen_string_literal: true
 
 class EditionsController < ApplicationController
+  before_action :check_permissions
+
   def create
     Editions::CreateInteractor.call(params: params, user: current_user)
     redirect_to edit_document_path(params[:document])
+  end
+
+private
+
+  def check_permissions
+    @edition = Edition.find_current(document: params[:document])
+    return if !@edition.history_mode? || current_user.has_permission?(User::MANAGE_LIVE_HISTORY_MODE)
+
+    render "missing_permissions/update_history_mode", status: :forbidden
   end
 end

--- a/app/controllers/unwithdraw_controller.rb
+++ b/app/controllers/unwithdraw_controller.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 class UnwithdrawController < ApplicationController
-  before_action :check_permission
+  before_action :check_permissions
 
   def confirm
     @edition = Edition.find_current(document: params[:document])
@@ -22,10 +22,16 @@ class UnwithdrawController < ApplicationController
 
 private
 
-  def check_permission
-    return if current_user.has_permission?(User::MANAGING_EDITOR_PERMISSION)
-
+  def check_permissions
     @edition = Edition.find_current(document: params[:document])
-    render :non_managing_editor, status: :forbidden
+
+    if !current_user.has_permission?(User::MANAGE_LIVE_HISTORY_MODE) && @edition.history_mode?
+      render "missing_permissions/update_history_mode", status: :forbidden
+      return
+    end
+
+    if !current_user.has_permission?(User::MANAGING_EDITOR_PERMISSION)
+      render :non_managing_editor, status: :forbidden
+    end
   end
 end

--- a/app/controllers/withdraw_controller.rb
+++ b/app/controllers/withdraw_controller.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 class WithdrawController < ApplicationController
-  before_action :check_permission
+  before_action :check_permissions
 
   def new
     @edition = Edition.find_current(document: params[:document])
@@ -35,10 +35,16 @@ class WithdrawController < ApplicationController
 
 private
 
-  def check_permission
-    return if current_user.has_permission?(User::MANAGING_EDITOR_PERMISSION)
-
+  def check_permissions
     @edition = Edition.find_current(document: params[:document])
-    render :non_managing_editor, status: :forbidden
+
+    if !current_user.has_permission?(User::MANAGE_LIVE_HISTORY_MODE) && @edition.history_mode?
+      render "missing_permissions/update_history_mode", status: :forbidden
+      return
+    end
+
+    if !current_user.has_permission?(User::MANAGING_EDITOR_PERMISSION)
+      render :non_managing_editor, status: :forbidden
+    end
   end
 end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -8,6 +8,7 @@ class User < ApplicationRecord
   DEBUG_PERMISSION = "debug"
   MANAGING_EDITOR_PERMISSION = "managing_editor"
   ACCESS_LIMIT_OVERRIDE_PERMISSION = "access_limit_override"
+  MANAGE_LIVE_HISTORY_MODE = "manage_live_history_mode"
 
   def can_access?(edition)
     return true unless edition.access_limit

--- a/app/views/missing_permissions/update_history_mode.govspeak.md
+++ b/app/views/missing_permissions/update_history_mode.govspeak.md
@@ -1,0 +1,4 @@
+Only a GDS admin can update a document in history mode. You do not have permission to do this.
+
+If this document needs to be updated you need to [make a request to GDS in GOV.UK support](https://support.publishing.service.gov.uk/content_advice_request/new)
+(link opens in a new window).

--- a/app/views/missing_permissions/update_history_mode.html.erb
+++ b/app/views/missing_permissions/update_history_mode.html.erb
@@ -1,0 +1,8 @@
+<% content_for :back_link, render_back_link(href: document_path(@edition.document)) %>
+<% content_for :title, t("missing_permissions.update_history_mode.title", title: @edition.title) %>
+
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-two-thirds">
+    <%= render_govspeak(File.read("app/views/missing_permissions/update_history_mode.govspeak.md")) %>
+  </div>
+</div>

--- a/config/locales/en/missing_permissions/update_history_mode.yml
+++ b/config/locales/en/missing_permissions/update_history_mode.yml
@@ -1,0 +1,4 @@
+en:
+  missing_permissions:
+    update_history_mode:
+      title: "You do not have permission to update ‘%{title}’"

--- a/config/locales/en/withdraw/withdraw.yml
+++ b/config/locales/en/withdraw/withdraw.yml
@@ -1,7 +1,7 @@
 en:
   withdraw:
     new:
-      title: "Withdraw '%{title}'"
+      title: "Withdraw ‘%{title}’"
       public_explanation:
         title: "Public explanation"
         guidance_title: Writing public explanation

--- a/spec/factories/user_factory.rb
+++ b/spec/factories/user_factory.rb
@@ -5,9 +5,16 @@ FactoryBot.define do
     name { "John Smith" }
     uid { SecureRandom.uuid }
     email { "someone@example.com" }
+    transient do
+      managing_editor { false }
+      manage_live_history_mode { false }
+    end
 
-    trait :managing_editor do
-      permissions { [User::MANAGING_EDITOR_PERMISSION] }
+    permissions do
+      [User::PRE_RELEASE_FEATURES_PERMISSION].tap do |p|
+        p << User::MANAGING_EDITOR_PERMISSION if managing_editor
+        p << User::MANAGE_LIVE_HISTORY_MODE if manage_live_history_mode
+      end
     end
   end
 end

--- a/spec/features/workflow/edit_withdrawal_spec.rb
+++ b/spec/features/workflow/edit_withdrawal_spec.rb
@@ -16,7 +16,7 @@ RSpec.feature "Edit a withdrawal" do
   end
 
   def and_i_am_a_managing_editor
-    login_as(create(:user, :managing_editor))
+    login_as(create(:user, managing_editor: true))
   end
 
   def when_i_visit_the_summary_page

--- a/spec/features/workflow/unwithdraw_publishing_api_down_spec.rb
+++ b/spec/features/workflow/unwithdraw_publishing_api_down_spec.rb
@@ -16,7 +16,7 @@ RSpec.feature "Unwithdraw when Publishing API is down" do
   end
 
   def and_i_am_a_managing_editor
-    login_as(create(:user, :managing_editor))
+    login_as(create(:user, managing_editor: true))
   end
 
   def and_the_publishing_api_is_down

--- a/spec/features/workflow/unwithdraw_spec.rb
+++ b/spec/features/workflow/unwithdraw_spec.rb
@@ -16,7 +16,7 @@ RSpec.feature "Unwithdraw" do
   end
 
   def and_i_am_a_managing_editor
-    login_as(create(:user, :managing_editor))
+    login_as(create(:user, managing_editor: true))
   end
 
   def when_i_visit_the_summary_page

--- a/spec/features/workflow/withdraw_publishing_api_down_spec.rb
+++ b/spec/features/workflow/withdraw_publishing_api_down_spec.rb
@@ -20,7 +20,7 @@ RSpec.feature "Withdraw a document when Publishing API is down" do
   end
 
   def and_i_am_a_managing_editor
-    login_as(create(:user, :managing_editor))
+    login_as(create(:user, managing_editor: true))
   end
 
   def when_i_visit_the_summary_page

--- a/spec/features/workflow/withdraw_requirements_spec.rb
+++ b/spec/features/workflow/withdraw_requirements_spec.rb
@@ -14,7 +14,7 @@ RSpec.feature "Withdrawal document requirements" do
   end
 
   def and_i_am_a_managing_editor
-    login_as(create(:user, :managing_editor))
+    login_as(create(:user, managing_editor: true))
   end
 
   def when_i_visit_the_document_withdrawal_page

--- a/spec/features/workflow/withdraw_spec.rb
+++ b/spec/features/workflow/withdraw_spec.rb
@@ -16,7 +16,7 @@ RSpec.feature "Withdraw a document" do
   end
 
   def and_i_am_a_managing_editor
-    login_as(create(:user, :managing_editor))
+    login_as(create(:user, managing_editor: true))
   end
 
   def when_i_visit_the_summary_page

--- a/spec/requests/editions_spec.rb
+++ b/spec/requests/editions_spec.rb
@@ -9,5 +9,26 @@ RSpec.describe "Editions" do
       expect { post create_edition_path(edition.document) }
         .to change { Edition.where(document_id: edition.document.id).count }.by(1)
     end
+
+    context "when the edition is in history mode" do
+      let(:edition) { create(:edition, :published, :political, :past_government) }
+
+      it "lets users holding the manage_live_history_mode permisssion create a new edition" do
+        user = create(:user, manage_live_history_mode: true)
+        login_as(user)
+        stub_publishing_api_put_content(edition.content_id, {})
+
+        expect { post create_edition_path(edition.document) }
+          .to change { Edition.where(document_id: edition.document.id).count }.by(1)
+      end
+
+      it "prevents users without the permission creating a new edition" do
+        edition = create(:edition, :published, :political, :past_government)
+        post create_edition_path(edition.document)
+
+        expect(response.body).to include(I18n.t!("missing_permissions.update_history_mode.title", title: edition.title))
+        expect(response.status).to eq(403)
+      end
+    end
   end
 end

--- a/spec/requests/editions_spec.rb
+++ b/spec/requests/editions_spec.rb
@@ -1,0 +1,13 @@
+# frozen_string_literal: true
+
+RSpec.describe "Editions" do
+  describe "POST /document/:document/editions" do
+    it "creates a new edition" do
+      edition = create(:edition, :published)
+      stub_publishing_api_put_content(edition.content_id, {})
+
+      expect { post create_edition_path(edition.document) }
+        .to change { Edition.where(document_id: edition.document.id).count }.by(1)
+    end
+  end
+end

--- a/spec/requests/unwithdraw_spec.rb
+++ b/spec/requests/unwithdraw_spec.rb
@@ -1,0 +1,54 @@
+# frozen_string_literal: true
+
+RSpec.describe "Unwithdraw" do
+  let(:edition) { create(:edition, :withdrawn, :political, :past_government) }
+
+  describe "POST /documents/:document/unwithdraw" do
+    context "when the edition is in history mode" do
+      it "lets users holding manage_live_history_mode permisssion unwithdraw the edition" do
+        stub_publishing_api_republish(edition.content_id, {})
+        user = create(:user, managing_editor: true, manage_live_history_mode: true)
+        login_as(user)
+
+        post unwithdraw_path(edition.document)
+        follow_redirect!
+
+        expect(response.body).to include(I18n.t!("documents.history.entry_types.unwithdrawn"))
+      end
+
+      it "prevents users without manage_live_history_mode permisssion to unwithdraw the edition" do
+        user = create(:user, managing_editor: true)
+        login_as(user)
+
+        post unwithdraw_path(edition.document)
+
+        expect(response.body).to include(I18n.t!("missing_permissions.update_history_mode.title", title: edition.title))
+        expect(response.status).to eq(403)
+      end
+    end
+  end
+
+  describe "GET /documents/:document/unwithdraw" do
+    context "when the edition is in history mode" do
+      it "lets users holding manage_live_history_mode permisssion to access unwithdraw page" do
+        user = create(:user, managing_editor: true, manage_live_history_mode: true)
+        login_as(user)
+
+        get unwithdraw_path(edition.document)
+        follow_redirect!
+
+        expect(response.body).to include(I18n.t!("documents.show.unwithdraw.title"))
+      end
+
+      it "prevents users without manage_live_history_mode permisssion to access unwithdraw page" do
+        user = create(:user, managing_editor: true)
+        login_as(user)
+
+        get unwithdraw_path(edition.document)
+
+        expect(response.body).to include(I18n.t!("missing_permissions.update_history_mode.title", title: edition.title))
+        expect(response.status).to eq(403)
+      end
+    end
+  end
+end

--- a/spec/requests/withdraw_spec.rb
+++ b/spec/requests/withdraw_spec.rb
@@ -1,0 +1,59 @@
+# frozen_string_literal: true
+
+RSpec.describe "Withdraw" do
+  let(:edition) { create(:edition, :published, :political, :past_government) }
+
+  describe "POST /documents/:document/withdraw" do
+    context "when the edition is in history mode" do
+      it "lets users holding manage_live_history_mode permisssion withdraw the edition" do
+        stub_publishing_api_unpublish(edition.content_id, body: {})
+        user = create(:user, managing_editor: true, manage_live_history_mode: true)
+        login_as(user)
+
+        post withdraw_path(edition.document), params: { public_explanation: "Just cos" }
+        follow_redirect!
+
+        withdrawal = edition.reload.status.details
+        expect(response.body).to include(
+          I18n.t!("documents.show.withdrawn.title",
+                  document_type: edition.document_type.label.downcase,
+                  withdrawn_date: withdrawal.created_at.strftime("%-d %B %Y")),
+        )
+      end
+
+      it "prevents users without manage_live_history_mode permisssion to withdraw the edition" do
+        user = create(:user, managing_editor: true)
+        login_as(user)
+
+        post withdraw_path(edition.document), params: { public_explanation: "Just cos" }
+
+        expect(response.body).to include(I18n.t!("missing_permissions.update_history_mode.title", title: edition.title))
+        expect(response.status).to eq(403)
+      end
+    end
+  end
+
+  describe "GET /documents/:document/withdraw" do
+    context "when the edition is in history mode" do
+      it "lets users holding manage_live_history_mode permisssion to access withdraw page" do
+        stub_publishing_api_unpublish(edition.content_id, body: {})
+        user = create(:user, managing_editor: true, manage_live_history_mode: true)
+        login_as(user)
+
+        get withdraw_path(edition.document)
+
+        expect(response.body).to include(I18n.t!("withdraw.new.title", title: edition.title))
+      end
+
+      it "prevents users without manage_live_history_mode permisssion to access withdraw" do
+        user = create(:user, managing_editor: true)
+        login_as(user)
+
+        get withdraw_path(edition.document)
+
+        expect(response.body).to include(I18n.t!("missing_permissions.update_history_mode.title", title: edition.title))
+        expect(response.status).to eq(403)
+      end
+    end
+  end
+end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -35,7 +35,7 @@ RSpec.configure do |config|
   config.include GdsApi::TestHelpers::PublishingApiV2
   config.include GdsApi::TestHelpers::AssetManager
   config.include GovukSchemas::RSpecMatchers
-  config.include AuthenticationHelper, type: :feature
+  config.include AuthenticationHelper, type: ->(spec) { spec.in?(%i[feature request]) }
 
   config.fixture_path = "#{::Rails.root}/spec/fixtures"
 
@@ -53,7 +53,7 @@ RSpec.configure do |config|
     ActionMailer::Base.deliveries.clear
   end
 
-  config.after :each, type: :feature do
+  config.after :each, type: ->(spec) { spec.in?(%i[feature request]) } do
     reset_authentication
   end
 end


### PR DESCRIPTION
We need to create a permission that can be granted to GDS Editors that will allow them to make changes to a live edition that is in history mode.

This PR starts to go down the road of request testing which is the new approach we want to take where logic doesn't need an explicit feature test. There is some repetition especially concerning the withdrawn / unwithdrawn permission logic so maybe we could abstract this away to a class to deal with permissions but then again we'd still have to handle the rendering from within the controller.

The two managing editor feature tests for withdraw and unwithdraw flows could be moved into request tests and will be in future work.

GDS editor permission error screen:
<img width="696" alt="Screenshot 2019-12-10 at 15 59 31" src="https://user-images.githubusercontent.com/24479188/70545917-41a26f80-1b66-11ea-8925-e2274bee3534.png">

TODO:

- [x]  test in integration
- [x]  content review

Trello:
https://trello.com/c/DXonAtIX/1209-permission-to-create-new-edition-withdraw-remove-restricted-when-document-in-history-mode