### PR TITLE
Rename services to match a verb/noun pattern

### DIFF
--- a/app/controllers/documents_controller.rb
+++ b/app/controllers/documents_controller.rb
@@ -69,7 +69,7 @@ class DocumentsController < ApplicationController
   def generate_path
     edition = Edition.find_current(document: params[:document])
     assert_edition_state(edition, &:editable?)
-    base_path = PathGeneratorService.call(edition.document, params[:title])
+    base_path = GenerateBasePathService.call(edition.document, params[:title])
     render plain: base_path
   end
 

--- a/app/interactors/access_limit/update_interactor.rb
+++ b/app/interactors/access_limit/update_interactor.rb
@@ -31,7 +31,7 @@ private
 
     if LIMIT_TYPES.exclude?(limit_type)
       context.fail! if edition.access_limit.nil?
-      EditEditionService.call(edition, user, access_limit: nil)
+      EditDraftEditionService.call(edition, user, access_limit: nil)
       return
     end
 
@@ -42,7 +42,7 @@ private
                                    limit_type: limit_type,
                                    revision_at_creation: edition.revision)
 
-    EditEditionService.call(edition, user, access_limit: access_limit)
+    EditDraftEditionService.call(edition, user, access_limit: access_limit)
   end
 
   def check_for_issues
@@ -72,6 +72,6 @@ private
   end
 
   def update_preview
-    FailsafePreviewService.call(edition)
+    FailsafeDraftPreviewService.call(edition)
   end
 end

--- a/app/interactors/backdate/destroy_interactor.rb
+++ b/app/interactors/backdate/destroy_interactor.rb
@@ -28,7 +28,7 @@ private
     updater.assign(backdated_to: nil)
     context.fail! unless updater.changed?
 
-    EditEditionService.call(edition, user, revision: updater.next_revision)
+    EditDraftEditionService.call(edition, user, revision: updater.next_revision)
     edition.save!
   end
 
@@ -42,6 +42,6 @@ private
   end
 
   def update_preview
-    FailsafePreviewService.call(edition)
+    FailsafeDraftPreviewService.call(edition)
   end
 end

--- a/app/interactors/backdate/update_interactor.rb
+++ b/app/interactors/backdate/update_interactor.rb
@@ -32,7 +32,7 @@ private
   def update_edition
     updater = Versioning::RevisionUpdater.new(edition.revision, user)
     updater.assign(backdated_to: date)
-    EditEditionService.call(edition, user, revision: updater.next_revision)
+    EditDraftEditionService.call(edition, user, revision: updater.next_revision)
     edition.save!
 
     context.fail! unless updater.changed?
@@ -66,6 +66,6 @@ private
   end
 
   def update_preview
-    FailsafePreviewService.call(edition)
+    FailsafeDraftPreviewService.call(edition)
   end
 end

--- a/app/interactors/documents/destroy_interactor.rb
+++ b/app/interactors/documents/destroy_interactor.rb
@@ -23,7 +23,7 @@ private
   end
 
   def discard_draft
-    DeleteDraftService.call(edition.document, user)
+    DeleteDraftEditionService.call(edition.document, user)
   rescue GdsApi::BaseError => e
     GovukError.notify(e)
     context.fail!(api_error: true)

--- a/app/interactors/documents/update_interactor.rb
+++ b/app/interactors/documents/update_interactor.rb
@@ -40,7 +40,7 @@ private
   end
 
   def update_edition
-    EditEditionService.call(edition, user, revision: revision)
+    EditDraftEditionService.call(edition, user, revision: revision)
     edition.save!
   end
 
@@ -49,7 +49,7 @@ private
   end
 
   def update_preview
-    FailsafePreviewService.call(edition)
+    FailsafeDraftPreviewService.call(edition)
   end
 
   def update_params(edition)
@@ -60,7 +60,7 @@ private
       .tap do |p|
         p[:title] = p[:title]&.strip
         p[:summary] = p[:summary]&.strip
-        p[:base_path] = PathGeneratorService.call(edition.document, p[:title])
+        p[:base_path] = GenerateBasePathService.call(edition.document, p[:title])
       end
   end
 end

--- a/app/interactors/editions/create_interactor.rb
+++ b/app/interactors/editions/create_interactor.rb
@@ -52,7 +52,7 @@ private
                   number: edition.document.next_edition_number,
                   created_by: user)
 
-    EditEditionService.call(next_edition, user, current: true, revision: next_revision)
+    EditDraftEditionService.call(next_edition, user, current: true, revision: next_revision)
     AssignEditionStatusService.call(next_edition, user, :draft)
     next_edition.save!
   end
@@ -68,6 +68,6 @@ private
   end
 
   def preview_next_edition
-    FailsafePreviewService.call(next_edition)
+    FailsafeDraftPreviewService.call(next_edition)
   end
 end

--- a/app/interactors/file_attachments/create_interactor.rb
+++ b/app/interactors/file_attachments/create_interactor.rb
@@ -33,7 +33,7 @@ private
   end
 
   def upload_attachment
