### PR TITLE
Store integrity check failures

### DIFF
--- a/db/migrate/20200109094012_add_integrity_check_problems_to_whitehall_document_migration.rb
+++ b/db/migrate/20200109094012_add_integrity_check_problems_to_whitehall_document_migration.rb
@@ -1,0 +1,10 @@
+# frozen_string_literal: true
+
+class AddIntegrityCheckProblemsToWhitehallDocumentMigration < ActiveRecord::Migration[6.0]
+  def change
+    change_table :whitehall_migration_document_imports, bulk: true do |t|
+      t.string :integrity_check_problems, array: true, default: [], null: false
+      t.json :integrity_check_proposed_payload, default: "{}", null: false
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -358,6 +358,8 @@ ActiveRecord::Schema.define(version: 2020_01_14_140323) do
     t.datetime "updated_at", null: false
     t.bigint "document_id"
     t.bigint "whitehall_migration_id"
+    t.string "integrity_check_problems", default: [], null: false, array: true
+    t.json "integrity_check_proposed_payload", default: "{}", null: false
   end
 
   create_table "whitehall_migrations", force: :cascade do |t|

--- a/lib/whitehall_importer.rb
+++ b/lib/whitehall_importer.rb
@@ -51,6 +51,13 @@ module WhitehallImporter
       document = Import.call(whitehall_import)
       whitehall_import.update!(document: document, state: "imported")
       create_timeline_entry(document.current_edition)
+    rescue IntegrityCheckError => e
+      whitehall_import.update!(
+        error_log: e.inspect,
+        state: "import_aborted",
+        integrity_check_problems: e.problems,
+        integrity_check_proposed_payload: e.payload,
+      )
     rescue AbortImportError => e
       whitehall_import.update!(error_log: e.inspect, state: "import_aborted")
     rescue StandardError => e

--- a/lib/whitehall_importer/import.rb
+++ b/lib/whitehall_importer/import.rb
@@ -84,7 +84,9 @@ module WhitehallImporter
     def check_edition_integrity(edition)
       integrity_checker = IntegrityChecker.new(edition)
 
-      raise AbortImportError, integrity_checker.problems.join(", ") unless integrity_checker.valid?
+      unless integrity_checker.valid?
+        raise WhitehallImporter::IntegrityCheckError.new(integrity_checker)
+      end
     end
   end
 end

--- a/lib/whitehall_importer/integrity_check_error.rb
+++ b/lib/whitehall_importer/integrity_check_error.rb
@@ -1,0 +1,15 @@
+# frozen_string_literal: true
+
+module WhitehallImporter
+  class IntegrityCheckError < AbortImportError
+    attr_reader :problems, :payload
+
+    def initialize(integrity_check)
+      @problems = integrity_check.problems
+      @payload = integrity_check.proposed_payload
+
+      publishing_status = integrity_check.edition.live? ? "live" : "draft"
+      super("#{publishing_status.titleize} integrity check failed")
+    end
+  end
+end

--- a/lib/whitehall_importer/integrity_checker.rb
+++ b/lib/whitehall_importer/integrity_checker.rb
@@ -16,6 +16,10 @@ module WhitehallImporter
       content_problems + image_problems + organisation_problems
     end
 
+    def proposed_payload
+      @proposed_payload ||= PreviewService::Payload.new(edition, republish: edition.live?).payload
+    end
+
   private
 
     def content_problems
@@ -94,10 +98,6 @@ module WhitehallImporter
 
     def organisations_match?
       proposed_payload.dig("links", "organisations")&.sort == publishing_api_link("organisations")&.sort
-    end
-
-    def proposed_payload
-      @proposed_payload ||= PreviewService::Payload.new(edition, republish: edition.live?).payload
     end
 
     def publishing_api_content

--- a/lib/whitehall_importer/integrity_checker.rb
+++ b/lib/whitehall_importer/integrity_checker.rb
@@ -27,7 +27,11 @@ module WhitehallImporter
          document_type
          schema_name).each do |attribute|
         if publishing_api_content[attribute] != proposed_payload[attribute]
-          problems << "#{attribute} doesn't match"
+          problems << problem_description(
+            "#{attribute} doesn't match",
+            publishing_api_content[attribute],
+            proposed_payload[attribute],
+          )
         end
       end
 
