### PR TITLE
Importing editors

### DIFF
--- a/app/models/edition.rb
+++ b/app/models/edition.rb
@@ -158,4 +158,10 @@ class Edition < ApplicationRecord
     orgs += supporting_organisation_ids if access_limit.tagged_organisations?
     orgs
   end
+
+  def add_edition_editor(user)
+    return unless user
+
+    edition_editors << user unless edition_editors.include?(user)
+  end
 end

--- a/app/models/edition.rb
+++ b/app/models/edition.rb
@@ -48,6 +48,10 @@ class Edition < ApplicationRecord
 
   has_many :internal_notes
 
+  has_and_belongs_to_many :edition_editors,
+                          class_name: "User",
+                          join_table: :edition_editors
+
   delegate :content_id, :locale, :topics, :document_topics, to: :document
 
   # delegate each state enum method

--- a/app/services/assign_edition_status_service.rb
+++ b/app/services/assign_edition_status_service.rb
@@ -18,6 +18,7 @@ class AssignEditionStatusService < ApplicationService
     if update_last_edited
       edition.last_edited_by = user
       edition.last_edited_at = Time.current
+      edition.add_edition_editor(user)
     end
   end
 

--- a/app/services/assign_edition_status_service.rb
+++ b/app/services/assign_edition_status_service.rb
@@ -1,11 +1,11 @@
 # frozen_string_literal: true
 
 class AssignEditionStatusService < ApplicationService
-  def initialize(edition, user, state, update_last_edited: true, status_details: nil)
+  def initialize(edition, user, state, record_edit: true, status_details: nil)
     @edition = edition
     @user = user
     @state = state
-    @update_last_edited = update_last_edited
+    @record_edit = record_edit
     @status_details = status_details
   end
 
@@ -15,7 +15,7 @@ class AssignEditionStatusService < ApplicationService
                                 revision_at_creation: edition.revision,
                                 details: status_details)
 
-    if update_last_edited
+    if record_edit
       edition.last_edited_by = user
       edition.last_edited_at = Time.current
       edition.add_edition_editor(user)
@@ -24,5 +24,5 @@ class AssignEditionStatusService < ApplicationService
 
 private
 
-  attr_reader :edition, :user, :state, :update_last_edited, :status_details
+  attr_reader :edition, :user, :state, :record_edit, :status_details
 end

--- a/app/services/edit_edition_service.rb
+++ b/app/services/edit_edition_service.rb
@@ -16,6 +16,7 @@ class EditEditionService < ApplicationService
 
     determine_political
     associate_with_government
+    edition.add_edition_editor(user)
   end
 
 private

--- a/app/services/publish_service.rb
+++ b/app/services/publish_service.rb
@@ -56,7 +56,7 @@ private
   def supersede_live_edition(live_edition)
     return unless live_edition
 
-    AssignEditionStatusService.call(live_edition, user, :superseded, update_last_edited: false)
+    AssignEditionStatusService.call(live_edition, user, :superseded, record_edit: false)
     live_edition.live = false
     live_edition.save!
   end

--- a/app/services/scheduled_publishing_failed_service.rb
+++ b/app/services/scheduled_publishing_failed_service.rb
@@ -27,7 +27,7 @@ private
     AssignEditionStatusService.call(edition,
                                     edition.status.created_by,
                                     :failed_to_publish,
-                                    update_last_edited: false,
+                                    record_edit: false,
                                     status_details: edition.status.details)
     edition.save!
   end

--- a/db/migrate/20191220080147_create_edition_editors.rb
+++ b/db/migrate/20191220080147_create_edition_editors.rb
@@ -1,0 +1,21 @@
+# frozen_string_literal: true
+
+class CreateEditionEditors < ActiveRecord::Migration[6.0]
+  def change
+    create_table :edition_editors do |t|
+      t.references :edition,
+                   foreign_key: { to_table: :editions, on_delete: :restrict },
+                   index: true,
+                   null: false
+
+      t.references :user,
+                   foreign_key: { to_table: :users, on_delete: :restrict },
+                   index: true,
+                   null: false
+
+      t.index %i[edition_id user_id], unique: true
+
+      t.datetime :created_at, null: false
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2019_12_13_094311) do
+ActiveRecord::Schema.define(version: 2019_12_20_080147) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -63,6 +63,15 @@ ActiveRecord::Schema.define(version: 2019_12_13_094311) do
     t.string "imported_from"
     t.index ["content_id", "locale"], name: "index_documents_on_content_id_and_locale", unique: true
     t.index ["created_by_id"], name: "index_documents_on_created_by_id"
