### PR TITLE
Quieten down Sidekiq for tests

### DIFF
--- a/config/application.rb
+++ b/config/application.rb
@@ -36,7 +36,6 @@ module ContentPublisher
     config.eager_load_paths << Rails.root.join("lib")
     config.autoload_paths << Rails.root.join("lib")
     config.exceptions_app = self.routes
-    config.active_job.logger = Sidekiq.logger
 
     unless Rails.application.secrets.jwt_auth_secret
       raise "JWT auth secret is not configured. See config/secrets.yml"

--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -62,4 +62,8 @@ Rails.application.configure do
   # Log Action Mailer emails instead of sending them to Notify
   config.action_mailer.delivery_method = :file
   config.action_mailer.default_options = { from: "test@example.com" }
+
+  # Send log notifications to the Sidekiq logger rather than using the Rails
+  # default
+  config.active_job.logger = Sidekiq.logger
 end

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -107,4 +107,8 @@ Rails.application.configure do
   # config.active_record.database_selector = { delay: 2.seconds }
   # config.active_record.database_resolver = ActiveRecord::Middleware::DatabaseSelector::Resolver
   # config.active_record.database_resolver_context = ActiveRecord::Middleware::DatabaseSelector::Resolver::Session
+
+  # Send log notifications to the Sidekiq logger rather than using the Rails
+  # default
+  config.active_job.logger = Sidekiq.logger
 end


### PR DESCRIPTION
Sorry! https://github.com/alphagov/content-publisher/pull/1533 wasn't such a good idea.

It turns out that setting the active_job.logger to use Sidekiq was not
great for the test environment as all log entries were output to STDOUT.
This remedies this by setting the Sidekiq logger only in the production
and development environments, which allows the test environment to
continue to use the Rails default.

I initially tried to do this by changing the test environment file and
leaving dev and prod to use application.rb but this was harder to get
working since I'd have needed to initialise a new logger for this as the
Rails one had not yet been created.