### PR TITLE
Fix publishing-api deprecation warnings

### DIFF
--- a/spec/features/editing_content/edit_edition_publishing_api_down_spec.rb
+++ b/spec/features/editing_content/edit_edition_publishing_api_down_spec.rb
@@ -18,7 +18,7 @@ RSpec.feature "Edit an edition when the Publishing API is down" do
   end
 
   def and_the_publishing_api_is_down
-    publishing_api_isnt_available
+    stub_publishing_api_isnt_available
     click_on "Save"
   end
 

--- a/spec/features/editing_content/insert_contact_embed_publishing_api_down_no_js_spec.rb
+++ b/spec/features/editing_content/insert_contact_embed_publishing_api_down_no_js_spec.rb
@@ -21,7 +21,7 @@ RSpec.feature "Insert contact embed without Javascript when the Publishing API i
   end
 
   def and_the_publishing_api_is_down
-    publishing_api_isnt_available
+    stub_publishing_api_isnt_available
   end
 
   def and_i_go_to_add_a_contact

--- a/spec/features/editing_content/insert_contact_embed_publishing_api_down_spec.rb
+++ b/spec/features/editing_content/insert_contact_embed_publishing_api_down_spec.rb
@@ -21,7 +21,7 @@ RSpec.feature "Insert contact embed when the Publishing API is down", js: true d
   end
 
   def and_the_publishing_api_is_down
-    publishing_api_isnt_available
+    stub_publishing_api_isnt_available
   end
 
   def and_i_go_to_add_a_contact

--- a/spec/features/editing_content_settings/edit_access_limit_publishing_api_down_spec.rb
+++ b/spec/features/editing_content_settings/edit_access_limit_publishing_api_down_spec.rb
@@ -23,7 +23,7 @@ RSpec.feature "Edit access limit when the Publishing API is down" do
   end
 
   def and_the_publishing_api_is_down
-    publishing_api_isnt_available
+    stub_publishing_api_isnt_available
   end
 
   def given_i_am_a_user_in_some_other_org

--- a/spec/features/editing_tags/edit_tags_publishing_api_down_spec.rb
+++ b/spec/features/editing_tags/edit_tags_publishing_api_down_spec.rb
@@ -17,7 +17,7 @@ RSpec.feature "Edit tags when the API is down" do
   end
 
   def and_the_publishing_api_is_down
-    publishing_api_isnt_available
+    stub_publishing_api_isnt_available
   end
 
   def when_i_visit_the_summary_page

--- a/spec/features/editing_tags/edit_tags_publishing_api_down_spec.rb
+++ b/spec/features/editing_tags/edit_tags_publishing_api_down_spec.rb
@@ -12,7 +12,7 @@ RSpec.feature "Edit tags when the API is down" do
   def given_there_is_an_edition
     tag_field = build(:tag_field, type: "multi_tag")
     document_type = build(:document_type, tags: [tag_field])
-    publishing_api_has_linkables([], document_type: tag_field.document_type)
+    stub_publishing_api_has_linkables([], document_type: tag_field.document_type)
     @edition = create(:edition, document_type_id: document_type.id)
   end
 

--- a/spec/features/editing_topics/edit_topics_publishing_api_down_spec.rb
+++ b/spec/features/editing_topics/edit_topics_publishing_api_down_spec.rb
@@ -13,7 +13,7 @@ RSpec.feature "Edit tags when the Publishing API is down" do
   end
 
   def and_the_publishing_api_is_down
-    publishing_api_isnt_available
+    stub_publishing_api_isnt_available
   end
 
   def when_i_visit_the_topics_page

--- a/spec/features/finding/index_organisation_filtering_publishing_api_down_spec.rb
+++ b/spec/features/finding/index_organisation_filtering_publishing_api_down_spec.rb
@@ -8,7 +8,7 @@ RSpec.feature "Index organisation filtering when the Publishing API is down" do
   end
 
   def given_the_publishing_api_is_down
-    publishing_api_isnt_available
+    stub_publishing_api_isnt_available
   end
 
   def when_i_visit_the_index_page

--- a/spec/features/scheduling/propose_publish_time_and_schedule_spec.rb
+++ b/spec/features/scheduling/propose_publish_time_and_schedule_spec.rb
@@ -46,7 +46,7 @@ RSpec.feature "Propose publish time and schedule" do
   end
 
   def when_i_submit_a_review_option
