### PR TITLE
Bind contextual guidance to inputs

### DIFF
--- a/app/views/documents/edit.html.erb
+++ b/app/views/documents/edit.html.erb
@@ -23,7 +23,8 @@
     if @edition.document_type.guidance_for("title")
       title_contextual_guidance.merge!({
         title: @edition.document_type.guidance_for("title").title,
-        content: @edition.document_type.guidance_for("title").body_govspeak
+        content: @edition.document_type.guidance_for("title").body_govspeak,
+        guidance_id: "title-guidance"
       })
     end
   %>
@@ -40,7 +41,8 @@
       error_items: @issues&.items_for(:title),
       rows: 2,
       maxlength: Requirements::ContentChecker::TITLE_MAX_LENGTH,
-      data: { "url-preview": "input" }
+      data: { "url-preview": "input" },
+      describedby: "title-guidance"
     } do %>
       <%= render "components/input_length_suggester", {
         for_id: "title-field",
@@ -70,7 +72,8 @@
     if @edition.document_type.guidance_for("title")
       summary_contextual_guidance.merge!({
         title: @edition.document_type.guidance_for("summary").title,
-        content: @edition.document_type.guidance_for("summary").body_govspeak
+        content: @edition.document_type.guidance_for("summary").body_govspeak,
+        guidance_id: "summary-guidance"
       })
     end
   %>
@@ -86,7 +89,8 @@
       value: @revision.summary,
       error_items: @issues&.items_for(:summary),
       rows: 4,
-      maxlength: Requirements::ContentChecker::SUMMARY_MAX_LENGTH
+      maxlength: Requirements::ContentChecker::SUMMARY_MAX_LENGTH,
+      describedby: "summary-guidance"
     } do %>
       <%= render "components/input_length_suggester", {
         for_id: "summary-field",

--- a/app/views/documents/fields/_govspeak_input.html.erb
+++ b/app/views/documents/fields/_govspeak_input.html.erb
@@ -15,7 +15,8 @@
   if edition.document_type.guidance_for(field.id)
     field_contextual_guidance.merge!({
       title: edition.document_type.guidance_for(field.id).title,
-      content: document_contents_guidance
+      content: document_contents_guidance,
+      guidance_id: "#{field.id}-guidance"
     })
   end
 %>
@@ -36,7 +37,8 @@
       name: "revision[contents][#{field.id}]",
       value: revision.contents[field.id],
       rows: 20,
-      spellcheck: "false"
+      spellcheck: "false",
+      describedby: "#{field.id}-guidance"
     },
     govspeak_path: govspeak_preview_path(edition.document),
     edition: edition,

--- a/app/views/images/edit.html.erb
+++ b/app/views/images/edit.html.erb
@@ -36,7 +36,8 @@ content_for :title, t(title_key, title: @edition.title_or_fallback)
     id: "alt-text",
     html_for: "image-alt-text",
     title: t("images.edit.form_labels.alt_text"),
-    content: render_govspeak(t("images.edit.guidance.alt_text_govspeak"))
+    content: render_govspeak(t("images.edit.guidance.alt_text_govspeak")),
+    guidance_id: "image-alt-text-guidance"
   } do %>
     <%= render "govuk_publishing_components/components/input", {
       label: {
@@ -46,7 +47,8 @@ content_for :title, t(title_key, title: @edition.title_or_fallback)
       id: "image-alt-text",
       name: "image_revision[alt_text]",
       value: @image_revision.alt_text,
-      error_items: @issues&.items_for(:alt_text)
+      error_items: @issues&.items_for(:alt_text),
+      describedby: "image-alt-text-guidance"
     } %>
   <% end %>
 
@@ -54,7 +56,8 @@ content_for :title, t(title_key, title: @edition.title_or_fallback)
     id: "caption",
     html_for: "image-caption",
     title: t("images.edit.form_labels.caption"),
-    content: render_govspeak(t("images.edit.guidance.caption_govspeak"))
+    content: render_govspeak(t("images.edit.guidance.caption_govspeak")),
+    guidance_id: "image-caption-guidance"
   } do %>
     <%= render "govuk_publishing_components/components/input", {
       label: {
@@ -64,7 +67,8 @@ content_for :title, t(title_key, title: @edition.title_or_fallback)
       id: "image-caption",
       name: "image_revision[caption]",
       value: @image_revision.caption,
-      error_items: @issues&.items_for(:caption)
+      error_items: @issues&.items_for(:caption),
+      describedby: "image-caption-guidance"
     } %>
   <% end %>
 
@@ -72,7 +76,8 @@ content_for :title, t(title_key, title: @edition.title_or_fallback)
     id: "credit",
     html_for: "image-credit",
     title: t("images.edit.form_labels.credit"),
-    content: render_govspeak(t("images.edit.guidance.credit_govspeak"))
+    content: render_govspeak(t("images.edit.guidance.credit_govspeak")),
+    guidance_id: "image-credit-guidance"
   } do %>
     <%= render "govuk_publishing_components/components/input", {
       label: {
@@ -82,7 +87,8 @@ content_for :title, t(title_key, title: @edition.title_or_fallback)
       id: "image-credit",
       name: "image_revision[credit]",
       value: @image_revision.credit,
-      error_items: @issues&.items_for(:credit)
+      error_items: @issues&.items_for(:credit),
+      describedby: "image-credit-guidance"
     } %>
   <% end %>
 

--- a/app/views/withdraw/new.html.erb
+++ b/app/views/withdraw/new.html.erb
@@ -19,10 +19,11 @@
   <% end %>
 
   <%= render "govuk_publishing_components/components/contextual_guidance", {
-    id: "withdrawal-public-explanation-guidance",
+    id: "withdrawal-public-explanation",
     html_for: "withdrawal_public_explanation",
     title: t("withdraw.new.public_explanation.guidance_title"),
-    content: withdrawal_public_explanation_guidance
+    content: withdrawal_public_explanation_guidance,
+    guidance_id: "withdrawal-public-explanation-guidance"
   } do %>
     <%= render "govuk_publishing_components/components/textarea", {
       label: {
@@ -33,7 +34,8 @@
       value: @public_explanation,
       error_items: @issues&.items_for(:public_explanation),
       name: "public_explanation",
-      rows: 6
+      rows: 6,
+      describedby: "withdrawal-public-explanation-guidance"
     } %>
   <% end %>
 


### PR DESCRIPTION
Using `aria-described-by` we now bind the guidance content to each input so it's being appended to the input description and provide additional information to screen readers' users.

Example for the document title using VoiceOver
<img width="1009" alt="Screenshot 2019-12-23 at 18 03 20" src="https://user-images.githubusercontent.com/788096/71367817-cea9e780-25ae-11ea-98b7-4a5bfa75fcc5.png">

[Trello card](https://trello.com/c/LQIMhHs0)