### PR TITLE
Add defaults for 'topics' feature on formats

### DIFF
--- a/app/models/document_type.rb
+++ b/app/models/document_type.rb
@@ -21,6 +21,7 @@ class DocumentType
         hash["tags"] = hash["tags"].to_a.map(&TagField.method(:new))
         hash["publishing_metadata"] = PublishingMetadata.new(hash["publishing_metadata"].to_h)
         hash["guidance"] = hash["guidance"].to_a.map(&Guidance.method(:new))
+        hash["topics"] = true # this feature is only disabled in tests
         new(hash)
       end
     end

--- a/config/document_types.yml
+++ b/config/document_types.yml
@@ -7,7 +7,6 @@
     Read the full [guidance on news stories](https://www.gov.uk/guidance/content-design/content-types#news-story).
   path_prefix: /government/news
   images: true
-  topics: true
   check_path_conflict: true
   publishing_metadata:
     schema_name: news_article
@@ -68,7 +67,6 @@
     Read the full [guidance on press releases](https://www.gov.uk/guidance/content-design/content-types#press-release).
   path_prefix: /government/news
   images: true
-  topics: true
   check_path_conflict: true
   publishing_metadata:
     schema_name: news_article

--- a/spec/factories/document_type_factory.rb
+++ b/spec/factories/document_type_factory.rb
@@ -14,6 +14,7 @@ FactoryBot.define do
     contents { [] }
     tags { [] }
     guidance { [] }
+    topics { false }
 
     publishing_metadata do
       DocumentType::PublishingMetadata.new(


### PR DESCRIPTION
https://trello.com/c/NLAjn71N/1101-spike-and-test-approach-for-format-field-definitions

Previously we had to manually specify that topics were supported on
every format, which is unnecesary since they always are. This makes
having topics the default for a format, but inverts this for (most)
tests, in order to avoid having extra API stubs.

It seems reasonable to keep the 'topics' flag, since it represents a
'unit feature' of a format, even though it's technically mandatory.