### PR TITLE
Create placeholder rake task for importing documents from Whitehall by organisation and document type

### DIFF
--- a/app/models/whitehall_migration.rb
+++ b/app/models/whitehall_migration.rb
@@ -1,0 +1,4 @@
+# frozen_string_literal: true
+
+class WhitehallMigration < ApplicationRecord
+end

--- a/app/models/whitehall_migration/document_import.rb
+++ b/app/models/whitehall_migration/document_import.rb
@@ -2,7 +2,7 @@
 
 # Represents the raw import of a document from Whitehall Publisher and
 # the import status of the document into Content Publisher
-class WhitehallImport < ApplicationRecord
+class WhitehallMigration::DocumentImport < ApplicationRecord
   belongs_to :document, optional: true
 
   enum state: { importing: "importing",

--- a/db/migrate/20191223085531_create_whitehall_migrations.rb
+++ b/db/migrate/20191223085531_create_whitehall_migrations.rb
@@ -1,0 +1,19 @@
+# frozen_string_literal: true
+
+class CreateWhitehallMigrations < ActiveRecord::Migration[6.0]
+  def change
+    create_table :whitehall_migrations do |t|
+      t.text :organisation_slug, null: false
+      t.text :document_type, null: false
+      t.datetime :start_time
+      t.datetime :end_time
+      t.timestamps
+    end
+
+    change_table :whitehall_imports, bulk: true do |t|
+      t.column :whitehall_migration_id, :bigint
+    end
+
+    add_foreign_key :whitehall_imports, :whitehall_migrations
+  end
+end

--- a/db/migrate/20191223092938_namespace_whitehall_import.rb
+++ b/db/migrate/20191223092938_namespace_whitehall_import.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+class NamespaceWhitehallImport < ActiveRecord::Migration[6.0]
+  def change
+    rename_table :whitehall_imports, :whitehall_migration_document_imports
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -344,6 +344,16 @@ ActiveRecord::Schema.define(version: 2019_12_23_091535) do
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.bigint "document_id"
+    t.bigint "whitehall_migration_id"
+  end
+
+  create_table "whitehall_migrations", force: :cascade do |t|
+    t.text "organisation_slug", null: false
+    t.text "document_type", null: false
+    t.datetime "start_time"
+    t.datetime "end_time"
+    t.datetime "created_at", precision: 6, null: false
+    t.datetime "updated_at", precision: 6, null: false
   end
 
   create_table "withdrawals", force: :cascade do |t|
@@ -416,5 +426,6 @@ ActiveRecord::Schema.define(version: 2019_12_23_091535) do
   add_foreign_key "timeline_entries", "statuses", on_delete: :restrict
   add_foreign_key "timeline_entries", "users", column: "created_by_id", on_delete: :restrict
   add_foreign_key "whitehall_imports", "documents", on_delete: :restrict
+  add_foreign_key "whitehall_imports", "whitehall_migrations"
   add_foreign_key "withdrawals", "statuses", column: "published_status_id", on_delete: :restrict
 end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2019_12_23_091535) do
+ActiveRecord::Schema.define(version: 2019_12_23_092938) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -335,7 +335,7 @@ ActiveRecord::Schema.define(version: 2019_12_23_091535) do
     t.datetime "updated_at", null: false
   end
 
-  create_table "whitehall_imports", force: :cascade do |t|
+  create_table "whitehall_migration_document_imports", force: :cascade do |t|
     t.bigint "whitehall_document_id", null: false
     t.json "payload", null: false
     t.uuid "content_id", null: false
@@ -425,7 +425,7 @@ ActiveRecord::Schema.define(version: 2019_12_23_091535) do
   add_foreign_key "timeline_entries", "revisions", on_delete: :restrict
   add_foreign_key "timeline_entries", "statuses", on_delete: :restrict
   add_foreign_key "timeline_entries", "users", column: "created_by_id", on_delete: :restrict
-  add_foreign_key "whitehall_imports", "documents", on_delete: :restrict
-  add_foreign_key "whitehall_imports", "whitehall_migrations"
+  add_foreign_key "whitehall_migration_document_imports", "documents", on_delete: :restrict
+  add_foreign_key "whitehall_migration_document_imports", "whitehall_migrations"
   add_foreign_key "withdrawals", "statuses", column: "published_status_id", on_delete: :restrict
 end

--- a/lib/tasks/import.rake
+++ b/lib/tasks/import.rake
@@ -3,8 +3,8 @@
 require "gds_api/json_client"
 
 namespace :import do
