### PR TITLE
Fix incorrect govspeak HTML generation issue

### DIFF
--- a/app/views/documents/confirm_delete_draft.html.erb
+++ b/app/views/documents/confirm_delete_draft.html.erb
@@ -5,9 +5,9 @@
   <div class="govuk-grid-column-full">
     <div class="govuk-grid-row">
       <div class="govuk-grid-column-two-thirds">
-        <p class="govuk-body">
+        <div class="govuk-body">
           <%= render_govspeak(t("documents.confirm_delete_draft.description_govspeak")) %>
-        </p>
+        </div>
       </div>
     </div>
 


### PR DESCRIPTION
When multiple lines are specified in an I18N YML file - and then rendered via govspeak -
govspeak will automatically generate `<p>` tags.  So, the use of `render_govspeak` should 
be inside a `<div>` tag not a `<p>` tag.  

Fixes an issue introduced in a previous PR.