### PR TITLE
Clear linkset links after resync

### DIFF
--- a/lib/tasks/import.rake
+++ b/lib/tasks/import.rake
@@ -19,6 +19,9 @@ namespace :import do
       puts "Import failed"
       puts "Error: #{import.error_log}"
       abort
+    else
+      document = Document.find_by(content_id: import.content_id)
+      WhitehallImporter.sync(document)
     end
   end
 end

--- a/lib/whitehall_importer.rb
+++ b/lib/whitehall_importer.rb
@@ -19,4 +19,9 @@ module WhitehallImporter
 
     record
   end
+
+  def self.sync(document)
+    ResyncService.call(document)
+    ClearLinksetLinks.call(document.content_id)
+  end
 end

--- a/lib/whitehall_importer/clear_linkset_links.rb
+++ b/lib/whitehall_importer/clear_linkset_links.rb
@@ -1,0 +1,33 @@
+# frozen_string_literal: true
+
+module WhitehallImporter
+  class ClearLinksetLinks
+    attr_reader :content_id
+
+    def self.call(*args)
+      new(*args).call
+    end
+
+    def initialize(content_id)
+      @content_id = content_id
+    end
+
+    def call
+      GdsApi.publishing_api_v2.patch_links(
+        content_id,
+        links: {
+          related_policies: [],
+          ministers: [],
+          topical_events: [],
+          world_locations: [],
+          worldwide_organisations: [],
+          roles: [],
+          people: [],
+          primary_publishing_organisation: [],
+          organisations: [],
+          government: [],
+        },
+      )
+    end
+  end
+end

--- a/spec/lib/whitehall_importer/clear_linkset_links_spec.rb
+++ b/spec/lib/whitehall_importer/clear_linkset_links_spec.rb
@@ -1,0 +1,32 @@
+# frozen_string_literal: true
+
+RSpec.describe WhitehallImporter::ClearLinksetLinks do
+  describe "#call" do
+    before do
+      stub_any_publishing_api_patch_links
+    end
+
+    it "clears all linkset links except topics and taxons" do
+      content_id = SecureRandom.uuid
+      linkset_params = {
+        links: {
+          related_policies: [],
+          ministers: [],
+          topical_events: [],
+          world_locations: [],
+          worldwide_organisations: [],
+          roles: [],
+          people: [],
+          primary_publishing_organisation: [],
+          organisations: [],
+          government: [],
+        },
+      }
+
+      request = stub_publishing_api_patch_links(content_id, linkset_params)
+      described_class.call(content_id)
+
+      expect(request).to have_been_requested
+    end
+  end
+end

--- a/spec/lib/whitehall_importer_spec.rb
+++ b/spec/lib/whitehall_importer_spec.rb
@@ -42,4 +42,14 @@ RSpec.describe WhitehallImporter do
       end
     end
   end
+
+  describe ".sync" do
+    it "syncs the imported document with publishing-api" do
+      record = WhitehallImporter.import(build(:whitehall_export_document))
+
+      expect(ResyncService).to receive(:call).with(record)
+      expect(WhitehallImporter::ClearLinksetLinks).to receive(:call).with(record.content_id)
+      WhitehallImporter.sync(record)
+    end
+  end
 end


### PR DESCRIPTION
Trello: https://trello.com/c/Ni6YDPQd

## What's changed and why?

Whitehall uses a mixture of [link-set links](https://github.com/alphagov/publishing-api/blob/master/doc/link-expansion.md#patch-link-set---link-set-links) and [edition links](https://github.com/alphagov/publishing-api/blob/master/doc/link-expansion.md#put-content---edition-links) depending on at what point the content was migrated.
Content Publisher however uses edition links near exclusively. As part of migration we need to reset links that shouldn't be set as linkset links based on the document type.

Based on [digging in Whitehall](https://github.com/alphagov/whitehall/blob/master/app/presenters/publishing_api/news_article_presenter.rb#L35-L43) and the [schema](https://github.com/alphagov/govuk-content-schemas/blob/master/formats/news_article.jsonnet#L44-L50) this should be the following fields for news/press releases:

- related_policies
- ministers
- topical_events
- world_locations
- worldwide_organisations
- roles
- people
- primary_publishing_organisation
- organisations

## Integration test results

### Before
```
#<Document id: 432421, created_at: "2019-12-11 12:22:23", updated_at: "2019-12-11 12:23:25", slug: "kylo-ren-crowned-supreme-leader-of-the-galaxy", document_type: "NewsArticle", content_id: "24eb0a0a-4f29-4323-85a4-1a0480999321", locked: false>


irb(main):005:0> GdsApi.publishing_api_v2.get_links("24eb0a0a-4f29-4323-85a4-1a0480999321").to_json
=> "[[\"content_id\",\"24eb0a0a-4f29-4323-85a4-1a0480999321\"],[\"links\",{\"government\":[\"d4fbc1b9-d47d-4386-af04-ac909f868f92\"],\"ministers\":[\"f50263f8-58ae-4a95-ba2d-ab5ffe21dec7\"],\"organisations\":[\"af07d5a5-df63-4ddc-9383-6a666845ebe9\"],\"original_primary_publishing_organisation\":[\"af07d5a5-df63-4ddc-9383-6a666845ebe9\"],\"people\":[\"f50263f8-58ae-4a95-ba2d-ab5ffe21dec7\"],\"primary_publishing_organisation\":[\"af07d5a5-df63-4ddc-9383-6a666845ebe9\"],\"roles\":[\"847538b3-c0f1-11e4-8223-005056011aef\"],\"taxons\":[\"d6c2de5d-ef90-45d1-82d4-5f2438369eea\"],\"topical_events\":[\"7dbb1a8b-2149-4aba-bd87-87bd929d3635\"]}],[\"version\",2]]"
```

### After
```
irb(main):007:0> pp GdsApi.publishing_api_v2.get_links("24eb0a0a-4f29-4323-85a4-1a0480999321").to_json
"[[\"content_id\",\"24eb0a0a-4f29-4323-85a4-1a0480999321\"],[\"links\",{\"original_primary_publishing_organisation\":[\"af07d5a5-df63-4ddc-9383-6a666845ebe9\"],\"taxons\":[\"d6c2de5d-ef90-45d1-82d4-5f2438369eea\"]}],[\"version\",3]]"
=> "[[\"content_id\",\"24eb0a0a-4f29-4323-85a4-1a0480999321\"],[\"links\",{\"original_primary_publishing_organisation\":[\"af07d5a5-df63-4ddc-9383-6a666845ebe9\"],\"taxons\":[\"d6c2de5d-ef90-45d1-82d4-5f2438369eea\"]}],[\"version\",3]]"
```