### PR TITLE
Show failing values in integrity check problems

### DIFF
--- a/lib/whitehall_importer/integrity_checker.rb
+++ b/lib/whitehall_importer/integrity_checker.rb
@@ -27,11 +27,21 @@ module WhitehallImporter
          document_type
          schema_name).each do |attribute|
         if publishing_api_content[attribute] != proposed_payload[attribute]
-          problems << "#{attribute} doesn't match"
+          problems << <<~HEREDOC
+            #{attribute} doesn't match.
+            proposed value: **#{proposed_payload[attribute]}**
+            publishing-api value: **#{publishing_api_content[attribute]}**
+          HEREDOC
         end
       end
 
-      problems << "body text doesn't match" unless body_text_matches?
+      unless body_text_matches?
+        problems << <<~HEREDOC
+          body text doesn't match.
+          proposed value: **#{proposed_payload.dig('details', 'body')}**
+          publishing-api value: **#{publishing_api_content.dig('details', 'body')}**
+        HEREDOC
+      end
 
       problems
     end
@@ -49,15 +59,32 @@ module WhitehallImporter
 
       %w(alt_text caption).each_with_object([]) do |attribute, problems|
         if publishing_api_image[attribute] != proposed_image_payload[attribute]
-          problems << "image #{attribute} doesn't match"
+          problems << <<~HEREDOC
+            image #{attribute} doesn't match.
+            proposed value: **#{proposed_image_payload[attribute]}**
+            publishing-api value: **#{publishing_api_image[attribute]}**
+          HEREDOC
         end
       end
     end
 
     def organisation_problems
       problems = []
-      problems << "primary_publishing_organisation doesn't match" unless primary_publishing_organisation_matches?
-      problems << "organisations don't match" unless organisations_match?
+      unless primary_publishing_organisation_matches?
+        problems << <<~HEREDOC
+          primary_publishing_organisation doesn't match.
+          proposed value: **#{proposed_payload.dig('links', 'primary_publishing_organisation')}**
+          publishing-api value: **#{publishing_api_link('primary_publishing_organisation')}**
+        HEREDOC
+      end
+
+      unless organisations_match?
+        problems << <<~HEREDOC
+          organisations don't match.
+          proposed value: **#{proposed_payload.dig('links', 'organisations')}**
+          publishing-api value: **#{publishing_api_link('organisations')}**
+        HEREDOC
+      end
 
       problems
     end

--- a/spec/lib/whitehall_importer/integrity_checker_spec.rb
+++ b/spec/lib/whitehall_importer/integrity_checker_spec.rb
@@ -70,35 +70,35 @@ RSpec.describe WhitehallImporter::IntegrityChecker do
       stub_publishing_api_has_item(content_id: edition.content_id, base_path: "base-path")
 
       integrity_check = WhitehallImporter::IntegrityChecker.new(edition)
-      expect(integrity_check.problems).to include("base_path doesn't match")
+      expect(integrity_check.problems).to include(match("base_path doesn't match"))
     end
 
     it "returns a problem when the titles don't match" do
       stub_publishing_api_has_item(content_id: edition.content_id, title: "title")
 
       integrity_check = WhitehallImporter::IntegrityChecker.new(edition)
-      expect(integrity_check.problems).to include("title doesn't match")
+      expect(integrity_check.problems).to include(match("title doesn't match"))
     end
 
     it "returns a problem when the descriptions don't match" do
       stub_publishing_api_has_item(content_id: edition.content_id, description: "description")
 
       integrity_check = WhitehallImporter::IntegrityChecker.new(edition)
-      expect(integrity_check.problems).to include("description doesn't match")
+      expect(integrity_check.problems).to include(match("description doesn't match"))
     end
 
     it "returns a problem when the document types don't match" do
       stub_publishing_api_has_item(content_id: edition.content_id, document_type: "news_story")
 
       integrity_check = WhitehallImporter::IntegrityChecker.new(edition)
