### PR TITLE
Longer retry cycle for PopulateBulkDataJob

### DIFF
--- a/spec/jobs/populate_bulk_data_job_spec.rb
+++ b/spec/jobs/populate_bulk_data_job_spec.rb
@@ -39,21 +39,12 @@ RSpec.describe PopulateBulkDataJob do
   end
 
   context "when it runs out of retries" do
-    it "reports the error to GovukError if the cause is not a GdsApi::HTTPServerError" do
-      stub_any_publishing_api_call.to_return(status: 429)
+    it "reports the error to GovukError" do
+      stub_publishing_api_isnt_available
 
       perform_enqueued_jobs do
         expect(GovukError).to receive(:notify)
                           .with(instance_of(BulkData::RemoteDataUnavailableError))
-        PopulateBulkDataJob.perform_later
-      end
-    end
-
-    it "doesn't report the error to GovukError when the cause is a GdsApi::HTTPServerError" do
-      stub_any_publishing_api_call.to_return(status: 500)
-
-      perform_enqueued_jobs do
-        expect(GovukError).not_to receive(:notify)
         PopulateBulkDataJob.perform_later
       end
     end


### PR DESCRIPTION
Trello: https://trello.com/c/TQ6GPOHU/1228-spike-into-loading-governments-from-publishing-api

Previously this job would use the default amount of retries which is 5
with 3s between them. This had the effect that it was quite vulnerable
to reporting an error particularly in integration and staging during a
data sync.

Initially I thought we'd not want this to be retrying for more than 15
minutes as we run the job on a 15 minute interval. However I think it's
actually fine for a job to be still retrying for a lot longer after that
so then it only needs to tell us an error after a long time has passed.

Given it's now such a long time it seems reasonable to alert on any
error.