-    blob_revision = FileAttachmentBlobService.call(
+    blob_revision = CreateFileAttachmentBlobService.call(
       file: params[:file], filename: unique_filename, user: user,
     )
 
@@ -55,16 +55,16 @@ private
   def update_edition
     updater = Versioning::RevisionUpdater.new(edition.revision, user)
     updater.add_file_attachment(attachment_revision)
-    EditEditionService.call(edition, user, revision: updater.next_revision)
+    EditDraftEditionService.call(edition, user, revision: updater.next_revision)
     edition.save!
   end
 
   def update_preview
-    FailsafePreviewService.call(edition)
+    FailsafeDraftPreviewService.call(edition)
   end
 
   def unique_filename
     existing_filenames = edition.revision.file_attachment_revisions.map(&:filename)
-    UniqueFilenameService.call(existing_filenames, params[:file].original_filename)
+    GenerateUniqueFilenameService.call(existing_filenames, params[:file].original_filename)
   end
 end

--- a/app/interactors/file_attachments/destroy_interactor.rb
+++ b/app/interactors/file_attachments/destroy_interactor.rb
@@ -29,7 +29,7 @@ private
 
     updater = Versioning::RevisionUpdater.new(edition.revision, user)
     updater.remove_file_attachment(attachment_revision)
-    EditEditionService.call(edition, user, revision: updater.next_revision)
+    EditDraftEditionService.call(edition, user, revision: updater.next_revision)
     edition.save!
   end
 
@@ -38,6 +38,6 @@ private
   end
 
   def update_preview
-    FailsafePreviewService.call(edition)
+    FailsafeDraftPreviewService.call(edition)
   end
 end

--- a/app/interactors/file_attachments/update_interactor.rb
+++ b/app/interactors/file_attachments/update_interactor.rb
@@ -56,7 +56,7 @@ private
 
     context.fail!(unchanged: true) unless updater.changed?
 
-    EditEditionService.call(edition, user, revision: updater.next_revision)
+    EditDraftEditionService.call(edition, user, revision: updater.next_revision)
     edition.save!
   end
 
@@ -66,7 +66,7 @@ private
   end
 
   def update_preview
-    FailsafePreviewService.call(edition)
+    FailsafeDraftPreviewService.call(edition)
   end
 
   def attachment_params
@@ -74,7 +74,7 @@ private
   end
 
   def blob_revision(file)
-    FileAttachmentBlobService.call(
+    CreateFileAttachmentBlobService.call(
       file: file, filename: unique_filename(file), user: user,
     )
   end
@@ -82,6 +82,6 @@ private
   def unique_filename(file)
     existing_filenames = edition.revision.file_attachment_revisions.map(&:filename)
     existing_filenames.delete(file_attachment_revision.filename)
-    UniqueFilenameService.call(existing_filenames, file.original_filename)
+    GenerateUniqueFilenameService.call(existing_filenames, file.original_filename)
   end
 end

--- a/app/interactors/history_mode/update_interactor.rb
+++ b/app/interactors/history_mode/update_interactor.rb
@@ -27,7 +27,7 @@ private
     updater = Versioning::RevisionUpdater.new(edition.revision, user)
 
     updater.assign(editor_political: params[:political] == "yes")
-    EditEditionService.call(edition, user, revision: updater.next_revision)
+    EditDraftEditionService.call(edition, user, revision: updater.next_revision)
     edition.save!
   end
 
@@ -41,6 +41,6 @@ private
   end
 
   def update_preview
-    FailsafePreviewService.call(edition)
+    FailsafeDraftPreviewService.call(edition)
   end
 end

--- a/app/interactors/images/create_interactor.rb
+++ b/app/interactors/images/create_interactor.rb
@@ -38,10 +38,10 @@ private
   end
 
   def create_image_revision
-    blob_revision = ImageBlobService.call(
+    blob_revision = CreateImageBlobService.call(
       user: user,
       temp_image: temp_image,
-      filename: UniqueFilenameService.call(
+      filename: GenerateUniqueFilenameService.call(
         edition.revision.image_revisions.map(&:filename),
         temp_image.original_filename,
       ),
@@ -58,7 +58,7 @@ private
   def update_edition
     updater = Versioning::RevisionUpdater.new(edition.revision, user)
     updater.add_image(image_revision)
-    EditEditionService.call(edition, user, revision: updater.next_revision)
+    EditDraftEditionService.call(edition, user, revision: updater.next_revision)
     edition.save!
   end
 end

--- a/app/interactors/images/destroy_interactor.rb
+++ b/app/interactors/images/destroy_interactor.rb
@@ -28,7 +28,7 @@ private
     context.image_revision = edition.image_revisions.find_by!(image_id: params[:image_id])
     updater = Versioning::RevisionUpdater.new(edition.revision, user)
     updater.remove_image(image_revision)
-    EditEditionService.call(edition, user, revision: updater.next_revision)
+    EditDraftEditionService.call(edition, user, revision: updater.next_revision)
     edition.save!
     context.removed_lead_image = updater.removed_lead_image?
   end
@@ -38,6 +38,6 @@ private
   end
 
   def update_preview
-    FailsafePreviewService.call(edition)
+    FailsafeDraftPreviewService.call(edition)
   end
 end

--- a/app/interactors/images/update_crop_interactor.rb
+++ b/app/interactors/images/update_crop_interactor.rb
@@ -44,7 +44,7 @@ private
     updater = Versioning::RevisionUpdater.new(edition.revision, user)
     updater.update_image(image_revision)
     context.fail! unless updater.changed?
-    EditEditionService.call(edition, user, revision: updater.next_revision)
+    EditDraftEditionService.call(edition, user, revision: updater.next_revision)
     edition.save!
   end
 
@@ -53,6 +53,6 @@ private
   end
 
   def update_preview
-    FailsafePreviewService.call(edition)
+    FailsafeDraftPreviewService.call(edition)
   end
 end

--- a/app/interactors/images/update_interactor.rb
+++ b/app/interactors/images/update_interactor.rb
@@ -56,7 +56,7 @@ private
 
     context.fail! unless updater.changed?
 
-    EditEditionService.call(edition, user, revision: updater.next_revision)
+    EditDraftEditionService.call(edition, user, revision: updater.next_revision)
     edition.save!
 
     context.selected_lead_image = updater.selected_lead_image?
@@ -76,6 +76,6 @@ private
   end
 
   def update_preview
-    FailsafePreviewService.call(edition)
+    FailsafeDraftPreviewService.call(edition)
   end
 end

--- a/app/interactors/lead_image/choose_interactor.rb
+++ b/app/interactors/lead_image/choose_interactor.rb
@@ -36,7 +36,7 @@ private
 
     context.fail! unless updater.changed?
 
-    EditEditionService.call(edition, user, revision: updater.next_revision)
+    EditDraftEditionService.call(edition, user, revision: updater.next_revision)
     edition.save!
   end
 
@@ -45,6 +45,6 @@ private
   end
 
   def update_preview
-    FailsafePreviewService.call(edition)
+    FailsafeDraftPreviewService.call(edition)
   end
 end

--- a/app/interactors/lead_image/remove_interactor.rb
+++ b/app/interactors/lead_image/remove_interactor.rb
@@ -36,7 +36,7 @@ private
     updater = Versioning::RevisionUpdater.new(edition.revision, user)
     updater.assign(lead_image_revision: nil)
 
-    EditEditionService.call(edition, user, revision: updater.next_revision)
+    EditDraftEditionService.call(edition, user, revision: updater.next_revision)
     edition.save!
   end
 
@@ -45,6 +45,6 @@ private
   end
 
   def update_preview
-    FailsafePreviewService.call(edition)
+    FailsafeDraftPreviewService.call(edition)
   end
 end

--- a/app/interactors/preview/create_interactor.rb
+++ b/app/interactors/preview/create_interactor.rb
@@ -29,7 +29,7 @@ private
   end
 
   def create_preview
-    PreviewService.call(edition)
+    PreviewDraftEditionService.call(edition)
   rescue GdsApi::BaseError => e
     GovukError.notify(e)
     context.fail!(preview_failed: true)

--- a/app/interactors/publish/publish_interactor.rb
+++ b/app/interactors/publish/publish_interactor.rb
@@ -46,7 +46,7 @@ private
   end
 
   def publish_edition
-    PublishService.call(edition, user, with_review: with_review?)
+    PublishDraftEditionService.call(edition, user, with_review: with_review?)
   rescue GdsApi::BaseError
     context.fail!(publish_failed: true)
   end

--- a/app/interactors/schedule/create_interactor.rb
+++ b/app/interactors/schedule/create_interactor.rb
@@ -47,7 +47,7 @@ private
                                 reviewed: params[:review_status] == "reviewed",
                                 publish_time: edition.proposed_publish_time)
 
-    ScheduleService.call(edition, user, scheduling)
+    SchedulePublishService.call(edition, user, scheduling)
   rescue GdsApi::BaseError => e
     GovukError.notify(e)
     context.fail!(api_error: true)

--- a/app/interactors/schedule/destroy_interactor.rb
+++ b/app/interactors/schedule/destroy_interactor.rb
@@ -30,7 +30,7 @@ private
 
     state = scheduling.reviewed? ? :submitted_for_review : :draft
 
-    EditEditionService.call(edition, user, revision: updater.next_revision)
+    EditDraftEditionService.call(edition, user, revision: updater.next_revision)
     AssignEditionStatusService.call(edition, user, state)
     edition.save!
   end

--- a/app/interactors/schedule/update_interactor.rb
+++ b/app/interactors/schedule/update_interactor.rb
@@ -44,7 +44,7 @@ private
     context.fail! if publish_time == scheduling.publish_time
 
     new_scheduling = scheduling.dup.tap { |s| s.publish_time = publish_time }
-    ScheduleService.call(edition, user, new_scheduling)
+    SchedulePublishService.call(edition, user, new_scheduling)
   rescue GdsApi::BaseError => e
     GovukError.notify(e)
     context.fail!(api_error: true)

--- a/app/interactors/schedule_proposal/destroy_interactor.rb
+++ b/app/interactors/schedule_proposal/destroy_interactor.rb
@@ -25,7 +25,7 @@ private
     updater.assign(proposed_publish_time: nil)
 
     if updater.changed?
-      EditEditionService.call(edition, user, revision: updater.next_revision)
+      EditDraftEditionService.call(edition, user, revision: updater.next_revision)
       edition.save!
     end
   end

--- a/app/interactors/schedule_proposal/update_interactor.rb
+++ b/app/interactors/schedule_proposal/update_interactor.rb
@@ -46,7 +46,7 @@ private
     context.fail! unless updater.changed?
 
     context.revision = updater.next_revision
-    EditEditionService.call(edition, user, revision: updater.next_revision)
+    EditDraftEditionService.call(edition, user, revision: updater.next_revision)
     edition.save!
   end
 

--- a/app/interactors/tags/update_interactor.rb
+++ b/app/interactors/tags/update_interactor.rb
@@ -44,7 +44,7 @@ private
   def update_edition
     context.fail! unless revision_updater.changed?
 
-    EditEditionService.call(edition, user, revision: revision)
+    EditDraftEditionService.call(edition, user, revision: revision)
     edition.save!
   end
 
@@ -53,7 +53,7 @@ private
   end
 
   def update_preview
-    FailsafePreviewService.call(edition)
+    FailsafeDraftPreviewService.call(edition)
   end
 
   def update_params(edition)

--- a/app/interactors/withdraw/create_interactor.rb
+++ b/app/interactors/withdraw/create_interactor.rb
@@ -44,7 +44,7 @@ private
   end
 
   def withdraw_edition
-    WithdrawService.call(edition, params[:public_explanation], user)
+    WithdrawDocumentService.call(edition, params[:public_explanation], user)
   rescue GdsApi::BaseError => e
     GovukError.notify(e)
     context.fail!(api_error: true)

--- a/app/jobs/scheduled_publishing_job.rb
+++ b/app/jobs/scheduled_publishing_job.rb
@@ -4,7 +4,7 @@ class ScheduledPublishingJob < ApplicationJob
   # retry at 3s, 18s, 83s, 258s, 627s
   retry_on(StandardError, wait: :exponentially_longer, attempts: 5) do |job, error|
     GovukError.notify(error)
-    ScheduledPublishingFailedService.call(job.arguments.first)
+    RescueScheduledPublishingService.call(job.arguments.first)
   end
 
   discard_and_log(ActiveRecord::RecordNotFound)
@@ -18,7 +18,7 @@ class ScheduledPublishingJob < ApplicationJob
 
       user = edition.status.created_by
       reviewed = edition.status.details.reviewed
-      PublishService.call(edition, user, with_review: reviewed)
+      PublishDraftEditionService.call(edition, user, with_review: reviewed)
       create_timeline_entry(edition, reviewed)
     end
 

--- a/app/services/create_file_attachment_blob_service.rb
+++ b/app/services/create_file_attachment_blob_service.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-class FileAttachmentBlobService < ApplicationService
+class CreateFileAttachmentBlobService < ApplicationService
   def initialize(file:, filename:, user: nil)
     @file = file
     @filename = filename

--- a/app/services/create_image_blob_service.rb
+++ b/app/services/create_image_blob_service.rb
@@ -2,7 +2,7 @@
 
 require "mini_magick"
 
-class ImageBlobService < ApplicationService
+class CreateImageBlobService < ApplicationService
   def initialize(temp_image:, filename:, user: nil)
     @temp_image = temp_image
     @filename = filename

--- a/app/services/create_image_blob_service/centre_crop.rb
+++ b/app/services/create_image_blob_service/centre_crop.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-class ImageBlobService::CentreCrop
+class CreateImageBlobService::CentreCrop
   attr_reader :width, :height, :desired_aspect_ratio
 
   def initialize(width, height, desired_aspect_ratio = nil)

--- a/app/services/delete_draft_edition_service.rb
+++ b/app/services/delete_draft_edition_service.rb
@@ -30,7 +30,7 @@ private
 
   def discard_path_reservations(edition)
     paths = edition.revisions.map(&:base_path).uniq.compact
-    publishing_app = PreviewService::Payload::PUBLISHING_APP
+    publishing_app = PreviewDraftEditionService::Payload::PUBLISHING_APP
 
     paths.each do |path|
       GdsApi.publishing_api.unreserve_path(path, publishing_app)

--- a/app/services/delete_draft_edition_service.rb
+++ b/app/services/delete_draft_edition_service.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-class DeleteDraftService < ApplicationService
+class DeleteDraftEditionService < ApplicationService
   def initialize(document, user)
     @document = document
     @user = user

--- a/app/services/edit_draft_edition_service.rb
+++ b/app/services/edit_draft_edition_service.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-class EditEditionService < ApplicationService
+class EditDraftEditionService < ApplicationService
   def initialize(edition, user, **attributes)
     @edition = edition
     @user = user

--- a/app/services/failsafe_draft_preview_service.rb
+++ b/app/services/failsafe_draft_preview_service.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-class FailsafePreviewService < ApplicationService
+class FailsafeDraftPreviewService < ApplicationService
   def initialize(edition)
     @edition = edition
   end

--- a/app/services/failsafe_draft_preview_service.rb
+++ b/app/services/failsafe_draft_preview_service.rb
@@ -9,7 +9,7 @@ class FailsafeDraftPreviewService < ApplicationService
     if has_issues?
       edition.update!(revision_synced: false)
     else
-      PreviewService.call(edition)
+      PreviewDraftEditionService.call(edition)
     end
   rescue GdsApi::BaseError => e
     edition.update!(revision_synced: false)

--- a/app/services/generate_base_path_service.rb
+++ b/app/services/generate_base_path_service.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-class PathGeneratorService < ApplicationService
+class GenerateBasePathService < ApplicationService
   def initialize(document, proposed_title, max_repeated_titles: 1000)
     @document = document
     @proposed_title = proposed_title

--- a/app/services/generate_unique_filename_service.rb
+++ b/app/services/generate_unique_filename_service.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-class UniqueFilenameService < ApplicationService
+class GenerateUniqueFilenameService < ApplicationService
   MAX_LENGTH = 65
 
   def initialize(existing_filenames, suggested_name)

--- a/app/services/preview_draft_edition_service.rb
+++ b/app/services/preview_draft_edition_service.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-class PreviewService < ApplicationService
+class PreviewDraftEditionService < ApplicationService
   def initialize(edition, republish: false)
     @edition = edition
     @republish = republish

--- a/app/services/preview_draft_edition_service/payload.rb
+++ b/app/services/preview_draft_edition_service/payload.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-class PreviewService::Payload
+class PreviewDraftEditionService::Payload
   PUBLISHING_APP = "content-publisher"
 
   attr_reader :edition, :document_type, :publishing_metadata, :republish

--- a/app/services/publish_assets_service.rb
+++ b/app/services/publish_assets_service.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-class PublishAssetService < ApplicationService
+class PublishAssetsService < ApplicationService
   def initialize(edition, live_edition)
     @edition = edition
     @live_edition = live_edition

--- a/app/services/publish_draft_edition_service.rb
+++ b/app/services/publish_draft_edition_service.rb
@@ -27,7 +27,7 @@ private
   delegate :document, to: :edition
 
   def publish_assets(live_edition)
-    PublishAssetService.call(edition, live_edition)
+    PublishAssetsService.call(edition, live_edition)
   end
 
   def associate_with_government
@@ -42,7 +42,7 @@ private
     edition.assign_attributes(government_id: government&.content_id)
 
     # We need to update the Publishing API if we're changing the government
-    PreviewService.call(edition) if edition.government_id_changed?
+    PreviewDraftEditionService.call(edition) if edition.government_id_changed?
   end
 
   def publish_current_edition

--- a/app/services/publish_draft_edition_service.rb
+++ b/app/services/publish_draft_edition_service.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-class PublishService < ApplicationService
+class PublishDraftEditionService < ApplicationService
   def initialize(edition, user, with_review:)
     @edition = edition
     @user = user

--- a/app/services/remove_document_service.rb
+++ b/app/services/remove_document_service.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-class RemoveService < ApplicationService
+class RemoveDocumentService < ApplicationService
   def initialize(edition, removal)
     @edition = edition
     @removal = removal

--- a/app/services/rescue_scheduled_publishing_service.rb
+++ b/app/services/rescue_scheduled_publishing_service.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-class ScheduledPublishingFailedService < ApplicationService
+class RescueScheduledPublishingService < ApplicationService
   def initialize(edition_id)
     @edition_id = edition_id
   end

--- a/app/services/resync_document_service.rb
+++ b/app/services/resync_document_service.rb
@@ -24,8 +24,8 @@ private
     live_edition.lock!
     set_political_and_government(live_edition)
     reserve_path(live_edition.base_path)
-    PreviewService.call(live_edition, republish: true)
-    PublishAssetService.call(live_edition, nil)
+    PreviewDraftEditionService.call(live_edition, republish: true)
+    PublishAssetsService.call(live_edition, nil)
 
     if live_edition.withdrawn?
       withdraw
@@ -40,7 +40,7 @@ private
     current_edition.lock!
     set_political_and_government(current_edition)
     reserve_path(current_edition.base_path)
-    FailsafePreviewService.call(current_edition)
+    FailsafeDraftPreviewService.call(current_edition)
 
     schedule if current_edition.scheduled?
   end
@@ -100,7 +100,7 @@ private
   end
 
   def schedule
-    payload = ScheduleService::Payload.new(current_edition).intent_payload
+    payload = SchedulePublishService::Payload.new(current_edition).intent_payload
     GdsApi.publishing_api.put_intent(current_edition.base_path, payload)
 
     scheduling = current_edition.status.details

--- a/app/services/resync_document_service.rb
+++ b/app/services/resync_document_service.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-class ResyncService < ApplicationService
+class ResyncDocumentService < ApplicationService
   attr_reader :document
 
   delegate :live_edition,

--- a/app/services/schedule_publish_service.rb
+++ b/app/services/schedule_publish_service.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-class ScheduleService < ApplicationService
+class SchedulePublishService < ApplicationService
   def initialize(edition, user, scheduling)
     @edition = edition
     @user = user

--- a/app/services/schedule_publish_service.rb
+++ b/app/services/schedule_publish_service.rb
@@ -21,7 +21,7 @@ private
     updater = Versioning::RevisionUpdater.new(edition.revision, user)
     updater.assign(proposed_publish_time: nil)
 
-    EditEditionService.call(edition, user, revision: updater.next_revision)
+    EditDraftEditionService.call(edition, user, revision: updater.next_revision)
     AssignEditionStatusService.call(edition, user, :scheduled, status_details: scheduling)
     edition.save!
   end

--- a/app/services/schedule_publish_service/payload.rb
+++ b/app/services/schedule_publish_service/payload.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-class ScheduleService::Payload
+class SchedulePublishService::Payload
   attr_reader :edition
 
   def initialize(edition)
@@ -10,7 +10,7 @@ class ScheduleService::Payload
   def intent_payload
     {
       publish_time: publish_time,
-      publishing_app: PreviewService::Payload::PUBLISHING_APP,
+      publishing_app: PreviewDraftEditionService::Payload::PUBLISHING_APP,
       rendering_app: rendering_app,
     }
   end

--- a/app/services/withdraw_document_service.rb
+++ b/app/services/withdraw_document_service.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-class WithdrawService < ApplicationService
+class WithdrawDocumentService < ApplicationService
   def initialize(edition, public_explanation, user = nil)
     @edition = edition
     @public_explanation = public_explanation

--- a/lib/tasks/resync.rake
+++ b/lib/tasks/resync.rake
@@ -9,13 +9,13 @@ namespace :resync do
 
     raise "No document exists for #{content_id_and_locale}" unless document
 
-    ResyncService.call(document)
+    ResyncDocumentService.call(document)
   end
 
   desc "Resync all documents with the publishing-api e.g. resync:all"
   task all: :environment do
     Document.find_each do |document|
-      ResyncService.call(document)
+      ResyncDocumentService.call(document)
     end
   end
 end

--- a/lib/tasks/unpublish.rake
+++ b/lib/tasks/unpublish.rake
@@ -15,7 +15,7 @@ namespace :unpublish do
     removal = Removal.new(explanatory_note: explanatory_note,
                           alternative_path: alternative_path)
 
-    RemoveService.call(document.live_edition, removal)
+    RemoveDocumentService.call(document.live_edition, removal)
   end
 
   desc "Remove and redirect a document on GOV.UK e.g. unpublish:remove_and_redirect['a-content-id'] NEW_PATH='/redirect-to-here'"
@@ -34,6 +34,6 @@ namespace :unpublish do
                           explanatory_note: explanatory_note,
                           alternative_path: redirect_path)
 
-    RemoveService.call(document.live_edition, removal)
+    RemoveDocumentService.call(document.live_edition, removal)
   end
 end

--- a/lib/whitehall_importer.rb
+++ b/lib/whitehall_importer.rb
@@ -71,7 +71,7 @@ module WhitehallImporter
     begin
       whitehall_import.update!(state: "syncing")
 
-      ResyncService.call(whitehall_import.document)
+      ResyncDocumentService.call(whitehall_import.document)
       ClearLinksetLinks.call(whitehall_import.document.content_id)
       MigrateAssets.call(whitehall_import)
 

--- a/lib/whitehall_importer/create_file_attachment_revision.rb
+++ b/lib/whitehall_importer/create_file_attachment_revision.rb
@@ -41,14 +41,14 @@ module WhitehallImporter
     end
 
     def unique_filename
-      @unique_filename ||= UniqueFilenameService.call(
+      @unique_filename ||= GenerateUniqueFilenameService.call(
         existing_filenames,
         File.basename(whitehall_file_attachment["url"]),
       )
     end
 
     def create_blob_revision(decorated_file)
-      FileAttachmentBlobService.call(
+      CreateFileAttachmentBlobService.call(
         file: decorated_file,
         filename: unique_filename,
       )

--- a/lib/whitehall_importer/create_image_revision.rb
+++ b/lib/whitehall_importer/create_image_revision.rb
@@ -44,9 +44,9 @@ module WhitehallImporter
     end
 
     def create_blob_revision(temp_image)
-      ImageBlobService.call(
+      CreateImageBlobService.call(
         temp_image: temp_image,
-        filename: UniqueFilenameService.call(
+        filename: GenerateUniqueFilenameService.call(
           filenames,
           File.basename(whitehall_image["url"]),
         ),

--- a/lib/whitehall_importer/integrity_checker.rb
+++ b/lib/whitehall_importer/integrity_checker.rb
@@ -17,7 +17,7 @@ module WhitehallImporter
     end
 
     def proposed_payload
-      @proposed_payload ||= PreviewService::Payload.new(edition, republish: edition.live?).payload
+      @proposed_payload ||= PreviewDraftEditionService::Payload.new(edition, republish: edition.live?).payload
     end
 
   private

--- a/spec/interactors/documents/update_interactor_spec.rb
+++ b/spec/interactors/documents/update_interactor_spec.rb
@@ -40,7 +40,7 @@ RSpec.describe Documents::UpdateInteractor do
     end
 
     it "updates the preview" do
-      expect(FailsafePreviewService).to receive(:call).with(edition)
+      expect(FailsafeDraftPreviewService).to receive(:call).with(edition)
       Documents::UpdateInteractor.call(params: build_params, user: user)
     end
 

--- a/spec/interactors/editions/create_interactor_spec.rb
+++ b/spec/interactors/editions/create_interactor_spec.rb
@@ -32,8 +32,8 @@ RSpec.describe Editions::CreateInteractor do
     it "sends a preview of the new edition to the Publishing API" do
       old_edition = create(:edition, :published)
 
-      expect(FailsafePreviewService).to receive(:call)
-      expect(FailsafePreviewService).not_to receive(:call).with(old_edition)
+      expect(FailsafeDraftPreviewService).to receive(:call)
+      expect(FailsafeDraftPreviewService).not_to receive(:call).with(old_edition)
 
       Editions::CreateInteractor
         .call(params: { document: old_edition.document.to_param }, user: user)

--- a/spec/interactors/file_attachments/create_interactor_spec.rb
+++ b/spec/interactors/file_attachments/create_interactor_spec.rb
@@ -2,7 +2,7 @@
 
 RSpec.describe FileAttachments::CreateInteractor do
   describe ".call" do
-    before { allow(FailsafePreviewService).to receive(:call) }
+    before { allow(FailsafeDraftPreviewService).to receive(:call) }
     let(:user) { create(:user) }
     let(:edition) { create(:edition) }
     let(:file) { fixture_file_upload("files/13kb-1-page-attachment.pdf") }
@@ -28,15 +28,15 @@ RSpec.describe FileAttachments::CreateInteractor do
           .to change { FileAttachment::Revision.count }.by(1)
       end
 
-      it "delegates saving the file to the FileAttachmentBlobService" do
-        expect(FileAttachmentBlobService).to receive(:call)
+      it "delegates saving the file to the CreateFileAttachmentBlobService" do
+        expect(CreateFileAttachmentBlobService).to receive(:call)
           .with(file: file, filename: file.original_filename, user: user)
           .and_call_original
         FileAttachments::CreateInteractor.call(**args)
       end
 
-      it "delegates generating a unique filename to UniqueFilenameService" do
-        expect(UniqueFilenameService).to receive(:call)
+      it "delegates generating a unique filename to GenerateUniqueFilenameService" do
+        expect(GenerateUniqueFilenameService).to receive(:call)
           .with(edition.revision.file_attachment_revisions.map(&:filename), file.original_filename)
           .and_call_original
         FileAttachments::CreateInteractor.call(**args)
@@ -64,7 +64,7 @@ RSpec.describe FileAttachments::CreateInteractor do
       end
 
       it "updates the preview" do
-        expect(FailsafePreviewService).to receive(:call).with(edition)
+        expect(FailsafeDraftPreviewService).to receive(:call).with(edition)
         FileAttachments::CreateInteractor.call(**args)
       end
     end

--- a/spec/interactors/history_mode/update_interactor_spec.rb
+++ b/spec/interactors/history_mode/update_interactor_spec.rb
@@ -39,7 +39,7 @@ RSpec.describe HistoryMode::UpdateInteractor do
     end
 
     it "sends a preview of the new edition to the Publishing API" do
-      expect(FailsafePreviewService).to receive(:call)
+      expect(FailsafeDraftPreviewService).to receive(:call)
 
       HistoryMode::UpdateInteractor.call(**args)
     end

--- a/spec/interactors/images/create_interactor_spec.rb
+++ b/spec/interactors/images/create_interactor_spec.rb
@@ -25,14 +25,14 @@ RSpec.describe Images::CreateInteractor do
           .to change { Image::Revision.count }.by(1)
       end
 
-      it "normalises the uploaded image and delegates saving it to ImageBlobService" do
+      it "normalises the uploaded image and delegates saving it to CreateImageBlobService" do
         temp_image = ImageNormaliser::TempImage.new(image_upload)
         expect(ImageNormaliser)
           .to receive(:new)
           .with(image_upload)
           .and_return(double(normalise: temp_image, issues: []))
 
-        expect(ImageBlobService)
+        expect(CreateImageBlobService)
           .to receive(:call)
           .with(user: user, temp_image: temp_image, filename: an_instance_of(String))
           .and_call_original

--- a/spec/interactors/schedule/create_interactor_spec.rb
+++ b/spec/interactors/schedule/create_interactor_spec.rb
@@ -16,11 +16,11 @@ RSpec.describe Schedule::CreateInteractor do
       expect(result).to be_success
     end
 
-    it "delegates to ScheduleService to schedule the edition for publishing" do
+    it "delegates to SchedulePublishService to schedule the edition for publishing" do
       publish_time = 3.days.from_now.beginning_of_day
       edition = create(:edition, :schedulable, proposed_publish_time: publish_time)
 
-      expect(ScheduleService)
+      expect(SchedulePublishService)
         .to receive(:call) do |schedule_edition, schedule_user, new_scheduling|
           expect(schedule_edition).to eq(edition)
           expect(schedule_user).to eq(user)
@@ -70,7 +70,7 @@ RSpec.describe Schedule::CreateInteractor do
       expect(result.issues).to have_issue(:schedule_review_status, :not_selected)
     end
 
-    it "fails with an API error when ScheduleService raises a GdsApi Error" do
+    it "fails with an API error when SchedulePublishService raises a GdsApi Error" do
       stub_publishing_api_isnt_available
       result = Schedule::CreateInteractor.call(params: build_params, user: user)
 

--- a/spec/interactors/schedule/update_interactor_spec.rb
+++ b/spec/interactors/schedule/update_interactor_spec.rb
@@ -28,8 +28,8 @@ RSpec.describe Schedule::UpdateInteractor do
       expect(result).to be_success
     end
 
-    it "delegates to ScheduleService to schedule the edition for publishing" do
-      expect(ScheduleService)
+    it "delegates to SchedulePublishService to schedule the edition for publishing" do
+      expect(SchedulePublishService)
         .to receive(:call) do |schedule_edition, schedule_user, new_scheduling|
           expect(schedule_edition).to eq(edition)
           expect(schedule_user).to eq(user)
@@ -51,7 +51,7 @@ RSpec.describe Schedule::UpdateInteractor do
       let(:params) { build_params(time: publish_time) }
 
       it "fails without scheduling the edition" do
-        expect(ScheduleService).not_to receive(:call)
+        expect(SchedulePublishService).not_to receive(:call)
         result = Schedule::UpdateInteractor.call(params: params, user: user)
         expect(result).to be_failure
       end
@@ -85,7 +85,7 @@ RSpec.describe Schedule::UpdateInteractor do
       expect(result.issues).to have_issue(:schedule_date, :in_the_past)
     end
 
-    it "fails with an API error when ScheduleService raises a GdsApi Error" do
+    it "fails with an API error when SchedulePublishService raises a GdsApi Error" do
       stub_publishing_api_isnt_available
       result = Schedule::UpdateInteractor.call(params: build_params, user: user)
 

--- a/spec/jobs/scheduled_publishing_job_spec.rb
+++ b/spec/jobs/scheduled_publishing_job_spec.rb
@@ -57,8 +57,8 @@ RSpec.describe ScheduledPublishingJob do
 
   context "when an exception is raised" do
     before do
-      allow(PublishService).to receive(:new).and_raise(RuntimeError)
-      allow(ScheduledPublishingFailedService).to receive(:call)
+      allow(PublishDraftEditionService).to receive(:new).and_raise(RuntimeError)
+      allow(RescueScheduledPublishingService).to receive(:call)
     end
 
     it "retries the job" do
@@ -68,7 +68,7 @@ RSpec.describe ScheduledPublishingJob do
     end
 
     it "when it is out of retries it calls the failed service" do
-      expect(ScheduledPublishingFailedService).to receive(:call).with(scheduled_edition.id)
+      expect(RescueScheduledPublishingService).to receive(:call).with(scheduled_edition.id)
 
       perform_enqueued_jobs do
         ScheduledPublishingJob.perform_later(scheduled_edition.id)

--- a/spec/lib/tasks/resync_spec.rb
+++ b/spec/lib/tasks/resync_spec.rb
@@ -5,7 +5,7 @@ RSpec.describe "Resync tasks" do
     it "resyncs a document" do
       document = create(:document)
 
-      expect(ResyncService)
+      expect(ResyncDocumentService)
         .to receive(:call)
         .once
         .with(document)
@@ -18,7 +18,7 @@ RSpec.describe "Resync tasks" do
     it "resyncs all documents" do
       create_list(:document, 2)
 
-      expect(ResyncService)
+      expect(ResyncDocumentService)
         .to receive(:call)
         .twice
 

--- a/spec/lib/whitehall_importer_spec.rb
+++ b/spec/lib/whitehall_importer_spec.rb
@@ -45,7 +45,7 @@ RSpec.describe WhitehallImporter do
     let(:whitehall_host) { Plek.new.external_url_for("whitehall-admin") }
 
     before do
-      allow(ResyncService).to receive(:call)
+      allow(ResyncDocumentService).to receive(:call)
       allow(WhitehallImporter::ClearLinksetLinks).to receive(:call)
       allow(WhitehallImporter::Import).to receive(:call).and_return(build(:document, :with_current_edition))
       stub_request(:get, "#{whitehall_host}/government/admin/export/document/123")
@@ -171,14 +171,14 @@ RSpec.describe WhitehallImporter do
 
   describe ".sync" do
     before do
-      allow(ResyncService).to receive(:call).with(whitehall_migration_document_import.document)
+      allow(ResyncDocumentService).to receive(:call).with(whitehall_migration_document_import.document)
       allow(WhitehallImporter::ClearLinksetLinks).to receive(:call).with(whitehall_migration_document_import.document.content_id)
     end
 
     let(:whitehall_migration_document_import) { create(:whitehall_migration_document_import, state: "imported") }
 
     it "syncs the imported document with publishing-api" do
-      expect(ResyncService).to receive(:call).with(whitehall_migration_document_import.document)
+      expect(ResyncDocumentService).to receive(:call).with(whitehall_migration_document_import.document)
       expect(WhitehallImporter::ClearLinksetLinks).to receive(:call).with(whitehall_migration_document_import.document.content_id)
       WhitehallImporter.sync(whitehall_migration_document_import)
     end
@@ -201,7 +201,7 @@ RSpec.describe WhitehallImporter do
 
     context "when the sync fails" do
       before do
-        allow(ResyncService).to receive(:call)
+        allow(ResyncDocumentService).to receive(:call)
           .with(whitehall_migration_document_import.document)
           .and_raise(GdsApi::HTTPTooManyRequests.new(429, message))
       end

--- a/spec/services/create_file_attachment_blob_service_spec.rb
+++ b/spec/services/create_file_attachment_blob_service_spec.rb
@@ -1,13 +1,13 @@
 # frozen_string_literal: true
 
-RSpec.describe FileAttachmentBlobService do
+RSpec.describe CreateFileAttachmentBlobService do
   let(:file) { fixture_file_upload("files/text-file-74bytes.txt") }
   let(:revision) { build(:revision) }
   let(:user) { build(:user) }
 
   describe ".call" do
     it "creates a file attachment blob revision" do
-      expect(FileAttachmentBlobService.call(file: file, filename: "file.txt"))
+      expect(CreateFileAttachmentBlobService.call(file: file, filename: "file.txt"))
         .to be_a(FileAttachment::BlobRevision)
     end
 
@@ -15,14 +15,14 @@ RSpec.describe FileAttachmentBlobService do
       let(:file) { fixture_file_upload("files/13kb-1-page-attachment.pdf", "application/pdf") }
 
       it "calculates the number of pages" do
-        blob_revision = FileAttachmentBlobService.call(file: file, filename: "file.txt")
+        blob_revision = CreateFileAttachmentBlobService.call(file: file, filename: "file.txt")
         expect(blob_revision.number_of_pages).to eql(1)
       end
     end
 
     context "when the upload is not a pdf" do
       it "sets nil for the number of pages" do
-        blob_revision = FileAttachmentBlobService.call(file: file, filename: "file.txt")
+        blob_revision = CreateFileAttachmentBlobService.call(file: file, filename: "file.txt")
         expect(blob_revision.number_of_pages).to be_nil
       end
     end

--- a/spec/services/create_image_blob_service/centre_crop_spec.rb
+++ b/spec/services/create_image_blob_service/centre_crop_spec.rb
@@ -1,10 +1,10 @@
 # frozen_string_literal: true
 
-RSpec.describe ImageBlobService::CentreCrop do
+RSpec.describe CreateImageBlobService::CentreCrop do
   describe ".new" do
     context "when no desired aspect ratio is specified" do
       it "uses a default aspect ratio" do
-        cropper = ImageBlobService::CentreCrop.new(500, 250)
+        cropper = CreateImageBlobService::CentreCrop.new(500, 250)
         default_ratio = Image::WIDTH.to_f / Image::HEIGHT
         expect(cropper.desired_aspect_ratio).to eq(default_ratio)
       end
@@ -14,7 +14,7 @@ RSpec.describe ImageBlobService::CentreCrop do
   describe "#dimensions" do
     context "when aspect ratios match" do
       it "doesn't suggest any cropping" do
-        cropper = ImageBlobService::CentreCrop.new(500, 250, 2.0)
+        cropper = CreateImageBlobService::CentreCrop.new(500, 250, 2.0)
         expect(cropper.dimensions)
           .to eq(x: 0, y: 0, width: 500, height: 250)
       end
@@ -22,7 +22,7 @@ RSpec.describe ImageBlobService::CentreCrop do
 
     context "when an image that is too wide is uploaded" do
       it "suggests reducing the width with a x offset" do
-        cropper = ImageBlobService::CentreCrop.new(500, 100, 16.to_f / 9)
+        cropper = CreateImageBlobService::CentreCrop.new(500, 100, 16.to_f / 9)
         expect(cropper.dimensions)
           .to eq(x: 161, y: 0, width: 178, height: 100)
       end
@@ -30,7 +30,7 @@ RSpec.describe ImageBlobService::CentreCrop do
 
     context "when an image that is too tall is uploaded" do
       it "suggests reducing the height with a y offset" do
-        cropper = ImageBlobService::CentreCrop.new(500, 600, 4.to_f / 3)
+        cropper = CreateImageBlobService::CentreCrop.new(500, 600, 4.to_f / 3)
         expect(cropper.dimensions)
           .to eq(x: 0, y: 112, width: 500, height: 375)
       end

--- a/spec/services/create_image_blob_service_spec.rb
+++ b/spec/services/create_image_blob_service_spec.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-RSpec.describe ImageBlobService do
+RSpec.describe CreateImageBlobService do
   let(:user) { build(:user) }
   let(:temp_image) do
     ImageNormaliser::TempImage.new(fixture_file_upload("files/1000x1000.jpg"))
@@ -8,7 +8,7 @@ RSpec.describe ImageBlobService do
 
   describe ".call" do
     it "creates a image blob revision" do
-      expect(ImageBlobService.call(user: user, temp_image: temp_image, filename: "1000x1000.jpg"))
+      expect(CreateImageBlobService.call(user: user, temp_image: temp_image, filename: "1000x1000.jpg"))
         .to be_a(Image::BlobRevision)
     end
   end

--- a/spec/services/delete_draft_edition_service_spec.rb
+++ b/spec/services/delete_draft_edition_service_spec.rb
@@ -1,20 +1,20 @@
 # frozen_string_literal: true
 
-RSpec.describe DeleteDraftService do
+RSpec.describe DeleteDraftEditionService do
   let(:user) { create :user }
 
   describe ".call" do
     it "raises an exception if there is not a current edition" do
       document = create :document
 
-      expect { DeleteDraftService.call(document, user) }
+      expect { DeleteDraftEditionService.call(document, user) }
         .to raise_error "Trying to delete a document without a current edition"
     end
 
     it "raises an exception if the current edition is live" do
       document = create :document, :with_live_edition
 
-      expect { DeleteDraftService.call(document, user) }
+      expect { DeleteDraftEditionService.call(document, user) }
         .to raise_error "Trying to delete a live document"
     end
 
@@ -22,7 +22,7 @@ RSpec.describe DeleteDraftService do
       document = create :document, :with_current_edition
       stub_publishing_api_unreserve_path(document.current_edition.base_path)
       request = stub_publishing_api_discard_draft(document.content_id)
-      DeleteDraftService.call(document, user)
+      DeleteDraftEditionService.call(document, user)
       expect(request).to have_been_requested
     end
 
@@ -37,7 +37,7 @@ RSpec.describe DeleteDraftService do
       stub_publishing_api_unreserve_path(edition.base_path)
       delete_request = stub_asset_manager_deletes_any_asset
 
-      DeleteDraftService.call(edition.document, user)
+      DeleteDraftEditionService.call(edition.document, user)
 
       expect(delete_request).to have_been_requested.at_least_once
       expect(image_revision.reload.assets.map(&:state).uniq).to eq(%w[absent])
@@ -53,15 +53,15 @@ RSpec.describe DeleteDraftService do
 
       unreserve_request1 = stub_publishing_api_unreserve_path(
         edition.base_path,
-        PreviewService::Payload::PUBLISHING_APP,
+        PreviewDraftEditionService::Payload::PUBLISHING_APP,
       )
 
       unreserve_request2 = stub_publishing_api_unreserve_path(
         previous_revision.base_path,
-        PreviewService::Payload::PUBLISHING_APP,
+        PreviewDraftEditionService::Payload::PUBLISHING_APP,
       )
 
-      DeleteDraftService.call(edition.document, user)
+      DeleteDraftEditionService.call(edition.document, user)
 
       expect(unreserve_request1).to have_been_requested
       expect(unreserve_request2).to have_been_requested
@@ -70,7 +70,7 @@ RSpec.describe DeleteDraftService do
     it "does not delete path reservations for published documents" do
       document = create :document, :with_current_and_live_editions
       stub_publishing_api_discard_draft(document.content_id)
-      DeleteDraftService.call(document, user)
+      DeleteDraftEditionService.call(document, user)
       expect(document.reload.current_edition).to eq document.live_edition
     end
 
@@ -78,7 +78,7 @@ RSpec.describe DeleteDraftService do
       document = create :document, :with_current_edition
       stub_publishing_api_unreserve_path(document.current_edition.base_path)
       stub_publishing_api_discard_draft(document.content_id)
-      DeleteDraftService.call(document, user)
+      DeleteDraftEditionService.call(document, user)
       expect(document.reload.current_edition).to be_nil
     end
 
@@ -87,7 +87,7 @@ RSpec.describe DeleteDraftService do
       live_edition = document.live_edition
       stub_publishing_api_unreserve_path(document.current_edition.base_path)
       stub_publishing_api_discard_draft(document.content_id)
-      DeleteDraftService.call(document, user)
+      DeleteDraftEditionService.call(document, user)
       expect(document.reload.current_edition).to eq(live_edition)
     end
 
@@ -96,7 +96,7 @@ RSpec.describe DeleteDraftService do
       edition = document.current_edition
       stub_publishing_api_unreserve_path(document.current_edition.base_path)
       stub_publishing_api_discard_draft(document.content_id)
-      DeleteDraftService.call(document, user)
+      DeleteDraftEditionService.call(document, user)
       expect(edition.status).to be_discarded
     end
 
@@ -104,7 +104,7 @@ RSpec.describe DeleteDraftService do
       document = create :document, :with_current_edition
       stub_publishing_api_unreserve_path(document.current_edition.base_path)
       stub_any_publishing_api_call_to_return_not_found
-      DeleteDraftService.call(document, user)
+      DeleteDraftEditionService.call(document, user)
       expect(document.reload.current_edition).to be_nil
     end
 
@@ -120,7 +120,7 @@ RSpec.describe DeleteDraftService do
       stub_any_publishing_api_discard_draft
         .to_return(status: 422, body: discard_draft_error.to_json)
 
-      DeleteDraftService.call(document, user)
+      DeleteDraftEditionService.call(document, user)
       expect(document.reload.current_edition).to be_nil
     end
 
@@ -136,7 +136,7 @@ RSpec.describe DeleteDraftService do
       stub_any_publishing_api_discard_draft
         .to_return(status: 422, body: discard_draft_error.to_json)
 
-      expect { DeleteDraftService.call(document, user) }
+      expect { DeleteDraftEditionService.call(document, user) }
         .to raise_error(GdsApi::HTTPUnprocessableEntity)
     end
 
@@ -149,7 +149,7 @@ RSpec.describe DeleteDraftService do
 
       stub_publishing_api_unreserve_path(edition.base_path)
       stub_publishing_api_discard_draft(edition.content_id)
-      DeleteDraftService.call(edition.document, user)
+      DeleteDraftEditionService.call(edition.document, user)
 
       expect(edition.reload.status).to be_discarded
       expect(image_revision.reload.assets.map(&:state).uniq).to eq(%w[absent])
@@ -161,7 +161,7 @@ RSpec.describe DeleteDraftService do
 
       stub_publishing_api_unreserve_path_not_found(edition.base_path)
       stub_publishing_api_discard_draft(edition.content_id)
-      DeleteDraftService.call(edition.document, user)
+      DeleteDraftEditionService.call(edition.document, user)
 
       expect(edition.reload.status).to be_discarded
     end
@@ -170,7 +170,7 @@ RSpec.describe DeleteDraftService do
       edition = create :edition, base_path: nil
 
       stub_publishing_api_discard_draft(edition.content_id)
-      DeleteDraftService.call(edition.document, user)
+      DeleteDraftEditionService.call(edition.document, user)
 
       expect(edition.reload.status).to be_discarded
     end
@@ -188,7 +188,7 @@ RSpec.describe DeleteDraftService do
 
       stub_publishing_api_unreserve_path(edition.base_path)
       stub_publishing_api_discard_draft(edition.content_id)
-      DeleteDraftService.call(edition.document, user)
+      DeleteDraftEditionService.call(edition.document, user)
 
       expect(edition.reload.status).to be_discarded
       expect(image_revision.reload.assets.map(&:state).uniq).to eq(%w[absent])
@@ -201,7 +201,7 @@ RSpec.describe DeleteDraftService do
       stub_publishing_api_discard_draft(edition.content_id)
       stub_publishing_api_unreserve_path_invalid(edition.base_path)
 
-      expect { DeleteDraftService.call(edition.document, user) }
+      expect { DeleteDraftEditionService.call(edition.document, user) }
         .to raise_error(GdsApi::BaseError)
 
       expect(edition.reload.revision_synced?).to be true
@@ -211,7 +211,7 @@ RSpec.describe DeleteDraftService do
       edition = create :edition
       stub_publishing_api_isnt_available
 
-      expect { DeleteDraftService.call(edition.document, user) }
+      expect { DeleteDraftEditionService.call(edition.document, user) }
         .to raise_error(GdsApi::BaseError)
 
       expect(edition.reload.revision_synced?).to be false
@@ -226,7 +226,7 @@ RSpec.describe DeleteDraftService do
 
       stub_asset_manager_isnt_available
 
-      expect { DeleteDraftService.call(edition.document, user) }
+      expect { DeleteDraftEditionService.call(edition.document, user) }
         .to raise_error(GdsApi::BaseError)
 
       expect(edition.reload.revision_synced?).to be false

--- a/spec/services/edit_draft_edition_service_spec.rb
+++ b/spec/services/edit_draft_edition_service_spec.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-RSpec.describe EditEditionService do
+RSpec.describe EditDraftEditionService do
   describe ".call" do
     let(:edition) { build(:edition) }
     let(:user) { build(:user) }
@@ -8,12 +8,12 @@ RSpec.describe EditEditionService do
     it "assigns attributes to an edition" do
       revision = build(:revision)
 
-      expect { EditEditionService.call(edition, user, revision: revision) }
+      expect { EditDraftEditionService.call(edition, user, revision: revision) }
         .to change { edition.revision }.to(revision)
     end
 
     it "does not save the edition" do
-      EditEditionService.call(edition, user, {})
+      EditDraftEditionService.call(edition, user, {})
 
       expect(edition).to be_new_record
     end
@@ -22,7 +22,7 @@ RSpec.describe EditEditionService do
       freeze_time do
         edition = build(:edition, last_edited_at: 3.weeks.ago)
 
-        expect { EditEditionService.call(edition, user) }
+        expect { EditDraftEditionService.call(edition, user) }
           .to change { edition.last_edited_by }.to(user)
           .and change { edition.last_edited_at }.to(Time.current)
       end
@@ -31,7 +31,7 @@ RSpec.describe EditEditionService do
     it "raises an error if a live edition is edited" do
       live_edition = build(:edition, live: true)
 
-      expect { EditEditionService.call(live_edition, user) }
+      expect { EditDraftEditionService.call(live_edition, user) }
         .to raise_error("cannot edit a live edition")
     end
 
@@ -39,7 +39,7 @@ RSpec.describe EditEditionService do
       it "adds an edition user if they are not already listed as an editor" do
         edition = build(:edition)
 
-        expect { EditEditionService.call(edition, user) }
+        expect { EditDraftEditionService.call(edition, user) }
           .to change { edition.editors.size }
           .by(1)
       end
@@ -52,7 +52,7 @@ RSpec.describe EditEditionService do
           .with(edition)
           .and_return(instance_double(PoliticalEditionIdentifier, political?: true))
 
-        expect { EditEditionService.call(edition, user) }
+        expect { EditDraftEditionService.call(edition, user) }
           .to change { edition.system_political }
           .to(true)
       end
@@ -65,7 +65,7 @@ RSpec.describe EditEditionService do
           .with(edition)
           .and_return(instance_double(PoliticalEditionIdentifier, political?: false))
 
-        expect { EditEditionService.call(edition, user) }
+        expect { EditDraftEditionService.call(edition, user) }
           .to change { edition.system_political }
           .to(false)
       end
@@ -78,7 +78,7 @@ RSpec.describe EditEditionService do
         populate_government_bulk_data(government)
         allow(edition).to receive(:public_first_published_at).and_return(time)
 
-        expect { EditEditionService.call(edition, user) }
+        expect { EditDraftEditionService.call(edition, user) }
           .to change { edition.government_id }
           .to(government.content_id)
       end
@@ -89,7 +89,7 @@ RSpec.describe EditEditionService do
         populate_government_bulk_data(government)
         edition = build(:edition, first_published_at: publish_date)
 
-        expect { EditEditionService.call(edition, user) }
+        expect { EditDraftEditionService.call(edition, user) }
           .not_to change { edition.government_id }
           .from(nil)
       end
@@ -97,7 +97,7 @@ RSpec.describe EditEditionService do
       it "sets the government to nil when an edition isn't backdated or the document published" do
         edition = build(:edition)
 
-        expect { EditEditionService.call(edition, user) }
+        expect { EditDraftEditionService.call(edition, user) }
           .not_to change { edition.government_id }
           .from(nil)
       end

--- a/spec/services/failsafe_preview_service_spec.rb
+++ b/spec/services/failsafe_preview_service_spec.rb
@@ -1,23 +1,23 @@
 # frozen_string_literal: true
 
-RSpec.describe FailsafePreviewService do
+RSpec.describe FailsafeDraftPreviewService do
   before do
-    allow(PreviewService).to receive(:call)
+    allow(PreviewDraftEditionService).to receive(:call)
     allow(AssetCleanupJob).to receive(:perform_later)
   end
 
   describe ".call" do
-    it "delegates to the PreviewService" do
+    it "delegates to the PreviewDraftEditionService" do
       edition = create(:edition)
-      expect(PreviewService).to receive(:call)
-      FailsafePreviewService.call(edition)
+      expect(PreviewDraftEditionService).to receive(:call)
+      FailsafeDraftPreviewService.call(edition)
     end
 
     context "when an external service is down" do
       it "sets revision_synced to false on the edition" do
-        allow(PreviewService).to receive(:call).and_raise(GdsApi::BaseError)
+        allow(PreviewDraftEditionService).to receive(:call).and_raise(GdsApi::BaseError)
         edition = create(:edition, revision_synced: true)
-        FailsafePreviewService.call(edition)
+        FailsafeDraftPreviewService.call(edition)
         expect(edition.revision_synced).to be(false)
       end
     end
@@ -26,13 +26,13 @@ RSpec.describe FailsafePreviewService do
       let(:edition) { create(:edition, title: "", revision_synced: true) }
 
       it "sets revision_synced to false on the edition" do
-        FailsafePreviewService.call(edition)
+        FailsafeDraftPreviewService.call(edition)
         expect(edition.revision_synced).to be(false)
       end
 
       it "doesn't send to the Publishing API" do
         request = stub_publishing_api_put_content(edition.content_id, {})
-        FailsafePreviewService.call(edition)
+        FailsafeDraftPreviewService.call(edition)
         expect(request).not_to have_been_requested
       end
     end

--- a/spec/services/generate_base_path_service_spec.rb
+++ b/spec/services/generate_base_path_service_spec.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-RSpec.describe PathGeneratorService do
+RSpec.describe GenerateBasePathService do
   describe ".call" do
     let(:document) { create(:document, :with_current_edition) }
 
@@ -8,7 +8,7 @@ RSpec.describe PathGeneratorService do
       new_document = build(:document, :with_current_edition)
       stub_publishing_api_has_lookups("#{document.current_edition.base_path}": nil)
 
-      expect(PathGeneratorService.call(new_document, document.current_edition.title))
+      expect(GenerateBasePathService.call(new_document, document.current_edition.title))
         .to eq("#{document.current_edition.base_path}-1")
     end
 
@@ -17,7 +17,7 @@ RSpec.describe PathGeneratorService do
       existing_paths = ["#{prefix}/a-title", "#{prefix}/a-title-1", "#{prefix}/a-title-2"]
       existing_paths.each { |path| create(:edition, base_path: path) }
 
-      expect { PathGeneratorService.call(document, "A title", max_repeated_titles: 2) }
+      expect { GenerateBasePathService.call(document, "A title", max_repeated_titles: 2) }
         .to raise_error("Already >2 paths with same title.")
     end
   end

--- a/spec/services/generate_unique_filename_service_spec.rb
+++ b/spec/services/generate_unique_filename_service_spec.rb
@@ -1,28 +1,28 @@
 # frozen_string_literal: true
 
-RSpec.describe UniqueFilenameService do
+RSpec.describe GenerateUniqueFilenameService do
   let(:existing_filenames) { ["file1.jpg"] }
 
   describe "#call" do
     it "parameterises the base filename" do
-      name = UniqueFilenameService.call(existing_filenames, "File $ name.jpg")
+      name = GenerateUniqueFilenameService.call(existing_filenames, "File $ name.jpg")
       expect(name).to eq "file-name.jpg"
     end
 
     it "copes if the file has no extension" do
-      name = UniqueFilenameService.call(existing_filenames, "file")
+      name = GenerateUniqueFilenameService.call(existing_filenames, "file")
       expect(name).to eq "file"
     end
 
     it "truncates lengthy base filenames" do
-      stub_const "UniqueFilenameService::MAX_LENGTH", 3
-      name = UniqueFilenameService.call(existing_filenames, "mylongname.jpg")
+      stub_const "GenerateUniqueFilenameService::MAX_LENGTH", 3
+      name = GenerateUniqueFilenameService.call(existing_filenames, "mylongname.jpg")
       expect(name).to eq "myl.jpg"
     end
 
     it "ensures the filename is unique for a list of filenames" do
       existing_filenames << "file.jpg"
-      name = UniqueFilenameService.call(existing_filenames, "file.jpg")
+      name = GenerateUniqueFilenameService.call(existing_filenames, "file.jpg")
       expect(name).to eq "file-1.jpg"
     end
   end

--- a/spec/services/preview_draft_edition_service/payload_spec.rb
+++ b/spec/services/preview_draft_edition_service/payload_spec.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-RSpec.describe PreviewService::Payload do
+RSpec.describe PreviewDraftEditionService::Payload do
   describe "#payload" do
     it "generates a payload for the publishing API" do
       document_type = build(:document_type)
@@ -10,7 +10,7 @@ RSpec.describe PreviewService::Payload do
                       summary: "document summary",
                       base_path: "/foo/bar/baz")
 
-      payload = PreviewService::Payload.new(edition).payload
+      payload = PreviewDraftEditionService::Payload.new(edition).payload
 
       payload_hash = {
         "base_path" => "/foo/bar/baz",
@@ -31,14 +31,14 @@ RSpec.describe PreviewService::Payload do
     it "specifies an auth bypass ID for anonymous previews" do
       edition = build(:edition)
       allow_any_instance_of(PreviewAuthBypass).to receive(:auth_bypass_id) { "id" }
-      payload = PreviewService::Payload.new(edition).payload
+      payload = PreviewDraftEditionService::Payload.new(edition).payload
       expect(payload["auth_bypass_ids"]).to eq(%w[id])
     end
 
     it "specifies organisations when the edition is access limited" do
       edition = build(:edition, :access_limited)
       allow(edition).to receive(:access_limit_organisation_ids) { %w[org-id] }
-      payload = PreviewService::Payload.new(edition).payload
+      payload = PreviewDraftEditionService::Payload.new(edition).payload
       expect(payload["access_limited"]["organisations"]).to eq %w[org-id]
     end
 
@@ -50,7 +50,7 @@ RSpec.describe PreviewService::Payload do
                       tags: { primary_publishing_organisation: %w[my-org-id],
                               organisations: %w[other-org-id] })
 
-      payload = PreviewService::Payload.new(edition).payload
+      payload = PreviewDraftEditionService::Payload.new(edition).payload
 
       expect(payload["links"]).to match a_hash_including(
         "primary_publishing_organisation" => %w[my-org-id],
@@ -66,7 +66,7 @@ RSpec.describe PreviewService::Payload do
                       tags: { primary_publishing_organisation: %w[my-org-id],
                               organisations: %w[my-org-id] })
 
-      payload = PreviewService::Payload.new(edition).payload
+      payload = PreviewDraftEditionService::Payload.new(edition).payload
 
       expect(payload["links"]["organisations"]).to eq %w[my-org-id]
     end
@@ -86,7 +86,7 @@ RSpec.describe PreviewService::Payload do
         "links" => { "person" => [person_id], "role" => [role_id] },
       )
 
-      payload = PreviewService::Payload.new(edition).payload
+      payload = PreviewDraftEditionService::Payload.new(edition).payload
 
       expect(payload["links"]).to match a_hash_including(
         "roles" => [role_id],
@@ -101,7 +101,7 @@ RSpec.describe PreviewService::Payload do
                       document_type_id: document_type.id,
                       contents: { body: "Hey **buddy**!" })
 
-      payload = PreviewService::Payload.new(edition).payload
+      payload = PreviewDraftEditionService::Payload.new(edition).payload
 
       expect(payload["details"]["body"]).to eq("<p>Hey <strong>buddy</strong>!</p>\n")
     end
@@ -119,7 +119,7 @@ RSpec.describe PreviewService::Payload do
                       document_type_id: document_type.id,
                       lead_image_revision: image_revision)
 
-      payload = PreviewService::Payload.new(edition).payload
+      payload = PreviewDraftEditionService::Payload.new(edition).payload
 
       payload_hash = {
         "url" => image_revision.asset_url("300"),
@@ -134,11 +134,11 @@ RSpec.describe PreviewService::Payload do
 
     it "includes the political status of the edition" do
       political_edition = build(:edition, :political)
-      payload = PreviewService::Payload.new(political_edition).payload
+      payload = PreviewDraftEditionService::Payload.new(political_edition).payload
       expect(payload["details"]["political"]).to be true
 
       not_political_edition = build(:edition, :not_political)
-      payload = PreviewService::Payload.new(not_political_edition).payload
+      payload = PreviewDraftEditionService::Payload.new(not_political_edition).payload
       expect(payload["details"]["political"]).to be false
     end
 
@@ -148,7 +148,7 @@ RSpec.describe PreviewService::Payload do
 
       edition = build(:edition, government_id: government.content_id)
 
-      payload = PreviewService::Payload.new(edition).payload
+      payload = PreviewDraftEditionService::Payload.new(edition).payload
 
       expect(payload["links"]["government"]).to eq [government.content_id]
     end
@@ -157,7 +157,7 @@ RSpec.describe PreviewService::Payload do
       edition = build(:edition,
                       update_type: "major",
                       change_note: "A change note")
-      payload = PreviewService::Payload.new(edition).payload
+      payload = PreviewDraftEditionService::Payload.new(edition).payload
 
       expect(payload).to match a_hash_including("change_note" => "A change note")
     end
@@ -166,7 +166,7 @@ RSpec.describe PreviewService::Payload do
       edition = build(:edition,
                       update_type: "minor",
                       change_note: "A change note")
-      payload = PreviewService::Payload.new(edition).payload
+      payload = PreviewDraftEditionService::Payload.new(edition).payload
 
       expect(payload).not_to match a_hash_including("change_note" => "A change note")
     end
@@ -175,7 +175,7 @@ RSpec.describe PreviewService::Payload do
       date = Time.current.yesterday
       revision = build(:revision, backdated_to: date)
       edition = build(:edition, revision: revision)
-      payload = PreviewService::Payload.new(edition).payload
+      payload = PreviewDraftEditionService::Payload.new(edition).payload
 
       expect(payload).to match a_hash_including("first_published_at" => date)
     end
@@ -184,14 +184,14 @@ RSpec.describe PreviewService::Payload do
       date = Time.current.yesterday
       revision = build(:revision, backdated_to: date)
       edition = build(:edition, revision: revision, number: 1)
-      payload = PreviewService::Payload.new(edition).payload
+      payload = PreviewDraftEditionService::Payload.new(edition).payload
 
       expect(payload).to match a_hash_including("public_updated_at" => date)
     end
 
     it "includes bulk_publishing and sets the update to republish if the edition is being republished" do
       edition = build(:edition)
-      payload = PreviewService::Payload.new(edition, republish: true).payload
+      payload = PreviewDraftEditionService::Payload.new(edition, republish: true).payload
 
       expect(payload).to match a_hash_including(
         "update_type" => "republish",

--- a/spec/services/preview_draft_edition_service_spec.rb
+++ b/spec/services/preview_draft_edition_service_spec.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-RSpec.describe PreviewService do
+RSpec.describe PreviewDraftEditionService do
   before do
     stub_any_publishing_api_put_content
     allow(PreviewAssetService).to receive(:call)
@@ -10,13 +10,13 @@ RSpec.describe PreviewService do
     it "updates the Publishing API" do
       edition = create(:edition)
       request = stub_publishing_api_put_content(edition.content_id, {})
-      PreviewService.call(edition)
+      PreviewDraftEditionService.call(edition)
       expect(request).to have_been_requested
     end
 
     it "marks the edition as 'revision_synced'" do
       edition = create(:edition, revision_synced: false)
-      PreviewService.call(edition)
+      PreviewDraftEditionService.call(edition)
       expect(edition.reload.revision_synced).to be(true)
     end
 
@@ -24,25 +24,25 @@ RSpec.describe PreviewService do
       image_revision = create(:image_revision)
       edition = create(:edition, image_revisions: [image_revision])
       expect(PreviewAssetService).to receive(:call).at_least(:once)
-      PreviewService.call(edition)
+      PreviewDraftEditionService.call(edition)
     end
 
     it "uploads any file attachment assets" do
       file_attachment_revision = create(:file_attachment_revision)
       edition = create(:edition, file_attachment_revisions: [file_attachment_revision])
       expect(PreviewAssetService).to receive(:call).at_least(:once)
-      PreviewService.call(edition)
+      PreviewDraftEditionService.call(edition)
     end
 
     it "sets an update type of republish" do
       edition = create(:edition)
 
-      expect(PreviewService::Payload)
+      expect(PreviewDraftEditionService::Payload)
         .to receive(:new)
         .with(edition, republish: true)
         .and_call_original
 
-      PreviewService.call(edition, republish: true)
+      PreviewDraftEditionService.call(edition, republish: true)
     end
 
     context "when Publishing API is down" do
@@ -52,7 +52,7 @@ RSpec.describe PreviewService do
 
       it "sets revision_synced to false on the edition" do
         edition = create(:edition, revision_synced: true)
-        expect { PreviewService.call(edition) }.to raise_error(GdsApi::BaseError)
+        expect { PreviewDraftEditionService.call(edition) }.to raise_error(GdsApi::BaseError)
         expect(edition.revision_synced).to be(false)
       end
     end
@@ -65,7 +65,7 @@ RSpec.describe PreviewService do
       it "sets revision_synced to false on the edition" do
         image_revision = create(:image_revision)
         edition = create(:edition, image_revisions: [image_revision], revision_synced: true)
-        expect { PreviewService.call(edition) }.to raise_error(GdsApi::BaseError)
+        expect { PreviewDraftEditionService.call(edition) }.to raise_error(GdsApi::BaseError)
         expect(edition.revision_synced).to be(false)
       end
     end

--- a/spec/services/publish_assets_service_spec.rb
+++ b/spec/services/publish_assets_service_spec.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-RSpec.describe PublishAssetService do
+RSpec.describe PublishAssetsService do
   describe ".call" do
     it "publishes the draft assets and marks them as live" do
       image_revision = create(:image_revision, :on_asset_manager, state: :draft)
@@ -12,7 +12,7 @@ RSpec.describe PublishAssetService do
                        image_revisions: [image_revision])
 
       request = stub_asset_manager_updates_any_asset
-      PublishAssetService.call(edition, nil)
+      PublishAssetsService.call(edition, nil)
       expect(image_revision.assets.map(&:state).uniq).to eq(%w[live])
       expect(file_attachment_revision.asset).to be_live
       expect(request).to have_been_requested.at_least_once
@@ -34,7 +34,7 @@ RSpec.describe PublishAssetService do
                        document: live_edition.document)
 
       request = stub_any_asset_manager_call
-      PublishAssetService.call(edition, live_edition)
+      PublishAssetsService.call(edition, live_edition)
       expect(request).to_not have_been_requested
     end
 
@@ -44,7 +44,7 @@ RSpec.describe PublishAssetService do
                        :publishable,
                        image_revisions: [image_revision])
 
-      expect { PublishAssetService.call(edition, nil) }.to raise_error("Expected asset to be on asset manager")
+      expect { PublishAssetsService.call(edition, nil) }.to raise_error("Expected asset to be on asset manager")
     end
 
     it "removes an asset not used by the current edition" do
@@ -64,7 +64,7 @@ RSpec.describe PublishAssetService do
 
       delete_request = stub_asset_manager_deletes_any_asset
 
-      PublishAssetService.call(edition, live_edition)
+      PublishAssetsService.call(edition, live_edition)
       expect(image_revision_to_remove.assets.map(&:state).uniq).to eq(%w[absent])
       expect(file_attachment_revision_to_remove.asset).to be_absent
       expect(delete_request).to have_been_requested.at_least_once
@@ -86,7 +86,7 @@ RSpec.describe PublishAssetService do
                      file_attachment_revisions: [file_attachment_revision_to_keep],
                      document: live_edition.document)
 
-    PublishAssetService.call(edition, live_edition)
+    PublishAssetsService.call(edition, live_edition)
     expect(image_revision_to_keep.assets.map(&:state).uniq).to eq(%w[live])
     expect(file_attachment_revision_to_keep.asset).to be_live
   end
@@ -109,7 +109,7 @@ RSpec.describe PublishAssetService do
                      document: live_edition.document)
 
     request = stub_asset_manager_updates_any_asset
-    PublishAssetService.call(edition, live_edition)
+    PublishAssetsService.call(edition, live_edition)
     expect(old_image_revision.assets.map(&:state).uniq).to eq(%w[superseded])
     expect(old_file_attachment_revision.asset).to be_superseded
     expect(request).to have_been_requested.at_least_once

--- a/spec/services/schedule_publish_service/payload_spec.rb
+++ b/spec/services/schedule_publish_service/payload_spec.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-RSpec.describe ScheduleService::Payload do
+RSpec.describe SchedulePublishService::Payload do
   describe "#intent_payload" do
     it "generates a payload for the publishing API" do
       document_type = build(:document_type, rendering_app: "government-frontend")
@@ -11,11 +11,11 @@ RSpec.describe ScheduleService::Payload do
                       document_type_id: document_type.id,
                       publish_time: publish_time)
 
-      payload = ScheduleService::Payload.new(edition).intent_payload
+      payload = SchedulePublishService::Payload.new(edition).intent_payload
 
       payload_hash = {
         publish_time: publish_time,
-        publishing_app: PreviewService::Payload::PUBLISHING_APP,
+        publishing_app: PreviewDraftEditionService::Payload::PUBLISHING_APP,
         rendering_app: "government-frontend",
       }
 

--- a/spec/services/schedule_publish_service_spec.rb
+++ b/spec/services/schedule_publish_service_spec.rb
@@ -1,15 +1,15 @@
 # frozen_string_literal: true
 
-RSpec.describe ScheduleService do
+RSpec.describe SchedulePublishService do
   let(:payload) do
-    instance_double(ScheduleService::Payload, intent_payload: "payload")
+    instance_double(SchedulePublishService::Payload, intent_payload: "payload")
   end
 
   include ActiveJob::TestHelper
 
   before(:each) do
     stub_any_publishing_api_put_intent
-    allow(ScheduleService::Payload).to receive(:new) { payload }
+    allow(SchedulePublishService::Payload).to receive(:new) { payload }
   end
 
   describe "#call" do
@@ -18,24 +18,24 @@ RSpec.describe ScheduleService do
     let(:scheduling) { create :scheduling, publish_time: edition.proposed_publish_time }
 
     it "sets an edition's state to 'scheduled'" do
-      ScheduleService.call(edition, user, scheduling)
+      SchedulePublishService.call(edition, user, scheduling)
       expect(edition).to be_scheduled
     end
 
     it "clears the editions proposed publish time" do
-      ScheduleService.call(edition, user, scheduling)
+      SchedulePublishService.call(edition, user, scheduling)
       expect(edition.reload.proposed_publish_time).to be_nil
     end
 
     it "creates a publishing intent" do
       request = stub_publishing_api_put_intent(edition.base_path, '"payload"')
-      ScheduleService.call(edition, user, scheduling)
+      SchedulePublishService.call(edition, user, scheduling)
       expect(request).to have_been_requested
     end
 
     it "schedules the edition to publish" do
       datetime = edition.proposed_publish_time
-      ScheduleService.call(edition, user, scheduling)
+      SchedulePublishService.call(edition, user, scheduling)
       expect(enqueued_jobs.count).to eq 1
       expect(enqueued_jobs.first[:args].first).to eq edition.id
       expect(enqueued_jobs.first[:at].to_i).to eq datetime.to_i

--- a/spec/services/withdraw_document_service_spec.rb
+++ b/spec/services/withdraw_document_service_spec.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-RSpec.describe WithdrawService do
+RSpec.describe WithdrawDocumentService do
   describe "#call" do
     let(:edition) { create(:edition, :published) }
     let(:user) { create(:user) }
@@ -14,7 +14,7 @@ RSpec.describe WithdrawService do
                                               body: { type: "withdrawal",
                                                       explanation: converted_public_explanation,
                                                       locale: edition.locale })
