### PR TITLE
Fix DB blocking data sanitisation process

### DIFF
--- a/db/migrate/20200107151448_cascade_edition_editor_deletion.rb
+++ b/db/migrate/20200107151448_cascade_edition_editor_deletion.rb
@@ -1,0 +1,13 @@
+# frozen_string_literal: true
+
+class CascadeEditionEditorDeletion < ActiveRecord::Migration[6.0]
+  def up
+    remove_foreign_key :edition_editors, :editions
+    add_foreign_key :edition_editors, :editions, on_delete: :cascade
+  end
+
+  def down
+    remove_foreign_key :edition_editors, :editions
+    add_foreign_key :edition_editors, :editions, on_delete: :restrict
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2019_12_24_112030) do
+ActiveRecord::Schema.define(version: 2020_01_07_151448) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -369,7 +369,7 @@ ActiveRecord::Schema.define(version: 2019_12_24_112030) do
   add_foreign_key "active_storage_attachments", "active_storage_blobs", column: "blob_id"
   add_foreign_key "content_revisions", "users", column: "created_by_id", on_delete: :restrict
   add_foreign_key "documents", "users", column: "created_by_id", on_delete: :restrict
-  add_foreign_key "edition_editors", "editions", on_delete: :restrict
+  add_foreign_key "edition_editors", "editions", on_delete: :cascade
   add_foreign_key "edition_editors", "users", on_delete: :restrict
   add_foreign_key "editions", "access_limits", on_delete: :restrict
   add_foreign_key "editions", "documents", on_delete: :restrict

--- a/spec/factories/edition_factory.rb
+++ b/spec/factories/edition_factory.rb
@@ -8,6 +8,7 @@ FactoryBot.define do
     government_id { government&.content_id }
     revision_synced { true }
     association :created_by, factory: :user
+    editors { [created_by] }
 
     revision_fields
 


### PR DESCRIPTION
The Content Publisher integration data sync has been broken since we used edition editors. These are not able to be automatically deleted as part of the removal of access limited content.

This PR first modifies the default factory so the problem was exposed in the unit tests and then applies a migration to fix the issue.

This is intended to resolve the regular [Sentry S3 asset not found issue](https://sentry.io/organizations/govuk/issues/1407796268/?referrer=slack) which I believe is because Postgres and S3 are out of sync.