### PR TITLE
Redirect Whitehall images and attachments

### DIFF
--- a/app/models/whitehall_import.rb
+++ b/app/models/whitehall_import.rb
@@ -4,6 +4,8 @@
 # the import status of the document into Content Publisher
 class WhitehallImport < ApplicationRecord
   belongs_to :document, optional: true
+  has_many :whitehall_imported_assets
+  alias_attribute :assets, :whitehall_imported_assets
 
   enum state: { importing: "importing",
                 imported: "imported",

--- a/app/models/whitehall_imported_asset.rb
+++ b/app/models/whitehall_imported_asset.rb
@@ -1,0 +1,6 @@
+# frozen_string_literal: true
+
+# Represents the raw import of an asset from Whitehall Publisher and
+# the import status of the asset into Content Publisher
+class WhitehallImportedAsset < ApplicationRecord
+end

--- a/app/models/whitehall_imported_asset.rb
+++ b/app/models/whitehall_imported_asset.rb
@@ -18,6 +18,12 @@ class WhitehallImportedAsset < ApplicationRecord
     end
   end
 
+  def asset_manager_id
+    url_array = original_asset_url.to_s.split("/")
+    # https://github.com/alphagov/asset-manager#create-an-asset
+    url_array[url_array.length - 2]
+  end
+
 private
 
   def associated_with_only_image_or_file_attachment

--- a/app/models/whitehall_imported_asset.rb
+++ b/app/models/whitehall_imported_asset.rb
@@ -5,5 +5,7 @@
 class WhitehallImportedAsset < ApplicationRecord
   belongs_to :whitehall_import
 
+  # belongs to one of these, not both
   belongs_to :image_revision, class_name: "Image::Revision", optional: true
+  belongs_to :file_attachment_revision, class_name: "FileAttachment::Revision", optional: true
 end

--- a/app/models/whitehall_imported_asset.rb
+++ b/app/models/whitehall_imported_asset.rb
@@ -10,6 +10,14 @@ class WhitehallImportedAsset < ApplicationRecord
 
   validate :associated_with_only_image_or_file_attachment
 
+  def revision
+    if image_revision.present?
+      image_revision
+    elsif file_attachment_revision.present?
+      file_attachment_revision
+    end
+  end
+
 private
 
   def associated_with_only_image_or_file_attachment

--- a/app/models/whitehall_imported_asset.rb
+++ b/app/models/whitehall_imported_asset.rb
@@ -18,6 +18,14 @@ class WhitehallImportedAsset < ApplicationRecord
     end
   end
 
+  def main_asset
+    if image_revision.present?
+      image_revision.asset("960")
+    else
+      file_attachment_revision.asset
+    end
+  end
+
   def asset_manager_id
     url_array = original_asset_url.to_s.split("/")
     # https://github.com/alphagov/asset-manager#create-an-asset

--- a/app/models/whitehall_imported_asset.rb
+++ b/app/models/whitehall_imported_asset.rb
@@ -3,4 +3,7 @@
 # Represents the raw import of an asset from Whitehall Publisher and
 # the import status of the asset into Content Publisher
 class WhitehallImportedAsset < ApplicationRecord
+  belongs_to :whitehall_import
+
+  belongs_to :image_revision, class_name: "Image::Revision", optional: true
 end

--- a/app/models/whitehall_imported_asset.rb
+++ b/app/models/whitehall_imported_asset.rb
@@ -5,7 +5,16 @@
 class WhitehallImportedAsset < ApplicationRecord
   belongs_to :whitehall_import
 
-  # belongs to one of these, not both
   belongs_to :image_revision, class_name: "Image::Revision", optional: true
   belongs_to :file_attachment_revision, class_name: "FileAttachment::Revision", optional: true
+
+  validate :associated_with_only_image_or_file_attachment
+
+private
+
+  def associated_with_only_image_or_file_attachment
+    if image_revision.present? && file_attachment_revision.present?
+      errors.add(:base, "Cannot be associated with both image revision AND file attachment revision")
+    end
+  end
 end

--- a/db/migrate/20191213123801_create_whitehall_imported_assets.rb
+++ b/db/migrate/20191213123801_create_whitehall_imported_assets.rb
@@ -1,0 +1,25 @@
+# frozen_string_literal: true
+
+class CreateWhitehallImportedAssets < ActiveRecord::Migration[6.0]
+  def change
+    create_table :whitehall_imported_assets do |t|
+      t.references :whitehall_import,
+                   foreign_key: { to_table: :whitehall_imports,
+                                  on_delete: :restrict },
+                   index: true,
+                   null: false
+      t.references :file_attachment_revision,
+                   foreign_key: { to_table: :file_attachment_revisions,
+                                  on_delete: :restrict }
+      t.references :image_revision,
+                   foreign_key: { to_table: :image_revisions,
+                                  on_delete: :restrict }
+
+      t.string :original_asset_url, null: false
+      t.json :variants, default: {}, null: false
+      t.string :state, null: false, default: "not_processed"
+      t.text :error_message
+      t.timestamps
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2019_12_13_094311) do
+ActiveRecord::Schema.define(version: 2019_12_13_123801) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -326,6 +326,21 @@ ActiveRecord::Schema.define(version: 2019_12_13_094311) do
     t.datetime "updated_at", null: false
   end
 
+  create_table "whitehall_imported_assets", force: :cascade do |t|
+    t.bigint "whitehall_import_id", null: false
+    t.bigint "file_attachment_revision_id"
+    t.bigint "image_revision_id"
+    t.string "original_asset_url", null: false
+    t.json "variants", default: {}, null: false
+    t.string "state", default: "not_processed", null: false
+    t.text "error_message"
+    t.datetime "created_at", precision: 6, null: false
+    t.datetime "updated_at", precision: 6, null: false
+    t.index ["file_attachment_revision_id"], name: "index_whitehall_imported_assets_on_file_attachment_revision_id"
+    t.index ["image_revision_id"], name: "index_whitehall_imported_assets_on_image_revision_id"
+    t.index ["whitehall_import_id"], name: "index_whitehall_imported_assets_on_whitehall_import_id"
+  end
+
   create_table "whitehall_imports", force: :cascade do |t|
     t.bigint "whitehall_document_id", null: false
     t.json "payload", null: false
@@ -404,6 +419,9 @@ ActiveRecord::Schema.define(version: 2019_12_13_094311) do
   add_foreign_key "timeline_entries", "revisions", on_delete: :restrict
   add_foreign_key "timeline_entries", "statuses", on_delete: :restrict
   add_foreign_key "timeline_entries", "users", column: "created_by_id", on_delete: :restrict
+  add_foreign_key "whitehall_imported_assets", "file_attachment_revisions", on_delete: :restrict
+  add_foreign_key "whitehall_imported_assets", "image_revisions", on_delete: :restrict
+  add_foreign_key "whitehall_imported_assets", "whitehall_imports", on_delete: :restrict
   add_foreign_key "whitehall_imports", "documents", on_delete: :restrict
   add_foreign_key "withdrawals", "statuses", column: "published_status_id", on_delete: :restrict
 end

