### PR TITLE
Retire the old `editors` method

### DIFF
--- a/app/models/edition.rb
+++ b/app/models/edition.rb
@@ -48,7 +48,7 @@ class Edition < ApplicationRecord
 
   has_many :internal_notes
 
-  has_and_belongs_to_many :edition_editors,
+  has_and_belongs_to_many :editors,
                           class_name: "User",
                           join_table: :edition_editors
 
@@ -146,11 +146,6 @@ class Edition < ApplicationRecord
     backdated_to || document.first_published_at
   end
 
-  def editors
-    user_ids = statuses.pluck(:created_by_id) + revisions.pluck(:created_by_id)
-    User.where(id: user_ids.uniq)
-  end
-
   def access_limit_organisation_ids
     raise "no access limit" unless access_limit
 
@@ -162,6 +157,6 @@ class Edition < ApplicationRecord
   def add_edition_editor(user)
     return unless user
 
-    edition_editors << user unless edition_editors.include?(user)
+    editors << user unless editors.include?(user)
   end
 end

--- a/spec/features/workflow/publish_spec.rb
+++ b/spec/features/workflow/publish_spec.rb
@@ -31,7 +31,8 @@ RSpec.feature "Publishing an edition" do
 
     @edition = create(:edition, :publishable,
                       created_by: @creator,
-                      base_path: "/news/banana-pricing-updates")
+                      base_path: "/news/banana-pricing-updates",
+                      editors: [@creator])
   end
 
   def when_i_visit_the_summary_page

--- a/spec/features/workflow/publish_without_review_spec.rb
+++ b/spec/features/workflow/publish_without_review_spec.rb
@@ -21,7 +21,8 @@ RSpec.feature "Publish without review" do
     @edition = create(:edition, :publishable,
                       created_by: @creator,
                       created_at: 1.day.ago,
-                      base_path: "/news/banana-pricing-updates")
+                      base_path: "/news/banana-pricing-updates",
+                      editors: [@creator])
   end
 
   def when_i_visit_the_summary_page

--- a/spec/models/edition_spec.rb
+++ b/spec/models/edition_spec.rb
@@ -190,16 +190,16 @@ RSpec.describe Edition do
       edition = build(:edition)
 
       edition.add_edition_editor(user)
-      expect(edition.edition_editors).to include(user)
+      expect(edition.editors).to include(user)
     end
 
     it "does not add an edition user if they are already listed as an editor" do
       user = build(:user)
-      edition = build(:edition, edition_editors: [user])
+      edition = build(:edition, editors: [user])
 
       expect do
         edition.add_edition_editor(user)
-          .not_to(change { edition.edition_editors })
+          .not_to(change { edition.editors })
       end
     end
   end

--- a/spec/services/assign_edition_status_service_spec.rb
+++ b/spec/services/assign_edition_status_service_spec.rb
@@ -57,7 +57,7 @@ RSpec.describe AssignEditionStatusService do
         edition = build(:edition)
 
         expect { AssignEditionStatusService.call(edition, user, :submitted_for_review) }
-          .to change { edition.edition_editors.size }
+          .to change { edition.editors.size }
           .by(1)
       end
     end

--- a/spec/services/edit_edition_service_spec.rb
+++ b/spec/services/edit_edition_service_spec.rb
@@ -40,7 +40,7 @@ RSpec.describe EditEditionService do
         edition = build(:edition)
 
         expect { EditEditionService.call(edition, user) }
-          .to change { edition.edition_editors.size }
+          .to change { edition.editors.size }
           .by(1)
       end
     end


### PR DESCRIPTION
Trello: https://trello.com/c/cS8R0OFd
Follows on from PRs #1547 and #1566

## What's changed and why?

Now that we're populating editors directly and have migrated editors to all be assigned in the database,
the old `editors` method on Edition can be replaced with the renamed has_many :editors association.