### PR TITLE
Redirect Whitehall images and attachments

### DIFF
--- a/app/models/whitehall_migration/asset_import.rb
+++ b/app/models/whitehall_migration/asset_import.rb
@@ -14,6 +14,18 @@ class WhitehallMigration::AssetImport < ApplicationRecord
 
   validate :associated_with_only_image_or_file_attachment
 
+  def content_publisher_asset
+    if image_revision.present?
+      if variant.nil? || variant == "s960"
+        image_revision.asset("960")
+      elsif variant == "s300"
+        image_revision.asset("300")
+      end
+    elsif variant.nil?
+      file_attachment_revision.asset
+    end
+  end
+
   def whitehall_asset_id
     url_array = original_asset_url.to_s.split("/")
     # https://github.com/alphagov/asset-manager#create-an-asset

--- a/app/models/whitehall_migration/asset_import.rb
+++ b/app/models/whitehall_migration/asset_import.rb
@@ -1,0 +1,10 @@
+# frozen_string_literal: true
+
+# Represents the raw import of an asset from Whitehall Publisher and
+# the import status of the asset into Content Publisher
+class WhitehallMigration::AssetImport < ApplicationRecord
+  enum state: { redirected: "redirected",
+                removed: "removed",
+                migration_failed: "migration_failed",
+                pending: "pending" }
+end

--- a/app/models/whitehall_migration/asset_import.rb
+++ b/app/models/whitehall_migration/asset_import.rb
@@ -3,6 +3,10 @@
 # Represents the raw import of an asset from Whitehall Publisher and
 # the import status of the asset into Content Publisher
 class WhitehallMigration::AssetImport < ApplicationRecord
+  belongs_to :document_import
+  belongs_to :image_revision, class_name: "Image::Revision", optional: true
+  belongs_to :file_attachment_revision, class_name: "FileAttachment::Revision", optional: true
+
   enum state: { redirected: "redirected",
                 removed: "removed",
                 migration_failed: "migration_failed",

--- a/app/models/whitehall_migration/asset_import.rb
+++ b/app/models/whitehall_migration/asset_import.rb
@@ -14,6 +14,12 @@ class WhitehallMigration::AssetImport < ApplicationRecord
 
   validate :associated_with_only_image_or_file_attachment
 
+  def whitehall_asset_id
+    url_array = original_asset_url.to_s.split("/")
+    # https://github.com/alphagov/asset-manager#create-an-asset
+    url_array[url_array.length - 2]
+  end
+
 private
 
   def associated_with_only_image_or_file_attachment

--- a/app/models/whitehall_migration/asset_import.rb
+++ b/app/models/whitehall_migration/asset_import.rb
@@ -11,4 +11,14 @@ class WhitehallMigration::AssetImport < ApplicationRecord
                 removed: "removed",
                 migration_failed: "migration_failed",
                 pending: "pending" }
+
+  validate :associated_with_only_image_or_file_attachment
+
+private
+
+  def associated_with_only_image_or_file_attachment
+    if image_revision.present? && file_attachment_revision.present?
+      errors.add(:base, "Cannot be associated with both image revision AND file attachment revision")
+    end
+  end
 end

--- a/app/models/whitehall_migration/document_import.rb
+++ b/app/models/whitehall_migration/document_import.rb
@@ -4,6 +4,7 @@
 # the import status of the document into Content Publisher
 class WhitehallMigration::DocumentImport < ApplicationRecord
   belongs_to :document, optional: true
+  has_many :assets, class_name: "WhitehallMigration::AssetImport"
 
   enum state: { pending: "pending",
                 importing: "importing",

--- a/app/models/whitehall_migration/document_import.rb
+++ b/app/models/whitehall_migration/document_import.rb
@@ -14,4 +14,8 @@ class WhitehallMigration::DocumentImport < ApplicationRecord
                 syncing: "syncing",
                 sync_failed: "sync failed",
                 completed: "completed" }
+
+  def migratable_assets
+    assets.select { |a| a.pending? || a.migration_failed? }
+  end
 end

--- a/db/migrate/20191230093500_create_whitehall_imported_assets.rb
+++ b/db/migrate/20191230093500_create_whitehall_imported_assets.rb
@@ -1,0 +1,27 @@
+# frozen_string_literal: true
+
+class CreateWhitehallImportedAssets < ActiveRecord::Migration[6.0]
+  def change
+    create_table :whitehall_migration_asset_imports do |t|
+      t.references :document_import,
+                   foreign_key: { to_table: :whitehall_migration_document_imports,
+                                  on_delete: :restrict },
+                   index: { name: :index_whitehall_migration_asset_on_document },
+                   null: false
+      t.references :file_attachment_revision,
+                   foreign_key: { to_table: :file_attachment_revisions,
+                                  on_delete: :restrict },
+                   index: false
+      t.references :image_revision,
+                   foreign_key: { to_table: :image_revisions,
+                                  on_delete: :restrict },
+                   index: false
+
+      t.string :original_asset_url, null: false
+      t.string :state, null: false, default: "pending"
+      t.string :variant
+      t.text :error_message
+      t.timestamps
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -335,6 +335,19 @@ ActiveRecord::Schema.define(version: 2020_01_07_151448) do
     t.datetime "updated_at", null: false
   end
 
+  create_table "whitehall_migration_asset_imports", force: :cascade do |t|
+    t.bigint "document_import_id", null: false
+    t.bigint "file_attachment_revision_id"
+    t.bigint "image_revision_id"
+    t.string "original_asset_url", null: false
+    t.string "state", default: "pending", null: false
+    t.string "variant"
+    t.text "error_message"
+    t.datetime "created_at", precision: 6, null: false
+    t.datetime "updated_at", precision: 6, null: false
+    t.index ["document_import_id"], name: "index_whitehall_migration_asset_on_document"
+  end
+
   create_table "whitehall_migration_document_imports", force: :cascade do |t|
     t.bigint "whitehall_document_id", null: false
     t.json "payload"
@@ -425,6 +438,9 @@ ActiveRecord::Schema.define(version: 2020_01_07_151448) do
   add_foreign_key "timeline_entries", "revisions", on_delete: :restrict
   add_foreign_key "timeline_entries", "statuses", on_delete: :restrict
   add_foreign_key "timeline_entries", "users", column: "created_by_id", on_delete: :restrict
+  add_foreign_key "whitehall_migration_asset_imports", "file_attachment_revisions", on_delete: :restrict
+  add_foreign_key "whitehall_migration_asset_imports", "image_revisions", on_delete: :restrict
+  add_foreign_key "whitehall_migration_asset_imports", "whitehall_migration_document_imports", column: "document_import_id", on_delete: :restrict
   add_foreign_key "whitehall_migration_document_imports", "documents", on_delete: :restrict
   add_foreign_key "whitehall_migration_document_imports", "whitehall_migrations"
   add_foreign_key "withdrawals", "statuses", column: "published_status_id", on_delete: :restrict

--- a/lib/whitehall_importer.rb
+++ b/lib/whitehall_importer.rb
@@ -60,6 +60,7 @@ module WhitehallImporter
 
       ResyncService.call(whitehall_import.document)
       ClearLinksetLinks.call(whitehall_import.document.content_id)
+      MigrateAssets.call(whitehall_import)
 
       whitehall_import.update!(state: "completed")
     rescue StandardError => e

