### PR TITLE
Add JS tests for modals

### DIFF
--- a/app/assets/javascripts/modal/modal-fetch.js
+++ b/app/assets/javascripts/modal/modal-fetch.js
@@ -58,7 +58,7 @@ window.ModalFetch._isFileUpload = function (form) {
 window.ModalFetch.debug = function (response) {
   var envMeta = document.querySelector('meta[name="app-environment"]')
 
-  if (envMeta.content !== 'production') {
+  if (envMeta && envMeta.content !== 'production') {
     return
   }
 

--- a/app/assets/javascripts/modal/modal-workflow.js
+++ b/app/assets/javascripts/modal/modal-workflow.js
@@ -7,6 +7,7 @@ function ModalWorkflow ($modal, actionCallback) {
   this.$multiSectionViewer = this.$modal
     .querySelector('[data-module="multi-section-viewer"]')
 
+  this.performAction = this.performAction.bind(this)
   this.renderSuccess = this.renderSuccess.bind(this)
   this.renderError = this.renderError.bind(this)
 }
@@ -49,7 +50,7 @@ ModalWorkflow.prototype.renderError = function (result) {
 
 ModalWorkflow.prototype.renderSuccess = function (result) {
   this.$multiSectionViewer.showDynamicSection(result.body)
-  this.overrideActions(this.performAction.bind(this))
+  this.overrideActions(this.performAction)
   this.initComponents()
 }
 

--- a/app/assets/javascripts/modal/modal-workflow.js
+++ b/app/assets/javascripts/modal/modal-workflow.js
@@ -12,6 +12,30 @@ function ModalWorkflow ($modal, actionCallback) {
   this.renderError = this.renderError.bind(this)
 }
 
+ModalWorkflow.prototype.performAction = function (item) {
+  this.$modal.focusDialog()
+  this.$multiSectionViewer.showStaticSection('loading')
+  this.actionCallback(item)
+}
+
+ModalWorkflow.prototype.render = function (response) {
+  response
+    .then(this.renderSuccess)
+    .catch(this.renderError)
+}
+
+ModalWorkflow.prototype.renderSuccess = function (result) {
+  this.$multiSectionViewer.showDynamicSection(result.body)
+  this.overrideActions(this.performAction)
+  this.initComponents()
+}
+
+ModalWorkflow.prototype.renderError = function (result) {
+  window.Raven.captureException(result)
+  console.error(result)
+  this.$multiSectionViewer.showStaticSection('error')
+}
+
 ModalWorkflow.prototype.initComponents = function () {
   window.GOVUK.modules.start($(this.$modal))
   window.GOVUKFrontend.initAll(this.$modal)
@@ -34,28 +58,4 @@ ModalWorkflow.prototype.overrideActions = function (actions) {
       actions(item)
     })
   })
-}
-
-ModalWorkflow.prototype.render = function (response) {
-  response
-    .then(this.renderSuccess)
-    .catch(this.renderError)
-}
-
-ModalWorkflow.prototype.renderError = function (result) {
-  window.Raven.captureException(result)
-  console.error(result)
-  this.$multiSectionViewer.showStaticSection('error')
-}
-
-ModalWorkflow.prototype.renderSuccess = function (result) {
-  this.$multiSectionViewer.showDynamicSection(result.body)
-  this.overrideActions(this.performAction)
-  this.initComponents()
-}
-
-ModalWorkflow.prototype.performAction = function (item) {
-  this.$modal.focusDialog()
-  this.$multiSectionViewer.showStaticSection('loading')
-  this.actionCallback(item)
 }

--- a/package.json
+++ b/package.json
@@ -25,6 +25,7 @@
     "core-js-bundle": "^3.6.4",
     "cropperjs": "^1.5.6",
     "es5-polyfill": "^0.0.6",
+    "fetch-mock": "^8.3.1",
     "markdown-toolbar-element": "^0.2.0",
     "miller-columns-element": "^1.2.1",
     "paste-html-to-govspeak": "^0.2.3",

--- a/spec/javascripts/components/markdown-editor-spec.js
+++ b/spec/javascripts/components/markdown-editor-spec.js
@@ -1,71 +1,15 @@
-/* eslint-env jasmine, jquery */
-/* global GOVUK spyOnEvent */
+/* eslint-env jasmine */
+/* global spyOnEvent, buildMarkdownEditor, removeMarkdownEditor */
 
 describe('Markdown editor component', function () {
   'use strict'
 
-  var container
-
   beforeEach(function () {
-    container = document.createElement('div')
-    container.innerHTML =
-      '<div class="app-c-markdown-editor" data-module="markdown-editor" data-govspeak-path="#">' +
-        '<label for="markdown-editor" class="gem-c-label govuk-label ">Body</label>' +
-        '<div class="app-c-markdown-editor__container js-markdown-editor__container">' +
-          '<div class="app-c-markdown-editor__head js-markdown-editor__head">' +
-            '<div class="app-c-markdown-editor__preview-toggle">' +
-              '<button type="button" class="app-c-markdown-editor__button app-c-markdown-editor__button--muted js-markdown-edit-button">Edit markdown</button>' +
-              '<button type="button" class="app-c-markdown-editor__button js-markdown-preview-button">Preview markdown</button>' +
-            '</div>' +
-            '<div class="app-c-markdown-editor__toolbar">' +
-              '<markdown-toolbar class="app-c-markdown-editor__toolbar-group" for="markdown-editor">' +
-                '<md-header-2 class="app-c-markdown-editor__toolbar-button">' +
-                  '<i class="app-c-markdown-editor__toolbar-icon app-c-markdown-editor__toolbar-icon--heading-2" title="Heading level 2" aria-hidden="true"></i>' +
-                  '<span class="govuk-visually-hidden">Heading level 2</span>' +
-                '</md-header-2>' +
-                '<md-header-3 class="app-c-markdown-editor__toolbar-button">' +
-                  '<i class="app-c-markdown-editor__toolbar-icon app-c-markdown-editor__toolbar-icon--heading-3" title="Heading level 3" aria-hidden="true"></i>' +
-                  '<span class="govuk-visually-hidden">Heading level 3</span>' +
-                '</md-header-3>' +
-                '<md-link class="app-c-markdown-editor__toolbar-button">' +
-                  '<i class="app-c-markdown-editor__toolbar-icon app-c-markdown-editor__toolbar-icon--link" title="Link" aria-hidden="true"></i>' +
-                  '<span class="govuk-visually-hidden">Link</span>' +
-                '</md-link>' +
-                '<md-quote class="app-c-markdown-editor__toolbar-button">' +
-                  '<i class="app-c-markdown-editor__toolbar-icon app-c-markdown-editor__toolbar-icon--blockquote" title="Blockquote" aria-hidden="true"></i>' +
-                  '<span class="govuk-visually-hidden">Blockquote</span>' +
-                '</md-quote>' +
-                '<md-ordered-list class="app-c-markdown-editor__toolbar-button">' +
-                  '<i class="app-c-markdown-editor__toolbar-icon app-c-markdown-editor__toolbar-icon--numbered-list" title="Numbered list" aria-hidden="true"></i>' +
-                  '<span class="govuk-visually-hidden">Numbered list</span>' +
-                '</md-ordered-list>' +
-                '<md-unordered-list class="app-c-markdown-editor__toolbar-button">' +
-                  '<i class="app-c-markdown-editor__toolbar-icon app-c-markdown-editor__toolbar-icon--bullets" title="Bullets" aria-hidden="true"></i>' +
-                  '<span class="govuk-visually-hidden">Bullets</span>' +
-                '</md-unordered-list>' +
-              '</markdown-toolbar>' +
-            '</div>' +
-          '</div>' +
-          '<div class="app-c-markdown-editor__input js-markdown-editor-input">' +
-            '<div class="govuk-form-group">' +
-              '<textarea name="markdown-editor" class="gem-c-textarea govuk-textarea" id="markdown-editor" rows="5" spellcheck="true"></textarea>' +
-            '</div>' +
-          '</div>' +
-          '<div class="app-c-markdown-editor__preview js-markdown-preview-body">' +
-            '<div class="gem-c-govspeak govuk-govspeak ">' +
-              '<div class="govuk-textarea"></div>' +
-            '</div>' +
-          '</div>' +
-        '</div>' +
-      '</div>'
-
-    document.body.appendChild(container)
-    var element = document.querySelector('[data-module="markdown-editor"]')
-    new GOVUK.Modules.MarkdownEditor().start($(element))
+    buildMarkdownEditor()
   })
 
   afterEach(function () {
-    document.body.removeChild(container)
+    removeMarkdownEditor()
   })
 
   it('should show the editor header', function () {

--- a/spec/javascripts/components/url-preview-spec.js
+++ b/spec/javascripts/components/url-preview-spec.js
@@ -1,10 +1,10 @@
 /* eslint-env jasmine, jquery */
-/* global GOVUK */
+/* global GOVUK, fetchMock */
 
 describe('URL preview component', function () {
   'use strict'
 
-  var container
+  var container, urlPreview
 
   beforeEach(function () {
     container = document.createElement('div')
@@ -26,41 +26,67 @@ describe('URL preview component', function () {
 
     document.body.appendChild(container)
     var element = document.querySelector('[data-module="url-preview"]')
-    new GOVUK.Modules.UrlPreview().start($(element))
+    urlPreview = new GOVUK.Modules.UrlPreview()
+    urlPreview.start($(element))
   })
 
   afterEach(function () {
     document.body.removeChild(container)
   })
 
-  it('should only display the default message if input is empty', function () {
-    // Interact with input and leave empty
-    var input = document.querySelector('[data-url-preview="input"]')
-    input.dispatchEvent(new window.Event('blur'))
+  it('displays a default message when the input is empty', function () {
+    urlPreview.input.value = ''
+    urlPreview.input.dispatchEvent(new window.Event('blur'))
 
-    var defaultMessage = document.querySelector('.js-url-preview-default-message')
-    expect(defaultMessage).toBeVisible()
-
-    var previewURL = document.querySelector('.js-url-preview-url')
-    expect(previewURL).toBeHidden()
-
-    var errorMessage = document.querySelector('.js-url-preview-error-message')
-    expect(errorMessage).toBeHidden()
+    expect(urlPreview.defaultMessage).toBeVisible()
+    expect(urlPreview.urlPreview).toBeHidden()
+    expect(urlPreview.errorMessage).toBeHidden()
   })
 
-  it('should only display the preview URL if input has value', function () {
-    // Interact with input and set value
-    var input = document.querySelector('[data-url-preview="input"]')
-    input.value = 'My title'
-    input.dispatchEvent(new window.Event('blur'))
+  it('displays the preview URL when a user inputs a value and a slug is generated', function (done) {
+    fetchMock.get(/generate-path\?title=My\+title/, 'my-title')
 
-    var defaultMessage = document.querySelector('.js-url-preview-default-message')
-    expect(defaultMessage).toBeHidden()
+    urlPreview.input.value = 'My title'
+    urlPreview.input.dispatchEvent(new window.Event('blur'))
 
-    var previewURL = document.querySelector('.js-url-preview-url')
-    expect(previewURL).toBeVisible()
+    fetchMock.flush(true).then(function () {
+      expect(urlPreview.defaultMessage).toBeHidden()
+      expect(urlPreview.urlPreview).toBeVisible()
+      expect(urlPreview.urlPreview).toContainText('my-title')
+      expect(urlPreview.errorMessage).toBeHidden()
+      done()
+    })
+  })
 
-    var errorMessage = document.querySelector('.js-url-preview-error-message')
-    expect(errorMessage).toBeHidden()
+  it('displays an error when the request to generate a path fails', function (done) {
+    fetchMock.get(/generate-path\?title=My\+title/, 500)
+
+    urlPreview.input.value = 'My title'
+    urlPreview.input.dispatchEvent(new window.Event('blur'))
+
+    fetchMock.flush(true).then(function () {
+      expect(urlPreview.defaultMessage).toBeHidden()
+      expect(urlPreview.urlPreview).toBeHidden()
+      expect(urlPreview.errorMessage).toBeVisible()
+      done()
+    })
+  })
+
+  it('displays an error if the request takes longer than 5 seconds', function (done) {
+    jasmine.clock().withMock(function () {
+      fetchMock.get(/generate-path\?title=My\+title/, 'my-title', { delay: 10000 })
+
+      urlPreview.input.value = 'My title'
+      urlPreview.input.dispatchEvent(new window.Event('blur'))
+
+      jasmine.clock().tick(5001)
+
+      fetchMock.flush(true).then(function () {
+        expect(urlPreview.defaultMessage).toBeHidden()
+        expect(urlPreview.urlPreview).toBeHidden()
+        expect(urlPreview.errorMessage).toBeVisible()
+        done()
+      })
+    })
   })
 })

--- a/spec/javascripts/helpers/fetch-mock.js
+++ b/spec/javascripts/helpers/fetch-mock.js
@@ -1,0 +1,6 @@
+/* eslint-env jasmine */
+/* global fetchMock */
+
+//= require fetch-mock/es5/client-bundle.js
+
+beforeEach(fetchMock.reset)

--- a/spec/javascripts/helpers/markdown-editor.js
+++ b/spec/javascripts/helpers/markdown-editor.js
@@ -1,0 +1,71 @@
+/* eslint-env jquery */
+/* global GOVUK */
+
+window.buildMarkdownEditor = function buildMarkdownEditor () {
+  var markdownEditor = document.createElement('div')
+  markdownEditor.className = 'app-c-markdown-editor'
+  markdownEditor.dataset.module = 'markdown-editor'
+  markdownEditor.dataset.govspeakPath = '#'
+
+  markdownEditor.innerHTML =
+    '<label for="markdown-editor" class="gem-c-label govuk-label ">Body</label>' +
+    '<div class="app-c-markdown-editor__container js-markdown-editor__container">' +
+      '<div class="app-c-markdown-editor__head js-markdown-editor__head">' +
+        '<div class="app-c-markdown-editor__preview-toggle">' +
+          '<button type="button" class="app-c-markdown-editor__button app-c-markdown-editor__button--muted js-markdown-edit-button">Edit markdown</button>' +
+          '<button type="button" class="app-c-markdown-editor__button js-markdown-preview-button">Preview markdown</button>' +
+        '</div>' +
+        '<div class="app-c-markdown-editor__toolbar">' +
+          '<markdown-toolbar class="app-c-markdown-editor__toolbar-group" for="markdown-editor">' +
+            '<md-header-2 class="app-c-markdown-editor__toolbar-button">' +
+              '<i class="app-c-markdown-editor__toolbar-icon app-c-markdown-editor__toolbar-icon--heading-2" title="Heading level 2" aria-hidden="true"></i>' +
+              '<span class="govuk-visually-hidden">Heading level 2</span>' +
+            '</md-header-2>' +
+            '<md-header-3 class="app-c-markdown-editor__toolbar-button">' +
+              '<i class="app-c-markdown-editor__toolbar-icon app-c-markdown-editor__toolbar-icon--heading-3" title="Heading level 3" aria-hidden="true"></i>' +
+              '<span class="govuk-visually-hidden">Heading level 3</span>' +
+            '</md-header-3>' +
+            '<md-link class="app-c-markdown-editor__toolbar-button">' +
+              '<i class="app-c-markdown-editor__toolbar-icon app-c-markdown-editor__toolbar-icon--link" title="Link" aria-hidden="true"></i>' +
+              '<span class="govuk-visually-hidden">Link</span>' +
+            '</md-link>' +
+            '<md-quote class="app-c-markdown-editor__toolbar-button">' +
+              '<i class="app-c-markdown-editor__toolbar-icon app-c-markdown-editor__toolbar-icon--blockquote" title="Blockquote" aria-hidden="true"></i>' +
+              '<span class="govuk-visually-hidden">Blockquote</span>' +
+            '</md-quote>' +
+            '<md-ordered-list class="app-c-markdown-editor__toolbar-button">' +
+              '<i class="app-c-markdown-editor__toolbar-icon app-c-markdown-editor__toolbar-icon--numbered-list" title="Numbered list" aria-hidden="true"></i>' +
+              '<span class="govuk-visually-hidden">Numbered list</span>' +
+            '</md-ordered-list>' +
+            '<md-unordered-list class="app-c-markdown-editor__toolbar-button">' +
+              '<i class="app-c-markdown-editor__toolbar-icon app-c-markdown-editor__toolbar-icon--bullets" title="Bullets" aria-hidden="true"></i>' +
+              '<span class="govuk-visually-hidden">Bullets</span>' +
+            '</md-unordered-list>' +
+          '</markdown-toolbar>' +
+        '</div>' +
+      '</div>' +
+      '<div class="app-c-markdown-editor__input js-markdown-editor-input">' +
+        '<div class="govuk-form-group">' +
+          '<textarea name="markdown-editor" class="gem-c-textarea govuk-textarea" id="markdown-editor" rows="5" spellcheck="true"></textarea>' +
+        '</div>' +
+      '</div>' +
+      '<div class="app-c-markdown-editor__preview js-markdown-preview-body">' +
+        '<div class="gem-c-govspeak govuk-govspeak ">' +
+          '<div class="govuk-textarea"></div>' +
+        '</div>' +
+      '</div>' +
+    '</div>'
+
+  // The markdown component can hit a number of errors if it is initialised
+  // before attached to the DOM.
+  document.body.appendChild(markdownEditor)
+  new GOVUK.Modules.MarkdownEditor().start($(markdownEditor))
+  return markdownEditor
+}
+
+window.removeMarkdownEditor = function removeMarkdownEditor () {
+  var markdownEditor = document.querySelector('.app-c-markdown-editor')
+  if (markdownEditor) {
+    markdownEditor.parentNode.removeChild(markdownEditor)
+  }
+}

--- a/spec/javascripts/helpers/modal-dialogue.js
+++ b/spec/javascripts/helpers/modal-dialogue.js
@@ -1,0 +1,35 @@
+/* eslint-env jquery */
+
+window.buildModalDialogue = function buildModalDialogue () {
+  window.removeModalDialogue()
+  var modal = document.createElement('div')
+  modal.className = 'gem-c-modal-dialogue gem-c-modal-dialogue__box--wide'
+  modal.id = 'modal'
+  modal.innerHTML =
+    '<dialog class="gem-c-modal-dialogue__box" aria-modal="true" role="dialogue" aria-labelledby="my-modal-title">' +
+      '<div class="gem-c-modal-dialogue__content">' +
+        '<div class="app-c-multi-section-viewer" data-module="multi-section-viewer">' +
+          '<section class="app-c-multi-section-viewer__section" id="loading"></section>' +
+          '<section class="app-c-multi-section-viewer__section" id="error"></section>' +
+          '<div class="app-c-multi-section-viewer__section js-dynamic-section"></div>' +
+        '</div>' +
+      '</div>' +
+      '<button class="gem-c-modal-dialogue__close-button" aria-label="Close modal dialogue">&times;</button>' +
+    '</dialog>'
+
+  document.body.appendChild(modal)
+  new window.GOVUK.Modules.ModalDialogue().start($(modal))
+
+  var multiSectionViewer = modal.querySelector('[data-module="multi-section-viewer"]')
+  new window.GOVUK.Modules.MultiSectionViewer().start($(multiSectionViewer))
+
+  return modal
+}
+
+window.removeModalDialogue = function removeModalDialogue () {
+  var modal = document.getElementById('modal')
+  if (modal) {
+    modal.close()
+    modal.parentNode.removeChild(modal)
+  }
+}

--- a/spec/javascripts/modal/modal-editor-spec.js
+++ b/spec/javascripts/modal/modal-editor-spec.js
@@ -1,0 +1,38 @@
+/* eslint-env jasmine */
+/* global ModalEditor, buildMarkdownEditor, removeMarkdownEditor */
+
+describe('ModalEditor', function () {
+  'use strict'
+
+  var modalEditor, markdownEditor
+
+  beforeEach(function () {
+    markdownEditor = buildMarkdownEditor()
+    // we'll simulate this being initialised by a control by selecting one of
+    // the toolbar buttons
+    var control = markdownEditor.querySelector('.app-c-markdown-editor__toolbar-button')
+    modalEditor = new ModalEditor(control)
+    spyOn(markdownEditor, 'selectionReplace')
+  })
+
+  afterEach(function () {
+    removeMarkdownEditor()
+  })
+
+  describe('modalEditor.insertBlock', function () {
+    it('delegates to markdownEditor to insert text surrounded by new lines', function () {
+      modalEditor.insertBlock('content')
+      expect(markdownEditor.selectionReplace).toHaveBeenCalledWith(
+        'content',
+        { surroundWithNewLines: true }
+      )
+    })
+  })
+
+  describe('modalEditor.insertInline', function () {
+    it('delegates to markdownEditor to insert text without surrounding it with new lines', function () {
+      modalEditor.insertInline('content')
+      expect(markdownEditor.selectionReplace).toHaveBeenCalledWith('content')
+    })
+  })
+})

--- a/spec/javascripts/modal/modal-fetch-spec.js
+++ b/spec/javascripts/modal/modal-fetch-spec.js
@@ -1,0 +1,218 @@
+/* eslint-env jasmine */
+/* global ModalFetch, Promise, fetchMock */
+
+describe('ModalFetch', function () {
+  'use strict'
+
+  describe('ModalFetch.getLink', function () {
+    var link
+
+    beforeEach(function () {
+      link = document.createElement('a')
+      link.href = 'https://example.com/'
+    })
+
+    it('returns a promise with body text based on link href', function (done) {
+      fetchMock.get('https://example.com', 'Response content')
+      var promise = ModalFetch.getLink(link)
+      promise.then(function (response) {
+        expect(response).toEqual({ body: 'Response content' })
+        done()
+      })
+    })
+
+    it('sets headers to set modal context and include credentials', function () {
+      fetchMock.get('https://example.com', 200)
+      ModalFetch.getLink(link)
+      expect(fetchMock.lastOptions()).toEqual(jasmine.objectContaining({
+        credentials: 'include',
+        headers: { 'Content-Publisher-Rendering-Context': 'modal' }
+      }))
+    })
+
+    it('allows overwriting the url with the modalActionUrl data attribute ', function (done) {
+      link.dataset.modalActionUrl = 'https://example.com/other'
+      fetchMock.get('https://example.com/other', 'Other content')
+      var promise = ModalFetch.getLink(link)
+      promise.then(function (response) {
+        expect(response).toEqual({ body: 'Other content' })
+        done()
+      })
+    })
+
+    it('returns a rejected promise on an unsuccessful request', function (done) {
+      fetchMock.get('https://example.com', 404)
+      var promise = ModalFetch.getLink(link)
+      promise.catch(function (error) {
+        expect(error).toEqual('Unable to fetch modal content')
+        done()
+      })
+    })
+
+    it('delegates to ModalFetch.debug an unsuccessful request', function (done) {
+      fetchMock.get('https://example.com', 404)
+      spyOn(window.ModalFetch, 'debug')
+      var promise = ModalFetch.getLink(link)
+      promise.catch(function () {
+        expect(window.ModalFetch.debug).toHaveBeenCalled()
+        done()
+      })
+    })
+
+    it('times out after 15 seconds', function (done) {
+      jasmine.clock().withMock(function () {
+        fetchMock.get('https://example.com', 200, { delay: 20000 })
+        var promise = window.ModalFetch.getLink(link)
+
+        jasmine.clock().tick(15000)
+
+        promise.catch(function (error) {
+          expect(error.name).toEqual('AbortError')
+          done()
+        })
+      })
+    })
+  })
+
+  describe('ModalFetch.postForm', function () {
+    var form
+
+    beforeEach(function () {
+      form = document.createElement('form')
+      form.action = 'https://example.com'
+    })
+
+    it('returns a promise with body text of the form response', function (done) {
+      fetchMock.post('https://example.com', 'Response content')
+      var promise = ModalFetch.postForm(form)
+      promise.then(function (response) {
+        expect(response).toEqual({
+          body: 'Response content',
+          unprocessableEntity: false
+        })
+        done()
+      })
+    })
+
+    it('returns body text when response is a unprocessable entity', function (done) {
+      fetchMock.post(
+        'https://example.com',
+        { status: 422, body: 'Response content' }
+      )
+      var promise = ModalFetch.postForm(form)
+      promise.then(function (response) {
+        expect(response).toEqual({
+          body: 'Response content',
+          unprocessableEntity: true
+        })
+        done()
+      })
+    })
+
+    it('submits the form with modal header, credentials and redirects followed', function () {
+      var input = document.createElement('input')
+      input.name = 'field'
+      input.value = 'value'
+      form.appendChild(input)
+
+      fetchMock.post('https://example.com', 200)
+      ModalFetch.postForm(form)
+      expect(fetchMock.lastOptions()).toEqual(jasmine.objectContaining({
+        credentials: 'include',
+        redirect: 'follow',
+        headers: { 'Content-Publisher-Rendering-Context': 'modal' }
+      }))
+      var bodyText = new URLSearchParams(fetchMock.lastOptions().body).toString()
+      expect(bodyText).toEqual('field=value')
+    })
+
+    it('returns a rejected promise on an unsuccessful request', function (done) {
+      fetchMock.post('https://example.com', 404)
+      var promise = ModalFetch.postForm(form)
+      promise.catch(function (error) {
+        expect(error).toEqual('Unable to fetch modal content')
+        done()
+      })
+    })
+
+    it('delegates to ModalFetch.debug on an unsuccessful request', function (done) {
+      fetchMock.post('https://example.com', 404)
+      spyOn(window.ModalFetch, 'debug')
+      var promise = ModalFetch.postForm(form)
+      promise.catch(function () {
+        expect(window.ModalFetch.debug).toHaveBeenCalled()
+        done()
+      })
+    })
+
+    it('times out after 15 seconds for a regular form', function (done) {
+      jasmine.clock().withMock(function () {
+        fetchMock.post('https://example.com', 200, { delay: 20000 })
+        var promise = window.ModalFetch.postForm(form)
+
+        jasmine.clock().tick(15000)
+
+        promise.catch(function (error) {
+          expect(error.name).toEqual('AbortError')
+          done()
+        })
+      })
+    })
+
+    it('doesn\'t abort on a multipart form submission', function (done) {
+      jasmine.clock().withMock(function () {
+        form.setAttribute('enctype', 'multipart/form-data')
+        fetchMock.post('https://example.com', 'Eventual success', { delay: 20000 })
+        var promise = window.ModalFetch.postForm(form)
+
+        jasmine.clock().tick(25000)
+
+        promise.then(function (response) {
+          expect(response).toEqual({
+            body: 'Eventual success',
+            unprocessableEntity: false
+          })
+          done()
+        })
+      })
+    })
+  })
+
+  describe('ModalFetch.debug', function () {
+    var meta
+
+    beforeEach(function () {
+      meta = document.createElement('meta')
+      meta.setAttribute('name', 'app-environment')
+      document.head.appendChild(meta)
+    })
+
+    afterEach(function () {
+      document.head.removeChild(meta)
+    })
+
+    it('sends the response text to console.debug when in production', function (done) {
+      meta.setAttribute('content', 'production')
+      var response = new window.Response('Error message')
+      spyOn(console, 'debug')
+      ModalFetch.debug(response)
+      // This is necessary because the debug call is done on a promise and this
+      // method doesn't return a promise of it's own
+      setTimeout(function () {
+        expect(console.debug).toHaveBeenCalledWith('Error message')
+        done()
+      }, 0)
+    })
+
+    it('doesn\'t send the response text to console.debug outside of production', function (done) {
+      meta.setAttribute('content', 'test')
+      var response = new window.Response('Error message')
+      spyOn(console, 'debug')
+      ModalFetch.debug(response)
+      setTimeout(function () {
+        expect(console.debug).not.toHaveBeenCalled()
+        done()
+      }, 0)
+    })
+  })
+})

--- a/spec/javascripts/modal/modal-workflow-spec.js
+++ b/spec/javascripts/modal/modal-workflow-spec.js
@@ -1,0 +1,141 @@
+/* eslint-env jasmine, jquery */
+/* global ModalWorkflow, buildModalDialogue, removeModalDialogue */
+
+describe('ModalWorkflow', function () {
+  'use strict'
+
+  var actionCallback, modal, modalWorkflow
+
+  beforeEach(function () {
+    actionCallback = jasmine.createSpy('actionCallback')
+    modal = buildModalDialogue()
+    modal.open()
+    modalWorkflow = new ModalWorkflow(modal, actionCallback)
+  })
+
+  afterEach(function () {
+    removeModalDialogue()
+  })
+
+  describe('modalWorkflow.performAction', function () {
+    it('shows a focused loading modal', function () {
+      spyOn(modal, 'focusDialog')
+      var loadingSection = modal.querySelector('#loading')
+
+      modalWorkflow.performAction(document.createElement('a'))
+
+      expect(modal.focusDialog).toHaveBeenCalled()
+      expect(loadingSection).toBeVisible()
+    })
+
+    it('calls the provided actionCallback', function () {
+      var item = document.createElement('a')
+      modalWorkflow.performAction(item)
+      expect(actionCallback).toHaveBeenCalledWith(item)
+    })
+  })
+
+  describe('modalWorkflow.renderSuccess', function () {
+    var dynamicSection
+
+    beforeEach(function () {
+      dynamicSection = modal.querySelector('.js-dynamic-section')
+      spyOn(modalWorkflow, 'performAction')
+    })
+
+    it('renders the result in the modals dynamic section', function () {
+      modalWorkflow.renderSuccess({ body: '<h1>Success</h1>' })
+      expect(dynamicSection).toBeVisible()
+      expect(dynamicSection).toContainHtml('<h1>Success</h1>')
+    })
+
+    it('intercepts submits on forms with modal-action data attributes', function () {
+      var body = '<form action="/" data-modal-action="anything">' +
+                   '<button>Submit</button>' +
+                 '</form>'
+      modalWorkflow.renderSuccess({ body: body })
+      var form = dynamicSection.querySelector('form')
+      form.querySelector('button').click()
+      expect(modalWorkflow.performAction).toHaveBeenCalledWith(form)
+    })
+
+    it('intercepts clicks on links with modal-action data attributes', function () {
+      var body = '<a href="/" data-modal-action="anything">link</a>'
+      modalWorkflow.renderSuccess({ body: body })
+      var link = dynamicSection.querySelector('a')
+      link.click()
+      expect(modalWorkflow.performAction).toHaveBeenCalledWith(link)
+    })
+
+    it('intercepts clicks on buttons with modal-action data attributes', function () {
+      var body = '<form action="/" data-modal-action="anything">' +
+                   '<button data-modal-action="anything">Submit</button>' +
+                 '</form>'
+      modalWorkflow.renderSuccess({ body: body })
+      var form = dynamicSection.querySelector('form')
+      var button = dynamicSection.querySelector('button')
+      button.click()
+      expect(modalWorkflow.performAction).toHaveBeenCalledWith(button)
+      expect(modalWorkflow.performAction).not.toHaveBeenCalledWith(form)
+    })
+
+    it('initialisises the components within the modal', function () {
+      spyOn(window.GOVUK.modules, 'start')
+      spyOn(window.GOVUKFrontend, 'initAll')
+      modalWorkflow.renderSuccess({ body: '' })
+      expect(window.GOVUK.modules.start).toHaveBeenCalledWith($(modal))
+      expect(window.GOVUKFrontend.initAll).toHaveBeenCalledWith(modal)
+    })
+  })
+
+  describe('modalWorkflow.renderError', function () {
+    var errorSection, error
+
+    beforeEach(function () {
+      errorSection = modal.querySelector('#error')
+      error = new Error('Failed')
+      spyOn(window.Raven, 'captureException')
+      spyOn(console, 'error')
+    })
+
+    it('shows the error section', function () {
+      modalWorkflow.renderError(error)
+      expect(errorSection).toBeVisible()
+    })
+
+    it('logs the error to the console and to raven', function () {
+      modalWorkflow.renderError(error)
+      expect(window.Raven.captureException).toHaveBeenCalledWith(error)
+      expect(console.error).toHaveBeenCalledWith(error)
+    })
+  })
+
+  describe('.render', function () {
+    beforeEach(function () {
+      spyOn(modalWorkflow, 'renderSuccess')
+      spyOn(modalWorkflow, 'renderError')
+    })
+
+    it('delegates to render success on a resolved promise response', function (done) {
+      var response = window.Promise.resolve('success')
+      modalWorkflow.render(response)
+
+      // timeout to ensure running after promise handling has completed
+      setTimeout(function () {
+        expect(modalWorkflow.renderSuccess).toHaveBeenCalledWith('success')
+        done()
+      }, 0)
+    })
+
+    it('delegates to render error on a rejected promise response', function (done) {
+      var response = window.Promise.reject('error')
+      modalWorkflow.render(response)
+
+      // timeout to ensure running after promise handling has completed
+      setTimeout(function () {
+        expect(modalWorkflow.renderError).toHaveBeenCalledWith('error')
+        done()
+      }, 0)
+    })
+  })
+})

--- a/spec/javascripts/modules/contact-embed-modal-spec.js
+++ b/spec/javascripts/modules/contact-embed-modal-spec.js
@@ -1,0 +1,83 @@
+/* eslint-env jasmine */
+/* global ContactEmbedModal, fetchMock, buildModalDialogue, removeModalDialogue */
+
+describe('ContactEmbedModal', function () {
+  'use strict'
+
+  var modal, openLink, contactEmbedModal
+
+  beforeEach(function () {
+    modal = buildModalDialogue()
+
+    openLink = document.createElement('a')
+    openLink.dataset.modalAction = 'open'
+    openLink.href = 'https://example.com/contact-embed'
+
+    contactEmbedModal = new ContactEmbedModal(openLink)
+    contactEmbedModal.init()
+  })
+
+  afterEach(function () {
+    removeModalDialogue()
+  })
+
+  describe('opening the modal', function () {
+    it('opens from a click and renders the linked resource in the modal dynamic section', function (done) {
+      fetchMock.get('https://example.com/contact-embed', '<h1>Contact response</h1>')
+
+      openLink.click()
+
+      fetchMock.flush(true).then(function () {
+        var dynamicSection = modal.querySelector('.js-dynamic-section')
+        expect(dynamicSection).toBeVisible()
+        expect(dynamicSection).toContainHtml('<h1>Contact response</h1>')
+        done()
+      })
+    })
+  })
+
+  describe('inserting a contact', function () {
+    beforeEach(function () {
+      modal.open()
+      var body = '<form action="https://example.com/contact-embed" method="post" data-modal-action="insert">' +
+                   '<button type="submit">Submit</button>' +
+                 '</form>'
+      contactEmbedModal.workflow.renderSuccess({ body: body })
+    })
+
+    it('closes the modal and adds the response to the editor on success', function (done) {
+      fetchMock.post('https://example.com/contact-embed', '[Contact:123]')
+      modal.querySelector('button').click()
+      spyOn(contactEmbedModal.editor, 'insertBlock')
+      fetchMock.flush(true).then(function () {
+        expect(modal).toBeHidden()
+        expect(contactEmbedModal.editor.insertBlock).toHaveBeenCalledWith('[Contact:123]')
+        done()
+      })
+    })
+
+    it('shows the response when there is a validation issue', function (done) {
+      fetchMock.post(
+        'https://example.com/contact-embed',
+        { status: 422, body: '<h1>Validation issues</h1>' }
+      )
+      modal.querySelector('button').click()
+      fetchMock.flush(true).then(function () {
+        var dynamicSection = modal.querySelector('.js-dynamic-section')
+        expect(dynamicSection).toBeVisible()
+        expect(dynamicSection).toContainHtml('<h1>Validation issues</h1>')
+        done()
+      })
+    })
+
+    it('shows the modal error view on a different error response', function (done) {
+      fetchMock.post('https://example.com/contact-embed', 500)
+      modal.querySelector('button').click()
+      fetchMock.flush(true).then(function () {
+        var errorSection = modal.querySelector('#error')
+        expect(errorSection).toBeVisible()
+        done()
+      })
+    })
+  })
+})

--- a/spec/javascripts/modules/inline-attachment-modal-spec.js
+++ b/spec/javascripts/modules/inline-attachment-modal-spec.js
@@ -1,0 +1,147 @@
+/* eslint-env jasmine */
+/* global InlineAttachmentModal, fetchMock, buildModalDialogue, removeModalDialogue */
+
+describe('InlineAttachmentModal', function () {
+  'use strict'
+
+  var modal, openLink, inlineAttachmentModal
+
+  function itBehavesLikeAFormAction (action) {
+    var url = 'https://example.com/' + action
+    var body = '<form action="' + url + '" method="post" data-modal-action="' + action + '">' +
+                 '<button>Submit</button>' +
+               '</form>'
+
+    it('updates the modal with the form response', function (done) {
+      modal.open()
+      inlineAttachmentModal.workflow.renderSuccess({ body: body })
+
+      fetchMock.post(url, '<h1>Form submitted</h1>')
+      var dynamicSection = modal.querySelector('.js-dynamic-section')
+      dynamicSection.querySelector('button').click()
+
+      fetchMock.flush(true).then(function () {
+        expect(dynamicSection).toBeVisible()
+        expect(dynamicSection).toContainHtml('<h1>Form submitted</h1>')
+        done()
+      })
+    })
+  }
+
+  function itBehavesLikeALinkAction (action) {
+    var url = 'https://example.com/' + action
+    var body = '<a href="' + url + '" data-modal-action="' + action + '">Link</a>'
+
+    it('updates the modal with the link response', function (done) {
+      modal.open()
+      inlineAttachmentModal.workflow.renderSuccess({ body: body })
+
+      fetchMock.get(url, '<h1>Link followed</h1>')
+      var dynamicSection = modal.querySelector('.js-dynamic-section')
+      dynamicSection.querySelector('a').click()
+
+      fetchMock.flush(true).then(function () {
+        expect(dynamicSection).toBeVisible()
+        expect(dynamicSection).toContainHtml('<h1>Link followed</h1>')
+        done()
+      })
+    })
+  }
+
+  beforeEach(function () {
+    modal = buildModalDialogue()
+
+    openLink = document.createElement('a')
+    openLink.dataset.modalAction = 'open'
+    openLink.href = 'https://example.com/inline-attachment'
+
+    inlineAttachmentModal = new InlineAttachmentModal(openLink)
+    inlineAttachmentModal.init()
+  })
+
+  afterEach(function () {
+    removeModalDialogue()
+  })
+
+  describe('open action', function () {
+    it('opens when the link is clicked and shows the content', function (done) {
+      fetchMock.get('https://example.com/inline-attachment', '<h1>Inline attachment</h1>')
+      openLink.click()
+
+      fetchMock.flush(true).then(function () {
+        var dynamicSection = modal.querySelector('.js-dynamic-section')
+        expect(dynamicSection).toBeVisible()
+        expect(dynamicSection).toContainHtml('<h1>Inline attachment</h1>')
+        done()
+      })
+    })
+  })
+
+  describe('upload action', function () {
+    itBehavesLikeAFormAction('upload')
+  })
+
+  describe('insert action', function () {
+    itBehavesLikeALinkAction('insert')
+  })
+
+  describe('delete action', function () {
+    itBehavesLikeAFormAction('delete')
+  })
+
+  describe('edit action', function () {
+    itBehavesLikeALinkAction('edit')
+  })
+
+  describe('update action', function () {
+    itBehavesLikeAFormAction('update')
+  })
+
+  describe('back action', function () {
+    itBehavesLikeALinkAction('back')
+  })
+
+  describe('insert-attachment-block action', function () {
+    beforeEach(function () {
+      modal.open()
+      var body = '<form action="https://example.com/insert-block" method="post" ' +
+                   'data-modal-action="insert-attachment-block" data-modal-data="[Attachment:file.pdf]">' +
+                   '<button>Submit</button>' +
+                 '</form>'
+      inlineAttachmentModal.workflow.renderSuccess({ body: body })
+    })
+
+    it('closes the modal and inserts the form modal data into the editor as block content', function (done) {
+      fetchMock.post('https://example.com/insert-block', 200)
+      spyOn(inlineAttachmentModal.editor, 'insertBlock')
+      modal.querySelector('button').click()
+      fetchMock.flush(true).then(function () {
+        expect(modal).toBeHidden()
+        expect(inlineAttachmentModal.editor.insertBlock).toHaveBeenCalledWith('[Attachment:file.pdf]')
+        done()
+      })
+    })
+  })
+
+  describe('insert-attachment-link action', function () {
+    beforeEach(function () {
+      modal.open()
+      var body = '<form action="https://example.com/insert-link" method="post" ' +
+                   'data-modal-action="insert-attachment-link" data-modal-data="[AttachmentLink:file.pdf]">' +
+                   '<button>Submit</button>' +
+                 '</form>'
+      inlineAttachmentModal.workflow.renderSuccess({ body: body })
+    })
+
+    it('closes the modal and inserts the form modal data into the editor as inline content', function (done) {
+      fetchMock.post('https://example.com/insert-link', 200)
+      spyOn(inlineAttachmentModal.editor, 'insertInline')
+      modal.querySelector('button').click()
+      fetchMock.flush(true).then(function () {
+        expect(modal).toBeHidden()
+        expect(inlineAttachmentModal.editor.insertInline).toHaveBeenCalledWith('[AttachmentLink:file.pdf]')
+        done()
+      })
+    })
+  })
+})

--- a/spec/javascripts/modules/inline-image-modal-spec.js
+++ b/spec/javascripts/modules/inline-image-modal-spec.js
@@ -1,0 +1,167 @@
+/* eslint-env jasmine */
+/* global InlineImageModal, fetchMock, buildModalDialogue, removeModalDialogue */
+
+describe('InlineImageModal', function () {
+  'use strict'
+
+  var modal, openLink, inlineImageModal
+
+  function itBehavesLikeAFormAction (action) {
+    var url = 'https://example.com/' + action
+    var body = '<form action="' + url + '" method="post" data-modal-action="' + action + '">' +
+                 '<button>Submit</button>' +
+               '</form>'
+
+    it('updates the modal with the form response', function (done) {
+      modal.open()
+      inlineImageModal.workflow.renderSuccess({ body: body })
+
+      fetchMock.post(url, '<h1>Form submitted</h1>')
+      var dynamicSection = modal.querySelector('.js-dynamic-section')
+      dynamicSection.querySelector('button').click()
+
+      fetchMock.flush(true).then(function () {
+        expect(dynamicSection).toBeVisible()
+        expect(dynamicSection).toContainHtml('<h1>Form submitted</h1>')
+        done()
+      })
+    })
+  }
+
+  function itBehavesLikeALinkAction (action) {
+    var url = 'https://example.com/' + action
+    var body = '<a href="' + url + '" data-modal-action="' + action + '">Link</a>'
+
+    it('updates the modal with the link response', function (done) {
+      modal.open()
+      inlineImageModal.workflow.renderSuccess({ body: body })
+
+      fetchMock.get(url, '<h1>Link followed</h1>')
+      var dynamicSection = modal.querySelector('.js-dynamic-section')
+      dynamicSection.querySelector('a').click()
+
+      fetchMock.flush(true).then(function () {
+        expect(dynamicSection).toBeVisible()
+        expect(dynamicSection).toContainHtml('<h1>Link followed</h1>')
+        done()
+      })
+    })
+  }
+
+  beforeEach(function () {
+    modal = buildModalDialogue()
+
+    openLink = document.createElement('a')
+    openLink.dataset.modalAction = 'open'
+    openLink.href = 'https://example.com/inline-image'
+
+    inlineImageModal = new InlineImageModal(openLink)
+    inlineImageModal.init()
+  })
+
+  afterEach(function () {
+    removeModalDialogue()
+  })
+
+  describe('open action', function () {
+    it('opens when the link is clicked and shows the content', function (done) {
+      fetchMock.get('https://example.com/inline-image', '<h1>Inline image</h1>')
+      openLink.click()
+
+      fetchMock.flush(true).then(function () {
+        var dynamicSection = modal.querySelector('.js-dynamic-section')
+        expect(dynamicSection).toBeVisible()
+        expect(dynamicSection).toContainHtml('<h1>Inline image</h1>')
+        done()
+      })
+    })
+  })
+
+  describe('insert action', function () {
+    it('inserts the markdown into the editor and closes the modal', function () {
+      var markdown = '[Image:file.jog]'
+      var body = '<button type="button" data-modal-action="insert" data-modal-data="' + markdown + '">Insert</button>'
+      modal.open()
+      inlineImageModal.workflow.renderSuccess({ body: body })
+      spyOn(inlineImageModal.editor, 'insertBlock')
+
+      modal.querySelector('button').click()
+      expect(modal).toBeHidden()
+      expect(inlineImageModal.editor.insertBlock).toHaveBeenCalledWith(markdown)
+    })
+  })
+
+  describe('upload action', function () {
+    itBehavesLikeAFormAction('upload')
+  })
+
+  describe('cropBack action', function () {
+    itBehavesLikeALinkAction('cropBack')
+  })
+
+  describe('metaBack action', function () {
+    itBehavesLikeALinkAction('metaBack')
+  })
+
+  describe('crop action', function () {
+    itBehavesLikeAFormAction('crop')
+  })
+
+  describe('delete action', function () {
+    itBehavesLikeAFormAction('delete')
+  })
+
+  describe('meta action', function () {
+    itBehavesLikeAFormAction('meta')
+  })
+
+  describe('edit action', function () {
+    itBehavesLikeALinkAction('edit')
+  })
+
+  describe('metaInsert action', function () {
+    beforeEach(function () {
+      modal.open()
+      var body = '<form action="https://example.com/meta-insert" method="post" ' +
+                   'data-modal-action="metaInsert" data-modal-data="[Image:file.jpg]">' +
+                   '<button>Submit</button>' +
+                 '</form>'
+      inlineImageModal.workflow.renderSuccess({ body: body })
+    })
+
+    it('closes the modal and inserts the form modal data into the editor', function (done) {
+      fetchMock.post('https://example.com/meta-insert', 200)
+      modal.querySelector('button').click()
+      spyOn(inlineImageModal.editor, 'insertBlock')
+      fetchMock.flush(true).then(function () {
+        expect(modal).toBeHidden()
+        expect(inlineImageModal.editor.insertBlock).toHaveBeenCalledWith('[Image:file.jpg]')
+        done()
+      })
+    })
+
+    it('shows the response when there is a validation issue', function (done) {
+      fetchMock.post(
+        'https://example.com/meta-insert',
+        { status: 422, body: '<h1>Validation issues</h1>' }
+      )
+      modal.querySelector('button').click()
+      fetchMock.flush(true).then(function () {
+        var dynamicSection = modal.querySelector('.js-dynamic-section')
+        expect(dynamicSection).toBeVisible()
+        expect(dynamicSection).toContainHtml('<h1>Validation issues</h1>')
+        done()
+      })
+    })
+
+    it('shows the modal error view on a different error response', function (done) {
+      fetchMock.post('https://example.com/meta-insert', 500)
+      modal.querySelector('button').click()
+      fetchMock.flush(true).then(function () {
+        var errorSection = modal.querySelector('#error')
+        expect(errorSection).toBeVisible()
+        done()
+      })
+    })
+  })
+})

--- a/spec/javascripts/modules/video-embed-modal-spec.js
+++ b/spec/javascripts/modules/video-embed-modal-spec.js
@@ -1,0 +1,82 @@
+/* eslint-env jasmine */
+/* global VideoEmbedModal, fetchMock, buildModalDialogue, removeModalDialogue */
+
+describe('VideoEmbedModal', function () {
+  'use strict'
+
+  var modal, openLink, videoEmbedModal
+
+  beforeEach(function () {
+    modal = buildModalDialogue()
+
+    openLink = document.createElement('a')
+    openLink.dataset.modalAction = 'open'
+    openLink.href = 'https://example.com/video-embed'
+
+    videoEmbedModal = new VideoEmbedModal(openLink)
+    videoEmbedModal.init()
+  })
+
+  afterEach(function () {
+    removeModalDialogue()
+  })
+
+  describe('open action', function () {
+    it('opens from a click and renders the linked resource in the modal dynamic section', function (done) {
+      fetchMock.get('https://example.com/video-embed', '<h1>Video response</h1>')
+      openLink.click()
+
+      fetchMock.flush(true).then(function () {
+        var dynamicSection = modal.querySelector('.js-dynamic-section')
+        expect(dynamicSection).toBeVisible()
+        expect(dynamicSection).toContainHtml('<h1>Video response</h1>')
+        done()
+      })
+    })
+  })
+
+  describe('insert action', function () {
+    beforeEach(function () {
+      modal.open()
+      var body = '<form action="https://example.com/video-embed" method="post" data-modal-action="insert">' +
+                   '<button>Submit</button>' +
+                 '</form>'
+      videoEmbedModal.workflow.renderSuccess({ body: body })
+    })
+
+    it('closes the modal and adds the response to the editor on success', function (done) {
+      fetchMock.post('https://example.com/video-embed', '[link](https://www.youtube.com/id)')
+      modal.querySelector('button').click()
+      spyOn(videoEmbedModal.editor, 'insertBlock')
+      fetchMock.flush(true).then(function () {
+        expect(modal).toBeHidden()
+        expect(videoEmbedModal.editor.insertBlock).toHaveBeenCalledWith('[link](https://www.youtube.com/id)')
+        done()
+      })
+    })
+
+    it('shows the response when there is a validation issue', function (done) {
+      fetchMock.post(
+        'https://example.com/video-embed',
+        { status: 422, body: '<h1>Validation issues</h1>' }
+      )
+      modal.querySelector('button').click()
+      fetchMock.flush(true).then(function () {
+        var dynamicSection = modal.querySelector('.js-dynamic-section')
+        expect(dynamicSection).toBeVisible()
+        expect(dynamicSection).toContainHtml('<h1>Validation issues</h1>')
+        done()
+      })
+    })
+
+    it('shows the modal error view on a different error response', function (done) {
+      fetchMock.post('https://example.com/video-embed', 500)
+      modal.querySelector('button').click()
+      fetchMock.flush(true).then(function () {
+        var errorSection = modal.querySelector('#error')
+        expect(errorSection).toBeVisible()
+        done()
+      })
+    })
+  })
+})

--- a/yarn.lock
+++ b/yarn.lock
@@ -14,7 +14,6 @@ abortcontroller-polyfill@^1.4.0:
 
 "accessible-autocomplete@git://github.com/kevindew/accessible-autocomplete.git":
   version "1.6.2"
-  uid "62b3992f9d3f2da6c7ea5bc0e302b9e453234271"
   resolved "git://github.com/kevindew/accessible-autocomplete.git#62b3992f9d3f2da6c7ea5bc0e302b9e453234271"
   dependencies:
     preact "^8.3.1"
@@ -94,6 +93,14 @@ babel-code-frame@^6.26.0:
     chalk "^1.1.3"
     esutils "^2.0.2"
     js-tokens "^3.0.2"
+
+babel-runtime@^6.26.0:
+  version "6.26.0"
+  resolved "https://registry.yarnpkg.com/babel-runtime/-/babel-runtime-6.26.0.tgz#965c7058668e82b55d7bfe04ff2337bc8b5647fe"
+  integrity sha1-llxwWGaOgrVde/4E/yM3vItWR/4=
+  dependencies:
+    core-js "^2.4.0"
+    regenerator-runtime "^0.11.0"
 
 balanced-match@^1.0.0:
   version "1.0.0"
@@ -188,6 +195,16 @@ core-js-bundle@^3.6.4:
   version "3.6.4"
   resolved "https://registry.yarnpkg.com/core-js-bundle/-/core-js-bundle-3.6.4.tgz#d4e098323c035f4a1b61f00db0b8def04c243920"
   integrity sha512-qDHS3GbIEs5dZaBiCVhhtCoF79KU/ek0w+H7zfJf9RuGN0GiKfxHZfAtDy4zFtQ6X00t7Wvvr3wHzMj+/IgbPg==
+
+core-js@^2.4.0:
+  version "2.6.11"
+  resolved "https://registry.yarnpkg.com/core-js/-/core-js-2.6.11.tgz#38831469f9922bded8ee21c9dc46985e0399308c"
+  integrity sha512-5wjnpaT/3dV+XB4borEsnAYQchn00XSgTAWKDkEqv+K8KevjbzmofK6hfJ9TZIlpj2N0xQpazy7PiRQiWHqzWg==
+
+core-js@^3.0.0:
+  version "3.6.2"
+  resolved "https://registry.yarnpkg.com/core-js/-/core-js-3.6.2.tgz#2799ea1a59050f0acf50dfe89b916d6503b16caa"
+  integrity sha512-hIE5dXkRzRvnZ5vhkRfQxUvDxQZmD9oueA08jDYRBKJHx+VIl/Pne/e0A4x9LObEEthC/TqiZybUoNM4tRgnKg==
 
 cropperjs@^1.5.6:
   version "1.5.6"
@@ -514,6 +531,19 @@ fast-levenshtein@~2.0.4:
   resolved "https://registry.yarnpkg.com/fast-levenshtein/-/fast-levenshtein-2.0.6.tgz#3d8a5c66883a16a30ca8643e851f19baa7797917"
   integrity sha1-PYpcZog6FqMMqGQ+hR8Zuqd5eRc=
 
+fetch-mock@^8.3.1:
+  version "8.3.1"
+  resolved "https://registry.yarnpkg.com/fetch-mock/-/fetch-mock-8.3.1.tgz#9c79aab22fa1752fe00b487e2b271ecfc1138461"
+  integrity sha512-7IEIUvkHO6zOHbDSzkMAvkb2mx3N5xy9BS4RjFnIe8kCUDOomoNKBDKGwhTj5E0uuieo8rg55c6cUKorJuk4rg==
+  dependencies:
+    babel-runtime "^6.26.0"
+    core-js "^3.0.0"
+    glob-to-regexp "^0.4.0"
+    lodash.isequal "^4.5.0"
+    path-to-regexp "^2.2.1"
+    querystring "^0.2.0"
+    whatwg-url "^6.5.0"
+
 figures@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/figures/-/figures-2.0.0.tgz#3ab1a2d2a62c8bfb431a0c94cb797a2fce27c962"
@@ -570,6 +600,11 @@ get-stdin@^6.0.0:
   version "6.0.0"
   resolved "https://registry.yarnpkg.com/get-stdin/-/get-stdin-6.0.0.tgz#9e09bf712b360ab9225e812048f71fde9c89657b"
   integrity sha512-jp4tHawyV7+fkkSKyvjuLZswblUtz+SQKzSWnBbii16BuZksJlU1wuBYXY75r+duh/llF1ur6oNwi+2ZzjKZ7g==
+
+glob-to-regexp@^0.4.0:
+  version "0.4.1"
+  resolved "https://registry.yarnpkg.com/glob-to-regexp/-/glob-to-regexp-0.4.1.tgz#c75297087c851b9a578bd217dd59a92f59fe546e"
+  integrity sha512-lkX1HJXwyMcprw/5YUZc2s7DrpAiHB21/V+E1rHUrVNokkvB6bqMzT0VfV6/86ZNabt1k14YOIaT7nDvOX3Iiw==
 
 glob@^7.0.5, glob@^7.1.2, glob@^7.1.3:
   version "7.1.4"
@@ -806,6 +841,16 @@ locate-path@^2.0.0:
     p-locate "^2.0.0"
     path-exists "^3.0.0"
 
+lodash.isequal@^4.5.0:
+  version "4.5.0"
+  resolved "https://registry.yarnpkg.com/lodash.isequal/-/lodash.isequal-4.5.0.tgz#415c4478f2bcc30120c22ce10ed3226f7d3e18e0"
+  integrity sha1-QVxEePK8wwEgwizhDtMib30+GOA=
+
+lodash.sortby@^4.7.0:
+  version "4.7.0"
+  resolved "https://registry.yarnpkg.com/lodash.sortby/-/lodash.sortby-4.7.0.tgz#edd14c824e2cc9c1e0b0a1b42bb5210516a42438"
+  integrity sha1-7dFMgk4sycHgsKG0K7UhBRakJDg=
+
 lodash@^4.17.4, lodash@^4.3.0:
   version "4.17.14"
   resolved "https://registry.yarnpkg.com/lodash/-/lodash-4.17.14.tgz#9ce487ae66c96254fe20b599f21b6816028078ba"
@@ -1002,6 +1047,11 @@ path-parse@^1.0.6:
   resolved "https://registry.yarnpkg.com/path-parse/-/path-parse-1.0.6.tgz#d62dbb5679405d72c4737ec58600e9ddcf06d24c"
   integrity sha512-GSmOT2EbHrINBf9SR7CDELwlJ8AENk3Qn7OikK4nFYAu3Ote2+JYNVvkpAEQm3/TLNEJFD/xZJjzyxg3KBWOzw==
 
+path-to-regexp@^2.2.1:
+  version "2.4.0"
+  resolved "https://registry.yarnpkg.com/path-to-regexp/-/path-to-regexp-2.4.0.tgz#35ce7f333d5616f1c1e1bfe266c3aba2e5b2e704"
+  integrity sha512-G6zHoVqC6GGTQkZwF4lkuEyMbVOjoBKAEybQUypI1WTkqinCOrq2x6U2+phkJ1XsEMTy4LjtwPI7HW+NVrRR2w==
+
 path-type@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/path-type/-/path-type-2.0.0.tgz#f012ccb8415b7096fc2daa1054c3d72389594c73"
@@ -1076,6 +1126,11 @@ punycode@^2.1.0:
   resolved "https://registry.yarnpkg.com/punycode/-/punycode-2.1.1.tgz#b58b010ac40c22c5657616c8d2c2c02c7bf479ec"
   integrity sha512-XRsRjdf+j5ml+y/6GKHPZbrF/8p2Yga0JPtdqTIY2Xe5ohJPD9saDJJLPvp9+NSBprVvevdXZybnj2cv8OEd0A==
 
+querystring@^0.2.0:
+  version "0.2.0"
+  resolved "https://registry.yarnpkg.com/querystring/-/querystring-0.2.0.tgz#b209849203bb25df820da756e747005878521620"
+  integrity sha1-sgmEkgO7Jd+CDadW50cAWHhSFiA=
+
 raven-js@^3.27.2:
   version "3.27.2"
   resolved "https://registry.yarnpkg.com/raven-js/-/raven-js-3.27.2.tgz#6c33df952026cd73820aa999122b7b7737a66775"
@@ -1102,6 +1157,11 @@ read-pkg@^2.0.0:
     load-json-file "^2.0.0"
     normalize-package-data "^2.3.2"
     path-type "^2.0.0"
+
+regenerator-runtime@^0.11.0:
+  version "0.11.1"
+  resolved "https://registry.yarnpkg.com/regenerator-runtime/-/regenerator-runtime-0.11.1.tgz#be05ad7f9bf7d22e056f9726cee5017fbf19e2e9"
+  integrity sha512-MguG95oij0fC3QV3URf4V2SDYGJhJnJGqvIIgdECeODCT98wSWDAJ94SSuVpYQUoTcGUIL6L4yNB7j1DFFHSBg==
 
 regexpp@^2.0.0, regexpp@^2.0.1:
   version "2.0.1"
@@ -1342,6 +1402,13 @@ tmp@^0.0.33:
   dependencies:
     os-tmpdir "~1.0.2"
 
+tr46@^1.0.1:
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/tr46/-/tr46-1.0.1.tgz#a8b13fd6bfd2489519674ccde55ba3693b706d09"
+  integrity sha1-qLE/1r/SSJUZZ0zN5VujaTtwbQk=
+  dependencies:
+    punycode "^2.1.0"
+
 type-check@~0.3.2:
   version "0.3.2"
   resolved "https://registry.yarnpkg.com/type-check/-/type-check-0.3.2.tgz#5884cab512cf1d355e3fb784f30804b2b520db72"
@@ -1374,9 +1441,23 @@ validate-npm-package-license@^3.0.1:
     spdx-correct "^3.0.0"
     spdx-expression-parse "^3.0.0"
 
+webidl-conversions@^4.0.2:
+  version "4.0.2"
+  resolved "https://registry.yarnpkg.com/webidl-conversions/-/webidl-conversions-4.0.2.tgz#a855980b1f0b6b359ba1d5d9fb39ae941faa63ad"
+  integrity sha512-YQ+BmxuTgd6UXZW3+ICGfyqRyHXVlD5GtQr5+qjiNW7bF0cqrzX500HVXPBOvgXb5YnzDd+h0zqyv61KUD7+Sg==
+
 whatwg-fetch@^3.0.0:
   version "3.0.0"
   resolved "https://registry.yarnpkg.com/whatwg-fetch/-/whatwg-fetch-3.0.0.tgz#fc804e458cc460009b1a2b966bc8817d2578aefb"
+
+whatwg-url@^6.5.0:
+  version "6.5.0"
+  resolved "https://registry.yarnpkg.com/whatwg-url/-/whatwg-url-6.5.0.tgz#f2df02bff176fd65070df74ad5ccbb5a199965a8"
+  integrity sha512-rhRZRqx/TLJQWUpQ6bmrt2UV4f0HCQ463yQuONJqC6fO2VoEb1pTYddbe59SkYq87aoM5A3bdhMZiUiVws+fzQ==
+  dependencies:
+    lodash.sortby "^4.7.0"
+    tr46 "^1.0.1"
+    webidl-conversions "^4.0.2"
 
 which@^1.2.9:
   version "1.3.1"


### PR DESCRIPTION
Trello: https://trello.com/c/wgkfOJsE/1283-improve-consistency-in-content-publisher-tests

This card ties into the [Contact Embed PR](https://github.com/alphagov/content-publisher/pull/1626), where Ben pointed out that feature tests were the only thing testing some modal code and a [wall of pain card](https://trello.com/c/GVp3CoMH/1030-our-modal-scripts-dont-have-tests) that Alex raised back in June following problems with the modal and discovering there wasn't prior art to testing them.

In these tests I wrestled a couple of things I wasn't too sure about: on one side what the convention is for the naming of Jasmine unit tests (for example `describe("Class.method")`) and wondering whether similar modal code should be tested with shared helpers or not.

Easiest way to review this would be to go through it commit by commit.