### PR TITLE
Remove redundant uses of the 'images' flag

### DIFF
--- a/spec/features/editing_content/insert_inline_image_no_js_spec.rb
+++ b/spec/features/editing_content/insert_inline_image_no_js_spec.rb
@@ -10,7 +10,7 @@ RSpec.feature "Insert inline image without Javascript" do
 
   def given_there_is_an_edition_with_images
     body_field = build(:field, id: "body", type: "govspeak")
-    document_type = build(:document_type, contents: [body_field], images: true)
+    document_type = build(:document_type, contents: [body_field])
     @image_revision = create(:image_revision,
                              :on_asset_manager,
                              filename: "foo.jpg")

--- a/spec/features/editing_content/insert_inline_image_spec.rb
+++ b/spec/features/editing_content/insert_inline_image_spec.rb
@@ -11,7 +11,7 @@ RSpec.feature "Insert inline image", js: true do
 
   def given_there_is_an_edition_with_images
     body_field = build(:field, id: "body", type: "govspeak")
-    document_type = build(:document_type, contents: [body_field], images: true)
+    document_type = build(:document_type, contents: [body_field])
     @image_revision = create(:image_revision,
                              :on_asset_manager,
                              filename: "foo.jpg")

--- a/spec/features/editing_file_attachments/upload_file_attachment_requirements_spec.rb
+++ b/spec/features/editing_file_attachments/upload_file_attachment_requirements_spec.rb
@@ -11,7 +11,7 @@ RSpec.feature "Upload a file attachment with requirements issues", js: true do
 
   def given_there_is_an_edition
     body_field = build(:field, id: "body", type: "govspeak")
-    document_type = build(:document_type, contents: [body_field], images: true)
+    document_type = build(:document_type, contents: [body_field])
     @edition = create(:edition, document_type_id: document_type.id)
   end
 


### PR DESCRIPTION
This flag is only necessary to support lead image and some image
management functions.