-      WithdrawService.call(edition, public_explanation, user)
+      WithdrawDocumentService.call(edition, public_explanation, user)
 
       expect(request).to have_been_requested
     end
@@ -22,7 +22,7 @@ RSpec.describe WithdrawService do
 
     it "updates the edition status to withdrawn" do
       travel_to(Time.current) do
-        WithdrawService.call(edition, public_explanation, user)
+        WithdrawDocumentService.call(edition, public_explanation, user)
         edition.reload
         withdrawal = edition.status.details
 
@@ -35,7 +35,7 @@ RSpec.describe WithdrawService do
     it "saves the published_status to the withdrawal record" do
       previous_published_status = edition.status
 
-      WithdrawService.call(edition, public_explanation, user)
+      WithdrawDocumentService.call(edition, public_explanation, user)
       edition.reload
 
       withdrawal = edition.status.details
@@ -47,7 +47,7 @@ RSpec.describe WithdrawService do
       withdrawn_edition = create(:edition, :withdrawn)
       previous_withdrawal = withdrawn_edition.status.details
 
-      WithdrawService.call(withdrawn_edition, public_explanation, user)
+      WithdrawDocumentService.call(withdrawn_edition, public_explanation, user)
 
       withdrawal = withdrawn_edition.status.details
 
@@ -57,7 +57,7 @@ RSpec.describe WithdrawService do
     context "when the given edition is a draft" do
       it "raises an error" do
         draft_edition = create(:edition)
