### PR TITLE
Fix migration so that it runs with future app code

### DIFF
--- a/db/migrate/20191223091535_populate_edition_editors.rb
+++ b/db/migrate/20191223091535_populate_edition_editors.rb
@@ -1,7 +1,13 @@
 # frozen_string_literal: true
 
 class PopulateEditionEditors < ActiveRecord::Migration[6.0]
-  def change
+  class Edition < ApplicationRecord
+    has_and_belongs_to_many :edition_editors,
+                            class_name: "User",
+                            join_table: :edition_editors
+  end
+
+  def up
     revision_editors = Revision.joins(:editions_revisions)
                        .group(:edition_id)
                        .pluck(:edition_id, Arel.sql("ARRAY_AGG(DISTINCT created_by_id)"))


### PR DESCRIPTION
Fixes the populate edition migration so that it uses a mocked version of the Edition code,
and is therefore future proofed against any changes to the Edition model.