### PR TITLE
Use I18n for supertypes

### DIFF
--- a/app/models/supertype.rb
+++ b/app/models/supertype.rb
@@ -3,7 +3,7 @@
 class Supertype
   include InitializeWithHash
 
-  attr_reader :id, :label, :description, :managed_elsewhere, :hint, :document_types
+  attr_reader :id, :managed_elsewhere, :document_types
 
   def self.all
     @all ||= begin

--- a/app/views/new_document/choose_document_type.html.erb
+++ b/app/views/new_document/choose_document_type.html.erb
@@ -1,11 +1,11 @@
-<% content_for :browser_title, @supertype.label %>
+<% content_for :browser_title, t("supertypes.#{@supertype.id}.label") %>
 <% content_for :back_link, render_back_link(href: new_document_path) %>
 
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
     <%= form_tag create_document_path, data: { gtm: "confirm-document-type" } do %>
       <%= render "govuk_publishing_components/components/radio", {
-        heading: @supertype.label,
+        heading: t("supertypes.#{@supertype.id}.label"),
         is_page_heading: true,
         name: "document_type",
         error_items: @issues&.items_for(:document_type),

--- a/app/views/new_document/choose_supertype.html.erb
+++ b/app/views/new_document/choose_supertype.html.erb
@@ -13,16 +13,19 @@
         name: "supertype",
         error_items: @issues&.items_for(:supertype),
         items: Supertype.all.map do |supertype|
+          id = supertype.id
+          label = I18n.t("supertypes.#{id}.label")
+          hint = I18n.t("supertypes.#{id}.hint")
           {
-            value: supertype.id,
-            text: supertype.label,
-            hint_text: supertype.description,
+            value: id,
+            text: label,
+            hint_text: I18n.t("supertypes.#{id}.description"),
             bold: true,
             data_attributes: {
               gtm: "choose-supertype",
-              "gtm-value": supertype.label,
+              "gtm-value": label,
             },
-            conditional: supertype.hint ? tag.p(supertype.hint, class: "govuk-body") : nil,
+            conditional: hint ? tag.p(hint, class: "govuk-body") : nil,
           }
         end
       } %>

--- a/config/locales/en/supertypes.yml
+++ b/config/locales/en/supertypes.yml
@@ -1,0 +1,33 @@
+en:
+  supertypes:
+    news:
+      label: News
+      description: To tell users about something government has done or will do
+      hint: For example, news stories, press releases, speeches, or statements
+
+    guidance:
+      label: Guidance
+      description: To help the user do something or understand what they need to do
+      hint: For example, manuals, or statutory guidance
+
+    transparency:
+      label: Transparency and statistics
+      description: To provide information that helps users hold government to account
+      hint: For example, statistics, FOI data, or reports
+
+    policy:
+      label: Policy or consultation
+      description: To explain the government’s position or request views or evidence on an issue
+      hint: For example, policy papers, impact assessments, or case studies
+
+    document-collection:
+      label: Document collection
+      description: To create a list of related documents on a single page
+
+    corporate-information:
+      label: Corporate information
+      description: Information about your organisation
+
+    not-sure:
+      label: I’m not sure if this should be on GOV.UK
+      description: View this guide to see what should go on GOV.UK and where else you can publish content

--- a/config/supertypes.yml
+++ b/config/supertypes.yml
@@ -1,8 +1,5 @@
 ---
 - id: news
-  label: News
-  description: To tell users about something government has done or will do
-  hint: For example, news stories, press releases, speeches, or statements
   display_document_types:
     - news_story
     - press_release
@@ -11,9 +8,6 @@
     - world_news_story
 
 - id: guidance
-  label: Guidance
-  description: To help the user do something or understand what they need to do
-  hint: For example, manuals, or statutory guidance
   display_document_types:
     - detailed_guide
     - any-whitehall-publication
@@ -22,38 +16,26 @@
     - travel_advice
 
 - id: transparency
-  label: Transparency and statistics
-  description: To provide information that helps users hold government to account
-  hint: For example, statistics, FOI data, or reports
   display_document_types:
     - any-whitehall-publication
     - statistical-data-set
 
 - id: policy
-  label: Policy or consultation
-  description: To explain the government’s position or request views or evidence on an issue
-  hint: For example, policy papers, impact assessments, or case studies
   display_document_types:
     - case_study
     - consultation
     - any-whitehall-publication
 
 - id: document-collection
-  label: Document collection
-  description: To create a list of related documents on a single page
   managed_elsewhere:
     hostname: whitehall-admin
     path: /government/admin/collections/new
 
 - id: corporate-information
