### PR TITLE
Update organisation import rake task to get list of documents from Whitehall

### DIFF
--- a/app/models/whitehall_migration/document_import.rb
+++ b/app/models/whitehall_migration/document_import.rb
@@ -5,7 +5,8 @@
 class WhitehallMigration::DocumentImport < ApplicationRecord
   belongs_to :document, optional: true
 
-  enum state: { importing: "importing",
+  enum state: { pending: "pending",
+                importing: "importing",
                 imported: "imported",
                 import_aborted: "import_aborted",
                 import_failed: "import_failed",

--- a/db/migrate/20191224093450_remove_not_null_from_document_import.rb
+++ b/db/migrate/20191224093450_remove_not_null_from_document_import.rb
@@ -1,0 +1,8 @@
+# frozen_string_literal: true
+
+class RemoveNotNullFromDocumentImport < ActiveRecord::Migration[6.0]
+  def change
+    change_column_null :whitehall_migration_document_imports, :payload, true
+    change_column_null :whitehall_migration_document_imports, :content_id, true
+  end
+end

--- a/db/migrate/20191224112030_rename_organisation_slug.rb
+++ b/db/migrate/20191224112030_rename_organisation_slug.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+class RenameOrganisationSlug < ActiveRecord::Migration[6.0]
+  def change
+    rename_column :whitehall_migrations, :organisation_slug, :organisation_content_id
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2019_12_24_093450) do
+ActiveRecord::Schema.define(version: 2019_12_24_112030) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -348,7 +348,7 @@ ActiveRecord::Schema.define(version: 2019_12_24_093450) do
   end
 
   create_table "whitehall_migrations", force: :cascade do |t|
-    t.text "organisation_slug", null: false
+    t.text "organisation_content_id", null: false
     t.text "document_type", null: false
     t.datetime "start_time"
     t.datetime "end_time"

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2019_12_23_092938) do
+ActiveRecord::Schema.define(version: 2019_12_24_093450) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -337,8 +337,8 @@ ActiveRecord::Schema.define(version: 2019_12_23_092938) do
 
   create_table "whitehall_migration_document_imports", force: :cascade do |t|
     t.bigint "whitehall_document_id", null: false
-    t.json "payload", null: false
-    t.uuid "content_id", null: false
+    t.json "payload"
+    t.uuid "content_id"
     t.string "state", null: false
     t.text "error_log"
     t.datetime "created_at", null: false

--- a/lib/gds_api/whitehall_export.rb
+++ b/lib/gds_api/whitehall_export.rb
@@ -9,9 +9,9 @@ module GdsApi
   end
 
   class WhitehallExport < Base