--- a/lib/whitehall_importer.rb
+++ b/lib/whitehall_importer.rb
@@ -20,7 +20,7 @@ module WhitehallImporter
     raise "Cannot import with a state of #{whitehall_import.state}" unless whitehall_import.importing?
 
     begin
-      document = Import.call(whitehall_import.payload)
+      document = Import.call(whitehall_import)
       whitehall_import.update!(document: document, state: "imported")
     rescue AbortImportError => e
       whitehall_import.update!(error_log: e.inspect, state: "import_aborted")

--- a/lib/whitehall_importer.rb
+++ b/lib/whitehall_importer.rb
@@ -37,6 +37,7 @@ module WhitehallImporter
 
       ResyncService.call(whitehall_import.document)
       ClearLinksetLinks.call(whitehall_import.document.content_id)
+      MigrateAssets.call(whitehall_import)
 
       whitehall_import.update!(state: "completed")
     rescue StandardError => e

--- a/lib/whitehall_importer/create_edition.rb
+++ b/lib/whitehall_importer/create_edition.rb
@@ -2,14 +2,14 @@
 
 module WhitehallImporter
   class CreateEdition
-    attr_reader :document, :current, :whitehall_edition, :edition_number, :user_ids
+    attr_reader :record, :current, :whitehall_edition, :edition_number, :user_ids
 
     def self.call(*args)
       new(*args).call
     end
 
-    def initialize(document:, whitehall_edition:, current: true, edition_number: 1, user_ids: {})
-      @document = document
+    def initialize(record:, whitehall_edition:, current: true, edition_number: 1, user_ids: {})
+      @record = record
       @current = current
       @whitehall_edition = whitehall_edition
       @edition_number = edition_number
@@ -39,7 +39,7 @@ module WhitehallImporter
   private
 
     def revision
-      @revision ||= CreateRevision.call(document, whitehall_edition)
+      @revision ||= CreateRevision.call(record, whitehall_edition)
     end
 
     def history