--- a/lib/whitehall_importer.rb
+++ b/lib/whitehall_importer.rb
@@ -42,7 +42,7 @@ module WhitehallImporter
     raise "Cannot import with a state of #{whitehall_import.state}" unless whitehall_import.importing?
 
     begin
-      document = Import.call(whitehall_import.payload)
+      document = Import.call(whitehall_import)
       whitehall_import.update!(document: document, state: "imported")
       create_timeline_entry(document.current_edition)
     rescue AbortImportError => e

--- a/lib/whitehall_importer/create_edition.rb
+++ b/lib/whitehall_importer/create_edition.rb
@@ -2,14 +2,14 @@
 
 module WhitehallImporter
   class CreateEdition
-    attr_reader :document, :current, :whitehall_edition, :edition_number, :user_ids
+    attr_reader :document_import, :current, :whitehall_edition, :edition_number, :user_ids
 
     def self.call(*args)
       new(*args).call
     end
 
-    def initialize(document:, whitehall_edition:, current: true, edition_number: 1, user_ids: {})
-      @document = document
+    def initialize(document_import:, whitehall_edition:, current: true, edition_number: 1, user_ids: {})
+      @document_import = document_import
       @current = current
       @whitehall_edition = whitehall_edition
       @edition_number = edition_number
@@ -39,7 +39,7 @@ module WhitehallImporter
   private
 
     def revision
-      @revision ||= CreateRevision.call(document, whitehall_edition)
+      @revision ||= CreateRevision.call(document_import, whitehall_edition)
     end
 
     def history