-    @request = stub_default_publishing_api_put_intent
+    @request = stub_any_publishing_api_put_intent
 
     choose I18n.t!("schedule.new.review_status.reviewed")
     click_on "Schedule"

--- a/spec/features/scheduling/schedule_publishing_api_down_spec.rb
+++ b/spec/features/scheduling/schedule_publishing_api_down_spec.rb
@@ -19,7 +19,7 @@ RSpec.feature "Schedule when Publishing API is down" do
   end
 
   def and_the_publishing_api_is_down
-    publishing_api_isnt_available
+    stub_publishing_api_isnt_available
     click_on "Schedule"
   end
 

--- a/spec/features/scheduling/scheduled_publishing_failed_spec.rb
+++ b/spec/features/scheduling/scheduled_publishing_failed_spec.rb
@@ -44,7 +44,7 @@ RSpec.feature "Scheduled publishing failed" do
   end
 
   def when_the_publishing_api_is_down
-    publishing_api_isnt_available
+    stub_publishing_api_isnt_available
   end
 
   def and_the_scheduled_publishing_job_runs

--- a/spec/features/scheduling/scheduled_publishing_failed_spec.rb
+++ b/spec/features/scheduling/scheduled_publishing_failed_spec.rb
@@ -34,7 +34,7 @@ RSpec.feature "Scheduled publishing failed" do
   end
 
   def and_i_submit_a_review_option
-    stub_default_publishing_api_put_intent
+    stub_any_publishing_api_put_intent
     choose I18n.t!("schedule.new.review_status.reviewed")
     click_on "Schedule"
   end

--- a/spec/features/scheduling/scheduled_publishing_spec.rb
+++ b/spec/features/scheduling/scheduled_publishing_spec.rb
@@ -35,7 +35,7 @@ RSpec.feature "Scheduled publishing" do
   end
 
   def and_i_submit_the_reviewed_option
