### PR TITLE
Do not try and import a "nil" editor

### DIFF
--- a/lib/whitehall_importer/create_edition.rb
+++ b/lib/whitehall_importer/create_edition.rb
@@ -145,7 +145,7 @@ module WhitehallImporter
       create_event ||= history.create_event!
       last_event ||= whitehall_edition["revision_history"].last
 
-      editor_ids = history.editors.map { |editor| user_ids[editor] }
+      editor_ids = history.editors.map { |editor| user_ids[editor] }.compact
 
       Edition.create!(
         document: document,


### PR DESCRIPTION
Removes and possible nil values from the editors history as we can't guarantee that every
user "whodunnit" in the edition history of a Whitehall import will actually be imported.