-    def document_list(organisation_slug, document_type)
+    def document_list(organisation_content_id, document_type)
       params = {
-        lead_organisation: organisation_slug,
+        lead_organisation: organisation_content_id,
         type: document_type,
         page_number: 1,
         page_count: 100,

--- a/lib/gds_api/whitehall_export.rb
+++ b/lib/gds_api/whitehall_export.rb
@@ -1,0 +1,16 @@
+# frozen_string_literal: true
+
+module GdsApi
+  def self.whitehall_export(options = {})
+    GdsApi::WhitehallExport.new(
+      Plek.find("whitehall-admin"),
+      { bearer_token: ENV.fetch("WHITEHALL_BEARER_TOKEN", "example") }.merge(options),
+    )
+  end
+
+  class WhitehallExport < Base
+    def document_export(document_id)
+      get_json("#{endpoint}/government/admin/export/document/#{document_id}")
+    end
+  end
+end

--- a/lib/gds_api/whitehall_export.rb
+++ b/lib/gds_api/whitehall_export.rb
@@ -9,8 +9,33 @@ module GdsApi
   end
 
   class WhitehallExport < Base
+    def document_list(organisation_slug, document_type)
+      params = {
+        lead_organisation: organisation_slug,
+        type: document_type,
+        page_number: 1,
+        page_count: 100,
+      }
+      Enumerator.new do |yielder|
+        next_link = document_list_url(params)
+        while next_link
+          yielder.yield begin
+            response = get_json(next_link)
+          end
+          params[:page_number] += 1
+          next_link = response["page_count"] == params[:page_count] ? document_list_url(params) : false
+        end
+      end
+    end
+
     def document_export(document_id)
       get_json("#{endpoint}/government/admin/export/document/#{document_id}")
+    end
+
+  private
+
+    def document_list_url(params)
+      "#{endpoint}/government/admin/export/document?#{params.to_query}"
     end
   end
 end

--- a/lib/tasks/import.rake
+++ b/lib/tasks/import.rake
@@ -3,9 +3,13 @@
 require "gds_api/whitehall_export"
 
 namespace :import do
-  desc "Import all documents matching an organisation and document type from Whitehall Publisher, e.g. import:whitehall_migration[organisation-slug, document-type]"
+  desc "Import all documents matching an organisation and document type from Whitehall Publisher, e.g. import:whitehall_migration[\"cabinet-office\",\"NewsArticle\"]"
   task :whitehall_migration, %i[organisation_slug document_type] => :environment do |_, args|
-    whitehall_migration = WhitehallImporter.create_migration(args.organisation_slug, args.document_type)
+    organisation_content_id = GdsApi.publishing_api.lookup_content_id(
+      base_path: "/government/organisations/#{args.organisation_slug}",
+    )
+
+    whitehall_migration = WhitehallImporter.create_migration(organisation_content_id, args.document_type)
 
     documents_to_import = WhitehallMigration::DocumentImport.where(whitehall_migration_id: whitehall_migration.id).count
     puts "Identified #{documents_to_import} documents to import"

--- a/lib/tasks/import.rake
+++ b/lib/tasks/import.rake
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-require "gds_api/json_client"
+require "gds_api/whitehall_export"
 
 namespace :import do
   desc "Import all documents matching an organisation and document type from Whitehall Publisher, e.g. import:whitehall_migration[organisation-slug, document-type]"
@@ -12,16 +12,8 @@ namespace :import do
 
   desc "Import a single document from Whitehall Publisher using Whitehall's internal document ID e.g. import:whitehall_document[123]"
   task :whitehall_document, [:document_id] => :environment do |_, args|
-    host = Plek.new.external_url_for("whitehall-admin")
-    endpoint = "#{host}/government/admin/export/document/#{args.document_id}"
-    options = {
-      "bearer_token": ENV["WHITEHALL_BEARER_TOKEN"] || "example",
-    }
-    client = GdsApi::JsonClient.new(options)
-    response = client.get_json(endpoint)
-    whitehall_export = response.to_hash
-
-    whitehall_import = WhitehallImporter.import_and_sync(whitehall_export)
+    whitehall_export = GdsApi.whitehall_export.document_export(args.document_id)
+    whitehall_import = WhitehallImporter.import_and_sync(whitehall_export.to_hash)
 
     unless whitehall_import.completed?
       puts whitehall_import.state.humanize

--- a/lib/tasks/import.rake
+++ b/lib/tasks/import.rake
@@ -5,9 +5,10 @@ require "gds_api/whitehall_export"
 namespace :import do
   desc "Import all documents matching an organisation and document type from Whitehall Publisher, e.g. import:whitehall_migration[organisation-slug, document-type]"
   task :whitehall_migration, %i[organisation_slug document_type] => :environment do |_, args|
-    WhitehallMigration.create!(organisation_slug: args.organisation_slug,
-                               document_type: args.document_type,
-                               start_time: Time.zone.now)
+    whitehall_migration = WhitehallImporter.create_migration(args.organisation_slug, args.document_type)
+
+    documents_to_import = WhitehallMigration::DocumentImport.where(whitehall_migration_id: whitehall_migration.id).count
+    puts "Identified #{documents_to_import} documents to import"
   end
 
   desc "Import a single document from Whitehall Publisher using Whitehall's internal document ID e.g. import:whitehall_document[123]"

--- a/lib/whitehall_importer.rb
+++ b/lib/whitehall_importer.rb
@@ -1,13 +1,13 @@
 # frozen_string_literal: true
 
 module WhitehallImporter
-  def self.create_migration(organisation_slug, document_type)
+  def self.create_migration(organisation_content_id, document_type)
     ActiveRecord::Base.transaction do
-      whitehall_migration = WhitehallMigration.create!(organisation_slug: organisation_slug,
+      whitehall_migration = WhitehallMigration.create!(organisation_content_id: organisation_content_id,
                                  document_type: document_type,
                                  start_time: Time.current)
 
-      whitehall_export = GdsApi.whitehall_export.document_list(organisation_slug, document_type)
+      whitehall_export = GdsApi.whitehall_export.document_list(organisation_content_id, document_type)
 
       whitehall_export.each do |page|
         page["documents"].each do |document|

--- a/spec/factories/whitehall_export/index_document_factory.rb
+++ b/spec/factories/whitehall_export/index_document_factory.rb
@@ -1,0 +1,19 @@
+# frozen_string_literal: true
+
+FactoryBot.define do
+  factory :whitehall_export_index_document, class: Hash do
+    skip_create
+
+    sequence(:document_id)
+
+    document_information {
+      {
+        locales: %w(en),
+        sub_types: %w(news_story),
+        lead_organisations: %w(96ae61d6-c2a1-48cb-8e67-da9d105ae381),
+      }.stringify_keys
+    }
+
+    initialize_with { attributes.stringify_keys }
+  end
+end

--- a/spec/factories/whitehall_export/index_factory.rb
+++ b/spec/factories/whitehall_export/index_factory.rb
@@ -1,0 +1,14 @@
+# frozen_string_literal: true
+
+FactoryBot.define do
+  factory :whitehall_export_index, class: Hash do
+    skip_create
+
+    documents { [build(:whitehall_export_index_document)] }
+
+    page_count { documents.size }
+    sequence(:page_number, 1)
+
+    initialize_with { attributes.stringify_keys }
+  end
+end

--- a/spec/lib/gds_api/whitehall_export_spec.rb
+++ b/spec/lib/gds_api/whitehall_export_spec.rb
@@ -1,0 +1,18 @@
+# frozen_string_literal: true
+
+RSpec.describe GdsApi::WhitehallExport do
+  describe "document_export" do
+    let(:whitehall_adapter) { GdsApi::WhitehallExport.new(Plek.find("whitehall-admin")) }
+    let(:whitehall_host) { Plek.new.external_url_for("whitehall-admin") }
+    let(:whitehall_export) { build(:whitehall_export_document) }
+
+    before do
+      stub_request(:get, "#{whitehall_host}/government/admin/export/document/123")
+        .to_return(status: 200, body: whitehall_export.to_json)
+    end
+
+    it "makes a GET request to whitehall" do
+      expect(whitehall_adapter.document_export("123")).to have_requested(:get, "#{whitehall_host}/government/admin/export/document/123")
+    end
+  end
+end

--- a/spec/lib/gds_api/whitehall_export_spec.rb
+++ b/spec/lib/gds_api/whitehall_export_spec.rb
@@ -1,6 +1,27 @@
 # frozen_string_literal: true
 
 RSpec.describe GdsApi::WhitehallExport do
+  describe "document_list" do
+    let(:whitehall_adapter) { GdsApi::WhitehallExport.new(Plek.find("whitehall-admin")) }
+    let(:whitehall_host) { Plek.new.external_url_for("whitehall-admin") }
+    let(:whitehall_export_page_1) { build(:whitehall_export_index, documents: build_list(:whitehall_export_index_document, 100)) }
+    let(:whitehall_export_page_2) { build(:whitehall_export_index, documents: build_list(:whitehall_export_index_document, 10)) }
+
+    before do
+      stub_request(:get, "#{whitehall_host}/government/admin/export/document?lead_organisation=123&type=NewsArticle&page_count=100&page_number=1")
+        .to_return(status: 200, body: whitehall_export_page_1.to_json)
+      stub_request(:get, "#{whitehall_host}/government/admin/export/document?lead_organisation=123&type=NewsArticle&page_count=100&page_number=2")
+        .to_return(status: 200, body: whitehall_export_page_2.to_json)
+    end
+
+    it "iterates through the correct number of pages" do
+      whitehall_document_list = whitehall_adapter.document_list("123", "NewsArticle")
+      expect(whitehall_document_list.next).to have_requested(:get, "#{whitehall_host}/government/admin/export/document?lead_organisation=123&type=NewsArticle&page_count=100&page_number=1")
+      expect(whitehall_document_list.next).to have_requested(:get, "#{whitehall_host}/government/admin/export/document?lead_organisation=123&type=NewsArticle&page_count=100&page_number=2")
+      expect { whitehall_document_list.next }.to raise_error(StopIteration)
+    end
+  end
+
   describe "document_export" do
     let(:whitehall_adapter) { GdsApi::WhitehallExport.new(Plek.find("whitehall-admin")) }
     let(:whitehall_host) { Plek.new.external_url_for("whitehall-admin") }

--- a/spec/lib/tasks/import_spec.rb
+++ b/spec/lib/tasks/import_spec.rb
@@ -7,12 +7,15 @@ RSpec.describe "Import tasks" do
     before do
       allow($stdout).to receive(:puts)
       Rake::Task["import:whitehall_migration"].reenable
+      stub_publishing_api_has_lookups(
+        "/government/organisations/cabinet-office" => "96ae61d6-c2a1-48cb-8e67-da9d105ae381",
+      )
       allow(WhitehallImporter).to receive(:create_migration).and_return(whitehall_migration_document_import)
     end
 
     it "calls WhitehallImport::create_migration with correct arguments" do
       Rake::Task["import:whitehall_migration"].invoke("cabinet-office", "NewsArticle")
-      expect(WhitehallImporter).to have_received(:create_migration).with("cabinet-office", "NewsArticle")
+      expect(WhitehallImporter).to have_received(:create_migration).with("96ae61d6-c2a1-48cb-8e67-da9d105ae381", "NewsArticle")
     end
   end
 

--- a/spec/lib/tasks/import_spec.rb
+++ b/spec/lib/tasks/import_spec.rb
@@ -2,17 +2,17 @@
 
 RSpec.describe "Import tasks" do
   describe "import:whitehall_migration" do
+    let(:whitehall_migration_document_import) { build(:whitehall_migration_document_import) }
+
     before do
+      allow($stdout).to receive(:puts)
       Rake::Task["import:whitehall_migration"].reenable
+      allow(WhitehallImporter).to receive(:create_migration).and_return(whitehall_migration_document_import)
     end
 
-    it "creates a WhitehallMigration" do
-      freeze_time do
-        expect { Rake::Task["import:whitehall_migration"].invoke("cabinet-office", "news_story") }.to change { WhitehallMigration.count }.by(1)
-        expect(WhitehallMigration.last.organisation_slug).to eq("cabinet-office")
-        expect(WhitehallMigration.last.document_type).to eq("news_story")
-        expect(WhitehallMigration.last.start_time).to eq(Time.current)
-      end
+    it "calls WhitehallImport::create_migration with correct arguments" do
+      Rake::Task["import:whitehall_migration"].invoke("cabinet-office", "NewsArticle")
+      expect(WhitehallImporter).to have_received(:create_migration).with("cabinet-office", "NewsArticle")
     end
   end
 

--- a/spec/lib/whitehall_importer_spec.rb
+++ b/spec/lib/whitehall_importer_spec.rb
@@ -1,6 +1,32 @@
 # frozen_string_literal: true
 
 RSpec.describe WhitehallImporter do
+  describe ".create_migration" do
+    let(:whitehall_host) { Plek.new.external_url_for("whitehall-admin") }
+    let(:whitehall_export_page_1) { build(:whitehall_export_index, documents: build_list(:whitehall_export_index_document, 100)) }
+    let(:whitehall_export_page_2) { build(:whitehall_export_index, documents: build_list(:whitehall_export_index_document, 10)) }
+
+    before do
+      stub_request(:get, "#{whitehall_host}/government/admin/export/document?lead_organisation=cabinet-office&page_count=100&page_number=1&type=NewsArticle")
+        .to_return(status: 200, body: whitehall_export_page_1.to_json)
+      stub_request(:get, "#{whitehall_host}/government/admin/export/document?lead_organisation=cabinet-office&page_count=100&page_number=2&type=NewsArticle")
+        .to_return(status: 200, body: whitehall_export_page_2.to_json)
+    end
+
+    it "creates a WhitehallMigration" do
+      freeze_time do
+        expect { WhitehallImporter.create_migration("cabinet-office", "NewsArticle") }.to change { WhitehallMigration.count }.by(1)
+        expect(WhitehallMigration.last.organisation_slug).to eq("cabinet-office")
+        expect(WhitehallMigration.last.document_type).to eq("NewsArticle")
+        expect(WhitehallMigration.last.start_time).to eq(Time.current)
+      end
+    end
+
+    it "creates a pending WhitehallMigration::DocumentImport for each listed item" do
+      expect { WhitehallImporter.create_migration("cabinet-office", "NewsArticle") }.to change { WhitehallMigration::DocumentImport.pending.count }.by(110)
+    end
+  end
+
   describe ".import_and_sync" do
     before do
       allow(ResyncService).to receive(:call)

--- a/spec/lib/whitehall_importer_spec.rb
+++ b/spec/lib/whitehall_importer_spec.rb
@@ -7,23 +7,23 @@ RSpec.describe WhitehallImporter do
     let(:whitehall_export_page_2) { build(:whitehall_export_index, documents: build_list(:whitehall_export_index_document, 10)) }
 
     before do
-      stub_request(:get, "#{whitehall_host}/government/admin/export/document?lead_organisation=cabinet-office&page_count=100&page_number=1&type=NewsArticle")
+      stub_request(:get, "#{whitehall_host}/government/admin/export/document?lead_organisation=123&page_count=100&page_number=1&type=NewsArticle")
         .to_return(status: 200, body: whitehall_export_page_1.to_json)
-      stub_request(:get, "#{whitehall_host}/government/admin/export/document?lead_organisation=cabinet-office&page_count=100&page_number=2&type=NewsArticle")
+      stub_request(:get, "#{whitehall_host}/government/admin/export/document?lead_organisation=123&page_count=100&page_number=2&type=NewsArticle")
         .to_return(status: 200, body: whitehall_export_page_2.to_json)
     end
 
     it "creates a WhitehallMigration" do
       freeze_time do
-        expect { WhitehallImporter.create_migration("cabinet-office", "NewsArticle") }.to change { WhitehallMigration.count }.by(1)
-        expect(WhitehallMigration.last.organisation_slug).to eq("cabinet-office")
+        expect { WhitehallImporter.create_migration("123", "NewsArticle") }.to change { WhitehallMigration.count }.by(1)
+        expect(WhitehallMigration.last.organisation_content_id).to eq("123")
         expect(WhitehallMigration.last.document_type).to eq("NewsArticle")
         expect(WhitehallMigration.last.start_time).to eq(Time.current)
       end
     end
 
     it "creates a pending WhitehallMigration::DocumentImport for each listed item" do
-      expect { WhitehallImporter.create_migration("cabinet-office", "NewsArticle") }.to change { WhitehallMigration::DocumentImport.pending.count }.by(110)
+      expect { WhitehallImporter.create_migration("123", "NewsArticle") }.to change { WhitehallMigration::DocumentImport.pending.count }.by(110)
     end
   end
 


### PR DESCRIPTION
In #1565, we created a rake task (`import:whitehall_migration`) that takes organisation and document type as arguments, then creates a `WhitehallMigration` model.  The changes here build on that work to:
* get a list of documents to import from Whitehall's export API (and deal with the paginated response from Whitehall)
* allow `WhitehallMigration::DocumentImport` to have a status of 'pending' (i.e. ready to import, but no import has been started yet)
* remove not-null requirement for two fields on `WhitehallMigration::DocumentImport` (since we will not have that data whilst the import is in a pending state)
* create a pending `WhitehallMigration::DocumentImport` for each document due to be imported
* create the `WhitehallMigration` and `WhitehallMigration::DocumentImport` models within a single transaction (per run of the `import:whitehall_migration` rake task) so we won't get partial data stored if the import fails for any reason

Later work will then take these pending `WhitehallMigration::DocumentImport` models and queue a job for each document.

Trello card: https://trello.com/c/4OFU8HHs