@@ -148,7 +148,7 @@ module WhitehallImporter
       editor_ids = history.editors.map { |editor| user_ids[editor] }.compact
 
       Edition.create!(
-        document: document,
+        document: document_import.document,
         number: edition_number,
         revision_synced: false,
         revision: revision,

--- a/lib/whitehall_importer/create_file_attachment_revision.rb
+++ b/lib/whitehall_importer/create_file_attachment_revision.rb
@@ -19,13 +19,15 @@ module WhitehallImporter
       check_file_requirements(decorated_file)
 
       blob_revision = create_blob_revision(decorated_file)
-      FileAttachment::Revision.create!(
+      revision = FileAttachment::Revision.create!(
         blob_revision: blob_revision,
         file_attachment: FileAttachment.create!,
         metadata_revision: FileAttachment::MetadataRevision.create!(
           title: whitehall_file_attachment["title"],
         ),
       )
+      record_assets(revision)
+      revision
     end
 
   private
@@ -64,6 +66,22 @@ module WhitehallImporter
       return if whitehall_file_attachment["type"] == "FileAttachment"
 
       raise WhitehallImporter::AbortImportError, "Unsupported file attachment: #{whitehall_file_attachment['type']}"
+    end
+
+    def record_assets(revision)
+      WhitehallMigration::AssetImport.create!(
+        document_import: document_import,
+        file_attachment_revision: revision,
+        original_asset_url: whitehall_file_attachment["url"],
+      )
+      whitehall_file_attachment["variants"].each do |variant, metadata|
+        WhitehallMigration::AssetImport.create!(
+          document_import: document_import,
+          file_attachment_revision: revision,
+          original_asset_url: metadata["url"],
+          variant: variant,
+        )
+      end
     end
 
     def abort_on_issue(issues)

--- a/lib/whitehall_importer/create_file_attachment_revision.rb
+++ b/lib/whitehall_importer/create_file_attachment_revision.rb
@@ -6,7 +6,8 @@ module WhitehallImporter
       new(*args).call
     end
 
-    def initialize(whitehall_file_attachment, existing_filenames = [])
+    def initialize(document_import, whitehall_file_attachment, existing_filenames = [])
+      @document_import = document_import
       @whitehall_file_attachment = whitehall_file_attachment
       @existing_filenames = existing_filenames
     end
@@ -29,7 +30,7 @@ module WhitehallImporter
 
   private
 
-    attr_reader :whitehall_file_attachment, :existing_filenames
+    attr_reader :document_import, :whitehall_file_attachment, :existing_filenames
 
     def download_file
       URI.parse(whitehall_file_attachment["url"]).open

--- a/lib/whitehall_importer/create_image_revision.rb
+++ b/lib/whitehall_importer/create_image_revision.rb
@@ -2,13 +2,14 @@
 
 module WhitehallImporter
   class CreateImageRevision
-    attr_reader :whitehall_image, :filenames
+    attr_reader :document_import, :whitehall_image, :filenames
 
     def self.call(*args)
       new(*args).call
     end
 
-    def initialize(whitehall_image, filenames = [])
+    def initialize(document_import, whitehall_image, filenames = [])
+      @document_import = document_import
       @whitehall_image = whitehall_image
       @filenames = filenames
     end

--- a/lib/whitehall_importer/create_revision.rb
+++ b/lib/whitehall_importer/create_revision.rb
@@ -118,13 +118,13 @@ module WhitehallImporter
 
     def create_image_revisions(images)
       images.reduce([]) do |memo, image|
-        memo << WhitehallImporter::CreateImageRevision.call(image, memo.map(&:filename))
+        memo << WhitehallImporter::CreateImageRevision.call(nil, image, memo.map(&:filename))
       end
     end
 
     def create_file_attachment_revisions(file_attachments)
       file_attachments.reduce([]) do |memo, file_attachment|
-        memo << WhitehallImporter::CreateFileAttachmentRevision.call(file_attachment, memo.map(&:filename))
+        memo << WhitehallImporter::CreateFileAttachmentRevision.call(nil, file_attachment, memo.map(&:filename))
       end
     end
 

--- a/lib/whitehall_importer/create_revision.rb
+++ b/lib/whitehall_importer/create_revision.rb
@@ -2,7 +2,9 @@
 
 module WhitehallImporter
   class CreateRevision
-    attr_reader :document, :whitehall_edition
+    attr_reader :document_import, :whitehall_edition
+
+    delegate :document, to: :document_import
 
     SUPPORTED_DOCUMENT_TYPES = %w(news_story press_release).freeze
     DOCUMENT_SUB_TYPES = %w[
@@ -16,8 +18,8 @@ module WhitehallImporter
       new(*args).call
     end
 
-    def initialize(document, whitehall_edition)
-      @document = document
+    def initialize(document_import, whitehall_edition)
+      @document_import = document_import
       @whitehall_edition = whitehall_edition
     end
 
@@ -118,13 +120,13 @@ module WhitehallImporter
 
     def create_image_revisions(images)
       images.reduce([]) do |memo, image|
-        memo << WhitehallImporter::CreateImageRevision.call(nil, image, memo.map(&:filename))
+        memo << WhitehallImporter::CreateImageRevision.call(document_import, image, memo.map(&:filename))
       end
     end
 
     def create_file_attachment_revisions(file_attachments)
       file_attachments.reduce([]) do |memo, file_attachment|
-        memo << WhitehallImporter::CreateFileAttachmentRevision.call(nil, file_attachment, memo.map(&:filename))
+        memo << WhitehallImporter::CreateFileAttachmentRevision.call(document_import, file_attachment, memo.map(&:filename))
       end
     end
 

--- a/lib/whitehall_importer/import.rb
+++ b/lib/whitehall_importer/import.rb
@@ -2,14 +2,15 @@
 
 module WhitehallImporter
   class Import
-    attr_reader :whitehall_document
+    attr_reader :document_import, :whitehall_document
 
     def self.call(*args)
       new(*args).call
     end
 
-    def initialize(whitehall_document)
-      @whitehall_document = whitehall_document
+    def initialize(document_import)
+      @document_import = document_import
+      @whitehall_document = document_import.payload
     end
 
     def call

--- a/lib/whitehall_importer/import.rb
+++ b/lib/whitehall_importer/import.rb
@@ -17,6 +17,7 @@ module WhitehallImporter
       ActiveRecord::Base.transaction do
         user_ids = create_users(whitehall_document["users"])
         document = create_document(user_ids)
+        document_import.update!(document: document)
 
         whitehall_document["editions"].each_with_index do |edition, edition_number|
           CreateEdition.call(

--- a/lib/whitehall_importer/import.rb
+++ b/lib/whitehall_importer/import.rb
@@ -16,12 +16,11 @@ module WhitehallImporter
     def call
       ActiveRecord::Base.transaction do
         user_ids = create_users(whitehall_document["users"])
-        document = create_document(user_ids)
-        document_import.update!(document: document)
+        document_import.update!(document: create_document(user_ids))
 
         whitehall_document["editions"].each_with_index do |edition, edition_number|
           CreateEdition.call(
-            document: document,
+            document_import: document_import,
             current: current?(edition),
             whitehall_edition: edition,
             edition_number: edition_number + 1,
@@ -29,8 +28,8 @@ module WhitehallImporter
           )
         end
 
-        check_document_integrity(document)
-        document
+        check_document_integrity(document_import.document)
+        document_import.document
       end
     end
 

--- a/lib/whitehall_importer/migrate_assets.rb
+++ b/lib/whitehall_importer/migrate_assets.rb
@@ -14,12 +14,15 @@ module WhitehallImporter
 
     def call
       whitehall_import.assets.each do |whitehall_asset|
-        if whitehall_asset.content_publisher_asset.present?
+        if whitehall_asset.content_publisher_asset.present? && whitehall_asset.content_publisher_asset.live?
           GdsApi.asset_manager.update_asset(
             whitehall_asset.whitehall_asset_id,
             redirect_url: whitehall_asset.content_publisher_asset.file_url,
           )
           whitehall_asset.update!(state: "redirected")
+        else
+          GdsApi.asset_manager.delete_asset(whitehall_asset.whitehall_asset_id)
+          whitehall_asset.update!(state: "removed")
         end
       end
     end

--- a/lib/whitehall_importer/migrate_assets.rb
+++ b/lib/whitehall_importer/migrate_assets.rb
@@ -13,7 +13,7 @@ module WhitehallImporter
     end
 
     def call
-      whitehall_import.assets.each do |whitehall_asset|
+      whitehall_import.migratable_assets.each do |whitehall_asset|
         begin
           if whitehall_asset.content_publisher_asset.present? && whitehall_asset.content_publisher_asset.live?
             GdsApi.asset_manager.update_asset(

--- a/lib/whitehall_importer/migrate_assets.rb
+++ b/lib/whitehall_importer/migrate_assets.rb
@@ -20,6 +20,7 @@ module WhitehallImporter
           whitehall_asset.update!(state: "migration_failed", error_message: e.inspect)
         end
       end
+      raise "Failed migrating at least one Whitehall asset" if whitehall_import.assets.migration_failed.any?
     end
 
   private

--- a/lib/whitehall_importer/migrate_assets.rb
+++ b/lib/whitehall_importer/migrate_assets.rb
@@ -14,15 +14,19 @@ module WhitehallImporter
 
     def call
       whitehall_import.assets.each do |whitehall_asset|
-        if whitehall_asset.content_publisher_asset.present? && whitehall_asset.content_publisher_asset.live?
-          GdsApi.asset_manager.update_asset(
-            whitehall_asset.whitehall_asset_id,
-            redirect_url: whitehall_asset.content_publisher_asset.file_url,
-          )
-          whitehall_asset.update!(state: "redirected")
-        else
-          GdsApi.asset_manager.delete_asset(whitehall_asset.whitehall_asset_id)
-          whitehall_asset.update!(state: "removed")
+        begin
+          if whitehall_asset.content_publisher_asset.present? && whitehall_asset.content_publisher_asset.live?
+            GdsApi.asset_manager.update_asset(
+              whitehall_asset.whitehall_asset_id,
+              redirect_url: whitehall_asset.content_publisher_asset.file_url,
+            )
+            whitehall_asset.update!(state: "redirected")
+          else
+            GdsApi.asset_manager.delete_asset(whitehall_asset.whitehall_asset_id)
+            whitehall_asset.update!(state: "removed")
+          end
+        rescue StandardError => e
+          whitehall_asset.update!(state: "migration_failed", error_message: e.inspect)
         end
       end
     end

--- a/lib/whitehall_importer/migrate_assets.rb
+++ b/lib/whitehall_importer/migrate_assets.rb
@@ -1,0 +1,19 @@
+# frozen_string_literal: true
+
+module WhitehallImporter
+  class MigrateAssets
+    attr_reader :whitehall_import
+
+    def self.call(*args)
+      new(*args).call
+    end
+
+    def initialize(whitehall_import)
+      @whitehall_import = whitehall_import
+    end
+
+    def call
+      # TODO
+    end
+  end
+end

--- a/lib/whitehall_importer/migrate_assets.rb
+++ b/lib/whitehall_importer/migrate_assets.rb
@@ -13,7 +13,15 @@ module WhitehallImporter
     end
 
     def call
-      # TODO
+      whitehall_import.assets.each do |whitehall_asset|
+        if whitehall_asset.content_publisher_asset.present?
+          GdsApi.asset_manager.update_asset(
+            whitehall_asset.whitehall_asset_id,
+            redirect_url: whitehall_asset.content_publisher_asset.file_url,
+          )
+          whitehall_asset.update!(state: "redirected")
+        end
+      end
     end
   end
 end

--- a/spec/factories/whitehall_export/file_attachment_factory.rb
+++ b/spec/factories/whitehall_export/file_attachment_factory.rb
@@ -48,8 +48,8 @@ FactoryBot.define do
     variants do
       {
         "thumbnail" => {
-          "content_type" => nil,
-          "url" => nil,
+          "content_type" => "image/png",
+          "url" => "https://asset-manager.gov.uk/blah/847150/thumb/#{filename}",
         },
       }
     end

--- a/spec/factories/whitehall_export/image_factory.rb
+++ b/spec/factories/whitehall_export/image_factory.rb
@@ -9,7 +9,11 @@ FactoryBot.define do
     caption { "This is a caption" }
     created_at { Time.current.rfc3339 }
     updated_at { Time.current.rfc3339 }
-    variants { {} }
+    variants do
+      {
+        "s960" => "https://assets.publishing.service.gov.uk/government/uploads/s960_#{filename}",
+      }
+    end
     url { "https://assets.publishing.service.gov.uk/government/uploads/#{filename}" }
 
     transient do

--- a/spec/factories/whitehall_migration_asset_import_factory.rb
+++ b/spec/factories/whitehall_migration_asset_import_factory.rb
@@ -1,0 +1,22 @@
+# frozen_string_literal: true
+
+FactoryBot.define do
+  factory :whitehall_migration_asset_import, class: WhitehallMigration::AssetImport do
+    document_import { association :whitehall_migration_document_import }
+    state { "pending" }
+
+    for_image
+
+    trait :for_image do
+      file_attachment_revision { nil }
+      image_revision { build(:image_revision) }
+      original_asset_url { "https://asset-manager.gov.uk/blah/847150/foo.jpg" }
+    end
+
+    trait :for_file_attachment do
+      image_revision { nil }
+      file_attachment_revision { build(:file_attachment_revision) }
+      original_asset_url { "https://asset-manager.gov.uk/blah/847150/foo.pdf" }
+    end
+  end
+end

--- a/spec/factories/whitehall_migration_asset_import_factory.rb
+++ b/spec/factories/whitehall_migration_asset_import_factory.rb
@@ -9,13 +9,13 @@ FactoryBot.define do
 
     trait :for_image do
       file_attachment_revision { nil }
-      image_revision { build(:image_revision) }
+      image_revision { build(:image_revision, :on_asset_manager, state: :live) }
       original_asset_url { "https://asset-manager.gov.uk/blah/847150/foo.jpg" }
     end
 
     trait :for_file_attachment do
       image_revision { nil }
-      file_attachment_revision { build(:file_attachment_revision) }
+      file_attachment_revision { build(:file_attachment_revision, :on_asset_manager, state: :live) }
       original_asset_url { "https://asset-manager.gov.uk/blah/847150/foo.pdf" }
     end
   end

--- a/spec/lib/whitehall_importer/create_edition_spec.rb
+++ b/spec/lib/whitehall_importer/create_edition_spec.rb
@@ -1,14 +1,15 @@
 # frozen_string_literal: true
 
 RSpec.describe WhitehallImporter::CreateEdition do
+  let(:document_import) { build(:whitehall_migration_document_import, document: document) }
+
   describe "#call" do
     let(:document) { create(:document, imported_from: "whitehall", locale: "en") }
-    let(:whitehall_document) { build(:whitehall_export_document) }
     let(:user_ids) { { 1 => create(:user).id } }
 
     it "can import an edition" do
       whitehall_edition = build(:whitehall_export_edition)
-      edition = described_class.call(document: document, whitehall_edition: whitehall_edition)
+      edition = described_class.call(document_import: document_import, whitehall_edition: whitehall_edition)
 
       expect(edition).to be_draft
       expect(edition.number).to eq(1)
@@ -17,7 +18,7 @@ RSpec.describe WhitehallImporter::CreateEdition do
 
     it "can set minor update type" do
       whitehall_edition = build(:whitehall_export_edition, minor_change: true)
-      edition = described_class.call(document: document, whitehall_edition: whitehall_edition)
+      edition = described_class.call(document_import: document_import, whitehall_edition: whitehall_edition)
 
       expect(edition.update_type).to eq("minor")
     end
@@ -32,13 +33,13 @@ RSpec.describe WhitehallImporter::CreateEdition do
       )
 
       expect {
-        described_class.call(document: document, whitehall_edition: whitehall_edition)
+        described_class.call(document_import: document_import, whitehall_edition: whitehall_edition)
       }.to raise_error(WhitehallImporter::AbortImportError)
     end
 
     it "defaults to an edition not being flagged as live" do
       whitehall_edition = build(:whitehall_export_edition)
-      edition = described_class.call(document: document, whitehall_edition: whitehall_edition)
+      edition = described_class.call(document_import: document_import, whitehall_edition: whitehall_edition)
 
       expect(edition).not_to be_live
     end
@@ -52,14 +53,14 @@ RSpec.describe WhitehallImporter::CreateEdition do
           build(:revision_history_event, event: "update", state: "published"),
         ],
       )
-      edition = described_class.call(document: document, whitehall_edition: whitehall_edition)
+      edition = described_class.call(document_import: document_import, whitehall_edition: whitehall_edition)
 
       expect(edition).to be_live
     end
 
     it "does not mark the edition as synced with Publishing API" do
       whitehall_edition = build(:whitehall_export_edition)
-      edition = described_class.call(document: document, whitehall_edition: whitehall_edition)
+      edition = described_class.call(document_import: document_import, whitehall_edition: whitehall_edition)
 
       expect(edition.revision_synced).to be false
     end
@@ -78,7 +79,7 @@ RSpec.describe WhitehallImporter::CreateEdition do
         ],
       )
 
