### PR TITLE
Use non-deprecated put-intent stub

### DIFF
--- a/spec/features/scheduling/update_publish_time_spec.rb
+++ b/spec/features/scheduling/update_publish_time_spec.rb
@@ -33,7 +33,7 @@ RSpec.feature "Update publish time" do
 
   def and_i_set_a_new_publish_time
     @new_time = Time.zone.parse("2019-08-15 23:00")
-    @put_intent_request = stub_default_publishing_api_put_intent.with(
+    @put_intent_request = stub_any_publishing_api_put_intent.with(
       body: hash_including(publish_time: @new_time),
     )
 


### PR DESCRIPTION
This change removes the warning below when the update_publish_time_spec.rb test file is run.

<img width="715" alt="Screenshot 2020-01-13 at 14 43 54" src="https://user-images.githubusercontent.com/24479188/72265123-d8ee5d00-3613-11ea-881c-24ad51f1d71f.png">