### PR TITLE
Add page info to pagination links

### DIFF
--- a/app/views/documents/history.html.erb
+++ b/app/views/documents/history.html.erb
@@ -75,11 +75,21 @@
     <% end %>
 
     <%
-    pages = {}
-    pages[:previous_page] = { url: document_history_path(page: @timeline_entries.prev_page),
-                              title: "Previous page" } if @timeline_entries.prev_page
-    pages[:next_page] = { url: document_history_path(page: @timeline_entries.next_page),
-                          title: "Next page" } if @timeline_entries.next_page
+      pages = {}
+      previous_page_info = t("documents.history.page_info",
+                             page: @timeline_entries.prev_page,
+                             pages: @timeline_entries.total_pages)
+
+      next_page_info = t("documents.history.page_info",
+                         page: @timeline_entries.next_page,
+                         pages: @timeline_entries.total_pages)
+
+      pages[:previous_page] = { url: document_history_path(page: @timeline_entries.prev_page),
+                                label: previous_page_info,
+                                title: "Previous page" } if @timeline_entries.prev_page
+      pages[:next_page] = { url: document_history_path(page: @timeline_entries.next_page),
+                            label: next_page_info,
+                            title: "Next page" } if @timeline_entries.next_page
     %>
 
     <%= render "govuk_publishing_components/components/previous_and_next_navigation", pages %>

--- a/app/views/documents/index.html.erb
+++ b/app/views/documents/index.html.erb
@@ -35,19 +35,22 @@
       <%= render "documents/index/results" %>
     <% end %>
 
-    <% pages = { } %>
+    <%
+      pages = {}
+      previous_page_info = t("documents.index.search_results.page_info",
+                             page: @editions.prev_page,
+                             pages: @editions.total_pages)
+      next_page_info = t("documents.index.search_results.page_info",
+                         page: @editions.next_page,
+                         pages: @editions.total_pages)
 
-    <% page_info = t("documents.index.search_results.page_info",
-                     page: @editions.current_page,
-                     pages: @editions.total_pages) %>
-
-    <% pages[:previous_page] = { url: documents_path(@filter_params.merge(page: @editions.prev_page)),
-                                 label: page_info,
-                                 title: "Previous page" } if @editions.prev_page %>
-
-    <% pages[:next_page] = { url: documents_path(@filter_params.merge(page: @editions.next_page)),
-                             label: page_info,
-                             title: "Next page" } if @editions.next_page %>
+      pages[:previous_page] = { url: documents_path(@filter_params.merge(page: @editions.prev_page)),
+                                label: previous_page_info,
+                                title: "Previous page" } if @editions.prev_page
+      pages[:next_page] = { url: documents_path(@filter_params.merge(page: @editions.next_page)),
+                            label: next_page_info,
+                            title: "Next page" } if @editions.next_page
+    %>
 
     <%= render "govuk_publishing_components/components/previous_and_next_navigation", pages %>
   </div>

--- a/config/locales/en/documents/history.yml
+++ b/config/locales/en/documents/history.yml
@@ -3,6 +3,7 @@ en:
     history:
       edition_header: "%{number} edition"
       add_internal_note: "Add internal note"
+      page_info: "%{page} of %{pages}"
       entry_types:
         created: "First created"
         submitted: "Submitted for review"

--- a/spec/features/finding/index_pagination_spec.rb
+++ b/spec/features/finding/index_pagination_spec.rb
@@ -22,7 +22,7 @@ RSpec.feature "User pages through a list of editions" do
   def then_i_should_see_the_first_results
     expect(page.html).to include(I18n.t!("documents.index.search_results.summary_html", count: 51))
     expect(all(".gem-c-document-list__item").count).to eq 50
-    expect(page).to have_content I18n.t!("documents.index.search_results.page_info", page: 1, pages: 2)
+    expect(page).to have_content I18n.t!("documents.index.search_results.page_info", page: 2, pages: 2)
     expect(page).to_not have_content("Previous page")
   end
 
@@ -37,7 +37,7 @@ RSpec.feature "User pages through a list of editions" do
   def then_i_should_see_the_next_results
     expect(page.html).to include(I18n.t!("documents.index.search_results.summary_html", count: 51))
     expect(all(".gem-c-document-list__item").count).to eq 1
-    expect(page).to have_content I18n.t!("documents.index.search_results.page_info", page: 2, pages: 2)
+    expect(page).to have_content I18n.t!("documents.index.search_results.page_info", page: 1, pages: 2)
     expect(page).to_not have_content("Next page")
   end
 end

--- a/spec/features/history/pagination_spec.rb
+++ b/spec/features/history/pagination_spec.rb
@@ -27,6 +27,8 @@ RSpec.feature "User can navigate through a documents history" do
 
   def then_i_see_a_list_of_timeline_entries
     expect(page).to have_content(I18n.t!("documents.history.entry_types.updated_content"), count: 50)
+                .and have_content(I18n.t!("documents.history.page_info", page: 2, pages: 2))
+                .and have_link("Next page")
   end
 
   def when_i_click_to_go_to_the_next_page
@@ -35,9 +37,7 @@ RSpec.feature "User can navigate through a documents history" do
 
   def then_i_see_some_more_timeline_entries
     expect(page).to have_content(I18n.t!("documents.history.entry_types.created"), count: 1)
-
-    within(".gem-c-pagination__item") do
-      expect(page).to have_link("Previous page")
-    end
+                .and have_content(I18n.t!("documents.history.page_info", page: 1, pages: 2))
+                .and have_link("Previous page")
   end
 end


### PR DESCRIPTION
The page information was missed on the first pass of implementing the pagination
feature, I believe because the prototype was out of date. Now the
pagination links display information around what page is currently being
displayed.

This comes after a product review from @Tobiogunsina.

## Before
<img width="376" alt="Screenshot 2020-01-15 at 11 54 04" src="https://user-images.githubusercontent.com/24479188/72431900-c435d480-378d-11ea-82f7-537589c737c1.png">
<img width="363" alt="Screenshot 2020-01-15 at 11 54 10" src="https://user-images.githubusercontent.com/24479188/72431896-c26c1100-378d-11ea-8163-56ef660b43a7.png">

## After 
<img width="367" alt="Screenshot 2020-01-15 at 11 42 13" src="https://user-images.githubusercontent.com/24479188/72431915-cdbf3c80-378d-11ea-8ad6-a22dbe9e606b.png">
<img width="351" alt="Screenshot 2020-01-15 at 13 08 28" src="https://user-images.githubusercontent.com/24479188/72514833-e6d7f400-3846-11ea-918f-db8469644beb.png">



Trello:
https://trello.com/c/TsRTLbiW/1276-move-document-history-from-tab-to-secondary-navigation-and-add-pagination
