### PR TITLE
Add more import statuses

### DIFF
--- a/app/models/whitehall_import.rb
+++ b/app/models/whitehall_import.rb
@@ -6,6 +6,10 @@ class WhitehallImport < ApplicationRecord
   belongs_to :document, optional: true
 
   enum state: { importing: "importing",
-                completed: "completed",
-                failed: "failed" }
+                imported: "imported",
+                import_aborted: "import_aborted",
+                import_failed: "import_failed",
+                syncing: "syncing",
+                sync_failed: "sync failed",
+                completed: "completed" }
 end

--- a/app/models/whitehall_import.rb
+++ b/app/models/whitehall_import.rb
@@ -3,6 +3,8 @@
 # Represents the raw import of a document from Whitehall Publisher and
 # the import status of the document into Content Publisher
 class WhitehallImport < ApplicationRecord
+  belongs_to :document, optional: true
+
   enum state: { importing: "importing",
                 completed: "completed",
                 failed: "failed" }

--- a/db/migrate/20191213094311_add_document_ref_to_whitehall_imports.rb
+++ b/db/migrate/20191213094311_add_document_ref_to_whitehall_imports.rb
@@ -1,0 +1,11 @@
+# frozen_string_literal: true
+
+class AddDocumentRefToWhitehallImports < ActiveRecord::Migration[6.0]
+  def change
+    add_reference :whitehall_imports,
+                  :document,
+                  foreign_key: { on_delete: :restrict },
+                  null: true,
+                  index: false
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2019_11_20_204541) do
+ActiveRecord::Schema.define(version: 2019_12_13_094311) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -334,6 +334,7 @@ ActiveRecord::Schema.define(version: 2019_11_20_204541) do
     t.text "error_log"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
+    t.bigint "document_id"
   end
 
   create_table "withdrawals", force: :cascade do |t|
@@ -403,5 +404,6 @@ ActiveRecord::Schema.define(version: 2019_11_20_204541) do
   add_foreign_key "timeline_entries", "revisions", on_delete: :restrict
   add_foreign_key "timeline_entries", "statuses", on_delete: :restrict
   add_foreign_key "timeline_entries", "users", column: "created_by_id", on_delete: :restrict
+  add_foreign_key "whitehall_imports", "documents", on_delete: :restrict
   add_foreign_key "withdrawals", "statuses", column: "published_status_id", on_delete: :restrict
 end

--- a/lib/tasks/import.rake
+++ b/lib/tasks/import.rake
@@ -15,7 +15,7 @@ namespace :import do
     whitehall_export = response.to_hash
     import = WhitehallImporter.import(whitehall_export)
 
-    if import.failed?
+    if import.import_failed?
       puts "Import failed"
       puts "Error: #{import.error_log}"
       abort

--- a/lib/tasks/import.rake
+++ b/lib/tasks/import.rake
@@ -13,15 +13,13 @@ namespace :import do
     client = GdsApi::JsonClient.new(options)
     response = client.get_json(endpoint)
     whitehall_export = response.to_hash
-    import = WhitehallImporter.import(whitehall_export)
 
-    if import.import_failed?
-      puts "Import failed"
-      puts "Error: #{import.error_log}"
+    whitehall_import = WhitehallImporter.import_and_sync(whitehall_export)
+
+    unless whitehall_import.completed?
+      puts whitehall_import.state.humanize
+      puts "Error: #{whitehall_import.error_log}"
       abort
-    else
-      document = Document.find_by(content_id: import.content_id)
-      WhitehallImporter.sync(document)
     end
   end
 end

--- a/lib/whitehall_importer.rb
+++ b/lib/whitehall_importer.rb
@@ -14,7 +14,7 @@ module WhitehallImporter
       record.update!(state: "completed")
     rescue StandardError => e
       record.update!(error_log: e.message,
-                     state: "failed")
+                     state: "import_failed")
     end
 
     record

--- a/lib/whitehall_importer.rb
+++ b/lib/whitehall_importer.rb
@@ -19,6 +19,8 @@ module WhitehallImporter
   def self.import(whitehall_import)
     document = Import.call(whitehall_import.payload)
     whitehall_import.update!(document: document, state: "imported")
+  rescue AbortImportError => e
+    whitehall_import.update!(error_log: e.inspect, state: "import_aborted")
   rescue StandardError => e
     whitehall_import.update!(error_log: e.inspect, state: "import_failed")
   end

