### PR TITLE
Enqueue document import

### DIFF
--- a/app/jobs/whitehall_document_import_job.rb
+++ b/app/jobs/whitehall_document_import_job.rb
@@ -3,5 +3,6 @@
 class WhitehallDocumentImportJob < ApplicationJob
   def perform(document_import)
     WhitehallImporter.import_and_sync(document_import)
+    document_import.whitehall_migration&.check_migration_finished
   end
 end

--- a/app/jobs/whitehall_document_import_job.rb
+++ b/app/jobs/whitehall_document_import_job.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+class WhitehallDocumentImportJob < ApplicationJob
+  def perform(document_import)
+    WhitehallImporter.import_and_sync(document_import)
+  end
+end

--- a/app/models/whitehall_migration.rb
+++ b/app/models/whitehall_migration.rb
@@ -2,4 +2,8 @@
 
 class WhitehallMigration < ApplicationRecord
   has_many :document_imports
+
+  def check_migration_finished
+    update!(end_time: Time.current) if document_imports.in_progress.empty?
+  end
 end

--- a/app/models/whitehall_migration.rb
+++ b/app/models/whitehall_migration.rb
@@ -1,4 +1,5 @@
 # frozen_string_literal: true
 
 class WhitehallMigration < ApplicationRecord
+  has_many :document_imports
 end

--- a/app/models/whitehall_migration/document_import.rb
+++ b/app/models/whitehall_migration/document_import.rb
@@ -4,6 +4,9 @@
 # the import status of the document into Content Publisher
 class WhitehallMigration::DocumentImport < ApplicationRecord
   belongs_to :document, optional: true
+
+  belongs_to :whitehall_migration, optional: true
+
   has_many :assets, class_name: "WhitehallMigration::AssetImport"
 
   enum state: { pending: "pending",
@@ -14,6 +17,8 @@ class WhitehallMigration::DocumentImport < ApplicationRecord
                 syncing: "syncing",
                 sync_failed: "sync failed",
                 completed: "completed" }
+
+  scope :in_progress, -> { pending.or(importing).or(imported).or(syncing) }
 
   def migratable_assets
     assets.select { |a| a.pending? || a.migration_failed? }

--- a/lib/tasks/import.rake
+++ b/lib/tasks/import.rake
@@ -17,8 +17,11 @@ namespace :import do
 
   desc "Import a single document from Whitehall Publisher using Whitehall's internal document ID e.g. import:whitehall_document[123]"
   task :whitehall_document, [:document_id] => :environment do |_, args|
-    whitehall_export = GdsApi.whitehall_export.document_export(args.document_id)
-    whitehall_import = WhitehallImporter.import_and_sync(whitehall_export.to_hash)
+    whitehall_import = WhitehallMigration::DocumentImport.create!(
+      whitehall_document_id: args.document_id,
+      state: "pending",
+    )
+    WhitehallImporter.import_and_sync(whitehall_import)
 
     unless whitehall_import.completed?
       puts whitehall_import.state.humanize

--- a/lib/whitehall_importer.rb
+++ b/lib/whitehall_importer.rb
@@ -1,9 +1,11 @@
 # frozen_string_literal: true
 
+require "gds_api/whitehall_export"
+
 module WhitehallImporter
   def self.create_migration(organisation_content_id, document_type)
