### PR TITLE
Rename the Whitehall Migrations end_time column

### DIFF
--- a/app/models/whitehall_migration.rb
+++ b/app/models/whitehall_migration.rb
@@ -4,6 +4,6 @@ class WhitehallMigration < ApplicationRecord
   has_many :document_imports
 
   def check_migration_finished
-    update!(end_time: Time.current) if document_imports.in_progress.empty?
+    update!(finished_at: Time.current) if document_imports.in_progress.empty?
   end
 end

--- a/db/migrate/20200114163932_rename_whitehall_migrations_end_time.rb
+++ b/db/migrate/20200114163932_rename_whitehall_migrations_end_time.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+class RenameWhitehallMigrationsEndTime < ActiveRecord::Migration[6.0]
+  def change
+    rename_column :whitehall_migrations, :end_time, :finished_at
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2020_01_14_140323) do
+ActiveRecord::Schema.define(version: 2020_01_14_163932) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -363,7 +363,7 @@ ActiveRecord::Schema.define(version: 2020_01_14_140323) do
   create_table "whitehall_migrations", force: :cascade do |t|
     t.text "organisation_content_id", null: false
     t.text "document_type", null: false
-    t.datetime "end_time"
+    t.datetime "finished_at"
     t.datetime "created_at", precision: 6, null: false
     t.datetime "updated_at", precision: 6, null: false
   end

--- a/spec/models/whitehall_migration_spec.rb
+++ b/spec/models/whitehall_migration_spec.rb
@@ -15,7 +15,7 @@ RSpec.describe WhitehallMigration do
       it "updates each of the end times" do
         freeze_time do
           whitehall_migration.check_migration_finished
-          expect(whitehall_migration.end_time).to eq(Time.current)
+          expect(whitehall_migration.finished_at).to eq(Time.current)
         end
       end
     end
@@ -29,7 +29,7 @@ RSpec.describe WhitehallMigration do
 
       it "does not update each of the end times" do
         whitehall_migration.check_migration_finished
-        expect(whitehall_migration.end_time).to be_nil
+        expect(whitehall_migration.finished_at).to be_nil
       end
     end
   end


### PR DESCRIPTION
This makes it more in line with rails customs. It also renames the references to the column.

Trello - https://trello.com/c/HxOpHnf9/1272-queue-a-job-to-import-document-from-whitehall