### PR TITLE
Yet more resilience on BulkData

### DIFF
--- a/app/jobs/populate_bulk_data_job.rb
+++ b/app/jobs/populate_bulk_data_job.rb
@@ -9,5 +9,8 @@ class PopulateBulkDataJob < ApplicationJob
     run_exclusively do
       BulkData::GovernmentRepository.new.populate_cache(older_than: 5.minutes.ago)
     end
+  rescue BulkData::RemoteDataUnavailableError => e
+    logger.warn(e.cause ? e.cause.inspect : e.inspect)
+    raise
   end
 end

--- a/lib/bulk_data/government_repository.rb
+++ b/lib/bulk_data/government_repository.rb
@@ -33,7 +33,7 @@ module BulkData
     def populate_cache(older_than: nil)
       return if older_than && Cache.written_after?(CACHE_KEY, older_than)
 
-      data = GdsApi.publishing_api_v2
+      data = GdsApi.publishing_api_v2(timeout: 30)
                    .get_paged_editions(document_types: %w[government],
                                        fields: %w[content_id locale title details],
                                        states: %w[published],


### PR DESCRIPTION
Trello: https://trello.com/c/TQ6GPOHU/1228-spike-into-loading-governments-from-publishing-api

I learnt today that the Publishing API can take a shockingly long amount of time to return data from the editions endpoint. See:

![Screenshot 2019-12-18 at 12 57 30](https://user-images.githubusercontent.com/282717/71117067-55388080-21cd-11ea-8312-5bf5bf50375e.png)

To handle these situations a bit better this adds further logging in for when an error occurs and increases the timeout massively. Hopefully I can have a chat with Platform Health to see if they can look into this as it's very strange that it's taking quite so long.