### PR TITLE
Fix publishing information headings

### DIFF
--- a/app/views/publisher_information/publisher_updates.html.erb
+++ b/app/views/publisher_information/publisher_updates.html.erb
@@ -3,9 +3,11 @@
   <%= render partial: "publication_info_nav", locals: {current_page: publisher_updates_path } %>
   <div class="govuk-grid-column-two-thirds">
     <h1 class='govuk-heading-l page-title'><%= t("publisher_information.publisher_updates.title") %></h1>
-
     <%= render_govspeak(t("publisher_information.publisher_updates.summary_govspeak")) %>
+
+    <h2 class="govuk-heading-m govuk-visually-hidden"><%= t("publisher_information.publisher_updates.updates_heading") %></h2>
     <%= render_govspeak(File.read("app/views/publisher_information/publisher_updates.govspeak.md")) %>
+
     <%= render_govspeak(File.read("app/views/publisher_information/request_feature.govspeak.md")) %>
   </div>
 </div>

--- a/config/locales/en/publisher_information/publisher_updates.yml
+++ b/config/locales/en/publisher_information/publisher_updates.yml
@@ -3,3 +3,4 @@ en:
     publisher_updates:
       title: What’s new in Content Publisher
       summary_govspeak: Summary of updates to Content Publisher, content design guidance, or the design of GOV.UK.
+      updates_heading: Publisher updates


### PR DESCRIPTION
Add hidden h2 to avoid skipping heading levels from h1 to h3, provide document structure and landmarks to navigate page content.

**Note:** The updated copy is pending a review from a content designer.

[Trello card](https://trello.com/c/fgE3IdKq)