### PR TITLE
Add secondary navigation component

### DIFF
--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -22,6 +22,7 @@
 @import "components/miller-columns";
 @import "components/multi-section-viewer";
 @import "components/page-preview";
+@import "components/secondary-navigation";
 @import "components/side-navigation";
 @import "components/toolbar-dropdown";
 @import "components/url-preview";

--- a/app/assets/stylesheets/components/_secondary-navigation.scss
+++ b/app/assets/stylesheets/components/_secondary-navigation.scss
@@ -1,0 +1,96 @@
+.app-c-secondary-navigation {
+  @include govuk-font(19);
+  @include govuk-responsive-margin(6, 'bottom');
+
+  display: block;
+
+  @include govuk-media-query($from: tablet) {
+    box-shadow: inset 0 -1px 0 $govuk-border-colour;
+    display: flex;
+  }
+}
+
+.app-c-secondary-navigation__list {
+  list-style: none;
+  margin-bottom: govuk-spacing(4);
+  padding: 0;
+
+  @include govuk-media-query($from: tablet) {
+    box-shadow: none;
+    display: flex;
+    margin: 0;
+    white-space: nowrap;
+  }
+}
+
+
+.app-c-secondary-navigation__list-item {
+  box-shadow: inset 0 -1px 0 $govuk-border-colour;
+
+  @include govuk-media-query($from: tablet) {
+    display: flex;
+    margin-right: 20px;
+
+    &:last-child {
+      margin-right: 0;
+    }
+  }
+
+  &:last-child {
+    box-shadow: none;
+  }
+
+  a,
+  a:link,
+  a:visited {
+    background-color: inherit;
+    border-left: 4px solid transparent;
+    color: govuk-colour('blue');
+    display: block;
+    padding: govuk-spacing(2);
+    text-decoration: none;
+
+    @include govuk-media-query($from: tablet) {
+      border-bottom: 4px solid transparent;
+      border-left: 0;
+      padding: govuk-spacing(2) 0;
+      padding-bottom: govuk-spacing(2) - 4px; // Compensate for 4px border
+    }
+  }
+
+  a:hover {
+    color: $govuk-link-hover-colour;
+  }
+
+  a:focus {
+    @include govuk-focused-text;
+
+    border-color: $govuk-focus-text-colour;
+    border-left-color: transparent;
+    position: relative;
+
+    @include govuk-media-query($from: tablet) {
+      box-shadow: none;
+    }
+  }
+
+}
+
+.app-c-secondary-navigation__list-item--current {
+  a:link,
+  a:visited {
+    border-color: govuk-colour('blue');
+    color: $govuk-text-colour;
+  }
+
+  a:focus {
+    @include govuk-focused-text;
+
+    border-color: $govuk-focus-text-colour;
+    border-left-color: transparent;
+
+    @include govuk-media-query($from: tablet) {
+      box-shadow: none;
+    }
+  }
+}

--- a/app/views/components/_secondary_navigation.html.erb
+++ b/app/views/components/_secondary_navigation.html.erb
@@ -1,0 +1,19 @@
+<%
+  id ||= nil
+  items ||= []
+%>
+
+<%= tag.nav class: "app-c-secondary-navigation", id: id, role: 'navigation', aria: { label: aria_label } do %>
+  <%= tag.ul class: "app-c-secondary-navigation__list" do %>
+    <% items.each do |item| %>
+      <%
+        item_classes = %w( app-c-secondary-navigation__list-item )
+        item_classes << "app-c-secondary-navigation__list-item--current" if item[:current]
+        item_aria_attributes = { current: "page" } if item[:current]
+      %>
+      <%= tag.li class: item_classes do %>
+        <%= link_to item[:label], item[:href], class: "govuk-link govuk-link--no-visited-state", data: item[:data_attributes], aria: item_aria_attributes %>
+      <% end %>
+    <% end %>
+  <% end %>
+<% end %>

--- a/app/views/components/docs/secondary_navigation.yml
+++ b/app/views/components/docs/secondary_navigation.yml
@@ -1,0 +1,23 @@
+name: Secondary navigation
+description: Displays a secondary navigation with the current page marked accordingly
+accessibility_criteria: |
+  The component must:
+
+  * indicate that it is navigation landmark
+  * indicate if a navigation item links to the currently-displayed page
+shared_accessibility_criteria:
+  - link
+examples:
+  default:
+    data:
+      aria_label: Document
+      items:
+        - label: Document summary
+          href: /document-summary
+          current: true
+          data_attributes:
+            gtm: summary-tab
+        - label: Document history
+          href: /document-history
+          data_attributes:
+            gtm: history-tab


### PR DESCRIPTION
Because of the high number of history entries that some documents have we need to paginate the history page. This involves splitting the History page away from the Summary page and replace the current tabs component with a secondary navigation component.

This implementation follows the visual appearance of [sub-navigation component from MoJ](https://moj-design-system.herokuapp.com/components/sub-navigation). 

### [Component preview](https://content-publisher-revi-pr-1576.herokuapp.com/component-guide/secondary_navigation)

### Usage example

Tested in `app/views/documents/show.html.erb`

```
<%= render "components/secondary_navigation", {
  aria_label: "Document",
  items: [
    {
      label: "Document summary",
      href: "/document-summary",
      current: true,
      data_attributes: {
        gtm: "summary-tab"
      }
    },
    {
      label: "Document history",
      href: "/document-history",
      data_attributes: {
        gtm: "history-tab"
      }
    }
  ]
} %>

<%= render("documents/show/summary_tab") %>

```

<table>
<tr><th>Before</th><th>After</th></tr>
<tr><td>

![content-publisher dev gov uk_documents_88929f8d-2f2c-45a0-8938-d303c390fcaf_en(iPad Pro) (1)](https://user-images.githubusercontent.com/788096/71517674-d7a0fe80-28b7-11ea-88af-576d46ab8311.png)


</td><td>

![content-publisher dev gov uk_documents_88929f8d-2f2c-45a0-8938-d303c390fcaf_en(iPad Pro)](https://user-images.githubusercontent.com/788096/71517676-da9bef00-28b7-11ea-8fac-a7407b61e510.png)


</td></tr>
</table>

[Trello card](https://trello.com/c/Gtx6NA7p)