### PR TITLE
Show content settings for published documents

### DIFF
--- a/app/views/documents/show/_content_settings.html.erb
+++ b/app/views/documents/show/_content_settings.html.erb
@@ -14,7 +14,10 @@
   <% end %>
 <% end %>
 
-<% items = [
+<% items = [] %>
+
+<% if @edition.editable? %>
+  <% items <<
   {
     field: t("documents.show.content_settings.access_limit.title"),
     value: access_limit,
@@ -22,10 +25,10 @@
       href: access_limit_path,
       data_attributes: { gtm: "edit-access-limit" }
     }
-  }
-] %>
+  } %>
+<% end %>
 
-<% if @edition.first? %>
+<% if @edition.first? && @edition.editable? %>
   <% items << {
     field: t("documents.show.content_settings.backdate.title"),
     value: backdating_status,
@@ -40,10 +43,7 @@
   <% items << {
     field: t("documents.show.content_settings.political.title"),
     value: @edition.political? ? t("documents.show.content_settings.political.true_label") : t("documents.show.content_settings.political.false_label"),
-    edit: {
-      href: political_path,
-      data_attributes: { gtm: "edit-political" }
-    }
+    edit: @edition.editable? ? { href: political_path, data_attributes: { gtm: "edit-political" } } : {}
   } %>
 <% end %>
 

--- a/app/views/documents/show/_summary_tab.html.erb
+++ b/app/views/documents/show/_summary_tab.html.erb
@@ -52,9 +52,6 @@
     <% end %>
 
     <%= render "documents/show/tags" %>
-
-    <% if @edition.editable? %>
-      <%= render "documents/show/content_settings" %>
-    <% end %>
+    <%= render "documents/show/content_settings" %>
   </div>
 </div>


### PR DESCRIPTION
Trello: https://trello.com/c/ssksY6cO

## What's changed and why?
Display the "Content Settings" section even if the document has been published so that the 'gets history mode' setting is always displayed.

The rules for showing if the document has been access limited or backdate have not changed.

### Draft
<img width="1532" alt="Screenshot 2019-12-12 at 11 29 19" src="https://user-images.githubusercontent.com/5793815/70708571-bf838980-1cd2-11ea-806d-1eac9c4d7e23.png">

### Published
<img width="1532" alt="Screenshot 2019-12-12 at 11 29 46" src="https://user-images.githubusercontent.com/5793815/70708598-cf9b6900-1cd2-11ea-8545-44c71f736f29.png">