-    ActiveRecord::Base.transaction do
-      whitehall_migration = WhitehallMigration.create!(organisation_content_id: organisation_content_id,
+    whitehall_migration = ActiveRecord::Base.transaction do
+      record = WhitehallMigration.create!(organisation_content_id: organisation_content_id,
                                  document_type: document_type,
                                  start_time: Time.current)
 
@@ -13,19 +15,24 @@ module WhitehallImporter
         page["documents"].each do |document|
           WhitehallMigration::DocumentImport.create!(
             whitehall_document_id: document["document_id"],
-            whitehall_migration_id: whitehall_migration.id,
+            whitehall_migration_id: record.id,
             state: "pending",
           )
         end
       end
-
-      whitehall_migration
+      record
     end
+    whitehall_migration.document_imports.find_each do |document_import|
+      WhitehallDocumentImportJob.perform_later(document_import)
+    end
+    whitehall_migration
   end
 
-  def self.import_and_sync(whitehall_document)
-    whitehall_import = WhitehallMigration::DocumentImport.create!(
-      whitehall_document_id: whitehall_document["id"],
+  def self.import_and_sync(whitehall_import)
+    raise "Cannot import with a state of #{whitehall_import.state}" unless whitehall_import.pending?
+
+    whitehall_document = GdsApi.whitehall_export.document_export(whitehall_import.whitehall_document_id).to_h
+    whitehall_import.update!(
       payload: whitehall_document,
       content_id: whitehall_document["content_id"],
       state: "importing",

--- a/spec/factories/whitehall_migration_factory.rb
+++ b/spec/factories/whitehall_migration_factory.rb
@@ -1,0 +1,12 @@
+# frozen_string_literal: true
+
+FactoryBot.define do
+  factory :whitehall_migration do
+    sequence(:id)
+    organisation_content_id { "content_id" }
+    document_type { "NewsArticle" }
+    start_time { Time.current }
+    created_at { Time.current.rfc3339 }
+    updated_at { Time.current.rfc3339 }
+  end
+end

--- a/spec/jobs/whitehall_document_import_job_spec.rb
+++ b/spec/jobs/whitehall_document_import_job_spec.rb
@@ -11,10 +11,16 @@ RSpec.describe WhitehallDocumentImportJob do
 
   before do
     allow(WhitehallImporter).to receive(:import_and_sync)
+    allow(whitehall_migration).to receive(:check_migration_finished)
   end
 
   it "calls on the import and sync method" do
     expect(WhitehallImporter).to receive(:import_and_sync).with(whitehall_migration_document_import)
+    WhitehallDocumentImportJob.perform_now(whitehall_migration_document_import)
+  end
+
+  it "calls on the mark migration completed method" do
+    expect(whitehall_migration_document_import.whitehall_migration).to receive(:check_migration_finished)
     WhitehallDocumentImportJob.perform_now(whitehall_migration_document_import)
   end
 end

--- a/spec/jobs/whitehall_document_import_job_spec.rb
+++ b/spec/jobs/whitehall_document_import_job_spec.rb
@@ -1,0 +1,20 @@
+# frozen_string_literal: true
+
+RSpec.describe WhitehallDocumentImportJob do
+  include ActiveJob::TestHelper
+
+  let(:whitehall_migration) { create(:whitehall_migration) }
+
+  let(:whitehall_migration_document_import) do
+    create(:whitehall_migration_document_import, whitehall_migration_id: whitehall_migration["id"], state: "pending")
+  end
+
+  before do
+    allow(WhitehallImporter).to receive(:import_and_sync)
+  end
+
+  it "calls on the import and sync method" do
+    expect(WhitehallImporter).to receive(:import_and_sync).with(whitehall_migration_document_import)
+    WhitehallDocumentImportJob.perform_now(whitehall_migration_document_import)
+  end
+end

--- a/spec/lib/whitehall_importer_spec.rb
+++ b/spec/lib/whitehall_importer_spec.rb
@@ -1,6 +1,7 @@
 # frozen_string_literal: true
 
 RSpec.describe WhitehallImporter do
+  include ActiveJob::TestHelper
   describe ".create_migration" do
     let(:whitehall_host) { Plek.new.external_url_for("whitehall-admin") }
     let(:whitehall_export_page_1) { build(:whitehall_export_index, documents: build_list(:whitehall_export_index_document, 100)) }
@@ -25,29 +26,42 @@ RSpec.describe WhitehallImporter do
     it "creates a pending WhitehallMigration::DocumentImport for each listed item" do
       expect { WhitehallImporter.create_migration("123", "NewsArticle") }.to change { WhitehallMigration::DocumentImport.pending.count }.by(110)
     end
+
+    it "queues a job for each listed document" do
+      WhitehallImporter.create_migration("123", "NewsArticle")
+      expect(WhitehallDocumentImportJob).to have_been_enqueued.exactly(110).times
+    end
   end
 
   describe ".import_and_sync" do
+    let(:whitehall_export_document) { build(:whitehall_export_document) }
+    let(:whitehall_migration_document_import) do
+      build(
+        :whitehall_migration_document_import,
+        whitehall_document_id: "123",
+        state: "pending",
+      )
+    end
+    let(:whitehall_host) { Plek.new.external_url_for("whitehall-admin") }
+
     before do
       allow(ResyncService).to receive(:call)
       allow(WhitehallImporter::ClearLinksetLinks).to receive(:call)
       allow(WhitehallImporter::Import).to receive(:call).and_return(build(:document, :with_current_edition))
+      stub_request(:get, "#{whitehall_host}/government/admin/export/document/123")
+        .to_return(status: 200, body: whitehall_export_document.to_json)
     end
 
-    let(:whitehall_export_document) { build(:whitehall_export_document) }
-
-    it "creates and returns a WhitehallMigration::DocumentImport" do
-      whitehall_migration_document_import = nil
-      expect { whitehall_migration_document_import = WhitehallImporter.import_and_sync(whitehall_export_document) }
+    it "returns a WhitehallMigration::DocumentImport" do
+      expect { WhitehallImporter.import_and_sync(whitehall_migration_document_import) }
         .to change { WhitehallMigration::DocumentImport.count }
         .by(1)
       expect(whitehall_migration_document_import).to be_an_instance_of(WhitehallMigration::DocumentImport)
     end
 
     it "stores the exported whitehall data" do
-      WhitehallImporter.import_and_sync(whitehall_export_document)
-      whitehall_migration_document_import = WhitehallMigration::DocumentImport.find_by(whitehall_document_id: whitehall_export_document["id"])
-      expect(whitehall_migration_document_import.payload).to eq(whitehall_export_document)
+      document_import = WhitehallImporter.import_and_sync(whitehall_migration_document_import)
+      expect(document_import.payload).to eq(whitehall_export_document)
     end
 
     it "doesn't sync if import fails" do
@@ -55,7 +69,13 @@ RSpec.describe WhitehallImporter do
         .and_raise(WhitehallImporter::AbortImportError, "Booo, import failed")
 
       expect(WhitehallImporter).not_to receive(:sync)
-      WhitehallImporter.import_and_sync(whitehall_export_document)
+      WhitehallImporter.import_and_sync(whitehall_migration_document_import)
+    end
+
+    it "raises if the WhitehallMigration::DocumentImport doesn't have a state of pending" do
+      whitehall_migration_document_import = create(:whitehall_migration_document_import, state: "importing")
+      expect { WhitehallImporter.import_and_sync(whitehall_migration_document_import) }
+        .to raise_error(RuntimeError, "Cannot import with a state of importing")
     end
   end
 

--- a/spec/models/whitehall_migration_spec.rb
+++ b/spec/models/whitehall_migration_spec.rb
@@ -1,0 +1,36 @@
+# frozen_string_literal: true
+
+RSpec.describe WhitehallMigration do
+  describe ".check_migration_completed" do
+    context "with only jobs that have finished running" do
+      let!(:whitehall_migration) { create(:whitehall_migration) }
+      before do
+        %i[completed import_aborted import_failed sync_failed].each do |state|
+          create(:whitehall_migration_document_import,
+                 whitehall_migration_id: whitehall_migration.id,
+                 state: state)
+        end
+      end
+
+      it "updates each of the end times" do
+        freeze_time do
+          whitehall_migration.check_migration_finished
+          expect(whitehall_migration.end_time).to eq(Time.current)
+        end
+      end
+    end
+
+    context "with some incomplete jobs" do
+      let!(:whitehall_migration) { create(:whitehall_migration) }
+      before do
+        create(:whitehall_migration_document_import, whitehall_migration_id: whitehall_migration["id"], state: "completed")
+        create(:whitehall_migration_document_import, whitehall_migration_id: whitehall_migration["id"], state: "pending")
+      end
+
+      it "does not update each of the end times" do
+        whitehall_migration.check_migration_finished
+        expect(whitehall_migration.end_time).to be_nil
+      end
+    end
+  end
+end


### PR DESCRIPTION
This allows us to queue a series of jobs to import multiple documents from Whitehall based on an organisation slug and document type.

Previously importing was being done by running a rake task (`whitehall_document`) that imported a single document.  This takes that logic and executes the same process inside a Sidekiq job.

A `WhitehallMigration` is created when the process begins, and is also marked as completed (by means of a `end_time`) when the import has finished.

Trello - https://trello.com/c/HxOpHnf9/1272-queue-a-job-to-import-document-from-whitehall