@@ -146,7 +146,7 @@ module WhitehallImporter
       last_event ||= whitehall_edition["revision_history"].last
 
       Edition.create!(
-        document: document,
+        document: record.document,
         number: edition_number,
         revision_synced: true,
         revision: revision,

--- a/lib/whitehall_importer/create_file_attachment_revision.rb
+++ b/lib/whitehall_importer/create_file_attachment_revision.rb
@@ -19,13 +19,20 @@ module WhitehallImporter
       check_file_requirements(decorated_file)
 
       blob_revision = create_blob_revision(decorated_file)
-      FileAttachment::Revision.create!(
+      revision = FileAttachment::Revision.create!(
         blob_revision: blob_revision,
         file_attachment: FileAttachment.create!,
         metadata_revision: FileAttachment::MetadataRevision.create!(
           title: whitehall_file_attachment["title"],
         ),
       )
+      WhitehallImportedAsset.create!(
+        whitehall_import: record,
+        file_attachment_revision: revision,
+        original_asset_url: whitehall_file_attachment["url"],
+        variants: whitehall_file_attachment["variants"],
+      )
+      revision
     end
 
   private

--- a/lib/whitehall_importer/create_file_attachment_revision.rb
+++ b/lib/whitehall_importer/create_file_attachment_revision.rb
@@ -6,7 +6,8 @@ module WhitehallImporter
       new(*args).call
     end
 
-    def initialize(whitehall_file_attachment, existing_filenames = [])
+    def initialize(record, whitehall_file_attachment, existing_filenames = [])
+      @record = record
       @whitehall_file_attachment = whitehall_file_attachment
       @existing_filenames = existing_filenames
     end
@@ -29,7 +30,7 @@ module WhitehallImporter
 
   private
 
-    attr_reader :whitehall_file_attachment, :existing_filenames
+    attr_reader :record, :whitehall_file_attachment, :existing_filenames
 
     def download_file
       URI.parse(whitehall_file_attachment["url"]).open

--- a/lib/whitehall_importer/create_image_revision.rb
+++ b/lib/whitehall_importer/create_image_revision.rb
@@ -17,7 +17,7 @@ module WhitehallImporter
     def call
       temp_image = normalise_image(download_file)
       blob_revision = create_blob_revision(temp_image)
-      Image::Revision.create!(
+      revision = Image::Revision.create!(
         image: Image.new,
         metadata_revision: Image::MetadataRevision.new(
           caption: whitehall_image["caption"],
@@ -25,6 +25,13 @@ module WhitehallImporter
         ),
         blob_revision: blob_revision,
       )
+      WhitehallImportedAsset.create!(
+        whitehall_import: record,
+        image_revision: revision,
+        original_asset_url: whitehall_image["url"],
+        variants: whitehall_image["variants"],
+      )
+      revision
     end
 
   private

--- a/lib/whitehall_importer/create_image_revision.rb
+++ b/lib/whitehall_importer/create_image_revision.rb
@@ -2,13 +2,14 @@
 
 module WhitehallImporter
   class CreateImageRevision
-    attr_reader :whitehall_image, :filenames
+    attr_reader :record, :whitehall_image, :filenames
 
     def self.call(*args)
       new(*args).call
     end
 
-    def initialize(whitehall_image, filenames = [])
+    def initialize(record, whitehall_image, filenames = [])
+      @record = record
       @whitehall_image = whitehall_image
       @filenames = filenames
     end

--- a/lib/whitehall_importer/create_revision.rb
+++ b/lib/whitehall_importer/create_revision.rb
@@ -2,7 +2,9 @@
 
 module WhitehallImporter
   class CreateRevision
-    attr_reader :document, :whitehall_edition
+    attr_reader :record, :whitehall_edition
+
+    delegate :document, to: :record
 
     SUPPORTED_DOCUMENT_TYPES = %w(news_story press_release).freeze
     DOCUMENT_SUB_TYPES = %w[
@@ -16,8 +18,8 @@ module WhitehallImporter
       new(*args).call
     end
 
-    def initialize(document, whitehall_edition)
-      @document = document
+    def initialize(record, whitehall_edition)
+      @record = record
       @whitehall_edition = whitehall_edition
     end
 
@@ -113,13 +115,13 @@ module WhitehallImporter
 
     def create_image_revisions(images)
       images.reduce([]) do |memo, image|
-        memo << WhitehallImporter::CreateImageRevision.call(nil, image, memo.map(&:filename))
+        memo << WhitehallImporter::CreateImageRevision.call(record, image, memo.map(&:filename))
       end
     end
 
     def create_file_attachment_revisions(file_attachments)
       file_attachments.reduce([]) do |memo, file_attachment|
-        memo << WhitehallImporter::CreateFileAttachmentRevision.call(nil, file_attachment, memo.map(&:filename))
+        memo << WhitehallImporter::CreateFileAttachmentRevision.call(record, file_attachment, memo.map(&:filename))
       end
     end
   end

--- a/lib/whitehall_importer/create_revision.rb
+++ b/lib/whitehall_importer/create_revision.rb
@@ -27,8 +27,8 @@ module WhitehallImporter
       document_type_key = DOCUMENT_SUB_TYPES.reject { |t| whitehall_edition[t].nil? }.first
       raise AbortImportError, "Edition has an unsupported document type" unless SUPPORTED_DOCUMENT_TYPES.include?(whitehall_edition[document_type_key])
 
-      file_attachment_revisions = create_file_attachment_revisions(whitehall_edition["attachments"])
-      image_revisions = create_image_revisions(whitehall_edition["images"])
+      file_attachment_revisions = find_or_create_file_attachment_revisions(whitehall_edition["attachments"])
+      image_revisions = find_or_create_image_revisions(whitehall_edition["images"])
       Revision.create!(
         document: document,
         number: document.next_revision_number,
@@ -113,15 +113,23 @@ module WhitehallImporter
       associations.map { |association| association["content_id"] }
     end
 
-    def create_image_revisions(images)
+    def find_or_create_image_revisions(images)
       images.reduce([]) do |memo, image|
-        memo << WhitehallImporter::CreateImageRevision.call(record, image, memo.map(&:filename))
+        memo << if (already_imported = WhitehallImportedAsset.find_by(original_asset_url: image["url"]))
+                  already_imported.revision
+                else
+                  WhitehallImporter::CreateImageRevision.call(record, image, memo.map(&:filename))
+                end
       end
     end
 
-    def create_file_attachment_revisions(file_attachments)
+    def find_or_create_file_attachment_revisions(file_attachments)
       file_attachments.reduce([]) do |memo, file_attachment|
-        memo << WhitehallImporter::CreateFileAttachmentRevision.call(record, file_attachment, memo.map(&:filename))
+        memo << if (already_imported = WhitehallImportedAsset.find_by(original_asset_url: file_attachment["url"]))
+                  already_imported.revision
+                else
+                  WhitehallImporter::CreateFileAttachmentRevision.call(record, file_attachment, memo.map(&:filename))
+                end
       end
     end
   end

--- a/lib/whitehall_importer/create_revision.rb
+++ b/lib/whitehall_importer/create_revision.rb
@@ -113,13 +113,13 @@ module WhitehallImporter
 
     def create_image_revisions(images)
       images.reduce([]) do |memo, image|
-        memo << WhitehallImporter::CreateImageRevision.call(image, memo.map(&:filename))
+        memo << WhitehallImporter::CreateImageRevision.call(nil, image, memo.map(&:filename))
       end
     end
 
     def create_file_attachment_revisions(file_attachments)
       file_attachments.reduce([]) do |memo, file_attachment|
-        memo << WhitehallImporter::CreateFileAttachmentRevision.call(file_attachment, memo.map(&:filename))
+        memo << WhitehallImporter::CreateFileAttachmentRevision.call(nil, file_attachment, memo.map(&:filename))
       end
     end
   end

--- a/lib/whitehall_importer/import.rb
+++ b/lib/whitehall_importer/import.rb
@@ -17,6 +17,7 @@ module WhitehallImporter
       ActiveRecord::Base.transaction do
         user_ids = create_users(whitehall_document["users"])
         document = create_document(user_ids)
+        record.update!(document: document)
 
         whitehall_document["editions"].each_with_index do |edition, edition_number|
           CreateEdition.call(

--- a/lib/whitehall_importer/import.rb
+++ b/lib/whitehall_importer/import.rb
@@ -2,14 +2,15 @@
 
 module WhitehallImporter
   class Import
-    attr_reader :whitehall_document
+    attr_reader :record, :whitehall_document
 
     def self.call(*args)
       new(*args).call
     end
 
-    def initialize(whitehall_document)
-      @whitehall_document = whitehall_document
+    def initialize(record)
+      @record = record
+      @whitehall_document = record.payload
     end
 
     def call

--- a/lib/whitehall_importer/import.rb
+++ b/lib/whitehall_importer/import.rb
@@ -16,12 +16,11 @@ module WhitehallImporter
     def call
       ActiveRecord::Base.transaction do
         user_ids = create_users(whitehall_document["users"])
-        document = create_document(user_ids)
-        record.update!(document: document)
+        record.update!(document: create_document(user_ids))
 
         whitehall_document["editions"].each_with_index do |edition, edition_number|
           CreateEdition.call(
-            document: document,
+            record: record,
             current: current?(edition),
             whitehall_edition: edition,
             edition_number: edition_number + 1,
@@ -29,7 +28,7 @@ module WhitehallImporter
           )
         end
 
-        document
+        record.document
       end
     end
 

--- a/lib/whitehall_importer/migrate_assets.rb
+++ b/lib/whitehall_importer/migrate_assets.rb
@@ -20,7 +20,10 @@ module WhitehallImporter
             whitehall_asset.asset_manager_id,
             redirect_url: whitehall_asset.main_asset.file_url,
           )
+        else
+          GdsApi.asset_manager.delete_asset(legacy_id)
         end
+
         whitehall_asset.update!(state: "processed")
       end
     end

--- a/lib/whitehall_importer/migrate_assets.rb
+++ b/lib/whitehall_importer/migrate_assets.rb
@@ -23,10 +23,22 @@ module WhitehallImporter
           )
         else
           GdsApi.asset_manager.delete_asset(whitehall_asset.asset_manager_id)
+          whitehall_asset.variants.each do |_variant, url|
+            GdsApi.asset_manager.delete_asset(asset_manager_id(url))
+          end
+          # @TODO - do we want to delete the content publisher bits too?
         end
 
         whitehall_asset.update!(state: "processed")
       end
+    end
+
+  private
+
+    def asset_manager_id(file_url)
+      url_array = file_url.to_s.split("/")
+      # https://github.com/alphagov/asset-manager#create-an-asset
+      url_array[url_array.length - 2]
     end
   end
 end

--- a/lib/whitehall_importer/migrate_assets.rb
+++ b/lib/whitehall_importer/migrate_assets.rb
@@ -21,7 +21,9 @@ module WhitehallImporter
             whitehall_asset.asset_manager_id,
             redirect_url: whitehall_asset.main_asset.file_url,
           )
-          if whitehall_asset.file_attachment_revision.present?
+          if whitehall_asset.image_revision.present?
+            redirect_variants(whitehall_asset, whitehall_asset.main_asset.file_url)
+          else
             delete_variants(whitehall_asset)
           end
         else
@@ -45,6 +47,15 @@ module WhitehallImporter
     def delete_variants(whitehall_asset)
       whitehall_asset.variants.each do |_variant, url|
         GdsApi.asset_manager.delete_asset(asset_manager_id(url))
+      end
+    end
+
+    def redirect_variants(whitehall_asset, redirect_url)
+      whitehall_asset.variants.each do |_variant, url|
+        GdsApi.asset_manager.update_asset(
+          asset_manager_id(url),
+          redirect_url: redirect_url,
+        )
       end
     end
   end

--- a/lib/whitehall_importer/migrate_assets.rb
+++ b/lib/whitehall_importer/migrate_assets.rb
@@ -1,0 +1,23 @@
+# frozen_string_literal: true
+
+module WhitehallImporter
+  class MigrateAssets
+    attr_reader :whitehall_import
+
+    def self.call(*args)
+      new(*args).call
+    end
+
+    def initialize(whitehall_import)
+      @whitehall_import = whitehall_import
+    end
+
+    def call
+      whitehall_import.assets.each do |asset|
+        asset.update!(state: "processing")
+        # TODO
+        asset.update!(state: "processed")
+      end
+    end
+  end
+end

--- a/lib/whitehall_importer/migrate_assets.rb
+++ b/lib/whitehall_importer/migrate_assets.rb
@@ -15,13 +15,14 @@ module WhitehallImporter
     def call
       whitehall_import.assets.each do |whitehall_asset|
         whitehall_asset.update!(state: "processing")
+
         if whitehall_asset.main_asset.state == "live"
           GdsApi.asset_manager.update_asset(
             whitehall_asset.asset_manager_id,
             redirect_url: whitehall_asset.main_asset.file_url,
           )
         else
-          GdsApi.asset_manager.delete_asset(legacy_id)
+          GdsApi.asset_manager.delete_asset(whitehall_asset.asset_manager_id)
         end
 
         whitehall_asset.update!(state: "processed")

--- a/lib/whitehall_importer/migrate_assets.rb
+++ b/lib/whitehall_importer/migrate_assets.rb
@@ -21,11 +21,12 @@ module WhitehallImporter
             whitehall_asset.asset_manager_id,
             redirect_url: whitehall_asset.main_asset.file_url,
           )
+          if whitehall_asset.file_attachment_revision.present?
+            delete_variants(whitehall_asset)
+          end
         else
           GdsApi.asset_manager.delete_asset(whitehall_asset.asset_manager_id)
-          whitehall_asset.variants.each do |_variant, url|
-            GdsApi.asset_manager.delete_asset(asset_manager_id(url))
-          end
+          delete_variants(whitehall_asset)
           # @TODO - do we want to delete the content publisher bits too?
         end
 
@@ -39,6 +40,12 @@ module WhitehallImporter
       url_array = file_url.to_s.split("/")
       # https://github.com/alphagov/asset-manager#create-an-asset
       url_array[url_array.length - 2]
+    end
+
+    def delete_variants(whitehall_asset)
+      whitehall_asset.variants.each do |_variant, url|
+        GdsApi.asset_manager.delete_asset(asset_manager_id(url))
+      end
     end
   end
 end

--- a/lib/whitehall_importer/migrate_assets.rb
+++ b/lib/whitehall_importer/migrate_assets.rb
@@ -13,10 +13,15 @@ module WhitehallImporter
     end
 
     def call
-      whitehall_import.assets.each do |asset|
-        asset.update!(state: "processing")
-        # TODO
-        asset.update!(state: "processed")
+      whitehall_import.assets.each do |whitehall_asset|
+        whitehall_asset.update!(state: "processing")
+        if whitehall_asset.main_asset.state == "live"
+          GdsApi.asset_manager.update_asset(
+            whitehall_asset.asset_manager_id,
+            redirect_url: whitehall_asset.main_asset.file_url,
+          )
+        end
+        whitehall_asset.update!(state: "processed")
       end
     end
   end

--- a/spec/factories/whitehall_export/file_attachment_factory.rb
+++ b/spec/factories/whitehall_export/file_attachment_factory.rb
@@ -48,8 +48,8 @@ FactoryBot.define do
     variants do
       {
         "thumbnail" => {
-          "content_type" => nil,
-          "url" => nil,
+          "content_type" => "image/png",
+          "url" => "https://asset-manager.gov.uk/blah/847150/thumb/#{filename}",
         },
       }
     end

--- a/spec/factories/whitehall_export/image_factory.rb
+++ b/spec/factories/whitehall_export/image_factory.rb
@@ -9,7 +9,11 @@ FactoryBot.define do
     caption { "This is a caption" }
     created_at { Time.current.rfc3339 }
     updated_at { Time.current.rfc3339 }
-    variants { {} }
+    variants do
+      {
+        "s960" => "https://assets.publishing.service.gov.uk/government/uploads/s960_#{filename}",
+      }
+    end
     url { "https://assets.publishing.service.gov.uk/government/uploads/#{filename}" }
 
     transient do

--- a/spec/factories/whitehall_import_factory.rb
+++ b/spec/factories/whitehall_import_factory.rb
@@ -7,5 +7,6 @@ FactoryBot.define do
     whitehall_document_id { payload["id"] }
     content_id { payload["content_id"] }
     document { association :document, imported_from: "whitehall" }
+    assets { [] }
   end
 end

--- a/spec/factories/whitehall_imported_asset_factory.rb
+++ b/spec/factories/whitehall_imported_asset_factory.rb
@@ -1,0 +1,29 @@
+# frozen_string_literal: true
+
+FactoryBot.define do
+  factory :whitehall_imported_asset do
+    original_asset_url { "https://asset-manager.gov.uk/blah/847150/foo.jpg" }
+    whitehall_import { build(:whitehall_import) }
+    state { "not_processed" }
+
+    trait :image do
+      image_revision { build(:image_revision) }
+      variants do
+        {
+          "s300": "https://asset-manager.gov.uk/blah/847151/s300_foo.jpg",
+          "s960": "https://asset-manager.gov.uk/blah/847152/s960_foo.jpg",
+        }
+      end
+    end
+
+    trait :file_attachment do
+      file_attachment_revision { build(:file_attachment_revision) }
+      original_asset_url { "https://asset-manager.gov.uk/blah/847150/foo.pdf" }
+      variants do
+        {
+          "thumbnail": "https://asset-manager.gov.uk/blah/847151/thumbnail_foo.jpg",
+        }
+      end
+    end
+  end
+end

--- a/spec/factories/whitehall_imported_asset_factory.rb
+++ b/spec/factories/whitehall_imported_asset_factory.rb
@@ -25,5 +25,9 @@ FactoryBot.define do
         }
       end
     end
+
+    trait :file_attachment do
+      file_attachment_revision { build(:file_attachment_revision) }
+    end
   end
 end

--- a/spec/factories/whitehall_imported_asset_factory.rb
+++ b/spec/factories/whitehall_imported_asset_factory.rb
@@ -25,9 +25,5 @@ FactoryBot.define do
         }
       end
     end
