### PR TITLE
Change submitted for review banner

### DIFF
--- a/app/controllers/review_controller.rb
+++ b/app/controllers/review_controller.rb
@@ -11,7 +11,6 @@ class ReviewController < ApplicationController
     elsif issues
       redirect_to document_path(params[:document]), tried_to_publish: true
     else
-      flash[:submitted_for_review] = true
       redirect_to document_path(params[:document])
     end
   end

--- a/app/views/documents/show/_submitted_for_review.html.erb
+++ b/app/views/documents/show/_submitted_for_review.html.erb
@@ -1,6 +1,6 @@
 <% copy_to_clipboard = render(
   "govuk_publishing_components/components/copy_to_clipboard",
-    label: t("documents.show.flashes.submitted_for_review.label"),
+    label: t("documents.show.submitted_for_review.label"),
     copyable_content: document_url(@edition.document,
                                    utm_source: "2i-link",
                                    utm_medium: "copy-paste",
@@ -16,5 +16,5 @@
 ) %>
 
 <%= render "components/inset_prompt",
-  title: t("documents.show.flashes.submitted_for_review.title"),
+  title: t("documents.show.submitted_for_review.title"),
   description: copy_to_clipboard %>

--- a/app/views/documents/show/_submitted_for_review.html.erb
+++ b/app/views/documents/show/_submitted_for_review.html.erb
@@ -15,6 +15,6 @@
     }
 ) %>
 
-<%= render "govuk_publishing_components/components/success_alert",
-  message: t("documents.show.flashes.submitted_for_review.title"),
+<%= render "components/inset_prompt",
+  title: t("documents.show.flashes.submitted_for_review.title"),
   description: copy_to_clipboard %>

--- a/app/views/documents/show/_summary_tab.html.erb
+++ b/app/views/documents/show/_summary_tab.html.erb
@@ -1,5 +1,11 @@
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
+    <% if @edition.failed_to_publish? %>
+      <%= render "documents/show/failed_to_publish_notice" %>
+    <% end %>
+
+    <%= render "documents/show/requirements" %>
+
     <% if @edition.submitted_for_review? %>
       <%= render "documents/show/submitted_for_review" %>
     <% end %>
@@ -10,12 +16,6 @@
 
     <% if @edition.withdrawn? %>
       <%= render "documents/show/withdrawn_notice" %>
-    <% end %>
-
-    <%= render "documents/show/requirements" %>
-
-    <% if @edition.failed_to_publish? %>
-      <%= render "documents/show/failed_to_publish_notice" %>
     <% end %>
   </div>
 

--- a/app/views/documents/show/_summary_tab.html.erb
+++ b/app/views/documents/show/_summary_tab.html.erb
@@ -1,6 +1,6 @@
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
-    <% if flash[:submitted_for_review] %>
+    <% if @edition.submitted_for_review? %>
       <%= render "documents/show/submitted_for_review" %>
     <% end %>
 

--- a/config/locales/en/documents/show.yml
+++ b/config/locales/en/documents/show.yml
@@ -69,6 +69,9 @@ en:
           It was scheduled to publish at %{time} on %{date}
 
           You can publish it now, schedule it to publish later, or edit it.
+      submitted_for_review:
+        title: Content has been marked as ready for 2i review
+        label: Send the Content Publisher link to another publisher for them to review. When content is ready you or they can publish it.
       flashes:
         pre_preview_issues:
           warning: To preview this document you need to
@@ -86,9 +89,6 @@ en:
           title: Something has gone wrong
           description_govspeak: Something went wrong when submitting your content for 2i review. Please try again or [raise a support request](https://support.publishing.service.gov.uk/technical_fault_report/new).
         approved: Content has been reviewed and approved
-        submitted_for_review:
-          title: Content has been marked as ready for 2i review
-          label: Send the Content Publisher link to another publisher for them to review. When content is ready you or they can publish it.
         schedule_error:
           title: Something has gone wrong
           description_govspeak: Something went wrong when scheduling your document. Please try again or [raise a support request](https://support.publishing.service.gov.uk/technical_fault_report/new).

--- a/spec/features/workflow/submit_for_2i_spec.rb
+++ b/spec/features/workflow/submit_for_2i_spec.rb
@@ -25,7 +25,7 @@ RSpec.feature "Submit for 2i" do
   end
 
   def then_i_see_the_edition_is_submitted
-    expect(page).to have_content I18n.t!("documents.show.flashes.submitted_for_review.title")
+    expect(page).to have_content I18n.t!("documents.show.submitted_for_review.title")
     expect(page).to have_content I18n.t!("user_facing_states.submitted_for_review.name")
 
     within first(".app-timeline-entry") do
@@ -34,11 +34,12 @@ RSpec.feature "Submit for 2i" do
   end
 
   def then_i_see_it_is_still_in_review
+    expect(page).to have_content I18n.t!("documents.show.submitted_for_review.title")
     expect(page).to have_content I18n.t!("user_facing_states.submitted_for_review.name")
   end
 
   def and_i_see_a_link_to_the_edition
-    review_url = find_field(I18n.t!("documents.show.flashes.submitted_for_review.label")).value
+    review_url = find_field(I18n.t!("documents.show.submitted_for_review.label")).value
     expect(review_url).to match(document_url(@edition.document))
   end
 


### PR DESCRIPTION
For https://trello.com/c/1zOX0xmQ/1285-submit-for-2i-review-banner

This changes the submit for review banner to use the inset prompt component and ensures it persists while a document is in a `submitted_for_review` state.

**Before**
<img width="985" alt="submitted_for_review_before" src="https://user-images.githubusercontent.com/13434452/71881867-1a21d100-312b-11ea-8d20-6feecee91507.png">

**After**
<img width="1004" alt="submitted_for_review_after" src="https://user-images.githubusercontent.com/13434452/71881776-e3e45180-312a-11ea-9ad5-26834fa87632.png">