--- a/lib/whitehall_importer.rb
+++ b/lib/whitehall_importer.rb
@@ -1,27 +1,31 @@
 # frozen_string_literal: true
 
 module WhitehallImporter
-  def self.import(whitehall_document)
-    record = WhitehallImport.create!(
+  def self.import_and_sync(whitehall_document)
+    whitehall_import = WhitehallImport.create!(
       whitehall_document_id: whitehall_document["id"],
       payload: whitehall_document,
       content_id: whitehall_document["content_id"],
       state: "importing",
     )
 
-    begin
-      Import.call(whitehall_document)
-      record.update!(state: "completed")
-    rescue StandardError => e
-      record.update!(error_log: e.message,
-                     state: "import_failed")
-    end
+    import(whitehall_import)
 
-    record
+    sync(whitehall_import) if whitehall_import.imported?
+
+    whitehall_import
   end
 
-  def self.sync(document)
-    ResyncService.call(document)
-    ClearLinksetLinks.call(document.content_id)
+  def self.import(whitehall_import)
+    document = Import.call(whitehall_import.payload)
+    whitehall_import.update!(document: document, state: "imported")
+  rescue StandardError => e
+    whitehall_import.update!(error_log: e.inspect, state: "import_failed")
+  end
+
+  def self.sync(whitehall_import)
+    ResyncService.call(whitehall_import.document)
+    ClearLinksetLinks.call(whitehall_import.document.content_id)
+    whitehall_import.update!(state: "completed")
   end
 end

--- a/lib/whitehall_importer.rb
+++ b/lib/whitehall_importer.rb
@@ -26,8 +26,13 @@ module WhitehallImporter
   end
 
   def self.sync(whitehall_import)
+    whitehall_import.update!(state: "syncing")
+
     ResyncService.call(whitehall_import.document)
     ClearLinksetLinks.call(whitehall_import.document.content_id)
+
     whitehall_import.update!(state: "completed")
+  rescue StandardError => e
+    whitehall_import.update!(error_log: e.inspect, state: "sync_failed")
   end
 end

--- a/spec/factories/whitehall_import_factory.rb
+++ b/spec/factories/whitehall_import_factory.rb
@@ -1,0 +1,11 @@
+# frozen_string_literal: true
+
+FactoryBot.define do
+  factory :whitehall_import do
+    state { "importing" }
+    payload { build(:whitehall_export_document) }
+    whitehall_document_id { payload["id"] }
+    content_id { payload["content_id"] }
+    document { association :document, imported_from: "whitehall" }
+  end
+end

--- a/spec/lib/tasks/import_spec.rb
+++ b/spec/lib/tasks/import_spec.rb
@@ -3,40 +3,31 @@
 RSpec.describe "Import tasks" do
   describe "import:whitehall" do
     let(:whitehall_host) { Plek.new.external_url_for("whitehall-admin") }
+    let(:whitehall_export) { build(:whitehall_export_document) }
 
     before do
       allow($stdout).to receive(:puts)
       Rake::Task["import:whitehall"].reenable
+      allow(ResyncService).to receive(:call)
+      allow(WhitehallImporter::ClearLinksetLinks).to receive(:call)
       stub_request(:get, "#{whitehall_host}/government/admin/export/document/123")
-        .to_return(status: 200, body: build(:whitehall_export_document).to_json)
+        .to_return(status: 200, body: whitehall_export.to_json)
     end
 
     it "creates a document" do
-      allow(WhitehallImporter).to receive(:sync)
       expect { Rake::Task["import:whitehall"].invoke("123") }.to change { Document.count }.by(1)
+    end
+
+    it "imports the export and syncs with publishing-api" do
+      expect(WhitehallImporter).to receive(:import_and_sync).with(whitehall_export).and_call_original
+      Rake::Task["import:whitehall"].invoke("123")
     end
 
     it "aborts if the import fails" do
       expect(WhitehallImporter::Import).to receive(:call).and_raise("Error importing")
 
       expect($stdout).to receive(:puts).with("Import failed")
-      expect($stdout).to receive(:puts).with("Error: Error importing")
-      expect { Rake::Task["import:whitehall"].invoke("123") }
-        .to raise_error(SystemExit)
-    end
-
-    it "syncs the imported document with publishing-api" do
-      document = create(:document, :with_current_and_live_editions)
-      allow(Document).to receive(:find_by).and_return(document)
-
-      expect(WhitehallImporter).to receive(:sync).with(document)
-      Rake::Task["import:whitehall"].invoke("123")
-    end
-
-    it "doesn't sync the imported document if the import fails" do
-      allow(WhitehallImporter::Import).to receive(:call).and_raise("Error importing")
-
-      expect(WhitehallImporter).to_not receive(:sync)
+      expect($stdout).to receive(:puts).with("Error: #<RuntimeError: Error importing>")
       expect { Rake::Task["import:whitehall"].invoke("123") }
         .to raise_error(SystemExit)
     end

--- a/spec/lib/whitehall_importer_spec.rb
+++ b/spec/lib/whitehall_importer_spec.rb
@@ -42,6 +42,12 @@ RSpec.describe WhitehallImporter do
       WhitehallImporter.import(whitehall_import)
     end
 
+    it "raises if the WhitehallImport doesn't have a state of importing" do
+      whitehall_import = create(:whitehall_import, state: "imported")
+      expect { WhitehallImporter.import(whitehall_import) }
+        .to raise_error(RuntimeError, "Cannot import with a state of imported")
+    end
+
     context "when the import is successful" do
       it "marks the import as imported" do
         WhitehallImporter.import(whitehall_import)
@@ -98,6 +104,12 @@ RSpec.describe WhitehallImporter do
     it "returns a completed WhitehallImport" do
       WhitehallImporter.sync(whitehall_import)
       expect(whitehall_import).to be_completed
+    end
+
+    it "raises if the WhitehallImport doesn't have a state of imported" do
+      whitehall_import = create(:whitehall_import, state: "importing")
+      expect { WhitehallImporter.sync(whitehall_import) }
+        .to raise_error(RuntimeError, "Cannot sync with a state of importing")
     end
 
     context "when the sync fails" do

--- a/spec/lib/whitehall_importer_spec.rb
+++ b/spec/lib/whitehall_importer_spec.rb
@@ -37,7 +37,7 @@ RSpec.describe WhitehallImporter do
 
       it "marks the import as failed and logs the error" do
         record = WhitehallImporter.import(build(:whitehall_export_document))
-        expect(record).to be_failed
+        expect(record).to be_import_failed
         expect(record.error_log).to eq(message)
       end
     end

--- a/spec/lib/whitehall_importer_spec.rb
+++ b/spec/lib/whitehall_importer_spec.rb
@@ -62,6 +62,23 @@ RSpec.describe WhitehallImporter do
         expect(whitehall_import.error_log).to eq("#<RuntimeError: #{message}>")
       end
     end
+
+    context "when the import aborts" do
+      before do
+        allow(WhitehallImporter::Import).to receive(:call).and_raise(
+          WhitehallImporter::AbortImportError,
+          message,
+        )
+      end
+
+      let(:message) { "Import aborted" }
+
+      it "marks the import as aborted and logs the error" do
+        WhitehallImporter.import(whitehall_import)
+        expect(whitehall_import).to be_import_aborted
+        expect(whitehall_import.error_log).to eq("#<WhitehallImporter::AbortImportError: #{message}>")
+      end
+    end
   end
 
   describe ".sync" do

--- a/spec/lib/whitehall_importer_spec.rb
+++ b/spec/lib/whitehall_importer_spec.rb
@@ -1,30 +1,51 @@
 # frozen_string_literal: true
 
 RSpec.describe WhitehallImporter do
-  describe ".import" do
-    before { allow(WhitehallImporter::Import).to receive(:call) }
-
-    it "creates a WhitehallImport" do
-      expect { WhitehallImporter.import(build(:whitehall_export_document)) }
-        .to change { WhitehallImport.count }
-        .by(1)
+  describe ".import_and_sync" do
+    before do
+      allow(ResyncService).to receive(:call)
+      allow(WhitehallImporter::ClearLinksetLinks).to receive(:call)
     end
 
-    it "imports a document" do
-      expect(WhitehallImporter::Import).to receive(:call)
-      WhitehallImporter.import(build(:whitehall_export_document))
+    let(:whitehall_export_document) { build(:whitehall_export_document) }
+
+    it "creates and returns a WhitehallImport" do
+      whitehall_import = nil
+      expect { whitehall_import = WhitehallImporter.import_and_sync(whitehall_export_document) }
+        .to change { WhitehallImport.count }
+        .by(1)
+      expect(whitehall_import).to be_an_instance_of(WhitehallImport)
     end
 
     it "stores the exported whitehall data" do
-      whitehall_export = build(:whitehall_export_document)
-      record = WhitehallImporter.import(whitehall_export)
-      expect(record.payload).to eq(whitehall_export)
+      WhitehallImporter.import_and_sync(whitehall_export_document)
+      whitehall_import = WhitehallImport.find_by(whitehall_document_id: whitehall_export_document["id"])
+      expect(whitehall_import.payload).to eq(whitehall_export_document)
+    end
+
+    it "doesn't sync if import fails" do
+      allow(WhitehallImporter::Import).to receive(:call)
+        .with(whitehall_export_document)
+        .and_raise(WhitehallImporter::AbortImportError, "Booo, import failed")
+
+      expect(WhitehallImporter).not_to receive(:sync)
+      WhitehallImporter.import_and_sync(whitehall_export_document)
+    end
+  end
+
+  describe ".import" do
+    before { allow(WhitehallImporter::Import).to receive(:call) }
+    let(:whitehall_import) { create(:whitehall_import) }
+
+    it "imports a document" do
+      expect(WhitehallImporter::Import).to receive(:call)
+      WhitehallImporter.import(whitehall_import)
     end
 
     context "when the import is successful" do
-      it "marks the import as completed" do
-        record = WhitehallImporter.import(build(:whitehall_export_document))
-        expect(record).to be_completed
+      it "marks the import as imported" do
+        WhitehallImporter.import(whitehall_import)
+        expect(whitehall_import).to be_imported
       end
     end
 
@@ -36,20 +57,30 @@ RSpec.describe WhitehallImporter do
       let(:message) { "Import failed" }
 
       it "marks the import as failed and logs the error" do
-        record = WhitehallImporter.import(build(:whitehall_export_document))
-        expect(record).to be_import_failed
-        expect(record.error_log).to eq(message)
+        WhitehallImporter.import(whitehall_import)
+        expect(whitehall_import).to be_import_failed
+        expect(whitehall_import.error_log).to eq("#<RuntimeError: #{message}>")
       end
     end
   end
 
   describe ".sync" do
-    it "syncs the imported document with publishing-api" do
-      record = WhitehallImporter.import(build(:whitehall_export_document))
+    before do
+      allow(ResyncService).to receive(:call).with(whitehall_import.document)
+      allow(WhitehallImporter::ClearLinksetLinks).to receive(:call).with(whitehall_import.document.content_id)
+    end
 
-      expect(ResyncService).to receive(:call).with(record)
-      expect(WhitehallImporter::ClearLinksetLinks).to receive(:call).with(record.content_id)
-      WhitehallImporter.sync(record)
+    let(:whitehall_import) { create(:whitehall_import, state: "imported") }
+
+    it "syncs the imported document with publishing-api" do
+      expect(ResyncService).to receive(:call).with(whitehall_import.document)
+      expect(WhitehallImporter::ClearLinksetLinks).to receive(:call).with(whitehall_import.document.content_id)
+      WhitehallImporter.sync(whitehall_import)
+    end
+
+    it "returns a completed WhitehallImport" do
+      WhitehallImporter.sync(whitehall_import)
+      expect(whitehall_import).to be_completed
     end
   end
 end


### PR DESCRIPTION
Currently the [WhitehallImport](https://github.com/alphagov/content-publisher/blob/fb45dd1ff913e9ffed8ab59ed4799be033f6eb59/app/models/whitehall_import.rb) has 3 statuses (importing, completed and failed) these are now not sufficient for the amount of things that can happen.

Below is the full list of import statuses implemented in this PR:
- importing -> doing the import process
- imported -> importing is complete
- import_aborted -> an AbortImportError is raised during import
- import_failed -> an unexpected error is raised during import
- syncing -> syncing the data with GOV.UK
- sync_failed -> an unexpected error is raised during syncing
- completed -> everything was successful

Related PR (separates out the migration which is also used by https://github.com/alphagov/content-publisher/pull/1530):
https://github.com/alphagov/content-publisher/pull/1534

Trello:
https://trello.com/c/GbgBv1Nz/1233-track-and-implement-more-statuses-in-whitehall-import-aborted-import-failed-syncing-sync-failed-complete