-
-    trait :file_attachment do
-      file_attachment_revision { build(:file_attachment_revision) }
-    end
   end
 end

--- a/spec/lib/whitehall_importer/create_file_attachment_revision_spec.rb
+++ b/spec/lib/whitehall_importer/create_file_attachment_revision_spec.rb
@@ -4,16 +4,17 @@ RSpec.describe WhitehallImporter::CreateFileAttachmentRevision do
   let(:whitehall_file_attachment) do
     build(:whitehall_export_file_attachment)
   end
+  let(:record) { nil }
 
   context "creates a file attachment" do
     it "fetches file from asset-manager" do
-      create_revision = described_class.new(whitehall_file_attachment)
+      create_revision = described_class.new(record, whitehall_file_attachment)
       expect(create_revision.call).to have_requested(:get, whitehall_file_attachment["url"])
     end
 
     it "creates a FileAttachment::Revision and sets correct metadata" do
       revision = nil
-      expect { revision = described_class.call(whitehall_file_attachment) }
+      expect { revision = described_class.call(record, whitehall_file_attachment) }
         .to change { FileAttachment::Revision.count }.by(1)
 
       expect(revision.metadata_revision.title).to eq(whitehall_file_attachment["title"])
@@ -23,7 +24,7 @@ RSpec.describe WhitehallImporter::CreateFileAttachmentRevision do
 
   shared_examples "rejected file attachment" do
     it "raises an AbortImportError with an informative error" do
