### PR TITLE
Replace straight quotes with curly ones in locale files

### DIFF
--- a/config/locales/en/access_limit/edit.yml
+++ b/config/locales/en/access_limit/edit.yml
@@ -3,7 +3,7 @@ en:
     edit:
       browser_title: Access limit content
       title: Who can access this document
-      api_down: This content can't be edited right now. We're having trouble getting the data we need for you to make changes on this page.
+      api_down: This content can’t be edited right now. We’re having trouble getting the data we need for you to make changes on this page.
       description: You can limit who is able to find and edit this document before it is published. Select an option that includes the organisation associated with your account.
       no_access_limit: All publishers have access
       type:

--- a/config/locales/en/contact_embed/new.yml
+++ b/config/locales/en/contact_embed/new.yml
@@ -4,12 +4,12 @@ en:
       title: Insert contact address
       label: Search saved contact
       hint_text: Select a contact address from the GOV.UK contacts list
-      api_down: Contacts can't be selected right now. We're having trouble getting the data we need for you to make changes on this page.
+      api_down: Contacts can’t be selected right now. We’re having trouble getting the data we need for you to make changes on this page.
       markdown_code: Markdown code
       contact_markdown: "[Contact: %{id}]"
       contact_instructions: |
         Copy the markdown code and paste it into the text in a new paragraph
         where you want the file to appear.
       contact_not_available_govspeak: |
-        If the contact you need is not available or is out of date, edit your organisation's contacts. [Full guidance on adding or editing contacts](https://www.gov.uk/guidance/how-to-publish-on-gov-uk/organisation-pages#organisation-contacts){:target="_blank"}.
+        If the contact you need is not available or is out of date, edit your organisation’s contacts. [Full guidance on adding or editing contacts](https://www.gov.uk/guidance/how-to-publish-on-gov-uk/organisation-pages#organisation-contacts){:target="_blank"}.
       preview_error: Unable to preview contact.

--- a/config/locales/en/documents/edit.yml
+++ b/config/locales/en/documents/edit.yml
@@ -12,13 +12,13 @@ en:
         summary: Summary
       url_preview:
         available: Page address
-        no_title: You haven't entered a title yet.
+        no_title: You haven’t entered a title yet.
         error: Unable to preview address, please edit title and try again.
       change_note:
         title: Public change note
         guidance_title: Writing change notes
         guidance: |
-          Describe the change for users. Include or refer to any new or updated information. This change note will be published on the page and emailed to subscribers. The 'last updated' date will change.
+          Describe the change for users. Include or refer to any new or updated information. This change note will be published on the page and emailed to subscribers. The ‘last updated’ date will change.
 
           [Full guidance on change notes](https://www.gov.uk/guidance/content-design/writing-for-gov-uk#change-notes)
       update_type:

--- a/config/locales/en/documents/show.yml
+++ b/config/locales/en/documents/show.yml
@@ -15,10 +15,10 @@ en:
       topics:
         title: Topics
         no_topics: No topics.
-        api_down: This content isn't available right now. We're having trouble getting the data we need to show you this content.
+        api_down: This content isn’t available right now. We’re having trouble getting the data we need to show you this content.
       tags:
         title: Tags
-        api_down: This content isn't available right now. We're having trouble getting the data we need to show you this content.
+        api_down: This content isn’t available right now. We’re having trouble getting the data we need to show you this content.
         none: None
       contents:
         title: Content
@@ -65,7 +65,7 @@ en:
       failed_to_publish:
         title: There is a problem
         description_govspeak: |
-          '%{title}' has not been published.<br>
+          ‘%{title}’ has not been published.<br>
           It was scheduled to publish at %{time} on %{date}
 
           You can publish it now, schedule it to publish later, or edit it.

--- a/config/locales/en/file_attachments/preview_pending.yml
+++ b/config/locales/en/file_attachments/preview_pending.yml
@@ -1,7 +1,7 @@
 en:
   file_attachments:
     preview_pending:
-      title: Sorry, you can't preview this file yet
+      title: Sorry, you can’t preview this file yet
       description_govspeak: |
         Your file is still being security scanned.
 

--- a/config/locales/en/remove/remove.yml
+++ b/config/locales/en/remove/remove.yml
@@ -1,4 +1,4 @@
 en:
   remove:
     remove:
-      title: Sorry, this hasn't been built yet
+      title: Sorry, this hasn’t been built yet

--- a/config/locales/en/tags/edit.yml
+++ b/config/locales/en/tags/edit.yml
@@ -3,5 +3,5 @@ en:
     edit:
       title: "Tags for ‘%{title}’"
       description: Add tags which describe what the content is about. Content will appear in lists on GOV.UK based on each tag.
-      api_down: This content can't be edited right now. We're having trouble getting the data we need for you to make changes on this page.
+      api_down: This content can’t be edited right now. We’re having trouble getting the data we need for you to make changes on this page.
       organisation_warning: Access to this document is restricted. Adding or removing organisation tags will change who can access it.

--- a/config/locales/en/topics/edit.yml
+++ b/config/locales/en/topics/edit.yml
@@ -11,7 +11,7 @@ en:
       link_guidance: Full guidance on topics
       link_suggest_new: Suggest a new topic
       link_suggest_change: Suggest a change to a topic
-      api_down: This content can't be edited right now. We're having trouble getting the data we need for you to make changes on this page.
+      api_down: This content can’t be edited right now. We’re having trouble getting the data we need for you to make changes on this page.
       flashes:
         topic_update_conflict:
           title: Somebody else changed the topics before you could


### PR DESCRIPTION
We have a preference for presenting users with curly quotes rather than
straight ones as they are more semantic visually. The vast majority of
our translation files use curly quotes but a few stray ones are
lingering around. This resolves that.