### PR TITLE
Add missing data lost during import from Whitehall to Content Publisher

### DIFF
--- a/lib/whitehall_importer/create_edition.rb
+++ b/lib/whitehall_importer/create_edition.rb
@@ -150,7 +150,7 @@ module WhitehallImporter
       Edition.create!(
         document: document,
         number: edition_number,
-        revision_synced: true,
+        revision_synced: false,
         revision: revision,
         status: status,
         current: current,

--- a/lib/whitehall_importer/create_edition.rb
+++ b/lib/whitehall_importer/create_edition.rb
@@ -158,6 +158,7 @@ module WhitehallImporter
         created_at: create_event["created_at"],
         updated_at: last_event["created_at"],
         created_by_id: user_ids[create_event["whodunnit"]],
+        last_edited_at: last_event["created_at"],
         last_edited_by_id: user_ids[last_event["whodunnit"]],
         editor_ids: editor_ids,
       )

--- a/lib/whitehall_importer/create_edition.rb
+++ b/lib/whitehall_importer/create_edition.rb
@@ -105,7 +105,7 @@ module WhitehallImporter
         raise AbortImportError, "Cannot create scheduled status without scheduled_publication"
       end
 
-      pre_scheduled_state = history.state_event("submitted") ? "submitted_for_review" : "draft"
+      pre_scheduled_state = history.last_state_event("submitted") ? "submitted_for_review" : "draft"
       edition = create_edition(status: build_status(pre_scheduled_state),
                                current: current,
                                edition_number: edition_number)
@@ -130,13 +130,13 @@ module WhitehallImporter
     end
 
     def build_status(state, details = nil)
-      state_event = history.state_event!(whitehall_edition["state"])
+      last_state_event = history.last_state_event!(whitehall_edition["state"])
 
       Status.new(
         state: state,
         revision_at_creation: revision,
-        created_by_id: user_ids[state_event["whodunnit"]],
-        created_at: state_event["created_at"],
+        created_by_id: user_ids[last_state_event["whodunnit"]],
+        created_at: last_state_event["created_at"],
         details: details,
       )
     end

--- a/lib/whitehall_importer/edition_history.rb
+++ b/lib/whitehall_importer/edition_history.rb
@@ -6,12 +6,12 @@ module WhitehallImporter
       @revision_history = revision_history
     end
 
-    def state_event(state)
+    def last_state_event(state)
       revision_history.select { |h| h["state"] == state }.last
     end
 
-    def state_event!(state)
-      state_event(state) || raise(AbortImportError, "Edition is missing a #{state} event")
+    def last_state_event!(state)
+      last_state_event(state) || raise(AbortImportError, "Edition is missing a #{state} event")
     end
 
     def next_event(event)

--- a/lib/whitehall_importer/edition_history.rb
+++ b/lib/whitehall_importer/edition_history.rb
@@ -14,6 +14,10 @@ module WhitehallImporter
       last_state_event(state) || raise(AbortImportError, "Edition is missing a #{state} event")
     end
 
+    def first_state_event(state)
+      revision_history.select { |h| h["state"] == state }.first
+    end
+
     def next_event(event)
       index = revision_history.index(event)
       return unless index

--- a/lib/whitehall_importer/import.rb
+++ b/lib/whitehall_importer/import.rb
@@ -61,8 +61,18 @@ module WhitehallImporter
         created_at: whitehall_document["created_at"],
         updated_at: whitehall_document["updated_at"],
         created_by_id: user_ids[event["whodunnit"]],
+        first_published_at: first_publish_date,
         imported_from: "whitehall",
       )
+    end
+
+    def first_publish_date
+      first_publish_event = first_edition_history.first_state_event("published") || {}
+      first_publish_event["created_at"]
+    end
+
+    def first_edition_history
+      EditionHistory.new(whitehall_document["editions"].first["revision_history"])
     end
   end
 end

--- a/lib/whitehall_importer/import.rb
+++ b/lib/whitehall_importer/import.rb
@@ -52,8 +52,7 @@ module WhitehallImporter
         raise AbortImportError, "Document with content_id #{content_id} already exists"
       end
 
