### PR TITLE
Consistently handle API errors in ScheduleController

### DIFF
--- a/app/interactors/schedule/create_interactor.rb
+++ b/app/interactors/schedule/create_interactor.rb
@@ -5,6 +5,7 @@ class Schedule::CreateInteractor < ApplicationInteractor
            :user,
            :edition,
            :issues,
+           :api_error,
            to: :context
 
   def call
@@ -47,6 +48,9 @@ private
                                 publish_time: edition.proposed_publish_time)
 
     ScheduleService.call(edition, user, scheduling)
+  rescue GdsApi::BaseError => e
+    GovukError.notify(e)
+    context.fail!(api_error: true)
   end
 
   def create_timeline_entry

--- a/app/interactors/schedule/update_interactor.rb
+++ b/app/interactors/schedule/update_interactor.rb
@@ -7,6 +7,7 @@ class Schedule::UpdateInteractor < ApplicationInteractor
            :revision,
            :issues,
            :publish_time,
+           :api_error,
            to: :context
 
   def call
@@ -44,6 +45,9 @@ private
 
     new_scheduling = scheduling.dup.tap { |s| s.publish_time = publish_time }
     ScheduleService.call(edition, user, new_scheduling)
+  rescue GdsApi::BaseError => e
+    GovukError.notify(e)
+    context.fail!(api_error: true)
   end
 
   def create_timeline_entry

--- a/spec/factories/edition_factory.rb
+++ b/spec/factories/edition_factory.rb
@@ -78,6 +78,10 @@ FactoryBot.define do
       summary { SecureRandom.alphanumeric(10) }
     end
 
+    trait :not_publishable do
+      summary { "" }
+    end
+
     trait :published do
       summary { SecureRandom.alphanumeric(10) }
       live { true }

--- a/spec/interactors/schedule/create_interactor_spec.rb
+++ b/spec/interactors/schedule/create_interactor_spec.rb
@@ -1,0 +1,81 @@
+# frozen_string_literal: true
+
+RSpec.describe Schedule::CreateInteractor do
+  describe ".call" do
+    before { stub_any_publishing_api_put_intent }
+    let(:edition) { create(:edition, :schedulable) }
+    let(:user) { build(:user) }
+
+    def build_params(document: edition.document, review_status: "reviewed")
+      ActionController::Parameters.new(document: document.to_param,
+                                       review_status: review_status)
+    end
+
+    it "succeeds with default paramaters" do
+      result = Schedule::CreateInteractor.call(params: build_params, user: user)
+      expect(result).to be_success
+    end
+
+    it "delegates to ScheduleService to schedule the edition for publishing" do
+      publish_time = 3.days.from_now.beginning_of_day
+      edition = create(:edition, :schedulable, proposed_publish_time: publish_time)
+
+      expect(ScheduleService)
+        .to receive(:call) do |schedule_edition, schedule_user, new_scheduling|
+          expect(schedule_edition).to eq(edition)
+          expect(schedule_user).to eq(user)
+          expect(new_scheduling.reviewed).to be(false)
+          expect(new_scheduling.publish_time).to eq(publish_time)
+        end
+
+      params = build_params(document: edition.document,
+                            review_status: "not_reviewed")
+      Schedule::CreateInteractor.call(params: params, user: user)
+    end
+
+    it "creates a timeline entry" do
+      expect { Schedule::CreateInteractor.call(params: build_params, user: user) }
+        .to change { TimelineEntry.where(entry_type: :scheduled).count }
+        .by(1)
+    end
+
+    it "raises an error when the edition isn't editable" do
+      params = build_params(document: create(:edition, :published).document)
+      expect { Schedule::CreateInteractor.call(params: params, user: user) }
+        .to raise_error(EditionAssertions::StateError)
+    end
+
+    it "raises an error when the edition hasn't got a proposed publish time" do
+      edition = create(:edition, proposed_publish_time: nil)
+      params = build_params(document: edition.document)
+      expect { Schedule::CreateInteractor.call(params: params, user: user) }
+        .to raise_error(EditionAssertions::StateError)
+    end
+
+    it "raises an error when the edition isn't publishable" do
+      edition = create(:edition,
+                       :not_publishable,
+                       proposed_publish_time: Time.zone.tomorrow)
+      params = build_params(document: edition.document)
+      expect { Schedule::CreateInteractor.call(params: params, user: user) }
+        .to raise_error(EditionAssertions::StateError)
+    end
+
+    it "fails with an issue when a review status isn't set" do
+      result = Schedule::CreateInteractor.call(
+        params: build_params.merge(review_status: nil),
+        user: user,
+      )
+      expect(result).to be_failure
+      expect(result.issues).to have_issue(:schedule_review_status, :not_selected)
+    end
+
+    it "fails with an API error when ScheduleService raises a GdsApi Error" do
+      stub_publishing_api_isnt_available
+      result = Schedule::CreateInteractor.call(params: build_params, user: user)
+
+      expect(result).to be_failure
+      expect(result.api_error).to be(true)
+    end
+  end
+end

