### PR TITLE
Update topic tests to use `have_been_requested`

### DIFF
--- a/spec/models/document_topics_spec.rb
+++ b/spec/models/document_topics_spec.rb
@@ -76,7 +76,9 @@ RSpec.describe DocumentTopics do
           previous_version: 1,
         }
 
-        assert_publishing_api_patch_links(document.content_id, expected_links, 1)
+        request = stub_publishing_api_patch_links(document.content_id, expected_links)
+
+        expect(request).to have_been_requested
         expect(document.document_topics.topic_content_ids).to eq(%w(level_one_topic))
       end
     end
@@ -102,7 +104,9 @@ RSpec.describe DocumentTopics do
           previous_version: 1,
         }
 
-        assert_publishing_api_patch_links(document.content_id, expected_links, 1)
+        request = stub_publishing_api_patch_links(document.content_id, expected_links)
+
+        expect(request).to have_been_requested
         expect(document.document_topics.topic_content_ids).to eq(%w(level_two_topic))
       end
     end
@@ -128,7 +132,9 @@ RSpec.describe DocumentTopics do
           previous_version: 1,
         }
 
-        assert_publishing_api_patch_links(document.content_id, expected_links, 1)
+        request = stub_publishing_api_patch_links(document.content_id, expected_links)
+
+        expect(request).to have_been_requested
         expect(document.document_topics.topic_content_ids).to eq(%w(level_two_topic unknown_taxon_content_id))
       end
     end


### PR DESCRIPTION
The convention in Content Publisher is to use the `have_been_requested` matcher rather
than the assertions in gds-api-adapters.