### PR TITLE
Create timeline entry for when document is imported

### DIFF
--- a/app/models/timeline_entry.rb
+++ b/app/models/timeline_entry.rb
@@ -57,7 +57,8 @@ class TimelineEntry < ApplicationRecord
                      access_limit_created: "access_limit_created",
                      access_limit_updated: "access_limit_updated",
                      access_limit_removed: "access_limit_removed",
-                     political_status_changed: "political_status_changed" }
+                     political_status_changed: "political_status_changed",
+                     imported_from_whitehall: "imported_from_whitehall" }
 
   def self.create_for_status_change(entry_type:,
                                     status:,

--- a/app/views/documents/show/_history_tab.html.erb
+++ b/app/views/documents/show/_history_tab.html.erb
@@ -9,51 +9,59 @@
           <% displayed_edition_number = entry.edition.number %>
         <% end %>
 
-        <h4 class="govuk-heading-s govuk-!-margin-bottom-1">
-          <%= t "documents.history.entry_types.#{entry.entry_type}" %>
-        </h4>
+        <% if entry.imported_from_whitehall? %>
+          <%= render "govuk_publishing_components/components/notice", {
+            title: "#{t "documents.history.entry_types.#{entry.entry_type}"}",
+            description_text: format_date(entry.created_at)
+          } %>
+        <% else %>
 
-        <div class="app-timeline-entry__dateline">
-          <%= format_date_at_time(entry.created_at) %>
-          <% if entry.created_by %>
-            by <%= name_or_fallback(entry.created_by) %>
-          <% end %>
-        </div>
+          <h4 class="govuk-heading-s govuk-!-margin-bottom-1">
+            <%= t "documents.history.entry_types.#{entry.entry_type}" %>
+          </h4>
 
-        <% if entry.internal_note? && entry.details %>
-          <%= simple_format(escape_and_link(entry.details.body)) %>
-        <% end %>
+          <div class="app-timeline-entry__dateline">
+            <%= format_date_at_time(entry.created_at) %>
+            <% if entry.created_by %>
+              by <%= name_or_fallback(entry.created_by) %>
+            <% end %>
+          </div>
 
-        <% if (entry.withdrawn? || entry.withdrawn_updated?) && entry.details %>
-          <%= entry.details.public_explanation %>
-        <% end %>
-
-        <% if entry.backdated? %>
-          <% date = format_date(entry.revision.backdated_to) %>
-          <%= t "documents.history.entry_content.backdated", date: date %>
-        <% end %>
-
-        <% if entry.removed? && entry.details %>
-          <% removal = entry.details %>
-          <% if removal.explanatory_note.present? %>
-            <p><%= removal.explanatory_note %></p>
+          <% if entry.internal_note? && entry.details %>
+            <%= simple_format(escape_and_link(entry.details.body)) %>
           <% end %>
 
-          <% if removal.alternative_path.present? %>
-            <% if removal.redirect? %>
-              <p>
-                Redirected to
-                <%= link_to(Plek.new.website_root + removal.alternative_path,
-                            nil,
-                            class: "govuk-link") %>
-              </p>
-            <% else %>
-              <p>
-                Alternative path
-                <%= link_to(Plek.new.website_root + removal.alternative_path,
-                            nil,
-                            class: "govuk-link") %>
-              </p>
+          <% if (entry.withdrawn? || entry.withdrawn_updated?) && entry.details %>
+            <%= entry.details.public_explanation %>
+          <% end %>
+
+          <% if entry.backdated? %>
+            <% date = format_date(entry.revision.backdated_to) %>
+            <%= t "documents.history.entry_content.backdated", date: date %>
+          <% end %>
+
+          <% if entry.removed? && entry.details %>
+            <% removal = entry.details %>
+            <% if removal.explanatory_note.present? %>
+              <p><%= removal.explanatory_note %></p>
+            <% end %>
+
+            <% if removal.alternative_path.present? %>
+              <% if removal.redirect? %>
+                <p>
+                  Redirected to
+                  <%= link_to(Plek.new.website_root + removal.alternative_path,
+                              nil,
+                              class: "govuk-link") %>
+                </p>
+              <% else %>
+                <p>
+                  Alternative path
+                  <%= link_to(Plek.new.website_root + removal.alternative_path,
+                              nil,
+                              class: "govuk-link") %>
+                </p>
+              <% end %>
             <% end %>
           <% end %>
         <% end %>

--- a/config/locales/en/documents/history.yml
+++ b/config/locales/en/documents/history.yml
@@ -38,5 +38,6 @@ en:
         access_limit_updated: "Access limit updated"
         access_limit_removed: "Access limit removed"
         political_status_changed: "History mode criteria updated"
+        imported_from_whitehall: "Imported from Whitehall"
       entry_content:
         backdated: "First published date backdated to %{date}"

--- a/lib/whitehall_importer.rb
+++ b/lib/whitehall_importer.rb
@@ -22,6 +22,7 @@ module WhitehallImporter
     begin
       document = Import.call(whitehall_import.payload)
       whitehall_import.update!(document: document, state: "imported")
+      create_timeline_entry(document.current_edition)
     rescue AbortImportError => e
       whitehall_import.update!(error_log: e.inspect, state: "import_aborted")
     rescue StandardError => e
@@ -43,4 +44,14 @@ module WhitehallImporter
       whitehall_import.update!(error_log: e.inspect, state: "sync_failed")
     end
   end
+
+  def self.create_timeline_entry(edition)
+    TimelineEntry.create_for_revision(
+      entry_type: :imported_from_whitehall,
+      revision: edition.revision,
+      edition: edition,
+    )
+  end
+
+  private_class_method :create_timeline_entry
 end

--- a/spec/lib/whitehall_importer_spec.rb
+++ b/spec/lib/whitehall_importer_spec.rb
@@ -34,7 +34,6 @@ RSpec.describe WhitehallImporter do
   end
 
   describe ".import" do
-    before { allow(WhitehallImporter::Import).to receive(:call) }
     let(:whitehall_migration_document_import) { create(:whitehall_migration_document_import) }
 
     it "imports a document" do
@@ -52,6 +51,11 @@ RSpec.describe WhitehallImporter do
       it "marks the import as imported" do
         WhitehallImporter.import(whitehall_migration_document_import)
         expect(whitehall_migration_document_import).to be_imported
+      end
+
+      it "sets the timeline entry as Imported from Whitehall" do
+        WhitehallImporter.import(whitehall_migration_document_import)
+        expect(TimelineEntry.last).to be_imported_from_whitehall
       end
     end
 


### PR DESCRIPTION
### User story
As a publisher
I want to see the history of a document
So that I can see what has changed and why it has changed over time.

We want to indicate when a document was imported into Content Publisher so that
publishers can understand any variations in how the history events are
presented.

[Trello card](https://trello.com/c/5Rfe68rk/1279-create-timeline-entry-for-when-its-imported)

_Tested in integration:_

<img width="977" alt="with_notice_component" src="https://user-images.githubusercontent.com/38078064/71518589-9145a280-28ab-11ea-87a4-42e96660c824.png">