--- a/spec/interactors/schedule/update_interactor_spec.rb
+++ b/spec/interactors/schedule/update_interactor_spec.rb
@@ -1,0 +1,96 @@
+# frozen_string_literal: true
+
+RSpec.describe Schedule::UpdateInteractor do
+  describe ".call" do
+    before { stub_any_publishing_api_put_intent }
+
+    let(:scheduling) { build(:scheduling) }
+    let(:edition) { create(:edition, :scheduled, scheduling: scheduling) }
+    let(:user) { build(:user) }
+    let(:publish_time) { 3.weeks.from_now.beginning_of_day }
+
+    def build_params(document: edition.document, time: publish_time)
+      ActionController::Parameters.new(
+        document: document.to_param,
+        schedule: {
+          time: time.strftime("%-l:%M%P"),
+          date: {
+            day: time.day,
+            month: time.month,
+            year: time.year,
+          },
+        },
+      )
+    end
+
+    it "succeeds with default paramaters" do
+      result = Schedule::UpdateInteractor.call(params: build_params, user: user)
+      expect(result).to be_success
+    end
+
+    it "delegates to ScheduleService to schedule the edition for publishing" do
+      expect(ScheduleService)
+        .to receive(:call) do |schedule_edition, schedule_user, new_scheduling|
+          expect(schedule_edition).to eq(edition)
+          expect(schedule_user).to eq(user)
+          expect(new_scheduling.reviewed).to eq(scheduling.reviewed)
+          expect(new_scheduling.publish_time).to eq(publish_time)
+        end
+
+      Schedule::UpdateInteractor.call(params: build_params, user: user)
+    end
+
+    it "creates a timeline entry" do
+      expect { Schedule::UpdateInteractor.call(params: build_params, user: user) }
+        .to change { TimelineEntry.where(entry_type: :schedule_updated).count }
+        .by(1)
+    end
+
+    context "when the scheduling is the same as scheduled time" do
+      let(:scheduling) { build(:scheduling, publish_time: publish_time) }
+      let(:params) { build_params(time: publish_time) }
+
+      it "fails without scheduling the edition" do
+        expect(ScheduleService).not_to receive(:call)
+        result = Schedule::UpdateInteractor.call(params: params, user: user)
+        expect(result).to be_failure
+      end
+
+      it "doesn't create a timeline entry" do
+        expect { Schedule::UpdateInteractor.call(params: params, user: user) }
+          .not_to(change { TimelineEntry.where(entry_type: :schedule_updated).count })
+      end
+    end
+
+    it "raises an error when the edition isn't scheduled" do
+      params = build_params(document: create(:document, :with_current_edition))
+      expect { Schedule::UpdateInteractor.call(params: params, user: user) }
+        .to raise_error(EditionAssertions::StateError)
+    end
+
+    it "fails with issues when date and time can't be parsed" do
+      params = build_params
+      params[:schedule][:time] = "invalid"
+
+      result = Schedule::UpdateInteractor.call(params: params, user: user)
+      expect(result).to be_failure
+      expect(result.issues).to have_issue(:schedule_time, :invalid)
+    end
+
+    it "fails with issues when the time fails the publish time requirements" do
+      params = build_params(time: Time.zone.yesterday)
+
+      result = Schedule::UpdateInteractor.call(params: params, user: user)
+      expect(result).to be_failure
+      expect(result.issues).to have_issue(:schedule_date, :in_the_past)
+    end
+
+    it "fails with an API error when ScheduleService raises a GdsApi Error" do
+      stub_publishing_api_isnt_available
+      result = Schedule::UpdateInteractor.call(params: build_params, user: user)
+
+      expect(result).to be_failure
+      expect(result.api_error).to be(true)
+    end
+  end
+end


### PR DESCRIPTION
This resolves an inconsistency we had where API errors are handled in ScheduleController rather than the corresponding interactor. This also adds in tests for the interactors.