+  end
+
+  create_table "edition_editors", force: :cascade do |t|
+    t.bigint "edition_id", null: false
+    t.bigint "user_id", null: false
+    t.datetime "created_at", null: false
+    t.index ["edition_id", "user_id"], name: "index_edition_editors_on_edition_id_and_user_id", unique: true
+    t.index ["edition_id"], name: "index_edition_editors_on_edition_id"
+    t.index ["user_id"], name: "index_edition_editors_on_user_id"
   end
 
   create_table "editions", force: :cascade do |t|
@@ -350,6 +359,8 @@ ActiveRecord::Schema.define(version: 2019_12_13_094311) do
   add_foreign_key "active_storage_attachments", "active_storage_blobs", column: "blob_id"
   add_foreign_key "content_revisions", "users", column: "created_by_id", on_delete: :restrict
   add_foreign_key "documents", "users", column: "created_by_id", on_delete: :restrict
+  add_foreign_key "edition_editors", "editions", on_delete: :restrict
+  add_foreign_key "edition_editors", "users", on_delete: :restrict
   add_foreign_key "editions", "access_limits", on_delete: :restrict
   add_foreign_key "editions", "documents", on_delete: :restrict
   add_foreign_key "editions", "revisions", on_delete: :restrict

--- a/spec/models/edition_spec.rb
+++ b/spec/models/edition_spec.rb
@@ -183,4 +183,24 @@ RSpec.describe Edition do
       end
     end
   end
+
+  describe "#add_edition_editor" do
+    it "adds an edition user if they are not already listed as an editor" do
+      user = build(:user)
+      edition = build(:edition)
+
+      edition.add_edition_editor(user)
+      expect(edition.edition_editors).to include(user)
+    end
+
+    it "does not add an edition user if they are already listed as an editor" do
+      user = build(:user)
+      edition = build(:edition, edition_editors: [user])
+
+      expect do
+        edition.add_edition_editor(user)
+          .not_to(change { edition.edition_editors })
+      end
+    end
+  end
 end

--- a/spec/services/assign_edition_status_service_spec.rb
+++ b/spec/services/assign_edition_status_service_spec.rb
@@ -34,7 +34,7 @@ RSpec.describe AssignEditionStatusService do
         AssignEditionStatusService.call(edition,
                                         user,
                                         :submitted_for_review,
-                                        update_last_edited: false)
+                                        record_edit: false)
 
         expect(edition.last_edited_at).not_to eq(Time.current)
         expect(edition.last_edited_at).to eq(3.weeks.ago)

--- a/spec/services/assign_edition_status_service_spec.rb
+++ b/spec/services/assign_edition_status_service_spec.rb
@@ -51,5 +51,15 @@ RSpec.describe AssignEditionStatusService do
 
       expect(edition.status.details).to eq(removal)
     end
+
+    describe "updates the edition editors" do
+      it "adds an edition user if they are not already listed as an editor" do
+        edition = build(:edition)
+
+        expect { AssignEditionStatusService.call(edition, user, :submitted_for_review) }
+          .to change { edition.edition_editors.size }
+          .by(1)
+      end
+    end
   end
 end

--- a/spec/services/edit_edition_service_spec.rb
+++ b/spec/services/edit_edition_service_spec.rb
@@ -35,6 +35,16 @@ RSpec.describe EditEditionService do
         .to raise_error("cannot edit a live edition")
     end
 
+    describe "updates the edition editors" do
+      it "adds an edition user if they are not already listed as an editor" do
+        edition = build(:edition)
+
+        expect { EditEditionService.call(edition, user) }
+          .to change { edition.edition_editors.size }
+          .by(1)
+      end
+    end
+
     describe "marks an edition as political" do
       it "sets system_political to true when the edition is identified as political" do
         allow(PoliticalEditionIdentifier)


### PR DESCRIPTION
**As a** User who has edited a Whitehall edition
**I want** to receive a notification when the edition is published
**So that** I can admire my work

Content Publisher has a concept of [editors](https://github.com/alphagov/content-publisher/blob/151f9b447880b8c63a20444624e17c82f74f78dd/app/models/edition.rb#L145-L148) who are people who have either modified content or have changed the state of it. We currently work this out at runtime by determining who created statuses and who created revisions of a particular edition. This approach will no longer work for content that is migrated from Whitehall, as we don't have revisions and statuses, and instead we should turn this into a database association. 

This pull request is for the following changes required by this story:

* Create a new table in which to store edition editors.
* Add an association on the `Edition` model.  This will temporarily be called `edition_editors`.  At a later date this will replace the existing `editors` method when it has been removed and then renamed at that point.
* Add a method on the `Edition` model to update edition editors.
* Update edition editors when assigning an edition status.
* Update edition editors after editing an edition.

[Trello](https://trello.com/c/cS8R0OFd/1263-importing-editors)