-      edition = described_class.call(document: document,
+      edition = described_class.call(document_import: document_import,
                                      whitehall_edition: whitehall_edition,
                                      user_ids: user_ids)
 
@@ -88,7 +89,7 @@ RSpec.describe WhitehallImporter::CreateEdition do
     context "when importing an access limited edition" do
       it "creates an access limit" do
         whitehall_edition = build(:whitehall_export_edition, access_limited: true)
-        edition = described_class.call(document: document, whitehall_edition: whitehall_edition)
+        edition = described_class.call(document_import: document_import, whitehall_edition: whitehall_edition)
 
         expect(edition.access_limit).to be_present
         expect(edition.access_limit).to be_tagged_organisations
@@ -98,7 +99,7 @@ RSpec.describe WhitehallImporter::CreateEdition do
     it "attributes the status to the user that created it and at the time that was done" do
       whitehall_edition = build(:whitehall_export_edition)
       user = create(:user)
-      edition = described_class.call(document: document,
+      edition = described_class.call(document_import: document_import,
                                      whitehall_edition: whitehall_edition,
                                      user_ids: { 1 => user.id })
 
@@ -119,7 +120,7 @@ RSpec.describe WhitehallImporter::CreateEdition do
       end
 
       let(:edition) do
-        described_class.call(document: document, whitehall_edition: whitehall_edition)
+        described_class.call(document_import: document_import, whitehall_edition: whitehall_edition)
       end
 
       it "creates two statuses" do
@@ -161,13 +162,13 @@ RSpec.describe WhitehallImporter::CreateEdition do
       end
 
       it "creates an edition with a status of removed" do
-        edition = described_class.call(document: document, whitehall_edition: whitehall_edition)
+        edition = described_class.call(document_import: document_import, whitehall_edition: whitehall_edition)
 
         expect(edition.removed?).to be_truthy
       end
 
       it "sets the correct removal metadata" do
-        edition = described_class.call(document: document, whitehall_edition: whitehall_edition)
+        edition = described_class.call(document_import: document_import, whitehall_edition: whitehall_edition)
 
         removal = edition.status.details
         expect(removal.explanatory_note).to eq(whitehall_edition["unpublishing"]["explanation"])
@@ -176,7 +177,7 @@ RSpec.describe WhitehallImporter::CreateEdition do
       end
 
       it "sets the correct timestamps on the edition" do
-        edition = described_class.call(document: document, whitehall_edition: whitehall_edition)
+        edition = described_class.call(document_import: document_import, whitehall_edition: whitehall_edition)
 
         expect(edition.created_at).to eq(created_at)
         expect(edition.updated_at).to eq(updated_at)
@@ -202,18 +203,18 @@ RSpec.describe WhitehallImporter::CreateEdition do
 
       it "creates two editions" do
         expect {
-          described_class.call(document: document, whitehall_edition: whitehall_edition)
+          described_class.call(document_import: document_import, whitehall_edition: whitehall_edition)
         } .to change { Edition.count }.by(2)
       end
 
       it "creates an edition with a status of removed" do
-        described_class.call(document: document, whitehall_edition: whitehall_edition)
+        described_class.call(document_import: document_import, whitehall_edition: whitehall_edition)
 
         expect(document.editions.first.removed?).to be_truthy
       end
 
       it "sets the correct removal metadata" do
-        described_class.call(document: document, whitehall_edition: whitehall_edition)
+        described_class.call(document_import: document_import, whitehall_edition: whitehall_edition)
 
         removal = document.editions.first.status.details
         expect(removal.explanatory_note).to eq(whitehall_edition["unpublishing"]["explanation"])
@@ -222,14 +223,14 @@ RSpec.describe WhitehallImporter::CreateEdition do
       end
 
       it "creates a draft edition and assigns as current" do
-        edition = described_class.call(document: document, whitehall_edition: whitehall_edition)
+        edition = described_class.call(document_import: document_import, whitehall_edition: whitehall_edition)
 
         expect(edition.draft?).to be_truthy
         expect(edition.current).to be_truthy
       end
 
       it "sets the correct timestamps on the edition" do
-        edition = described_class.call(document: document, whitehall_edition: whitehall_edition)
+        edition = described_class.call(document_import: document_import, whitehall_edition: whitehall_edition)
 
         expect(edition.created_at).to eq(created_at)
         expect(edition.updated_at).to eq(created_at)
@@ -249,7 +250,7 @@ RSpec.describe WhitehallImporter::CreateEdition do
       )
 
       expect {
-        described_class.call(document: document, whitehall_edition: whitehall_edition)
+        described_class.call(document_import: document_import, whitehall_edition: whitehall_edition)
       }.to raise_error(WhitehallImporter::AbortImportError)
     end
   end
@@ -262,7 +263,7 @@ RSpec.describe WhitehallImporter::CreateEdition do
       whitehall_edition = build(:whitehall_export_edition,
                                 :scheduled,
                                 scheduled_publication: publish_time.rfc3339)
-      edition = described_class.call(document: document,
+      edition = described_class.call(document_import: document_import,
                                      whitehall_edition: whitehall_edition)
 
       expect(edition).to be_scheduled
@@ -273,7 +274,7 @@ RSpec.describe WhitehallImporter::CreateEdition do
       whitehall_edition = build(:whitehall_export_edition,
                                 :scheduled,
                                 previous_state: "submitted")
-      edition = described_class.call(document: document,
+      edition = described_class.call(document_import: document_import,
                                      whitehall_edition: whitehall_edition)
 
       statuses = edition.statuses.map(&:state)
@@ -285,7 +286,7 @@ RSpec.describe WhitehallImporter::CreateEdition do
       whitehall_edition = build(:whitehall_export_edition,
                                 :scheduled,
                                 previous_state: "draft")
-      edition = described_class.call(document: document,
+      edition = described_class.call(document_import: document_import,
                                      whitehall_edition: whitehall_edition)
 
       statuses = edition.statuses.map(&:state)
@@ -297,7 +298,7 @@ RSpec.describe WhitehallImporter::CreateEdition do
       whitehall_edition = build(:whitehall_export_edition,
                                 :scheduled,
                                 force_published: false)
-      edition = described_class.call(document: document,
+      edition = described_class.call(document_import: document_import,
                                      whitehall_edition: whitehall_edition)
       expect(edition.status.details.reviewed).to be true
     end
@@ -306,7 +307,7 @@ RSpec.describe WhitehallImporter::CreateEdition do
       whitehall_edition = build(:whitehall_export_edition,
                                 :scheduled,
                                 force_published: true)
-      edition = described_class.call(document: document,
+      edition = described_class.call(document_import: document_import,
                                      whitehall_edition: whitehall_edition)
       expect(edition.status.details.reviewed).to be false
     end
@@ -317,7 +318,7 @@ RSpec.describe WhitehallImporter::CreateEdition do
                                 scheduled_publication: nil)
 
       expect {
-        described_class.call(document: document, whitehall_edition: whitehall_edition)
+        described_class.call(document_import: document_import, whitehall_edition: whitehall_edition)
       }.to raise_error(
         WhitehallImporter::AbortImportError,
         "Cannot create scheduled status without scheduled_publication",

--- a/spec/lib/whitehall_importer/create_file_attachment_revision_spec.rb
+++ b/spec/lib/whitehall_importer/create_file_attachment_revision_spec.rb
@@ -4,16 +4,17 @@ RSpec.describe WhitehallImporter::CreateFileAttachmentRevision do
   let(:whitehall_file_attachment) do
     build(:whitehall_export_file_attachment)
   end
+  let(:document_import) { nil }
 
   context "creates a file attachment" do
     it "fetches file from asset-manager" do
-      create_revision = described_class.new(whitehall_file_attachment)
+      create_revision = described_class.new(document_import, whitehall_file_attachment)
       expect(create_revision.call).to have_requested(:get, whitehall_file_attachment["url"])
     end
 
     it "creates a FileAttachment::Revision and sets correct metadata" do
       revision = nil
-      expect { revision = described_class.call(whitehall_file_attachment) }
+      expect { revision = described_class.call(document_import, whitehall_file_attachment) }
         .to change { FileAttachment::Revision.count }.by(1)
 
       expect(revision.metadata_revision.title).to eq(whitehall_file_attachment["title"])
@@ -23,7 +24,7 @@ RSpec.describe WhitehallImporter::CreateFileAttachmentRevision do
 
   shared_examples "rejected file attachment" do
     it "raises an AbortImportError with an informative error" do
-      create_revision = described_class.new(whitehall_file_attachment)
+      create_revision = described_class.new(document_import, whitehall_file_attachment)
       expect { create_revision.call }.to raise_error(
         WhitehallImporter::AbortImportError,
         error_message,

--- a/spec/lib/whitehall_importer/create_image_revision_spec.rb
+++ b/spec/lib/whitehall_importer/create_image_revision_spec.rb
@@ -3,15 +3,32 @@
 RSpec.describe WhitehallImporter::CreateImageRevision do
   describe "#call" do
     let(:whitehall_image) { build(:whitehall_export_image) }
-    let(:document_import) { nil }
+    let(:document_import) { build(:whitehall_migration_document_import) }
 
-    it "should create an Image::Revision when a valid image is provided" do
-      image_revision = nil
-      expect { image_revision = described_class.call(document_import, whitehall_image) }
-        .to change { Image::Revision.count }.by(1)
-      expect(image_revision.caption).to eq(whitehall_image["caption"])
-      expect(image_revision.alt_text).to eq(whitehall_image["alt_text"])
-      expect(image_revision.filename).to eq("valid-image.jpg")
+    context "Valid image is provided" do
+      it "should create an Image::Revision" do
+        image_revision = nil
+        expect { image_revision = described_class.call(document_import, whitehall_image) }
+          .to change { Image::Revision.count }.by(1)
+        expect(image_revision.caption).to eq(whitehall_image["caption"])
+        expect(image_revision.alt_text).to eq(whitehall_image["alt_text"])
+        expect(image_revision.filename).to eq("valid-image.jpg")
+      end
+
+      it "should create a WhitehallMigration::AssetImport for each image variant" do
+        revision = described_class.call(document_import, whitehall_image)
+
+        expect(document_import.assets.size).to eq(2)
+        expect(document_import.assets.map(&:attributes).map(&:with_indifferent_access))
+          .to contain_exactly(
+            a_hash_including(variant: nil,
+                            image_revision_id: revision.id,
+                            original_asset_url: whitehall_image["url"]),
+            a_hash_including(variant: "s960",
+                            image_revision_id: revision.id,
+                            original_asset_url: whitehall_image["variants"]["s960"]),
+          )
+      end
     end
 
     context "Image is not available" do

--- a/spec/lib/whitehall_importer/create_revision_spec.rb
+++ b/spec/lib/whitehall_importer/create_revision_spec.rb
@@ -76,6 +76,14 @@ RSpec.describe WhitehallImporter::CreateRevision do
         expect(revision.image_revisions.last.blob_revision.filename).to eq("image-1.jpg")
       end
 
+      it "skips any image it has encountered before" do
+        image = build(:whitehall_export_image, filename: "image.jpg")
+        revision1 = described_class.call(document_import, build(:whitehall_export_edition, images: [image]))
+        revision2 = described_class.call(document_import, build(:whitehall_export_edition, images: [image]))
+        expect(revision1.image_revisions.count).to eq(1)
+        expect(revision1.image_revisions).to eq(revision2.image_revisions)
+      end
+
       it "uses the first image as the lead image" do
         whitehall_edition = build(
           :whitehall_export_edition,
@@ -108,13 +116,21 @@ RSpec.describe WhitehallImporter::CreateRevision do
           :whitehall_export_edition,
           attachments: [
             build(:whitehall_export_file_attachment, filename: "attach.txt"),
-            build(:whitehall_export_file_attachment, filename: "attach.txt"),
+            build(:whitehall_export_file_attachment, filename: "subdir/attach.txt"),
           ],
         )
         revision = described_class.call(document_import, whitehall_edition)
 
         expect(revision.file_attachment_revisions.first.blob_revision.filename).to eq("attach.txt")
         expect(revision.file_attachment_revisions.last.blob_revision.filename).to eq("attach-1.txt")
+      end
+
+      it "skips any attachment it has encountered before" do
+        attachment = build(:whitehall_export_file_attachment, filename: "attach.txt")
+        revision1 = described_class.call(document_import, build(:whitehall_export_edition, attachments: [attachment]))
+        revision2 = described_class.call(document_import, build(:whitehall_export_edition, attachments: [attachment]))
+        expect(revision1.file_attachment_revisions.count).to eq(1)
+        expect(revision1.file_attachment_revisions).to eq(revision2.file_attachment_revisions)
       end
     end
 

--- a/spec/lib/whitehall_importer/import_spec.rb
+++ b/spec/lib/whitehall_importer/import_spec.rb
@@ -11,27 +11,28 @@ RSpec.describe WhitehallImporter::Import do
     end
 
     it "creates a document" do
-      expect { described_class.call(build(:whitehall_export_document)) }
+      expect { described_class.call(build(:whitehall_migration_document_import)) }
         .to change { Document.count }.by(1)
     end
 
     it "aborts if a document already exists" do
       content_id = create(:document).content_id
       import_data = build(:whitehall_export_document, content_id: content_id)
-      expect { described_class.call(import_data) }
+      document_import = build(:whitehall_migration_document_import, payload: import_data)
+      expect { described_class.call(document_import) }
         .to raise_error(WhitehallImporter::AbortImportError)
     end
 
     it "sets the document as being imported from Whitehall" do
-      document = described_class.call(build(:whitehall_export_document))
+      document = described_class.call(build(:whitehall_migration_document_import))
 
       expect(document).to be_imported_from_whitehall
     end
 
     it "creates users who have never logged into Content Publisher" do
       import_data = build(:whitehall_export_document, users: [whitehall_user])
-
-      described_class.call(import_data)
+      document_import = build(:whitehall_migration_document_import, payload: import_data)
+      described_class.call(document_import)
       expect(User.last.attributes).to match hash_including(
         "uid" => whitehall_user["uid"],
         "name" => whitehall_user["name"],
@@ -44,8 +45,9 @@ RSpec.describe WhitehallImporter::Import do
     it "does not add users who have logged into Content Publisher" do
       User.create!(uid: whitehall_user["uid"])
       import_data = build(:whitehall_export_document, users: [whitehall_user])
+      document_import = build(:whitehall_migration_document_import, payload: import_data)
 
-      expect { described_class.call(import_data) }.not_to(change { User.count })
+      expect { described_class.call(document_import) }.not_to(change { User.count })
     end
 
     it "sets created_by_id as the original author" do
@@ -58,7 +60,8 @@ RSpec.describe WhitehallImporter::Import do
       import_data = build(:whitehall_export_document,
                           editions: [edition],
                           users: [whitehall_user])
-      document = described_class.call(import_data)
+      document_import = build(:whitehall_migration_document_import, payload: import_data)
+      document = described_class.call(document_import)
 
       expect(document.created_by).to eq(user)
     end
@@ -77,6 +80,7 @@ RSpec.describe WhitehallImporter::Import do
       import_data = build(:whitehall_export_document,
                           editions: [past_edition, current_edition],
                           users: [whitehall_user])
+      document_import = build(:whitehall_migration_document_import, payload: import_data)
 
       expect(WhitehallImporter::CreateEdition).to receive(:call).with(
         hash_including(current: false),
@@ -86,7 +90,7 @@ RSpec.describe WhitehallImporter::Import do
         hash_including(current: true),
       ).ordered
 
-      described_class.call(import_data)
+      described_class.call(document_import)
     end
 
     it "sets first_published_at date to publish time of first edition" do
@@ -119,7 +123,9 @@ RSpec.describe WhitehallImporter::Import do
         build(:whitehall_export_edition),
         build(:whitehall_export_edition, :published),
       ]
-      described_class.call(build(:whitehall_export_document, editions: editions))
+      import_data = build(:whitehall_export_document, editions: editions)
+      document_import = build(:whitehall_migration_document_import, payload: import_data)
+      described_class.call(document_import)
 
       expect(WhitehallImporter::IntegrityChecker.new).to have_received(:valid?).twice
     end
@@ -134,7 +140,7 @@ RSpec.describe WhitehallImporter::Import do
                       problems: [problems],
                     ))
 
-      expect { described_class.call(build(:whitehall_export_document)) }
+      expect { described_class.call(build(:whitehall_migration_document_import)) }
         .to raise_error(WhitehallImporter::AbortImportError, problems)
     end
   end

--- a/spec/lib/whitehall_importer/import_spec.rb
+++ b/spec/lib/whitehall_importer/import_spec.rb
@@ -119,8 +119,8 @@ RSpec.describe WhitehallImporter::Import do
 
       import_data = build(:whitehall_export_document,
                           editions: [first_edition, second_edition])
-
-      document = described_class.call(import_data)
+      document_import = build(:whitehall_migration_document_import, payload: import_data)
+      document = described_class.call(document_import)
 
       expect(document.first_published_at).to eq(first_publish_date)
     end

--- a/spec/lib/whitehall_importer/import_spec.rb
+++ b/spec/lib/whitehall_importer/import_spec.rb
@@ -29,6 +29,13 @@ RSpec.describe WhitehallImporter::Import do
       expect(document).to be_imported_from_whitehall
     end
 
+    it "associates the created document with the import record" do
+      import_record = build(:whitehall_migration_document_import)
+      document = described_class.call(import_record)
+
+      expect(import_record.document).to eq(document)
+    end
+
     it "creates users who have never logged into Content Publisher" do
       import_data = build(:whitehall_export_document, users: [whitehall_user])
       document_import = build(:whitehall_migration_document_import, payload: import_data)

--- a/spec/lib/whitehall_importer/migrate_assets_spec.rb
+++ b/spec/lib/whitehall_importer/migrate_assets_spec.rb
@@ -2,8 +2,45 @@
 
 RSpec.describe WhitehallImporter::MigrateAssets do
   describe ".call" do
-    it "should take a WhitehallMigration::DocumentImport record as an argument" do
-      expect { described_class.call(build(:whitehall_migration_document_import)) }.not_to raise_error
+    before { stub_any_asset_manager_call }
+
+    it "should redirect live attachments to their content publisher equivalents" do
+      asset = build(:whitehall_migration_asset_import, :for_file_attachment)
+      whitehall_import = build(:whitehall_migration_document_import, assets: [asset])
+      redirect_request = stub_asset_manager_update_asset(
+        asset.whitehall_asset_id,
+        redirect_url: asset.file_attachment_revision.asset_url,
+      )
+
+      described_class.call(whitehall_import)
+      expect(redirect_request).to have_been_requested
+      expect(asset.state).to eq("redirected")
+    end
+
+    it "should redirect live images to their content publisher equivalents" do
+      asset = build(:whitehall_migration_asset_import, :for_image)
+      whitehall_import = build(:whitehall_migration_document_import, assets: [asset])
+      redirect_request = stub_asset_manager_update_asset(
+        asset.whitehall_asset_id,
+        redirect_url: asset.image_revision.asset_url("960"),
+      )
+
+      described_class.call(whitehall_import)
+      expect(redirect_request).to have_been_requested
+      expect(asset.state).to eq("redirected")
+    end
+
+    it "should redirect live image variants to their content publisher equivalents" do
+      asset = build(:whitehall_migration_asset_import, :for_image, variant: "s300")
+      whitehall_import = build(:whitehall_migration_document_import, assets: [asset])
+      redirect_request = stub_asset_manager_update_asset(
+        asset.whitehall_asset_id,
+        redirect_url: asset.image_revision.asset_url("300"),
+      )
+
+      described_class.call(whitehall_import)
+      expect(redirect_request).to have_been_requested
+      expect(asset.state).to eq("redirected")
     end
   end
 end

--- a/spec/lib/whitehall_importer/migrate_assets_spec.rb
+++ b/spec/lib/whitehall_importer/migrate_assets_spec.rb
@@ -4,6 +4,30 @@ RSpec.describe WhitehallImporter::MigrateAssets do
   describe ".call" do
     before { stub_any_asset_manager_call }
 
+    it "should delete draft assets" do
+      image_revision = build(:image_revision, :on_asset_manager, state: :draft)
+      asset = create(:whitehall_migration_asset_import, image_revision: image_revision)
+      whitehall_import = build(:whitehall_migration_document_import, assets: [asset])
+      delete_asset_request = stub_asset_manager_delete_asset(asset.whitehall_asset_id)
+
+      described_class.call(whitehall_import)
+      expect(delete_asset_request).to have_been_requested
+      expect(asset.state).to eq("removed")
+    end
+
+    it "should delete draft asset variants" do
+      image_revision = build(:image_revision, :on_asset_manager, state: :draft)
+      asset = create(:whitehall_migration_asset_import,
+                     image_revision: image_revision,
+                     variant: "s300")
+      delete_asset_request = stub_asset_manager_delete_asset(asset.whitehall_asset_id)
+      whitehall_import = build(:whitehall_migration_document_import, assets: [asset])
+
+      described_class.call(whitehall_import)
+      expect(delete_asset_request).to have_been_requested
+      expect(asset.state).to eq("removed")
+    end
+
     it "should redirect live attachments to their content publisher equivalents" do
       asset = build(:whitehall_migration_asset_import, :for_file_attachment)
       whitehall_import = build(:whitehall_migration_document_import, assets: [asset])
@@ -15,6 +39,18 @@ RSpec.describe WhitehallImporter::MigrateAssets do
       described_class.call(whitehall_import)
       expect(redirect_request).to have_been_requested
       expect(asset.state).to eq("redirected")
+    end
+
+    it "should delete attachment variants even if they are live" do
+      asset = create(:whitehall_migration_asset_import,
+                     :for_file_attachment,
+                     variant: "thumbnail")
+      whitehall_import = build(:whitehall_migration_document_import, assets: [asset])
+      delete_request = stub_asset_manager_delete_asset(asset.whitehall_asset_id)
+
+      described_class.call(whitehall_import)
+      expect(delete_request).to have_been_requested
+      expect(asset.state).to eq("removed")
     end
 
     it "should redirect live images to their content publisher equivalents" do
@@ -41,6 +77,16 @@ RSpec.describe WhitehallImporter::MigrateAssets do
       described_class.call(whitehall_import)
       expect(redirect_request).to have_been_requested
       expect(asset.state).to eq("redirected")
+    end
+
+    it "should delete live image variants that have no content publisher equivalent" do
+      asset = build(:whitehall_migration_asset_import, :for_image, variant: "s216")
+      whitehall_import = build(:whitehall_migration_document_import, assets: [asset])
+      delete_request = stub_asset_manager_delete_asset(asset.whitehall_asset_id)
+
+      described_class.call(whitehall_import)
+      expect(delete_request).to have_been_requested
+      expect(asset.state).to eq("removed")
     end
   end
 end

--- a/spec/lib/whitehall_importer/migrate_assets_spec.rb
+++ b/spec/lib/whitehall_importer/migrate_assets_spec.rb
@@ -4,6 +4,15 @@ RSpec.describe WhitehallImporter::MigrateAssets do
   describe ".call" do
     before { stub_any_asset_manager_call }
 
+    it "should skip migrating any assets that have already been processed" do
+      asset = create(:whitehall_migration_asset_import, state: "removed")
+      whitehall_import = build(:whitehall_migration_document_import, assets: [asset])
+      expect(asset).not_to receive(:update!)
+      asset_manager_call = stub_any_asset_manager_call
+      described_class.call(whitehall_import)
+      expect(asset_manager_call).to_not have_been_requested
+    end
+
     it "should log errors and put into an aborted state" do
       whitehall_import = build(:whitehall_migration_document_import, assets: [asset])
       allow(asset).to receive(:whitehall_asset_id).and_raise(StandardError.new("Some error"))

--- a/spec/lib/whitehall_importer/migrate_assets_spec.rb
+++ b/spec/lib/whitehall_importer/migrate_assets_spec.rb
@@ -4,6 +4,14 @@ RSpec.describe WhitehallImporter::MigrateAssets do
   describe ".call" do
     before { stub_any_asset_manager_call }
 
+    it "should log errors and put into an aborted state" do
+      whitehall_import = build(:whitehall_migration_document_import, assets: [asset])
+      allow(asset).to receive(:whitehall_asset_id).and_raise(StandardError.new("Some error"))
+      described_class.call(whitehall_import)
+      expect(asset.state).to eq("migration_failed")
+      expect(asset.error_message).to include("Some error")
+    end
+
     it "should delete draft assets" do
       image_revision = build(:image_revision, :on_asset_manager, state: :draft)
       asset = create(:whitehall_migration_asset_import, image_revision: image_revision)

--- a/spec/lib/whitehall_importer/migrate_assets_spec.rb
+++ b/spec/lib/whitehall_importer/migrate_assets_spec.rb
@@ -1,0 +1,9 @@
+# frozen_string_literal: true
+
+RSpec.describe WhitehallImporter::MigrateAssets do
+  describe ".call" do
+    it "should take a WhitehallMigration::DocumentImport record as an argument" do
+      expect { described_class.call(build(:whitehall_migration_document_import)) }.not_to raise_error
+    end
+  end
+end

--- a/spec/lib/whitehall_importer_spec.rb
+++ b/spec/lib/whitehall_importer_spec.rb
@@ -52,7 +52,6 @@ RSpec.describe WhitehallImporter do
 
     it "doesn't sync if import fails" do
       allow(WhitehallImporter::Import).to receive(:call)
-        .with(whitehall_export_document)
         .and_raise(WhitehallImporter::AbortImportError, "Booo, import failed")
 
       expect(WhitehallImporter).not_to receive(:sync)

--- a/spec/lib/whitehall_importer_spec.rb
+++ b/spec/lib/whitehall_importer_spec.rb
@@ -135,6 +135,11 @@ RSpec.describe WhitehallImporter do
       WhitehallImporter.sync(whitehall_migration_document_import)
     end
 
+    it "redirects or deletes the corresponding Whitehall assets" do
+      expect(WhitehallImporter::MigrateAssets).to receive(:call).with(whitehall_migration_document_import)
+      WhitehallImporter.sync(whitehall_migration_document_import)
+    end
+
     it "returns a completed WhitehallMigration::DocumentImport" do
       WhitehallImporter.sync(whitehall_migration_document_import)
       expect(whitehall_migration_document_import).to be_completed

--- a/spec/models/whitehall_migration/asset_import_spec.rb
+++ b/spec/models/whitehall_migration/asset_import_spec.rb
@@ -1,6 +1,38 @@
 # frozen_string_literal: true
 
 RSpec.describe WhitehallMigration::AssetImport do
+  describe ".content_publisher_asset" do
+    it "returns the file attachment asset when associated with one" do
+      asset = build(:whitehall_migration_asset_import, :for_file_attachment)
+      expect(asset.content_publisher_asset).to be_kind_of(FileAttachment::Asset)
+    end
+
+    it "returns the 960 image asset when associated with an image" do
+      asset = build(:whitehall_migration_asset_import, :for_image)
+      expect(asset.content_publisher_asset)
+        .to be_kind_of(Image::Asset).and eq(asset.image_revision.asset("960"))
+    end
+
+    it "returns the correct sized image when called on a recognised image size" do
+      image_300_wide = build(:whitehall_migration_asset_import, :for_image, variant: "s300")
+      image_960_wide = build(:whitehall_migration_asset_import, :for_image, variant: "s960")
+      expect(image_300_wide.content_publisher_asset)
+        .to be_kind_of(Image::Asset).and eq(image_300_wide.image_revision.asset("300"))
+      expect(image_960_wide.content_publisher_asset)
+        .to be_kind_of(Image::Asset).and eq(image_960_wide.image_revision.asset("960"))
+    end
+
+    it "returns nil when called on an unrecognised image size" do
+      asset = build(:whitehall_migration_asset_import, :for_image, variant: "s216")
+      expect(asset.content_publisher_asset).to be_nil
+    end
+
+    it "returns nil when called on a file attachment variant" do
+      asset = build(:whitehall_migration_asset_import, :for_file_attachment, variant: "thumbnail")
+      expect(asset.content_publisher_asset).to be_nil
+    end
+  end
+
   describe ".whitehall_asset_id" do
     it "returns the asset manager ID of the original asset" do
       whitehall_asset_id = "847150"

--- a/spec/models/whitehall_migration/asset_import_spec.rb
+++ b/spec/models/whitehall_migration/asset_import_spec.rb
@@ -1,0 +1,17 @@
+# frozen_string_literal: true
+
+RSpec.describe WhitehallMigration::AssetImport do
+  describe ".associated_with_only_image_or_file_attachment" do
+    it "raises a validation error if associated with an image and a file attachment" do
+      illegal_params = {
+        file_attachment_revision: build(:file_attachment_revision),
+        image_revision: build(:image_revision),
+      }
+      expect { create(:whitehall_migration_asset_import, illegal_params) }
+        .to raise_error(
+          ActiveRecord::RecordInvalid,
+          "Validation failed: Cannot be associated with both image revision AND file attachment revision",
+        )
+    end
+  end
+end

--- a/spec/models/whitehall_migration/asset_import_spec.rb
+++ b/spec/models/whitehall_migration/asset_import_spec.rb
@@ -1,6 +1,17 @@
 # frozen_string_literal: true
 
 RSpec.describe WhitehallMigration::AssetImport do
+  describe ".whitehall_asset_id" do
+    it "returns the asset manager ID of the original asset" do
+      whitehall_asset_id = "847150"
+      asset = build(
+        :whitehall_migration_asset_import,
+        original_asset_url: "https://asset-manager.gov.uk/blah/#{whitehall_asset_id}/foo.jpg",
+      )
+      expect(asset.whitehall_asset_id).to eq(whitehall_asset_id)
+    end
+  end
+
   describe ".associated_with_only_image_or_file_attachment" do
     it "raises a validation error if associated with an image and a file attachment" do
       illegal_params = {

--- a/spec/models/whitehall_migration/document_import_spec.rb
+++ b/spec/models/whitehall_migration/document_import_spec.rb
@@ -1,0 +1,19 @@
+# frozen_string_literal: true
+
+RSpec.describe WhitehallMigration::DocumentImport do
+  describe ".migratable_assets" do
+    it "should return assets that are 'pending' or 'migration_failed'" do
+      assets_to_be_processed = [
+        create(:whitehall_migration_asset_import, state: "pending"),
+        create(:whitehall_migration_asset_import, state: "migration_failed"),
+      ]
+      assets_to_be_ignored = [
+        create(:whitehall_migration_asset_import, state: "redirected"),
+        create(:whitehall_migration_asset_import, state: "removed"),
+      ]
+      document_import = build(:whitehall_migration_document_import,
+                              assets: assets_to_be_processed + assets_to_be_ignored)
+      expect(document_import.migratable_assets).to eq(assets_to_be_processed)
+    end
+  end
+end


### PR DESCRIPTION
This PR has all the code for tidying up a Whitehall document's assets once the document has been imported into Content Publisher. After import, we can run the new `MigrateAssets` service to:

* delete all Whitehall assets (images/file attachments) that only existed on the draft stack
* redirect all 'master' assets (e.g. the 960 size image, rather than its thumbnails) to the new master version on Content Publisher, if the Whitehall assets were on the live stack
* delete all variants of Whitehall file attachments (whether on live or draft stack), since they'll no longer appear anywhere
* redirect all variants of Whitehall images to the new master image on Content Publisher, since the old images may be hotlinked from elsewhere
* log any assets that fail to migrate, and fail the sync step at the end

## How it works

### At the import stage
Creates a `WhitehallMigration::AssetImport` record for every asset (Image/FileAttachment) referenced in the Whitehall export. It creates a record for each variant of each asset too. However, it avoids creating duplicate records, so that if an asset exists in multiple editions in a Whitehall export, it will only have one record created for it.

### At the migration stage

We've created a `MigrateAssets` service which is called from the WhitehallImporter `sync`/`import_and_sync` methods. It iterates over each `WhitehallMigration::AssetImport` record, deleting the asset if its 'master' asset is not live, or deleting it if it is a 'variant' file attachment (e.g. thumbnail). Otherwise, it redirects the Whitehall asset to the main asset on Content Publisher.

**NOTE: if something goes wrong in the import_and_sync step, such that the master asset was not successfully synchronised with asset manager and does not have the 'live' state, there is a risk we will delete Whitehall assets and have no assets at all. However, in a dev discussion before Christmas we decided that the migration code should make the assumption that everything was imported correctly.**

## Background information

This work comes out of a spike in #1509, and further investigative work in #1530.

Trello card: https://trello.com/c/DMpTECux/1232-handle-redirecting-and-removing-old-assets-as-part-of-whitehall-migration