### PR TITLE
Stop sending government information in details

### DIFF
--- a/app/models/government.rb
+++ b/app/models/government.rb
@@ -46,12 +46,4 @@ class Government
   def current?
     self == self.class.current
   end
-
-  def publishing_api_payload
-    {
-      "title" => name,
-      "slug" => slug,
-      "current" => current?,
-    }
-  end
 end

--- a/app/services/preview_service/payload.rb
+++ b/app/services/preview_service/payload.rb
@@ -83,7 +83,6 @@ private
 
   def details
     details = { "political" => edition.political? }
-    details["government"] = edition.government.publishing_api_payload if edition.government
 
     document_type.contents.each do |field|
       details[field.id] = perform_input_type_specific_transformations(field)

--- a/spec/models/government_spec.rb
+++ b/spec/models/government_spec.rb
@@ -152,18 +152,4 @@ RSpec.describe Government do
       expect(government.current?).to be false
     end
   end
-
-  describe "#publishing_api_payload" do
-    it "returns the fields needed for presenting to Publishing API" do
-      government = build(:government,
-                         name: "Past Government",
-                         slug: "past-government")
-
-      expect(government.publishing_api_payload).to eq(
-        "title" => "Past Government",
-        "slug" => "past-government",
-        "current" => false,
-      )
-    end
-  end
 end

--- a/spec/services/preview_service/payload_spec.rb
+++ b/spec/services/preview_service/payload_spec.rb
@@ -148,12 +148,6 @@ RSpec.describe PreviewService::Payload do
 
       payload = PreviewService::Payload.new(edition).payload
 
-      expect(payload["details"]["government"]).to eq(
-        "title" => current_government.name,
-        "slug" => current_government.slug,
-        "current" => true,
-      )
-
       expect(payload["links"]["government"]).to eq [current_government.content_id]
     end
 


### PR DESCRIPTION
Using a government link is the preferred method for setting the
government association and whether the government is current. By
removing this data we remove the risk of this data conflicting with that
provided by the links.