@@ -49,17 +53,39 @@ module WhitehallImporter
 
       %w(alt_text caption).each_with_object([]) do |attribute, problems|
         if publishing_api_image[attribute] != proposed_image_payload[attribute]
-          problems << "image #{attribute} doesn't match"
+          problems << problem_description(
+            "image #{attribute} doesn't match",
+            publishing_api_image[attribute],
+            proposed_image_payload[attribute],
+          )
         end
       end
     end
 
     def organisation_problems
       problems = []
-      problems << "primary_publishing_organisation doesn't match" unless primary_publishing_organisation_matches?
-      problems << "organisations don't match" unless organisations_match?
+
+      unless primary_publishing_organisation_matches?
+        problems << problem_description(
+          "primary_publishing_organisation doesn't match",
+          publishing_api_link("primary_publishing_organisation"),
+          proposed_payload.dig("links", "primary_publishing_organisation"),
+        )
+      end
+
+      unless organisations_match?
+        problems << problem_description(
+          "organisations don't match",
+          publishing_api_link("organisations"),
+          proposed_payload.dig("links", "organisations"),
+        )
+      end
 
       problems
+    end
+
+    def problem_description(message, expected, actual)
+      "#{message}, expected: #{expected.inspect}, actual: #{actual.inspect}"
     end
 
     def primary_publishing_organisation_matches?

--- a/spec/lib/whitehall_importer/import_spec.rb
+++ b/spec/lib/whitehall_importer/import_spec.rb
@@ -137,18 +137,19 @@ RSpec.describe WhitehallImporter::Import do
       expect(WhitehallImporter::IntegrityChecker.new).to have_received(:valid?).twice
     end
 
-    it "aborts with a list of problems if the integrity check fails" do
-      problems = "base path doesn't match"
+    it "aborts if the integrity check fails" do
       allow(WhitehallImporter::IntegrityChecker)
         .to receive(:new)
         .and_return(instance_double(
                       WhitehallImporter::IntegrityChecker,
                       valid?: false,
-                      problems: [problems],
+                      problems: ["foo doesn't match"],
+                      proposed_payload: { "foo" => "bar" },
+                      edition: build(:edition),
                     ))
 
       expect { described_class.call(build(:whitehall_migration_document_import)) }
-        .to raise_error(WhitehallImporter::AbortImportError, problems)
+        .to raise_error(WhitehallImporter::IntegrityCheckError)
     end
   end
 end

--- a/spec/lib/whitehall_importer/integrity_checker_spec.rb
+++ b/spec/lib/whitehall_importer/integrity_checker_spec.rb
@@ -70,35 +70,35 @@ RSpec.describe WhitehallImporter::IntegrityChecker do
       stub_publishing_api_has_item(content_id: edition.content_id, base_path: "base-path")
 
       integrity_check = WhitehallImporter::IntegrityChecker.new(edition)
-      expect(integrity_check.problems).to include("base_path doesn't match")
+      expect(integrity_check.problems).to include(match("base_path doesn't match"))
     end
 
     it "returns a problem when the titles don't match" do
       stub_publishing_api_has_item(content_id: edition.content_id, title: "title")
 
       integrity_check = WhitehallImporter::IntegrityChecker.new(edition)
-      expect(integrity_check.problems).to include("title doesn't match")
+      expect(integrity_check.problems).to include(match("title doesn't match"))
     end
 
     it "returns a problem when the descriptions don't match" do
       stub_publishing_api_has_item(content_id: edition.content_id, description: "description")
 
       integrity_check = WhitehallImporter::IntegrityChecker.new(edition)
-      expect(integrity_check.problems).to include("description doesn't match")
+      expect(integrity_check.problems).to include(match("description doesn't match"))
     end
 
     it "returns a problem when the document types don't match" do
       stub_publishing_api_has_item(content_id: edition.content_id, document_type: "news_story")
 
       integrity_check = WhitehallImporter::IntegrityChecker.new(edition)
-      expect(integrity_check.problems).to include("document_type doesn't match")
+      expect(integrity_check.problems).to include(match("document_type doesn't match"))
     end
 
     it "returns a problem when the schema names don't match" do
       stub_publishing_api_has_item(content_id: edition.content_id, schema_name: "news_article")
 
       integrity_check = WhitehallImporter::IntegrityChecker.new(edition)
