### PR TITLE
Make navigation landmarks unique

### DIFF
--- a/app/views/components/_side_navigation.html.erb
+++ b/app/views/components/_side_navigation.html.erb
@@ -3,7 +3,7 @@
   items ||= []
 %>
 
-<%= tag.nav class: "app-c-side-navigation", id: id, role: 'navigation' do %>
+<%= tag.nav class: "app-c-side-navigation", id: id, role: 'navigation', aria: { label: aria_label } do %>
   <%= tag.ul class: "app-c-side-navigation__list" do %>
     <% items.each do |item| %>
       <%

--- a/app/views/components/docs/side_navigation.yml
+++ b/app/views/components/docs/side_navigation.yml
@@ -10,6 +10,7 @@ shared_accessibility_criteria:
 examples:
   default:
     data:
+      aria_label: Publisher information
       items:
         - label: What the Beta can and cannot do
           href: /beta-capabilities

--- a/app/views/publisher_information/_publication_info_nav.html.erb
+++ b/app/views/publisher_information/_publication_info_nav.html.erb
@@ -1,5 +1,6 @@
 <div class="govuk-grid-column-one-third">
   <%= render "components/side_navigation", {
+    aria_label: "Publisher information",
     items: [
       {
         label: "What the Beta can and cannot do",

--- a/app/views/topics/edit.html.erb
+++ b/app/views/topics/edit.html.erb
@@ -8,7 +8,7 @@
 
   <div class="govuk-grid-column-one-third">
     <div class="gem-c-related-navigation">
-      <nav role="navigation" class="gem-c-related-navigation__nav-section">
+      <nav role="navigation" class="gem-c-related-navigation__nav-section" aria-label="Topics">
         <ul class="gem-c-related-navigation__link-list">
           <li class="gem-c-related-navigation__link">
             <a href="https://www.gov.uk/guidance/how-to-publish-on-gov-uk/creating-and-updating-pages#add-topic-tagging"


### PR DESCRIPTION
Landmarks must have a unique role or role/label. Given that we always have the main navigation on the page, any additional navigation landmark must be accompanied by a label to make it unique. `aria-label` is being appended to the landmark type (e.g. navigation) when provided – as seen in the example below.

**Note:** The updated copy is pending a review from a content designer.

**Example:** Using VoiceOver (⌘+F5 to enable VoiceOver, Ctrl+⎇+U to switch to landmarks and arrows to switch mode)
<img width="1080" alt="Screenshot 2019-12-13 at 11 52 39" src="https://user-images.githubusercontent.com/788096/70813714-d9e86080-1dc1-11ea-9aef-9ed351d55ee5.png">


[Trello card](https://trello.com/c/oCRMPDT2)