-        expect { WithdrawService.call(draft_edition, public_explanation, user) }
+        expect { WithdrawDocumentService.call(draft_edition, public_explanation, user) }
           .to raise_error "attempted to withdraw an edition other than the live edition"
       end
     end
@@ -70,7 +70,7 @@ RSpec.describe WithdrawService do
                               current: false,
                               document: draft_edition.document)
 
-        expect { WithdrawService.call(live_edition, public_explanation, user) }
+        expect { WithdrawDocumentService.call(live_edition, public_explanation, user) }
           .to raise_error "Publishing API does not support unpublishing while there is a draft"
       end
     end
@@ -80,7 +80,7 @@ RSpec.describe WithdrawService do
         image_revision = create(:image_revision, :on_asset_manager)
         edition = create(:edition, :published, lead_image_revision: image_revision)
         delete_request = stub_asset_manager_deletes_any_asset
-        WithdrawService.call(edition, public_explanation, user)
+        WithdrawDocumentService.call(edition, public_explanation, user)
         expect(delete_request).not_to have_been_requested
       end
     end
@@ -88,7 +88,7 @@ RSpec.describe WithdrawService do
     context "when an edition is already withdrawn and public_explanation differs" do
       it "updates public_explanation" do
         withdrawn_edition = create(:edition, :withdrawn)
