### PR TITLE
Import edition editors

### DIFF
--- a/lib/whitehall_importer/create_edition.rb
+++ b/lib/whitehall_importer/create_edition.rb
@@ -145,6 +145,8 @@ module WhitehallImporter
       create_event ||= history.create_event!
       last_event ||= whitehall_edition["revision_history"].last
 
+      editor_ids = history.editors.map { |editor| user_ids[editor] }
+
       Edition.create!(
         document: document,
         number: edition_number,
@@ -157,6 +159,7 @@ module WhitehallImporter
         updated_at: last_event["created_at"],
         created_by_id: user_ids[create_event["whodunnit"]],
         last_edited_by_id: user_ids[last_event["whodunnit"]],
+        editor_ids: editor_ids,
       )
     end
 

--- a/lib/whitehall_importer/edition_history.rb
+++ b/lib/whitehall_importer/edition_history.rb
@@ -56,6 +56,10 @@ module WhitehallImporter
       revision_history.last != unpublishing_event
     end
 
+    def editors
+      revision_history.pluck("whodunnit").uniq
+    end
+
   private
 
     attr_reader :revision_history

--- a/spec/lib/whitehall_importer/create_edition_spec.rb
+++ b/spec/lib/whitehall_importer/create_edition_spec.rb
@@ -57,6 +57,27 @@ RSpec.describe WhitehallImporter::CreateEdition do
       expect(edition).to be_live
     end
 
+    it "sets the editors of an edition" do
+      user_ids = {
+        1 => create(:user).id,
+        2 => create(:user).id,
+      }
+
+      whitehall_edition = build(
+        :whitehall_export_edition,
+        revision_history: [
+          build(:revision_history_event, whodunnit: 1),
+          build(:revision_history_event, whodunnit: 2),
+        ],
+      )
+
+      edition = described_class.call(document: document,
+                                     whitehall_edition: whitehall_edition,
+                                     user_ids: user_ids)
+
+      expect(edition.editors.count).to eq(2)
+    end
+
     context "when importing an access limited edition" do
       it "creates an access limit" do
         whitehall_edition = build(:whitehall_export_edition, access_limited: true)

--- a/spec/lib/whitehall_importer/edition_history_spec.rb
+++ b/spec/lib/whitehall_importer/edition_history_spec.rb
@@ -133,4 +133,26 @@ RSpec.describe WhitehallImporter::EditionHistory do
       expect(instance.edited_after_unpublishing?).to be(false)
     end
   end
+
+  describe "#editors" do
+    it "returns all of the editors who have contributed to an edition" do
+      first_event = build(:revision_history_event, whodunnit: 1)
+      second_event = build(:revision_history_event, whodunnit: 2)
+
+      instance = described_class.new([first_event, second_event])
+
+      expect(instance.editors.count).to eq(2)
+      expect(instance.editors).to eq([1, 2])
+    end
+
+    it "doesn't return the same editor more than once" do
+      first_event = build(:revision_history_event, whodunnit: 1)
+      second_event = build(:revision_history_event, whodunnit: 1)
+
+      instance = described_class.new([first_event, second_event])
+
+      expect(instance.editors.count).to eq(1)
+      expect(instance.editors).to eq([1])
+    end
+  end
 end


### PR DESCRIPTION
Trello: https://trello.com/c/cS8R0OFd
Follows on from PRs:  #1547 #1566 and #1567 

## What's changed and why?
We need to import editors in as part of a Whitehall import. Determines all the distinct user ids who are in the revision history of a whitehall edition and assigns them as editors when we create an edition.

## Testing in integration

Whitehall document: https://whitehall-admin.integration.publishing.service.gov.uk/government/admin/export/document/426794

Running:
```
https://deploy.integration.publishing.service.gov.uk/job/run-rake-task/107464/console
```

creates a document: 

```
#<Document id: 666, content_id: "09568fdb-0497-445b-a84a-d62cf9959b5a", locale: "en", created_at: "2019-09-17 15:33:54", updated_at: "2019-09-18 16:00:01", created_by_id: 48, first_published_at: nil, imported_from: "whitehall">
irb(main):002:0> edition = Edition.where(document_id: 666)
```

and edition:

```
edition = Edition.where(document_id: 666).last
=> #<Edition id: 954, number: 1, last_edited_at: "2019-12-23 16:45:30", created_at: "2019-09-17 15:33:54", updated_at: "2019-12-23 16:45:33", document_id: 666, created_by_id: 48, current: true, live: true, last_edited_by_id: 129, status_id: 2890, revision_id: 5699, revision_synced: true, access_limit_id: nil, system_political: false, government_id: nil>
```

with the following editors:

```
irb(main):005:0> edition.editors
=> #<ActiveRecord::Associations::CollectionProxy [#<User id: 48, name: "Clare Fuller", email: "clare.fuller@nda.gov.uk", uid: "7c0b50b0-ee17-0135-ec4e-005056010932", organisation_slug: "nuclear-decommissioning-authority", organisation_content_id: "bd692b3d-2d4c-43d9-aa85-32c465e1984a", app_name: nil, permissions: ["signin"], remotely_signed_out: false, disabled: false, created_at: "2019-03-08 14:21:53", updated_at: "2019-03-08 14:21:53">, #<User id: 28, name: "Sophie Palmer", email: "sophie.palmer@nda.gov.uk", uid: "83f4e1f0-9ff8-0132-2bd0-0050560114fe", organisation_slug: "nuclear-decommissioning-authority", organisation_content_id: "bd692b3d-2d4c-43d9-aa85-32c465e1984a", app_name: nil, permissions: ["managing_editor", "signin"], remotely_signed_out: false, disabled: false, created_at: "2019-01-24 14:38:11", updated_at: "2019-05-31 10:42:19">, #<User id: 129, name: "Scheduled Publishing Robot", email: nil, uid: nil, organisation_slug: nil, organisation_content_id: "", app_name: nil, permissions: [], remotely_signed_out: false, disabled: false, created_at: "2019-12-23 16:45:29", updated_at: "2019-12-23 16:45:29">, #<User id: 130, name: "Tracey Hodgson", email: "tracey.hodgson@nda.gov.uk", uid: "83d1d210-9ff8-0132-2bd0-0050560114fe", organisation_slug: "nuclear-decommissioning-authority", organisation_content_id: "bd692b3d-2d4c-43d9-aa85-32c465e1984a", app_name: nil, permissions: [], remotely_signed_out: false, disabled: false, created_at: "2019-12-23 16:45:29", updated_at: "2019-12-23 16:45:29">]>
irb(main):006:0> edition.editors.count
=> 4
```