-  desc "Import a single document from Whitehall Publisher using Whitehall's internal document ID e.g. import:whitehall[123]"
-  task :whitehall, [:document_id] => :environment do |_, args|
+  desc "Import a single document from Whitehall Publisher using Whitehall's internal document ID e.g. import:whitehall_document[123]"
+  task :whitehall_document, [:document_id] => :environment do |_, args|
     host = Plek.new.external_url_for("whitehall-admin")
     endpoint = "#{host}/government/admin/export/document/#{args.document_id}"
     options = {

--- a/lib/tasks/import.rake
+++ b/lib/tasks/import.rake
@@ -3,6 +3,13 @@
 require "gds_api/json_client"
 
 namespace :import do
+  desc "Import all documents matching an organisation and document type from Whitehall Publisher, e.g. import:whitehall_migration[organisation-slug, document-type]"
+  task :whitehall_migration, %i[organisation_slug document_type] => :environment do |_, args|
+    WhitehallMigration.create!(organisation_slug: args.organisation_slug,
+                               document_type: args.document_type,
+                               start_time: Time.zone.now)
+  end
+
   desc "Import a single document from Whitehall Publisher using Whitehall's internal document ID e.g. import:whitehall_document[123]"
   task :whitehall_document, [:document_id] => :environment do |_, args|
     host = Plek.new.external_url_for("whitehall-admin")

--- a/lib/whitehall_importer.rb
+++ b/lib/whitehall_importer.rb
@@ -2,7 +2,7 @@
 
 module WhitehallImporter
   def self.import_and_sync(whitehall_document)
-    whitehall_import = WhitehallImport.create!(
+    whitehall_import = WhitehallMigration::DocumentImport.create!(
       whitehall_document_id: whitehall_document["id"],
       payload: whitehall_document,
       content_id: whitehall_document["content_id"],

--- a/spec/factories/whitehall_migration_document_import_factory.rb
+++ b/spec/factories/whitehall_migration_document_import_factory.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 FactoryBot.define do
-  factory :whitehall_import do
+  factory :whitehall_migration_document_import, class: WhitehallMigration::DocumentImport do
     state { "importing" }
     payload { build(:whitehall_export_document) }
     whitehall_document_id { payload["id"] }

--- a/spec/lib/tasks/import_spec.rb
+++ b/spec/lib/tasks/import_spec.rb
@@ -1,6 +1,21 @@
 # frozen_string_literal: true
 
 RSpec.describe "Import tasks" do
+  describe "import:whitehall_migration" do
+    before do
+      Rake::Task["import:whitehall_migration"].reenable
+    end
+
+    it "creates a WhitehallMigration" do
+      freeze_time do
+        expect { Rake::Task["import:whitehall_migration"].invoke("cabinet-office", "news_story") }.to change { WhitehallMigration.count }.by(1)
+        expect(WhitehallMigration.last.organisation_slug).to eq("cabinet-office")
+        expect(WhitehallMigration.last.document_type).to eq("news_story")
+        expect(WhitehallMigration.last.start_time).to eq(Time.current)
+      end
+    end
+  end
+
   describe "import:whitehall_document" do
     let(:whitehall_host) { Plek.new.external_url_for("whitehall-admin") }
     let(:whitehall_export) { build(:whitehall_export_document) }

--- a/spec/lib/tasks/import_spec.rb
+++ b/spec/lib/tasks/import_spec.rb
@@ -1,13 +1,13 @@
 # frozen_string_literal: true
 
 RSpec.describe "Import tasks" do
-  describe "import:whitehall" do
+  describe "import:whitehall_document" do
     let(:whitehall_host) { Plek.new.external_url_for("whitehall-admin") }
     let(:whitehall_export) { build(:whitehall_export_document) }
 
     before do
       allow($stdout).to receive(:puts)
-      Rake::Task["import:whitehall"].reenable
+      Rake::Task["import:whitehall_document"].reenable
       allow(ResyncService).to receive(:call)
       allow(WhitehallImporter::ClearLinksetLinks).to receive(:call)
       stub_request(:get, "#{whitehall_host}/government/admin/export/document/123")
@@ -15,12 +15,12 @@ RSpec.describe "Import tasks" do
     end
 
     it "creates a document" do
-      expect { Rake::Task["import:whitehall"].invoke("123") }.to change { Document.count }.by(1)
+      expect { Rake::Task["import:whitehall_document"].invoke("123") }.to change { Document.count }.by(1)
     end
 
     it "imports the export and syncs with publishing-api" do
       expect(WhitehallImporter).to receive(:import_and_sync).with(whitehall_export).and_call_original
-      Rake::Task["import:whitehall"].invoke("123")
+      Rake::Task["import:whitehall_document"].invoke("123")
     end
 
     it "aborts if the import fails" do
@@ -28,7 +28,7 @@ RSpec.describe "Import tasks" do
 
       expect($stdout).to receive(:puts).with("Import failed")
       expect($stdout).to receive(:puts).with("Error: #<RuntimeError: Error importing>")
-      expect { Rake::Task["import:whitehall"].invoke("123") }
+      expect { Rake::Task["import:whitehall_document"].invoke("123") }
         .to raise_error(SystemExit)
     end
   end


### PR DESCRIPTION
We currently have a model (`WhitehallImport`) that stores the status, content and outcome for an individual document that is imported from Whitehall.  Once we begin importing based on specific document types for a single organisation, we need to also store information about this run.  Therefore the `WhitehallMigration` model has been created to store this information.

The `WhitehallImport` model (which has been namespaced `WhitehallMigration::DocumentImport` to avoid creating many different types of `WhitehallSomething` models), references the WhitehallMigration record (one `WhitehallMigration` will have many `WhitehallMigration::DocumentImport`).

Additionally, the `import:whitehall[document-id]` rake task has been renamed `import:whitehall-document[document-id]` to make it clear this task only imports a single document.  A new rake task `import:whitehall-migration[organisation-slug,document-type]` has been created as a placeholder for future work which will enable us to import the entirety of an organisation's documents (of a defined document type).

Trello card: https://trello.com/c/XyTS7QCv