### PR TITLE
Fix flakey array assertions

### DIFF
--- a/spec/lib/whitehall_importer/create_edition_spec.rb
+++ b/spec/lib/whitehall_importer/create_edition_spec.rb
@@ -278,7 +278,7 @@ RSpec.describe WhitehallImporter::CreateEdition do
                                      whitehall_edition: whitehall_edition)
 
       statuses = edition.statuses.map(&:state)
-      expect(statuses).to eq(%w[submitted_for_review scheduled])
+      expect(statuses).to contain_exactly("submitted_for_review", "scheduled")
       expect(edition.status.details.pre_scheduled_status).to be_submitted_for_review
     end
 
@@ -290,7 +290,7 @@ RSpec.describe WhitehallImporter::CreateEdition do
                                      whitehall_edition: whitehall_edition)
 
       statuses = edition.statuses.map(&:state)
-      expect(statuses).to eq(%w[draft scheduled])
+      expect(statuses).to contain_exactly("draft", "scheduled")
       expect(edition.status.details.pre_scheduled_status).to be_draft
     end
 


### PR DESCRIPTION
These tests were asserting that an array contained the expected items
and was in a certain order. This ordering is non-deterministic so we're
at risk of these causing failed builds as was seen in
https://ci.integration.publishing.service.gov.uk/job/content-publisher/job/modal-tests/4/console

The verify that these tests were actually flakey and that this fixed the
issue I ran these both 5000 times (I know that seems rather high, the
issue didn't seem to reveal itself on a 500 test run). The results were
as follows:

Before:

Finished in 5 minutes 51 seconds (files took 5.4 seconds to load)
10026 examples, 8294 failures

After:

Finished in 6 minutes 25 seconds (files took 5.73 seconds to load)
10026 examples, 0 failures