-      create_revision = described_class.new(whitehall_file_attachment)
+      create_revision = described_class.new(record, whitehall_file_attachment)
       expect { create_revision.call }.to raise_error(
         WhitehallImporter::AbortImportError,
         error_message,

--- a/spec/lib/whitehall_importer/create_file_attachment_revision_spec.rb
+++ b/spec/lib/whitehall_importer/create_file_attachment_revision_spec.rb
@@ -4,7 +4,7 @@ RSpec.describe WhitehallImporter::CreateFileAttachmentRevision do
   let(:whitehall_file_attachment) do
     build(:whitehall_export_file_attachment)
   end
-  let(:record) { nil }
+  let(:record) { build(:whitehall_import) }
 
   context "creates a file attachment" do
     it "fetches file from asset-manager" do
@@ -19,6 +19,15 @@ RSpec.describe WhitehallImporter::CreateFileAttachmentRevision do
 
       expect(revision.metadata_revision.title).to eq(whitehall_file_attachment["title"])
       expect(revision.filename).to eq("some-txt.txt")
+    end
+
+    it "creates a WhitehallImportedAsset record" do
+      revision = nil
+      expect { revision = described_class.call(record, whitehall_file_attachment) }
+        .to change { WhitehallImportedAsset.count }.by(1)
+      expect(WhitehallImportedAsset.last.file_attachment_revision).to eq(revision)
+      expect(WhitehallImportedAsset.last.original_asset_url).to eq(whitehall_file_attachment["url"])
+      expect(WhitehallImportedAsset.last.variants).to eq(whitehall_file_attachment["variants"])
     end
   end
 

--- a/spec/lib/whitehall_importer/create_image_revision_spec.rb
+++ b/spec/lib/whitehall_importer/create_image_revision_spec.rb
@@ -3,15 +3,26 @@
 RSpec.describe WhitehallImporter::CreateImageRevision do
   describe "#call" do
     let(:whitehall_image) { build(:whitehall_export_image) }
-    let(:record) { nil }
+    let(:record) { build(:whitehall_import) }
 
-    it "should create an Image::Revision when a valid image is provided" do
-      image_revision = nil
-      expect { image_revision = described_class.call(record, whitehall_image) }
-        .to change { Image::Revision.count }.by(1)
-      expect(image_revision.caption).to eq(whitehall_image["caption"])
-      expect(image_revision.alt_text).to eq(whitehall_image["alt_text"])
-      expect(image_revision.filename).to eq("valid-image.jpg")
+    context "Valid image is provided" do
+      it "should create an Image::Revision" do
+        image_revision = nil
+        expect { image_revision = described_class.call(record, whitehall_image) }
+          .to change { Image::Revision.count }.by(1)
+        expect(image_revision.caption).to eq(whitehall_image["caption"])
+        expect(image_revision.alt_text).to eq(whitehall_image["alt_text"])
+        expect(image_revision.filename).to eq("valid-image.jpg")
+      end
+
+      it "should create a WhitehallImportedAsset record" do
+        image_revision = nil
+        expect { image_revision = described_class.call(record, whitehall_image) }
+          .to change { WhitehallImportedAsset.count }.by(1)
+        expect(WhitehallImportedAsset.last.image_revision).to eq(image_revision)
+        expect(WhitehallImportedAsset.last.original_asset_url).to eq(whitehall_image["url"])
+        expect(WhitehallImportedAsset.last.variants).to eq(whitehall_image["variants"])
+      end
     end
 
     context "Image is not available" do

--- a/spec/lib/whitehall_importer/create_image_revision_spec.rb
+++ b/spec/lib/whitehall_importer/create_image_revision_spec.rb
@@ -3,10 +3,11 @@
 RSpec.describe WhitehallImporter::CreateImageRevision do
   describe "#call" do
     let(:whitehall_image) { build(:whitehall_export_image) }
+    let(:record) { nil }
 
     it "should create an Image::Revision when a valid image is provided" do
       image_revision = nil
-      expect { image_revision = described_class.call(whitehall_image) }
+      expect { image_revision = described_class.call(record, whitehall_image) }
         .to change { Image::Revision.count }.by(1)
       expect(image_revision.caption).to eq(whitehall_image["caption"])
       expect(image_revision.alt_text).to eq(whitehall_image["alt_text"])
@@ -22,7 +23,7 @@ RSpec.describe WhitehallImporter::CreateImageRevision do
       end
 
       it "should raise a WhitehallImporter::AbortImportError" do
-        expect { described_class.call(whitehall_image) }.to raise_error(
+        expect { described_class.call(record, whitehall_image) }.to raise_error(
           WhitehallImporter::AbortImportError,
           "Image does not exist: #{image_url}",
         )
@@ -36,7 +37,7 @@ RSpec.describe WhitehallImporter::CreateImageRevision do
 
       it "should pass through ImageUploadChecker and raise a WhitehallImporter::AbortImportError" do
         expect(Requirements::ImageUploadChecker).to receive(:new).and_call_original
-        expect { described_class.call(whitehall_image) }.to raise_error(
+        expect { described_class.call(record, whitehall_image) }.to raise_error(
           WhitehallImporter::AbortImportError,
           I18n.t!("requirements.image_upload.unsupported_type.form_message"),
         )
@@ -50,7 +51,7 @@ RSpec.describe WhitehallImporter::CreateImageRevision do
 
       it "should pass through ImageNormaliser and raise a WhitehallImporter::AbortImportError" do
         expect(ImageNormaliser).to receive(:new).and_call_original
-        expect { described_class.call(whitehall_image) }.to raise_error(
+        expect { described_class.call(record, whitehall_image) }.to raise_error(
           WhitehallImporter::AbortImportError,
           I18n.t!("requirements.image_upload.too_small.form_message", width: 960, height: 640),
         )
@@ -63,13 +64,13 @@ RSpec.describe WhitehallImporter::CreateImageRevision do
       end
 
       it "should rename the file to something URL-friendly" do
-        described_class.call(whitehall_image)
+        described_class.call(record, whitehall_image)
         expect(Image::BlobRevision.last.filename).to eq("whitehall-asset_-image.jpg")
       end
     end
 
     it "should rename the file if duplicate filenames are passed" do
-      described_class.call(whitehall_image, ["valid-image.jpg"])
+      described_class.call(record, whitehall_image, ["valid-image.jpg"])
       expect(Image::BlobRevision.last.filename).to eq("valid-image-1.jpg")
     end
   end

--- a/spec/lib/whitehall_importer/create_revision_spec.rb
+++ b/spec/lib/whitehall_importer/create_revision_spec.rb
@@ -3,16 +3,17 @@
 RSpec.describe WhitehallImporter::CreateRevision do
   describe ".call" do
     let(:document) { build(:document, imported_from: "whitehall", locale: "en") }
+    let(:record) { build(:whitehall_import, document: document) }
 
     it "creates a revision" do
       whitehall_edition = build(:whitehall_export_edition)
-      expect { described_class.call(document, whitehall_edition) }
+      expect { described_class.call(record, whitehall_edition) }
         .to change { Revision.count }
         .by(1)
     end
 
     it "marks the revision as imported" do
-      revision = described_class.call(document, build(:whitehall_export_edition))
+      revision = described_class.call(record, build(:whitehall_export_edition))
 
       expect(revision.imported).to be(true)
     end
@@ -25,7 +26,7 @@ RSpec.describe WhitehallImporter::CreateRevision do
                           base_path: "/a-path")
       whitehall_edition = build(:whitehall_export_edition,
                                 translations: [translation])
-      revision = described_class.call(document, whitehall_edition)
+      revision = described_class.call(record, whitehall_edition)
       expect(revision.title).to eq("Revision title")
       expect(revision.summary).to eq("Revision summary")
       expect(revision.base_path).to eq("/a-path")
@@ -36,7 +37,7 @@ RSpec.describe WhitehallImporter::CreateRevision do
         whitehall_image = build(:whitehall_export_image, filename: "foo.jpg")
         whitehall_edition = build(:whitehall_export_edition, images: [whitehall_image])
         revision = nil
-        expect { revision = described_class.call(document, whitehall_edition) }
+        expect { revision = described_class.call(record, whitehall_edition) }
           .to change { Image::Revision.count }.by(1)
         expect(revision.image_revisions.last.caption).to eq(whitehall_image["caption"])
         expect(revision.image_revisions.last.alt_text).to eq(whitehall_image["alt_text"])
@@ -51,7 +52,7 @@ RSpec.describe WhitehallImporter::CreateRevision do
             build(:whitehall_export_image, filename: "subdir/image.jpg"),
           ],
         )
-        revision = described_class.call(document, whitehall_edition)
+        revision = described_class.call(record, whitehall_edition)
 
         expect(revision.image_revisions.first.blob_revision.filename).to eq("image.jpg")
         expect(revision.image_revisions.last.blob_revision.filename).to eq("image-1.jpg")
@@ -65,7 +66,7 @@ RSpec.describe WhitehallImporter::CreateRevision do
             build(:whitehall_export_image, filename: "second.jpg"),
           ],
         )
