### PR TITLE
Always 'run_exclusively' within a transaction

### DIFF
--- a/app/jobs/application_job.rb
+++ b/app/jobs/application_job.rb
@@ -5,19 +5,16 @@ class ApplicationJob < ActiveJob::Base
     discard_on(exception) { |_, error| Rails.logger.warn(error) }
   end
 
-  def run_exclusively(transaction: true, lock_name: self.class.name)
+  def run_exclusively(lock_name: self.class.name)
     name = "content-publisher:#{lock_name}"
-    options = { timeout_seconds: 0, transaction: transaction }
-    result = if transaction
-               ApplicationRecord.transaction do
-                 ApplicationRecord.with_advisory_lock_result(name, options) { yield }
-               end
-             else
-               ApplicationRecord.with_advisory_lock_result(name, options) { yield }
-             end
+    options = { timeout_seconds: 0, transaction: true }
+
+    result = ApplicationRecord.transaction do
+      ApplicationRecord.with_advisory_lock_result(name, options) { yield }
+    end
 
     unless result.lock_was_acquired?
-      logger.info("Job skipped as exclusive lock '#{name}' could not be acuqired")
+      logger.info("Job skipped as exclusive lock '#{name}' could not be acquired")
     end
 
     result.result

--- a/spec/jobs/application_job_spec.rb
+++ b/spec/jobs/application_job_spec.rb
@@ -33,12 +33,12 @@ RSpec.describe ApplicationJob do
 
       expect(job.logger)
         .to receive(:info)
-        .with("Job skipped as exclusive lock 'content-publisher:ApplicationJob' could not be acuqired")
+        .with("Job skipped as exclusive lock 'content-publisher:ApplicationJob' could not be acquired")
 
       job.run_exclusively
     end
 
-    it "defaults to running within a transaction" do
+    it "runs within a transaction" do
       expect(ApplicationRecord).to receive(:transaction).and_yield
       expect(ApplicationRecord)
         .to receive(:with_advisory_lock_result)
@@ -46,16 +46,6 @@ RSpec.describe ApplicationJob do
         .and_return(result)
 
       ApplicationJob.new.run_exclusively
-    end
-
-    it "can be run outside a transaction" do
-      expect(ApplicationRecord).not_to receive(:transaction)
-      expect(ApplicationRecord)
-        .to receive(:with_advisory_lock_result)
-        .with(instance_of(String), a_hash_including(transaction: false))
-        .and_return(result)
-
-      ApplicationJob.new.run_exclusively(transaction: false)
     end
 
     it "defaults to using the class name for the lock name" do


### PR DESCRIPTION
This remove the option to run a job exclusively outside of a
transaction, since we don't use this capability and to avoid the
risk of locks being persisted if the app fails. (Also fix the
typo for 'acquired'.)