### PR TITLE
Remove use of publishing_api_v2

### DIFF
--- a/app/interactors/unwithdraw/unwithdraw_interactor.rb
+++ b/app/interactors/unwithdraw/unwithdraw_interactor.rb
@@ -32,7 +32,7 @@ private
   end
 
   def republish_edition
-    GdsApi.publishing_api_v2.republish(edition.content_id, locale: "en")
+    GdsApi.publishing_api.republish(edition.content_id, locale: "en")
   rescue GdsApi::BaseError => e
     GovukError.notify(e)
     context.fail!(api_error: true)

--- a/app/models/document_topics.rb
+++ b/app/models/document_topics.rb
@@ -6,7 +6,7 @@ class DocumentTopics
   attr_accessor :document, :version, :topic_content_ids, :index
 
   def self.find_by_document(document, index)
-    publishing_api = GdsApi.publishing_api_v2
+    publishing_api = GdsApi.publishing_api
     links = publishing_api.get_links(document.content_id)
 
     new(
@@ -40,7 +40,7 @@ class DocumentTopics
 
     @topics = nil
 
-    GdsApi.publishing_api_v2.patch_links(
+    GdsApi.publishing_api.patch_links(
       document.content_id,
       links: {
         taxons: leaf_topic_content_ids + unknown_taxon_content_ids,

--- a/app/services/delete_draft_service.rb
+++ b/app/services/delete_draft_service.rb
@@ -45,7 +45,7 @@ private
 
   def discard_draft(edition)
     begin
-      GdsApi.publishing_api_v2.discard_draft(document.content_id)
+      GdsApi.publishing_api.discard_draft(document.content_id)
     rescue GdsApi::HTTPNotFound
       Rails.logger.warn("No draft to discard for content id #{document.content_id}")
     rescue GdsApi::HTTPUnprocessableEntity => e

--- a/app/services/preview_service.rb
+++ b/app/services/preview_service.rb
@@ -20,7 +20,7 @@ private
 
   def put_draft_content
     payload = Payload.new(edition, republish: republish).payload
-    GdsApi.publishing_api_v2.put_content(edition.content_id, payload)
+    GdsApi.publishing_api.put_content(edition.content_id, payload)
     edition.update!(revision_synced: true)
   end
 

--- a/app/services/preview_service/payload.rb
+++ b/app/services/preview_service/payload.rb
@@ -100,7 +100,7 @@ private
 
     role_appointments
       .each_with_object("roles" => [], "people" => []) do |appointment_id, memo|
-        response = GdsApi.publishing_api_v2.get_links(appointment_id).to_hash
+        response = GdsApi.publishing_api.get_links(appointment_id).to_hash
 
         roles = response.dig("links", "role") || []
         people = response.dig("links", "person") || []

--- a/app/services/publish_service.rb
+++ b/app/services/publish_service.rb
@@ -46,7 +46,7 @@ private
   end
 
   def publish_current_edition
-    GdsApi.publishing_api_v2.publish(
+    GdsApi.publishing_api.publish(
       document.content_id,
       nil, # Sending update_type is deprecated (now in payload)
       locale: document.locale,

--- a/app/services/remove_service.rb
+++ b/app/services/remove_service.rb
@@ -23,7 +23,7 @@ private
   attr_reader :edition, :removal
 
   def unpublish_edition
-    GdsApi.publishing_api_v2.unpublish(
+    GdsApi.publishing_api.unpublish(
       edition.content_id,
       type: removal.redirect? ? "redirect" : "gone",
       explanation: removal.explanatory_note,

--- a/app/services/resync_service.rb
+++ b/app/services/resync_service.rb
@@ -57,7 +57,7 @@ private
   end
 
   def reserve_path(base_path)
-    GdsApi.publishing_api_v2.put_path(
+    GdsApi.publishing_api.put_path(
       base_path,
       publishing_app: "content-publisher",
       override_existing: true,
@@ -65,7 +65,7 @@ private
   end
 
   def publish
-    GdsApi.publishing_api_v2.publish(
+    GdsApi.publishing_api.publish(
       live_edition.document.content_id,
       nil, # Sending update_type is deprecated (now in payload)
       locale: live_edition.document.locale,
@@ -76,7 +76,7 @@ private
     withdrawal = live_edition.status.details
     explanation_html = GovspeakDocument.new(withdrawal.public_explanation, live_edition).payload_html
 
-    GdsApi.publishing_api_v2.unpublish(
+    GdsApi.publishing_api.unpublish(
       live_edition.document.content_id,
       type: "withdrawal",
       explanation: explanation_html,
@@ -88,7 +88,7 @@ private
 
   def redirect_or_remove
     removal = live_edition.status.details
-    GdsApi.publishing_api_v2.unpublish(
+    GdsApi.publishing_api.unpublish(
       live_edition.content_id,
       type: removal.redirect? ? "redirect" : "gone",
       explanation: removal.explanatory_note,

--- a/app/services/withdraw_service.rb
+++ b/app/services/withdraw_service.rb
@@ -20,7 +20,7 @@ private
   attr_reader :edition, :public_explanation, :user
 
   def unpublish_edition
-    GdsApi.publishing_api_v2.unpublish(
+    GdsApi.publishing_api.unpublish(
       edition.content_id,
       type: "withdrawal",
       explanation: format_govspeak(public_explanation, edition),

--- a/lib/bulk_data/government_repository.rb
+++ b/lib/bulk_data/government_repository.rb
@@ -33,7 +33,7 @@ module BulkData
     def populate_cache(older_than: nil)
       return if older_than && Cache.written_after?(CACHE_KEY, older_than)
 
-      data = GdsApi.publishing_api_v2(timeout: 30)
+      data = GdsApi.publishing_api(timeout: 30)
                    .get_paged_editions(document_types: %w[government],
                                        fields: %w[content_id locale title details],
                                        states: %w[published],

--- a/lib/contacts.rb
+++ b/lib/contacts.rb
@@ -30,7 +30,7 @@ private
 
   def load_all_contacts
     GdsApi
-      .publishing_api_v2
+      .publishing_api
       .get_paged_editions(EDITION_PARAMS)
       .inject([]) { |memo, page| memo + page["results"] }
   end

--- a/lib/linkables.rb
+++ b/lib/linkables.rb
@@ -24,7 +24,7 @@ private
     # Maybe we'll need to go further with this a la:
     # https://github.com/alphagov/whitehall/blob/fc62edcd5a9b1ba8bfb22911f69f128083535127/app/models/policy.rb#L45-L58
     @linkables ||= Rails.cache.fetch("linkables.#{document_type}", CACHE_OPTIONS) do
-      GdsApi.publishing_api_v2(timeout: 3).get_linkables(document_type: document_type).to_hash
+      GdsApi.publishing_api(timeout: 3).get_linkables(document_type: document_type).to_hash
     end
   end
 end

--- a/lib/organisations.rb
+++ b/lib/organisations.rb
@@ -8,7 +8,7 @@ class Organisations
 
   def self.by_content_id(content_id)
     Rails.cache.fetch("organisations.#{content_id}", CACHE_OPTIONS) do
-      GdsApi.publishing_api_v2.get_content(content_id).to_h
+      GdsApi.publishing_api.get_content(content_id).to_h
     end
   end
 

--- a/lib/requirements/path_checker.rb
+++ b/lib/requirements/path_checker.rb
@@ -26,7 +26,7 @@ module Requirements
   private
 
     def base_path_conflict?
-      base_path_owner = GdsApi.publishing_api_v2.lookup_content_id(
+      base_path_owner = GdsApi.publishing_api.lookup_content_id(
         base_path: revision.base_path,
         with_drafts: true,
         exclude_document_types: [],

--- a/lib/topic_index.rb
+++ b/lib/topic_index.rb
@@ -73,6 +73,6 @@ private
   end
 
   def publishing_api
-    GdsApi.publishing_api_v2
+    GdsApi.publishing_api
   end
 end

--- a/lib/whitehall_importer/clear_linkset_links.rb
+++ b/lib/whitehall_importer/clear_linkset_links.rb
@@ -13,7 +13,7 @@ module WhitehallImporter
     end
 
     def call
-      GdsApi.publishing_api_v2.patch_links(
+      GdsApi.publishing_api.patch_links(
         content_id,
         links: {
           related_policies: [],

--- a/spec/services/resync_service_spec.rb
+++ b/spec/services/resync_service_spec.rb
@@ -211,12 +211,5 @@ RSpec.describe ResyncService do
         end
       end
     end
-
-    def stub_publishing_api_path_reservation(base_path, params)
-      endpoint = GdsApi::TestHelpers::PublishingApi::PUBLISHING_API_ENDPOINT
-      url = endpoint + "/paths#{base_path}"
-
-      stub_request(:put, url).with(body: params)
-    end
   end
 end

--- a/spec/services/resync_service_spec.rb
+++ b/spec/services/resync_service_spec.rb
@@ -63,7 +63,7 @@ RSpec.describe ResyncService do
 
       it "doesn't publish the edition" do
         expect(FailsafePreviewService).to receive(:call).with(edition)
-        expect(GdsApi.publishing_api_v2).not_to receive(:publish)
+        expect(GdsApi.publishing_api).not_to receive(:publish)
         ResyncService.call(edition.document)
       end
     end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -32,7 +32,6 @@ RSpec.configure do |config|
   config.include ActiveSupport::Testing::TimeHelpers
   config.include FactoryBot::Syntax::Methods
   config.include GdsApi::TestHelpers::PublishingApi
-  config.include GdsApi::TestHelpers::PublishingApiV2
   config.include GdsApi::TestHelpers::AssetManager
   config.include GovukSchemas::RSpecMatchers
   config.include AuthenticationHelper, type: ->(spec) { spec.in?(%i[feature request]) }

--- a/spec/support/topics_helper.rb
+++ b/spec/support/topics_helper.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 module TopicsHelper
-  ENDPOINT = GdsApi::TestHelpers::PublishingApiV2::PUBLISHING_API_V2_ENDPOINT
+  ENDPOINT = GdsApi::TestHelpers::PublishingApi::PUBLISHING_API_V2_ENDPOINT
 
   def stub_any_publishing_api_no_links
     stub_request(:get, %r(\A#{ENDPOINT}/links/[a-z0-9\-]+\Z))


### PR DESCRIPTION
## What's changed and why?

`publishing_api` and `publishing_api_v2` were combined in version 63.1.0 of `gds-api-adapters`, so all references to publishing_api_v2 have been removed.