-        revision = described_class.call(document, whitehall_edition)
+        revision = described_class.call(record, whitehall_edition)
 
         expect(revision.lead_image_revision.filename).to eq("first.jpg")
       end
@@ -80,7 +81,7 @@ RSpec.describe WhitehallImporter::CreateRevision do
           ],
         )
 
-        expect { described_class.call(document, whitehall_edition) }
+        expect { described_class.call(record, whitehall_edition) }
           .to change { FileAttachment::Revision.count }.by(1)
       end
 
@@ -92,7 +93,7 @@ RSpec.describe WhitehallImporter::CreateRevision do
             build(:whitehall_export_file_attachment, filename: "attach.txt"),
           ],
         )
-        revision = described_class.call(document, whitehall_edition)
+        revision = described_class.call(record, whitehall_edition)
 
         expect(revision.file_attachment_revisions.first.blob_revision.filename).to eq("attach.txt")
         expect(revision.file_attachment_revisions.last.blob_revision.filename).to eq("attach-1.txt")
@@ -113,7 +114,7 @@ RSpec.describe WhitehallImporter::CreateRevision do
         images: ["foo.jpg"],
         attachments: ["attach.txt"],
       )
-      described_class.call(document, whitehall_edition)
+      described_class.call(record, whitehall_edition)
     end
 
     it "aborts when a translation isn't available for the documents locale" do
@@ -121,7 +122,7 @@ RSpec.describe WhitehallImporter::CreateRevision do
       whitehall_edition = build(:whitehall_export_edition,
                                 translations: [translation])
 
-      expect { described_class.call(document, whitehall_edition) }
+      expect { described_class.call(record, whitehall_edition) }
         .to raise_error(WhitehallImporter::AbortImportError)
     end
 
@@ -129,7 +130,7 @@ RSpec.describe WhitehallImporter::CreateRevision do
       whitehall_edition = build(:whitehall_export_edition,
                                 news_article_type: "unsupported")
 
-      expect { described_class.call(document, whitehall_edition) }
+      expect { described_class.call(record, whitehall_edition) }
         .to raise_error(WhitehallImporter::AbortImportError)
     end
 
@@ -140,7 +141,7 @@ RSpec.describe WhitehallImporter::CreateRevision do
         organisations: [lead_organisation],
       )
 
-      revision = described_class.call(document, whitehall_edition)
+      revision = described_class.call(record, whitehall_edition)
 
       expect(revision.primary_publishing_organisation_id)
         .to eq(lead_organisation["content_id"])
@@ -154,7 +155,7 @@ RSpec.describe WhitehallImporter::CreateRevision do
         organisations: [lead_organisation, supporting_organisation],
       )
 
-      revision = described_class.call(document, whitehall_edition)
+      revision = described_class.call(record, whitehall_edition)
 
       expect(revision.supporting_organisation_ids)
         .to eq([supporting_organisation["content_id"]])
@@ -163,7 +164,7 @@ RSpec.describe WhitehallImporter::CreateRevision do
     it "aborts if there are no organisations" do
       whitehall_edition = build(:whitehall_export_edition, organisations: [])
 
-      expect { described_class.call(document, whitehall_edition) }
+      expect { described_class.call(record, whitehall_edition) }
         .to raise_error(WhitehallImporter::AbortImportError)
     end
 
@@ -173,7 +174,7 @@ RSpec.describe WhitehallImporter::CreateRevision do
         organisations: [build(:whitehall_export_organisation)],
       )
 
-      expect { described_class.call(document, whitehall_edition) }
+      expect { described_class.call(record, whitehall_edition) }
         .to raise_error(WhitehallImporter::AbortImportError)
     end
 
@@ -185,7 +186,7 @@ RSpec.describe WhitehallImporter::CreateRevision do
         organisations: [first_lead_organisation, second_lead_organisation],
       )
 
-      expect { described_class.call(document, whitehall_edition) }
+      expect { described_class.call(record, whitehall_edition) }
         .to raise_error(WhitehallImporter::AbortImportError)
     end
 
@@ -194,7 +195,7 @@ RSpec.describe WhitehallImporter::CreateRevision do
       whitehall_edition = build(:whitehall_export_edition,
                                 role_appointments: [role_appointment])
 
-      revision = described_class.call(document, whitehall_edition)
+      revision = described_class.call(record, whitehall_edition)
 
       expect(revision.tags["role_appointments"])
         .to eq([role_appointment["content_id"]])
@@ -205,7 +206,7 @@ RSpec.describe WhitehallImporter::CreateRevision do
       whitehall_edition = build(:whitehall_export_edition,
                                 topical_events: [topical_event])
 
-      revision = described_class.call(document, whitehall_edition)
+      revision = described_class.call(record, whitehall_edition)
 
       expect(revision.tags["topical_events"])
         .to eq([topical_event["content_id"]])
@@ -216,7 +217,7 @@ RSpec.describe WhitehallImporter::CreateRevision do
       whitehall_edition = build(:whitehall_export_edition,
                                 world_locations: [world_location])
 
-      revision = described_class.call(document, whitehall_edition)
+      revision = described_class.call(record, whitehall_edition)
 
       expect(revision.tags["world_locations"].first)
         .to eq(world_location["content_id"])