-      expect(integrity_check.problems).to include("document_type doesn't match")
+      expect(integrity_check.problems).to include(match("document_type doesn't match"))
     end
 
     it "returns a problem when the schema names don't match" do
       stub_publishing_api_has_item(content_id: edition.content_id, schema_name: "news_article")
 
       integrity_check = WhitehallImporter::IntegrityChecker.new(edition)
-      expect(integrity_check.problems).to include("schema_name doesn't match")
+      expect(integrity_check.problems).to include(match("schema_name doesn't match"))
     end
 
     it "returns a problem when the body text doesn't match" do
@@ -110,7 +110,7 @@ RSpec.describe WhitehallImporter::IntegrityChecker do
       )
 
       integrity_check = WhitehallImporter::IntegrityChecker.new(edition)
-      expect(integrity_check.problems).to include("body text doesn't match")
+      expect(integrity_check.problems).to include(match("body text doesn't match"))
     end
 
     it "returns a problem when the image alt_text doesn't match" do
@@ -124,7 +124,7 @@ RSpec.describe WhitehallImporter::IntegrityChecker do
       )
 
       integrity_check = WhitehallImporter::IntegrityChecker.new(edition)
-      expect(integrity_check.problems).to include("image alt_text doesn't match")
+      expect(integrity_check.problems).to include(match("image alt_text doesn't match"))
     end
 
     it "returns a problem when the image caption doesn't match" do
@@ -138,7 +138,7 @@ RSpec.describe WhitehallImporter::IntegrityChecker do
       )
 
       integrity_check = WhitehallImporter::IntegrityChecker.new(edition)
-      expect(integrity_check.problems).to include("image caption doesn't match")
+      expect(integrity_check.problems).to include(match("image caption doesn't match"))
     end
 
     it "returns a problem when the primary_publishing_organisation doesn't match" do
@@ -150,7 +150,7 @@ RSpec.describe WhitehallImporter::IntegrityChecker do
       )
 
       integrity_check = WhitehallImporter::IntegrityChecker.new(edition)
-      expect(integrity_check.problems).to include("primary_publishing_organisation doesn't match")
+      expect(integrity_check.problems).to include(match("primary_publishing_organisation doesn't match"))
     end
 
     it "returns a problem when the organisations don't match" do
@@ -162,7 +162,7 @@ RSpec.describe WhitehallImporter::IntegrityChecker do
       )
 
       integrity_check = WhitehallImporter::IntegrityChecker.new(edition)
-      expect(integrity_check.problems).to include("organisations don't match")
+      expect(integrity_check.problems).to include(match("organisations don't match"))
     end
   end
 end


### PR DESCRIPTION
Trello: https://trello.com/c/A9GjvYyp

## What's changed and why?
It's quite difficult to dig through the console output to see what's
actually failed when the import fails. This is because the document
that's created is rolled back, and there is nothing to generate the
proposed payload from for comparison with the publishing-api.

Adds an `**` to the boundaries of the field values in the problem list.
This is to identify differences in whitespace.

Example output:

```
14:21:46 Import aborted
14:21:46 Error: #<WhitehallImporter::AbortImportError: image alt_text doesn't match.
14:21:46 proposed value: **An image of the First Generation Reprocesiing Plant stack and the Sellafield site with only a 9 metre stub left. **
14:21:46 publishing-api value: **An image of the First Generation Reprocesiing Plant stack and the Sellafield site with only a 9 metre stub left.**
14:21:46 , image caption doesn't match.
14:21:46 proposed value: **The demolition success is thanks to a collaboration between Sellafield Ltd, demolition partner Nuvia, steeplejacks Delta International, and lift operator Alimak.
14:21:46 **
14:21:46 publishing-api value: **The demolition success is thanks to a collaboration between Sellafield Ltd, demolition partner Nuvia, steeplejacks Delta International, and lift operator Alimak.**
14:21:46 >
14:21:46 Build step 'Execute shell' marked build as failure
14:21:46 Finished: FAILURE
```