-    @publish_intent_request = stub_default_publishing_api_put_intent.with(
+    @publish_intent_request = stub_any_publishing_api_put_intent.with(
       body: hash_including(publish_time: @edition.proposed_publish_time),
     )
     choose I18n.t!("schedule.new.review_status.reviewed")

--- a/spec/features/scheduling/scheduled_publishing_without_review_spec.rb
+++ b/spec/features/scheduling/scheduled_publishing_without_review_spec.rb
@@ -33,7 +33,7 @@ RSpec.feature "Scheduled publishing without review" do
   end
 
   def and_i_submit_the_not_reviewed_option
-    stub_default_publishing_api_put_intent
+    stub_any_publishing_api_put_intent
     choose I18n.t!("schedule.new.review_status.not_reviewed")
     click_on "Schedule"
   end

--- a/spec/features/scheduling/unschedule_publishing_api_down_spec.rb
+++ b/spec/features/scheduling/unschedule_publishing_api_down_spec.rb
@@ -15,7 +15,7 @@ RSpec.feature "Unschedule when Publishing API is down" do
   end
 
   def and_the_publishing_api_is_down
-    publishing_api_isnt_available
+    stub_publishing_api_isnt_available
   end
 
   def when_i_visit_the_summary_page

--- a/spec/features/scheduling/update_publish_time_publishing_api_down_spec.rb
+++ b/spec/features/scheduling/update_publish_time_publishing_api_down_spec.rb
@@ -15,7 +15,7 @@ RSpec.feature "Update publish time when Publishing API is down" do
   end
 
   def and_the_publishing_api_is_down
-    publishing_api_isnt_available
+    stub_publishing_api_isnt_available
   end
 
   def when_i_visit_the_summary_page

--- a/spec/features/scheduling/update_publish_time_spec.rb
+++ b/spec/features/scheduling/update_publish_time_spec.rb
@@ -19,7 +19,7 @@ RSpec.feature "Update publish time" do
 
   def given_there_is_a_scheduled_edition
     @edition = create(:edition, :scheduled)
-    @request = stub_default_publishing_api_put_intent
+    @request = stub_any_publishing_api_put_intent
   end
 
   def when_i_visit_the_summary_page
@@ -32,7 +32,7 @@ RSpec.feature "Update publish time" do
 
   def and_i_set_a_new_publish_time
     @new_time = Time.zone.parse("2019-08-15 23:00")
-    @request = stub_default_publishing_api_put_intent.with(
+    @request = stub_any_publishing_api_put_intent.with(
       body: hash_including(publish_time: @new_time),
     )
 

--- a/spec/features/workflow/delete_draft_publishing_api_down_spec.rb
+++ b/spec/features/workflow/delete_draft_publishing_api_down_spec.rb
@@ -27,7 +27,7 @@ RSpec.feature "Delete draft when the Publishing API is down" do
   end
 
   def and_the_publishing_api_is_down
-    publishing_api_isnt_available
+    stub_publishing_api_isnt_available
   end
 
   def and_i_delete_the_draft

--- a/spec/features/workflow/preview_publishing_api_down_spec.rb
+++ b/spec/features/workflow/preview_publishing_api_down_spec.rb
@@ -24,7 +24,7 @@ RSpec.feature "Previewing an edition when the Publishing API is down" do
   end
 
   def and_the_publishing_api_is_down
-    publishing_api_isnt_available
+    stub_publishing_api_isnt_available
   end
 
   def and_i_click_the_preview_button

--- a/spec/features/workflow/publish_requirements_publishing_api_down_spec.rb
+++ b/spec/features/workflow/publish_requirements_publishing_api_down_spec.rb
@@ -21,7 +21,7 @@ RSpec.feature "Publish requirements when the Publishing API is down" do
   end
 
   def when_the_publishing_api_is_down
-    publishing_api_isnt_available
+    stub_publishing_api_isnt_available
     visit document_path(@edition.document)
   end
 

--- a/spec/requests/unwithdraw_spec.rb
+++ b/spec/requests/unwithdraw_spec.rb
@@ -16,7 +16,7 @@ RSpec.describe "Unwithdraw" do
     end
 
     it "returns an error when publishing-api is down" do
-      publishing_api_isnt_available
+      stub_publishing_api_isnt_available
       login_as(managing_editor)
 
       post unwithdraw_path(withdrawn_edition.document)

--- a/spec/requests/withdraw_spec.rb
+++ b/spec/requests/withdraw_spec.rb
@@ -21,7 +21,7 @@ RSpec.describe "Withdraw" do
     end
 
     it "returns an error when publishing-api is down" do
-      publishing_api_isnt_available
+      stub_publishing_api_isnt_available
       login_as(managing_editor)
 
       post withdraw_path(published_edition.document), params: { public_explanation: "Just cos" }

--- a/spec/services/resync_service_spec.rb
+++ b/spec/services/resync_service_spec.rb
@@ -7,7 +7,7 @@ RSpec.describe ResyncService do
     before do
       stub_any_publishing_api_publish
       stub_any_publishing_api_put_content
-      stub_default_publishing_api_put_intent
+      stub_any_publishing_api_put_intent
       stub_default_publishing_api_path_reservation
       populate_default_government_bulk_data
     end

--- a/spec/services/resync_service_spec.rb
+++ b/spec/services/resync_service_spec.rb
@@ -8,7 +8,7 @@ RSpec.describe ResyncService do
       stub_any_publishing_api_publish
       stub_any_publishing_api_put_content
       stub_any_publishing_api_put_intent
-      stub_default_publishing_api_path_reservation
+      stub_any_publishing_api_path_reservation
       populate_default_government_bulk_data
     end
 

--- a/spec/services/schedule_service_spec.rb
+++ b/spec/services/schedule_service_spec.rb
@@ -8,7 +8,7 @@ RSpec.describe ScheduleService do
   include ActiveJob::TestHelper
 
   before(:each) do
-    stub_default_publishing_api_put_intent
+    stub_any_publishing_api_put_intent
     allow(ScheduleService::Payload).to receive(:new) { payload }
   end
 


### PR DESCRIPTION
Fixes warnings for:

```
#publishing_api_isnt_available is deprecated on GdsApi::TestHelpers::PublishingApi and will be removed in a future version. Use #stub_publishing_api_isnt_available instead
#stub_default_publishing_api_put_intent is deprecated on GdsApi::TestHelpers::PublishingApi and will be removed in a future version. Use #stub_any_publishing_api_put_intent instead
.
.
.
```