### PR TITLE
Add migration to populate editors of old editions

### DIFF
--- a/db/migrate/20191223091535_populate_edition_editors.rb
+++ b/db/migrate/20191223091535_populate_edition_editors.rb
@@ -1,0 +1,19 @@
+# frozen_string_literal: true
+
+class PopulateEditionEditors < ActiveRecord::Migration[6.0]
+  def change
+    revision_editors = Revision.joins(:editions_revisions)
+                       .group(:edition_id)
+                       .pluck(:edition_id, Arel.sql("ARRAY_AGG(DISTINCT created_by_id)"))
+                       .to_h
+
+    status_editors = Status.group(:edition_id)
+                     .pluck(:edition_id, Arel.sql("ARRAY_AGG(DISTINCT created_by_id)"))
+                     .to_h
+
+    Edition.all.each do |edition|
+      editor_ids = (revision_editors[edition.id] + status_editors[edition.id]).uniq
+      edition.edition_editor_ids = editor_ids
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2019_12_20_080147) do
+ActiveRecord::Schema.define(version: 2019_12_23_091535) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"


### PR DESCRIPTION
Trello: https://trello.com/c/cS8R0OFd

Follows on from PR #1547 

## What's changed and why?

Content Publisher has a concept of editors who are people who have either modified content or have changed the state of it. We currently work this out at runtime by determining who created statuses and who created revisions of a particular edition. This approach will no longer work for content that is migrated from Whitehall, as we don't have revisions and statuses, and instead we should turn this into a database association.

Creates a database migration to set the editor associations on existing editions. The migration we should uses as little application code as possible as this can break migrations that run later. 