-  label: Corporate information
-  description: Information about your organisation
   managed_elsewhere:
     hostname: whitehall-admin
     path: /government/admin/organisations/government-digital-service/corporate_information_pages
 
 - id: not-sure
-  label: I’m not sure if this should be on GOV.UK
-  description: View this guide to see what should go on GOV.UK and where else you can publish content
   managed_elsewhere:
     path: /documents/publishing-guidance

--- a/spec/features/formats/consultation_spec.rb
+++ b/spec/features/formats/consultation_spec.rb
@@ -9,7 +9,7 @@ RSpec.describe "Consultation format" do
   def when_i_choose_this_document_type
     visit "/"
     click_on "Create new document"
-    choose Supertype.find("policy").label
+    choose I18n.t!("supertypes.policy.label")
     click_on "Continue"
     choose DocumentType.find("consultation").label
     click_on "Continue"

--- a/spec/features/formats/detailed_guide_spec.rb
+++ b/spec/features/formats/detailed_guide_spec.rb
@@ -9,7 +9,7 @@ RSpec.describe "Detailed guide format" do
   def when_i_choose_this_document_type
     visit "/"
     click_on "Create new document"
-    choose Supertype.find("guidance").label
+    choose I18n.t!("supertypes.guidance.label")
     click_on "Continue"
     choose DocumentType.find("detailed_guide").label
     click_on "Continue"

--- a/spec/features/formats/news_story_spec.rb
+++ b/spec/features/formats/news_story_spec.rb
@@ -18,7 +18,7 @@ RSpec.describe "News story format" do
   def when_i_choose_this_document_type
     visit root_path
     click_on "Create new document"
-    choose Supertype.find("news").label
+    choose I18n.t!("supertypes.news.label")
     click_on "Continue"
     choose DocumentType.find("news_story").label
     click_on "Continue"

--- a/spec/features/formats/not_sure_spec.rb
+++ b/spec/features/formats/not_sure_spec.rb
@@ -13,7 +13,7 @@ RSpec.describe "User is not sure about the supertype" do
   end
 
   def and_i_choose_i_am_not_sure_if_it_belongs_on_govuk
-    choose Supertype.find("not-sure").label
+    choose I18n.t!("supertypes.not-sure.label")
     click_on "Continue"
   end
 

--- a/spec/features/formats/press_release_spec.rb
+++ b/spec/features/formats/press_release_spec.rb
@@ -18,7 +18,7 @@ RSpec.describe "Press release format" do
   def when_i_choose_this_document_type
     visit root_path
     click_on "Create new document"
-    choose Supertype.find("news").label
+    choose I18n.t!("supertypes.news.label")
     click_on "Continue"
     choose DocumentType.find("press_release").label
     click_on "Continue"

--- a/spec/features/workflow/create_document_spec.rb
+++ b/spec/features/workflow/create_document_spec.rb
@@ -22,7 +22,7 @@ RSpec.feature "Create a document" do
   end
 
   def and_i_select_a_supertype
-    choose Supertype.all.first.label
+    choose I18n.t("supertypes.news.label")
     click_on "Continue"
   end
 

--- a/spec/models/supertype_spec.rb
+++ b/spec/models/supertype_spec.rb
@@ -6,8 +6,8 @@ RSpec.describe Supertype do
       describe "Supertype #{supertype.id}" do
         it "has the required attributes for #{supertype.id}" do
           expect(supertype.id).to_not be_blank
-          expect(supertype.label).to_not be_blank
-          expect(supertype.description).to_not be_blank
+          expect(I18n.t("supertypes.#{supertype.id}.label")).to_not be_blank
+          expect(I18n.t("supertypes.#{supertype.id}.description")).to_not be_blank
         end
       end
     end

--- a/spec/requests/new_document_spec.rb
+++ b/spec/requests/new_document_spec.rb
@@ -6,7 +6,7 @@ RSpec.describe "New Document" do
       supertype = Supertype.all.reject(&:managed_elsewhere).first
       get choose_document_type_path, params: { supertype: supertype.id }
       expect(response).to have_http_status(:ok)
-      expect(response.body).to have_content(supertype.label)
+      expect(response.body).to have_content(I18n.t!("supertypes.#{supertype.id}.label"))
     end
 
     it "redirects when a supertype managed elsewhere is selected" do


### PR DESCRIPTION
Trello - https://trello.com/c/hAJkXW1T/1325-use-i18n-to-manage-copy-for-each-supertype

This moves the copy from a yaml file to be internationalised. This is more in line with how i18n is meant to be used and will make configuration easier once we start iterating the supertype model.