--- a/spec/lib/whitehall_importer/create_revision_spec.rb
+++ b/spec/lib/whitehall_importer/create_revision_spec.rb
@@ -58,6 +58,15 @@ RSpec.describe WhitehallImporter::CreateRevision do
         expect(revision.image_revisions.last.blob_revision.filename).to eq("image-1.jpg")
       end
 
+      it "skips any image it has encountered before" do
+        image = build(:whitehall_export_image, filename: "image.jpg")
+        revision1 = described_class.call(record, build(:whitehall_export_edition, images: [image]))
+        revision2 = described_class.call(record, build(:whitehall_export_edition, images: [image]))
+        expect(revision1.image_revisions.count).to eq(1)
+        expect(revision2.image_revisions.count).to eq(1)
+        expect(revision1.image_revisions.first).to eq(revision2.image_revisions.first)
+      end
+
       it "uses the first image as the lead image" do
         whitehall_edition = build(
           :whitehall_export_edition,
@@ -90,13 +99,22 @@ RSpec.describe WhitehallImporter::CreateRevision do
           :whitehall_export_edition,
           attachments: [
             build(:whitehall_export_file_attachment, filename: "attach.txt"),
-            build(:whitehall_export_file_attachment, filename: "attach.txt"),
+            build(:whitehall_export_file_attachment, filename: "subdir/attach.txt"),
           ],
         )
         revision = described_class.call(record, whitehall_edition)
 
         expect(revision.file_attachment_revisions.first.blob_revision.filename).to eq("attach.txt")
         expect(revision.file_attachment_revisions.last.blob_revision.filename).to eq("attach-1.txt")
+      end
+
+      it "skips any attachment it has encountered before" do
+        attachment = build(:whitehall_export_file_attachment, filename: "attach.txt")
+        revision1 = described_class.call(record, build(:whitehall_export_edition, attachments: [attachment]))
+        revision2 = described_class.call(record, build(:whitehall_export_edition, attachments: [attachment]))
+        expect(revision1.file_attachment_revisions.count).to eq(1)
+        expect(revision2.file_attachment_revisions.count).to eq(1)
+        expect(revision1.file_attachment_revisions.first).to eq(revision2.file_attachment_revisions.first)
       end
     end
 

--- a/spec/lib/whitehall_importer/import_spec.rb
+++ b/spec/lib/whitehall_importer/import_spec.rb
@@ -23,6 +23,13 @@ RSpec.describe WhitehallImporter::Import do
       expect(document).to be_imported_from_whitehall
     end
 
+    it "associates the created document with the import record" do
+      import_record = build(:whitehall_import)
+      document = described_class.call(import_record)
+
+      expect(import_record.document).to eq(document)
+    end
+
     it "creates users who have never logged into Content Publisher" do
       import_data = build(:whitehall_export_document, users: [whitehall_user])
       record = build(:whitehall_import, payload: import_data)

--- a/spec/lib/whitehall_importer/migrate_assets_spec.rb
+++ b/spec/lib/whitehall_importer/migrate_assets_spec.rb
@@ -1,0 +1,18 @@
+# frozen_string_literal: true
+
+RSpec.describe WhitehallImporter::MigrateAssets do
+  describe ".call" do
+    let(:asset) { build(:whitehall_imported_asset) }
+    let(:whitehall_import) { build(:whitehall_import, assets: [asset]) }
+
+    it "should take a WhitehallImport record as an argument" do
+      expect { described_class.call(whitehall_import) }.not_to raise_error
+    end
+
+    it "should mark each asset as processing before marking as processed" do
+      expect(asset).to receive(:update!).with(state: "processing").once.ordered
+      expect(asset).to receive(:update!).with(state: "processed").once.ordered
+      described_class.call(whitehall_import)
+    end
+  end
+end

--- a/spec/lib/whitehall_importer/migrate_assets_spec.rb
+++ b/spec/lib/whitehall_importer/migrate_assets_spec.rb
@@ -71,6 +71,14 @@ RSpec.describe WhitehallImporter::MigrateAssets do
         expect(update_asset_request).to have_been_requested
       end
 
+      it "should delete live attachment variants" do
+        allow(asset.file_attachment_revision.asset).to receive(:state).and_return("live")
+        delete_request = stub_asset_manager_delete_asset("847151") # thumbnail
+
+        described_class.call(whitehall_import)
+        expect(delete_request).to have_been_requested
+      end
+
       it "should delete draft attachments" do
         allow(asset.file_attachment_revision.asset).to receive(:state).and_return("draft")
         delete_asset_request = stub_asset_manager_delete_asset(asset_id)

--- a/spec/lib/whitehall_importer/migrate_assets_spec.rb
+++ b/spec/lib/whitehall_importer/migrate_assets_spec.rb
@@ -35,6 +35,17 @@ RSpec.describe WhitehallImporter::MigrateAssets do
       expect(update_asset_request).to have_been_requested
     end
 
+    it "should redirect live image variants" do
+      allow(asset.image_revision.asset("960")).to receive(:state).and_return("live")
+      redirect_url = asset.image_revision.asset_url("960")
+      redirect_request1 = stub_asset_manager_update_asset("847151", redirect_url: redirect_url)
+      redirect_request2 = stub_asset_manager_update_asset("847152", redirect_url: redirect_url)
+
+      described_class.call(whitehall_import)
+      expect(redirect_request1).to have_been_requested
+      expect(redirect_request2).to have_been_requested
+    end
+
     it "should delete draft images" do
       allow(asset.image_revision.asset("960")).to receive(:state).and_return("draft")
       delete_asset_request = stub_asset_manager_delete_asset("847150")

--- a/spec/lib/whitehall_importer/migrate_assets_spec.rb
+++ b/spec/lib/whitehall_importer/migrate_assets_spec.rb
@@ -34,5 +34,13 @@ RSpec.describe WhitehallImporter::MigrateAssets do
       described_class.call(whitehall_import)
       expect(update_asset_request).to have_been_requested
     end
+
+    it "should delete draft assets" do
+      allow(asset.image_revision.asset("960")).to receive(:state).and_return("draft")
+      delete_asset_request = stub_asset_manager_delete_asset("847150")
+
+      described_class.call(whitehall_import)
+      expect(delete_asset_request).to have_been_requested
+    end
   end
 end

--- a/spec/lib/whitehall_importer/migrate_assets_spec.rb
+++ b/spec/lib/whitehall_importer/migrate_assets_spec.rb
@@ -2,8 +2,17 @@
 
 RSpec.describe WhitehallImporter::MigrateAssets do
   describe ".call" do
-    let(:asset) { build(:whitehall_imported_asset) }
+    let(:asset_id) { "847150" }
+    let(:asset) do
+      build(:whitehall_imported_asset,
+            :image,
+            original_asset_url: "https://asset-manager.gov.uk/blah/#{asset_id}/foo.jpg")
+    end
     let(:whitehall_import) { build(:whitehall_import, assets: [asset]) }
+
+    before :each do
+      stub_any_asset_manager_call
+    end
 
     it "should take a WhitehallImport record as an argument" do
       expect { described_class.call(whitehall_import) }.not_to raise_error
