### PR TITLE
Remove the start_time column from Whitehall Migrations

### DIFF
--- a/db/migrate/20200114140323_remove_migration_start_time.rb
+++ b/db/migrate/20200114140323_remove_migration_start_time.rb
@@ -1,0 +1,9 @@
+# frozen_string_literal: true
+
+class RemoveMigrationStartTime < ActiveRecord::Migration[6.0]
+  def change
+    remove_column :whitehall_migrations,
+                  :start_time,
+                  :datetime
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2020_01_07_151448) do
+ActiveRecord::Schema.define(version: 2020_01_14_140323) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -363,7 +363,6 @@ ActiveRecord::Schema.define(version: 2020_01_07_151448) do
   create_table "whitehall_migrations", force: :cascade do |t|
     t.text "organisation_content_id", null: false
     t.text "document_type", null: false
-    t.datetime "start_time"
     t.datetime "end_time"
     t.datetime "created_at", precision: 6, null: false
     t.datetime "updated_at", precision: 6, null: false

--- a/lib/whitehall_importer.rb
+++ b/lib/whitehall_importer.rb
@@ -6,8 +6,7 @@ module WhitehallImporter
   def self.create_migration(organisation_content_id, document_type)
     whitehall_migration = ActiveRecord::Base.transaction do
       record = WhitehallMigration.create!(organisation_content_id: organisation_content_id,
-                                 document_type: document_type,
-                                 start_time: Time.current)
+                                          document_type: document_type)
 
       whitehall_export = GdsApi.whitehall_export.document_list(organisation_content_id, document_type)
 

--- a/spec/factories/whitehall_migration_factory.rb
+++ b/spec/factories/whitehall_migration_factory.rb
@@ -5,7 +5,6 @@ FactoryBot.define do
     sequence(:id)
     organisation_content_id { "content_id" }
     document_type { "NewsArticle" }
-    start_time { Time.current }
     created_at { Time.current.rfc3339 }
     updated_at { Time.current.rfc3339 }
   end

--- a/spec/lib/whitehall_importer_spec.rb
+++ b/spec/lib/whitehall_importer_spec.rb
@@ -19,7 +19,7 @@ RSpec.describe WhitehallImporter do
         expect { WhitehallImporter.create_migration("123", "NewsArticle") }.to change { WhitehallMigration.count }.by(1)
         expect(WhitehallMigration.last.organisation_content_id).to eq("123")
         expect(WhitehallMigration.last.document_type).to eq("NewsArticle")
-        expect(WhitehallMigration.last.start_time).to eq(Time.current)
+        expect(WhitehallMigration.last.created_at).to eq(Time.current)
       end
     end
 


### PR DESCRIPTION
It was surplus to requirements and also doesn't fit in with rails convention. We'll be using the `created_at` column from here on out. This also changes any references to the `start_time` column.

Trello - https://trello.com/c/HxOpHnf9/1272-queue-a-job-to-import-document-from-whitehall
Related - https://github.com/alphagov/content-publisher/pull/1615