-        expect { WithdrawService.call(withdrawn_edition, public_explanation, user) }
+        expect { WithdrawDocumentService.call(withdrawn_edition, public_explanation, user) }
           .to change { withdrawn_edition.reload.status.details.public_explanation }
           .to(public_explanation)
       end
@@ -98,7 +98,7 @@ RSpec.describe WithdrawService do
         withdrawal = build(:withdrawal, withdrawn_at: withdrawn_at)
         withdrawn_edition = create(:edition, :withdrawn, withdrawal: withdrawal)
 
-        expect { WithdrawService.call(withdrawn_edition, public_explanation, user) }
+        expect { WithdrawDocumentService.call(withdrawn_edition, public_explanation, user) }
           .not_to change { withdrawn_edition.reload.status.details.withdrawn_at }
           .from(withdrawn_at)
       end


### PR DESCRIPTION
https://github.com/alphagov/content-publisher/issues/1256

https://trello.com/c/f1QaCH7x/231-our-services-directory-is-a-mess

This tries to bring some closure to our work on the code in the `app/services` 
directory. In many cases, I think the new names are more precise than 
the old, shorter ones. It's meant to be a set of open suggestions, though, 
so feel free to suggest alternatives.

From the commit:

    This renames a few services to follow a pattern where the single action
    a service performs is described in terms of a verb, like 'create' or
    'publish', operating on a noun, like 'filename' or 'scheduled
    publishing'. In the case of 'edition' vs 'draft', I've gone with
    'draft', which is less ambiguous than an arbitrary edition.