@@ -13,6 +22,17 @@ RSpec.describe WhitehallImporter::MigrateAssets do
       expect(asset).to receive(:update!).with(state: "processing").once.ordered
       expect(asset).to receive(:update!).with(state: "processed").once.ordered
       described_class.call(whitehall_import)
+    end
+
+    it "should redirect live assets" do
+      allow(asset.image_revision.asset("960")).to receive(:state).and_return("live")
+      update_asset_request = stub_asset_manager_update_asset(
+        asset_id,
+        redirect_url: asset.image_revision.asset_url("960"),
+      )
+
+      described_class.call(whitehall_import)
+      expect(update_asset_request).to have_been_requested
     end
   end
 end

--- a/spec/lib/whitehall_importer/migrate_assets_spec.rb
+++ b/spec/lib/whitehall_importer/migrate_assets_spec.rb
@@ -43,6 +43,16 @@ RSpec.describe WhitehallImporter::MigrateAssets do
       expect(delete_asset_request).to have_been_requested
     end
 
+    it "should delete variants of draft images" do
+      allow(asset.image_revision.asset("960")).to receive(:state).and_return("draft")
+      delete_request1 = stub_asset_manager_delete_asset("847151") # s300
+      delete_request2 = stub_asset_manager_delete_asset("847152") # s960
+
+      described_class.call(whitehall_import)
+      expect(delete_request1).to have_been_requested
+      expect(delete_request2).to have_been_requested
+    end
+
     context "assets are attachments" do
       let(:asset) do
         build(:whitehall_imported_asset,
@@ -67,6 +77,14 @@ RSpec.describe WhitehallImporter::MigrateAssets do
 
         described_class.call(whitehall_import)
         expect(delete_asset_request).to have_been_requested
+      end
+
+      it "should delete variants of draft attachments" do
+        allow(asset.file_attachment_revision.asset).to receive(:state).and_return("draft")
+        delete_request = stub_asset_manager_delete_asset("847151") # thumbnail
+
+        described_class.call(whitehall_import)
+        expect(delete_request).to have_been_requested
       end
     end
   end

--- a/spec/lib/whitehall_importer_spec.rb
+++ b/spec/lib/whitehall_importer_spec.rb
@@ -25,7 +25,6 @@ RSpec.describe WhitehallImporter do
 
     it "doesn't sync if import fails" do
       allow(WhitehallImporter::Import).to receive(:call)
-        .with(whitehall_export_document)
         .and_raise(WhitehallImporter::AbortImportError, "Booo, import failed")
 
       expect(WhitehallImporter).not_to receive(:sync)

--- a/spec/lib/whitehall_importer_spec.rb
+++ b/spec/lib/whitehall_importer_spec.rb
@@ -100,6 +100,11 @@ RSpec.describe WhitehallImporter do
       WhitehallImporter.sync(whitehall_import)
     end
 
+    it "redirects or deletes the corresponding Whitehall assets" do
+      expect(WhitehallImporter::MigrateAssets).to receive(:call).with(whitehall_import)
+      WhitehallImporter.sync(whitehall_import)
+    end
+
     it "returns a completed WhitehallImport" do
       WhitehallImporter.sync(whitehall_import)
       expect(whitehall_import).to be_completed

--- a/spec/models/whitehall_imported_asset_spec.rb
+++ b/spec/models/whitehall_imported_asset_spec.rb
@@ -13,6 +13,19 @@ RSpec.describe WhitehallImportedAsset do
     end
   end
 
+  describe ".main_asset" do
+    it "returns the file attachment asset when associated with one" do
+      asset = build(:whitehall_imported_asset, :file_attachment)
+      expect(asset.main_asset).to be_kind_of(FileAttachment::Asset)
+    end
+
+    it "returns the 960 image asset when associated with an image" do
+      asset = build(:whitehall_imported_asset, :image)
+      expect(asset.main_asset).to be_kind_of(Image::Asset)
+      expect(asset.main_asset).to eq(asset.revision.asset("960"))
+    end
+  end
+
   describe ".asset_manager_id" do
     it "returns the asset manager ID of the original asset" do
       asset_manager_id = "847150"

--- a/spec/models/whitehall_imported_asset_spec.rb
+++ b/spec/models/whitehall_imported_asset_spec.rb
@@ -13,6 +13,17 @@ RSpec.describe WhitehallImportedAsset do
     end
   end
 
+  describe ".asset_manager_id" do
+    it "returns the asset manager ID of the original asset" do
+      asset_manager_id = "847150"
+      asset = build(
+        :whitehall_imported_asset,
+        original_asset_url: "https://asset-manager.gov.uk/blah/#{asset_manager_id}/foo.jpg",
+      )
+      expect(asset.asset_manager_id).to eq(asset_manager_id)
+    end
+  end
+
   describe ".associated_with_only_image_or_file_attachment" do
     it "raises a validation error if associated with an image and a file attachment" do
       expect { create(:whitehall_imported_asset, :image, :file_attachment) }

--- a/spec/models/whitehall_imported_asset_spec.rb
+++ b/spec/models/whitehall_imported_asset_spec.rb
@@ -1,0 +1,13 @@
+# frozen_string_literal: true
+
+RSpec.describe WhitehallImportedAsset do
+  describe ".associated_with_only_image_or_file_attachment" do
+    it "raises a validation error if associated with an image and a file attachment" do
+      expect { create(:whitehall_imported_asset, :image, :file_attachment) }
+        .to raise_error(
+          ActiveRecord::RecordInvalid,
+          "Validation failed: Cannot be associated with both image revision AND file attachment revision",
+        )
+    end
+  end
+end

--- a/spec/models/whitehall_imported_asset_spec.rb
+++ b/spec/models/whitehall_imported_asset_spec.rb
@@ -1,6 +1,18 @@
 # frozen_string_literal: true
 
 RSpec.describe WhitehallImportedAsset do
+  describe ".revision" do
+    it "returns a file attachment revision when associated with one" do
+      asset = build(:whitehall_imported_asset, :file_attachment)
+      expect(asset.revision).to be_kind_of(FileAttachment::Revision)
+    end
+
+    it "returns an image revision when associated with one" do
+      asset = build(:whitehall_imported_asset, :image)
+      expect(asset.revision).to be_kind_of(Image::Revision)
+    end
+  end
+
   describe ".associated_with_only_image_or_file_attachment" do
     it "raises a validation error if associated with an image and a file attachment" do
       expect { create(:whitehall_imported_asset, :image, :file_attachment) }


### PR DESCRIPTION
This PR creates a MigrateAssets service which is called from the WhitehallImporter `sync`/`import_and_sync` methods. It:

* Creates a record for each imported asset (image or file attachment)
* On successful import, it will either redirect the Whitehall asset to the Content Publisher one or delete it if it only exists on the draft stack
* For each variant of the asset, the variant is either deleted (for file attachments, or for draft images) or redirected (live image variants are redirected to the canonical Content Publisher image).

This work comes out of a spike in #1509.

Todo:
- [ ] Better variants
- [ ] Error logging

Trello card: https://trello.com/c/DMpTECux/1232-handle-redirecting-and-removing-old-assets-as-part-of-whitehall-migration