### PR TITLE
Change edition request tests to match consistent strategy

### DIFF
--- a/spec/requests/editions_spec.rb
+++ b/spec/requests/editions_spec.rb
@@ -1,13 +1,19 @@
 # frozen_string_literal: true
 
 RSpec.describe "Editions" do
+  it_behaves_like "requests that assert edition state",
+                  "creating a new edition on a non live edition",
+                  routes: { create_edition_path: %i[post] } do
+    let(:edition) { create(:edition) }
+  end
+
   describe "POST /document/:document/editions" do
-    it "creates a new edition" do
+    it "redirects to edit document" do
       edition = create(:edition, :published)
       stub_publishing_api_put_content(edition.content_id, {})
 
-      expect { post create_edition_path(edition.document) }
-        .to change { Edition.where(document_id: edition.document.id).count }.by(1)
+      post create_edition_path(edition.document)
+      expect(response).to redirect_to(edit_document_path(edition.document))
     end
 
     context "when the edition is in history mode" do
@@ -18,15 +24,18 @@ RSpec.describe "Editions" do
         login_as(user)
         stub_publishing_api_put_content(edition.content_id, {})
 
-        expect { post create_edition_path(edition.document) }
-          .to change { Edition.where(document_id: edition.document.id).count }.by(1)
+        post create_edition_path(edition.document)
+        expect(response).to redirect_to(edit_document_path(edition.document))
       end
 
       it "prevents users without the permission creating a new edition" do
         post create_edition_path(edition.document)
 
-        expect(response.body).to include(I18n.t!("missing_permissions.update_history_mode.title", title: edition.title))
-        expect(response.status).to eq(403)
+        expect(response).to have_http_status(:forbidden)
+        expect(response.body).to have_content(
+          I18n.t!("missing_permissions.update_history_mode.title",
+                  title: edition.title),
+        )
       end
     end
   end


### PR DESCRIPTION
Trello: https://trello.com/c/wgkfOJsE/1283-improve-consistency-in-content-publisher-tests

This follows on the test strategy introduced in #1590. Towards this I've done a bunch of writing of request tests and deleting of feature tests. Rather than do one large PR I thought it was best to separate into distinct PR's that are easier to review and thought I'd start with one that covers a few.

This PR does some refactoring of the edition request tests we already had to make them consistent with other request tests.