### PR TITLE
Use Sidekiq logger for ActiveJob

### DIFF
--- a/config/application.rb
+++ b/config/application.rb
@@ -36,6 +36,7 @@ module ContentPublisher
     config.eager_load_paths << Rails.root.join("lib")
     config.autoload_paths << Rails.root.join("lib")
     config.exceptions_app = self.routes
+    config.active_job.logger = Sidekiq.logger
 
     unless Rails.application.secrets.jwt_auth_secret
       raise "JWT auth secret is not configured. See config/secrets.yml"


### PR DESCRIPTION
Turns out none of the log messages we were setting in jobs was making it
through to the sidekiq logs. Just another ActiveJob pain point.