-      expect(integrity_check.problems).to include("schema_name doesn't match")
+      expect(integrity_check.problems).to include(match("schema_name doesn't match"))
     end
 
     it "returns a problem when the body text doesn't match" do
@@ -124,7 +124,7 @@ RSpec.describe WhitehallImporter::IntegrityChecker do
       )
 
       integrity_check = WhitehallImporter::IntegrityChecker.new(edition)
-      expect(integrity_check.problems).to include("image alt_text doesn't match")
+      expect(integrity_check.problems).to include(match("image alt_text doesn't match"))
     end
 
     it "returns a problem when the image caption doesn't match" do
@@ -138,7 +138,7 @@ RSpec.describe WhitehallImporter::IntegrityChecker do
       )
 
       integrity_check = WhitehallImporter::IntegrityChecker.new(edition)
-      expect(integrity_check.problems).to include("image caption doesn't match")
+      expect(integrity_check.problems).to include(match("image caption doesn't match"))
     end
 
     it "returns a problem when the primary_publishing_organisation doesn't match" do
@@ -150,7 +150,7 @@ RSpec.describe WhitehallImporter::IntegrityChecker do
       )
 
       integrity_check = WhitehallImporter::IntegrityChecker.new(edition)
-      expect(integrity_check.problems).to include("primary_publishing_organisation doesn't match")
+      expect(integrity_check.problems).to include(match("primary_publishing_organisation doesn't match"))
     end
 
     it "returns a problem when the organisations don't match" do
@@ -162,7 +162,7 @@ RSpec.describe WhitehallImporter::IntegrityChecker do
       )
 
       integrity_check = WhitehallImporter::IntegrityChecker.new(edition)
-      expect(integrity_check.problems).to include("organisations don't match")
+      expect(integrity_check.problems).to include(match("organisations don't match"))
     end
   end
 end

--- a/spec/lib/whitehall_importer_spec.rb
+++ b/spec/lib/whitehall_importer_spec.rb
@@ -139,6 +139,34 @@ RSpec.describe WhitehallImporter do
         expect(whitehall_migration_document_import.error_log).to eq("#<WhitehallImporter::AbortImportError: #{message}>")
       end
     end
+
+    context "when the integrity check fails" do
+      let(:problems) { ["foo failed"] }
+      let(:payload) { { "foo" => "bar" } }
+      let(:integrity_check) do
+        instance_double(
+          WhitehallImporter::IntegrityChecker,
+          valid?: false,
+          problems: problems,
+          proposed_payload: payload,
+          edition: build(:edition),
+        )
+      end
+
+      before do
+        allow(WhitehallImporter::Import).to receive(:call).and_raise(
+          WhitehallImporter::IntegrityCheckError.new(integrity_check),
+        )
+      end
+
+      it "marks the import as aborted and logs the error and the payload" do
+        WhitehallImporter.import(whitehall_migration_document_import)
+
+        expect(whitehall_migration_document_import).to be_import_aborted
+        expect(whitehall_migration_document_import.integrity_check_problems).to eq(problems)
+        expect(whitehall_migration_document_import.integrity_check_proposed_payload).to eq(payload)
+      end
+    end
   end
 
   describe ".sync" do


### PR DESCRIPTION
Trello: https://trello.com/c/A9GjvYyp

## What's changed and why?
The integrity check added in PR #1602 has highlighted some discrepancies between how some of the fields are handled. 

For example, if the image caption is blank, it's recorded in publishing-api as `nil`, however, the import process tries to replace this value with an empty string. Also, some fields are being sent to publishing-api with an extra space or newline at the end of them.

All of these discrepancies will cause the integrity check and therefore the import to fail. 

Debugging integrity check failures is difficult. As the integrity check runs within a transaction, when the import fails and the transaction rolls back, all of the documents, editions and revisions the import created are obliterated, which means that the proposed payload that we wanted to send to publishing-api is also lost. Trying to recreate this payload in a console is quite difficult because of the need to also create all of the editions and revisions etc.

This change keeps a copy of this payload in the database, to make it easier for the investigator to find out what's failed and why. We're already storing a copy of the export taken from Whitehall in the `whitehall_migration_document_imports` table and the proposed payload will be stored along side it. 
We don't need to store what publishing-api expects because it's easy enough to see that by calling the `get_content`, `get_live_content` and `get_links` api methods.