-      event = whitehall_document["editions"].first["revision_history"].select { |h| h["event"] == "create" }.first
-      raise AbortImportError, "First edition is missing a create event" unless event
+      event = first_edition_history.create_event!
 
       Document.create!(
         content_id: content_id,

--- a/spec/lib/whitehall_importer/create_edition_spec.rb
+++ b/spec/lib/whitehall_importer/create_edition_spec.rb
@@ -57,6 +57,13 @@ RSpec.describe WhitehallImporter::CreateEdition do
       expect(edition).to be_live
     end
 
+    it "does not mark the edition as synced with Publishing API" do
+      whitehall_edition = build(:whitehall_export_edition)
+      edition = described_class.call(document: document, whitehall_edition: whitehall_edition)
+
+      expect(edition.revision_synced).to be false
+    end
+
     it "sets the editors of an edition" do
       user_ids = {
         1 => create(:user).id,

--- a/spec/lib/whitehall_importer/create_edition_spec.rb
+++ b/spec/lib/whitehall_importer/create_edition_spec.rb
@@ -180,6 +180,7 @@ RSpec.describe WhitehallImporter::CreateEdition do
 
         expect(edition.created_at).to eq(created_at)
         expect(edition.updated_at).to eq(updated_at)
+        expect(edition.last_edited_at).to eq(updated_at)
       end
     end
 

--- a/spec/lib/whitehall_importer/create_revision_spec.rb
+++ b/spec/lib/whitehall_importer/create_revision_spec.rb
@@ -31,6 +31,24 @@ RSpec.describe WhitehallImporter::CreateRevision do
       expect(revision.base_path).to eq("/a-path")
     end
 
+    it "sets backdated_to when edition has been backdated" do
+      backdated_to = Time.current.yesterday.rfc3339
+      whitehall_edition = build(:whitehall_export_edition,
+                                first_published_at: backdated_to)
+
+      revision = described_class.call(document, whitehall_edition)
+
+      expect(revision.backdated_to).to eq(backdated_to)
+    end
+
+    it "does not set backdated_to when edition has not been backdated" do
+      whitehall_edition = build(:whitehall_export_edition)
+
+      revision = described_class.call(document, whitehall_edition)
+
+      expect(revision.backdated_to).to be_nil
+    end
+
     context "when creating images" do
       it "imports a single image" do
         whitehall_image = build(:whitehall_export_image, filename: "foo.jpg")

--- a/spec/lib/whitehall_importer/edition_history_spec.rb
+++ b/spec/lib/whitehall_importer/edition_history_spec.rb
@@ -18,24 +18,24 @@ RSpec.describe WhitehallImporter::EditionHistory do
     end
   end
 
-  describe "#state_event" do
+  describe "#last_state_event" do
     it "returns the last event associated with the state" do
       first_draft_event = build(:revision_history_event, state: "draft")
       last_draft_event = build(:revision_history_event, state: "draft")
       instance = described_class.new([first_draft_event, last_draft_event])
 
-      expect(instance.state_event("draft")).to be(last_draft_event)
+      expect(instance.last_state_event("draft")).to be(last_draft_event)
     end
 
     it "returns nil if the edition is missing a state event" do
       draft_event = build(:revision_history_event, state: "draft")
-      expect(described_class.new([draft_event]).state_event("published"))
+      expect(described_class.new([draft_event]).last_state_event("published"))
         .to be_nil
     end
   end
 
-  describe "#state_event!" do
-    it_behaves_like "an event bang method", :state_event, %w[draft]
+  describe "#last_state_event!" do
+    it_behaves_like "an event bang method", :last_state_event, %w[draft]
   end
 
   describe "#next_event" do

--- a/spec/lib/whitehall_importer/edition_history_spec.rb
+++ b/spec/lib/whitehall_importer/edition_history_spec.rb
@@ -38,6 +38,22 @@ RSpec.describe WhitehallImporter::EditionHistory do
     it_behaves_like "an event bang method", :last_state_event, %w[draft]
   end
 
+  describe "#first_state_event" do
+    it "returns the first event associated with the state" do
+      first_draft_event = build(:revision_history_event, state: "draft")
+      last_draft_event = build(:revision_history_event, state: "draft")
+      instance = described_class.new([first_draft_event, last_draft_event])
+
+      expect(instance.first_state_event("draft")).to be(first_draft_event)
+    end
+
+    it "returns nil if the edition is missing a state event" do
+      draft_event = build(:revision_history_event, state: "draft")
+      expect(described_class.new([draft_event]).first_state_event("published"))
+        .to be_nil
+    end
+  end
+
   describe "#next_event" do
     it "returns the event associated with the state" do
       first_event = build(:revision_history_event)

--- a/spec/lib/whitehall_importer/import_spec.rb
+++ b/spec/lib/whitehall_importer/import_spec.rb
@@ -82,5 +82,30 @@ RSpec.describe WhitehallImporter::Import do
 
       described_class.call(import_data)
     end
+
+    it "sets first_published_at date to publish time of first edition" do
+      first_publish_date = Time.current.yesterday.rfc3339
+      first_edition = build(
+        :whitehall_export_edition,
+        revision_history: [
+          build(:revision_history_event),
+          build(:revision_history_event, event: "update", state: "published", created_at: first_publish_date),
+        ],
+      )
+      second_edition = build(
+        :whitehall_export_edition,
+        revision_history: [
+          build(:revision_history_event),
+          build(:revision_history_event, event: "update", state: "published", created_at: Time.current),
+        ],
+      )
+
+      import_data = build(:whitehall_export_document,
+                          editions: [first_edition, second_edition])
+
+      document = described_class.call(import_data)
+
+      expect(document.first_published_at).to eq(first_publish_date)
+    end
   end
 end


### PR DESCRIPTION
We were missing some data when importing a document from Whitehall to Content Publisher.

This PR adds the following:
- Imported editions are marked with a `backdated_to` timestamp where appropriate (when the edition was backdated in Whitehall, determined by comparing the first published timestamp with the time of the first publish event)
- Import the `first_published_at` date for the document (taken from the first publish event on the first edition of a document; cannot be overridden by backdating)
- Editions have a `last_edited_at` timestamp (most recent edit event from the Whitehall `revision_history`)
- Imported editions are not marked as `revision_synced` (i.e. not marked as synced with Publishing API, which has not been completed at the import stage)

Trello card: https://trello.com/c/1RIiRBUF