### PR TITLE
BulkData resilient to time existing but key not

### DIFF
--- a/lib/bulk_data/cache.rb
+++ b/lib/bulk_data/cache.rb
@@ -25,6 +25,8 @@ module BulkData
     end
 
     def self.written_at(key)
+      return unless cache.exist?(key)
+
       cache.read("#{key}:created")
     end
 

--- a/spec/lib/bulk_data/cache_spec.rb
+++ b/spec/lib/bulk_data/cache_spec.rb
@@ -45,6 +45,12 @@ RSpec.describe BulkData::Cache do
     it "returns nil when the entry doesn't exist" do
       expect(BulkData::Cache.written_at("key")).to be_nil
     end
+
+    it "returns nil when only the created value exists but not the actual entry" do
+      BulkData::Cache.cache.write("key:created", Time.current)
+
+      expect(BulkData::Cache.written_at("key")).to be_nil
+    end
   end
 
   describe ".written_after?" do


### PR DESCRIPTION
I'm not sure how but we ended up in a situation on staging where the
created key was set but the cache entry was not. This causes the app to
fall into a loop where it will keep trying to run the job to populate
the cache and this job won't do anything because it thinks the cache is
populated.