### PR TITLE
Use I18n to manage copy for each document type

### DIFF
--- a/app/helpers/document_type_helper.rb
+++ b/app/helpers/document_type_helper.rb
@@ -1,0 +1,20 @@
+# frozen_string_literal: true
+
+module DocumentTypeHelper
+  def t_doctype_exists?(i18n_key)
+    I18n.exists?(i18n_key) || I18n.exists?(doctype_default_key(i18n_key))
+  end
+
+  def t_doctype(i18n_key)
+    match = I18n.t!(I18n.exists?(i18n_key) ? i18n_key : doctype_default_key(i18n_key))
+    match.is_a?(String) ? match : match.stringify_keys
+  end
+
+private
+
+  def doctype_default_key(i18n_key)
+    parts = i18n_key.split(".")
+    parts[1] = "default"
+    parts.join(".")
+  end
+end

--- a/app/helpers/document_type_helper.rb
+++ b/app/helpers/document_type_helper.rb
@@ -1,15 +1,21 @@
 # frozen_string_literal: true
 
 module DocumentTypeHelper
-  def t_doctype_exists?(i18n_key)
+  def t_doctype_field?(edition, partial_i18n_key)
+    i18n_key = prefix_doctype_field(edition, partial_i18n_key)
     I18n.exists?(i18n_key) || I18n.exists?(doctype_default_key(i18n_key))
   end
 
-  def t_doctype(i18n_key)
+  def t_doctype_field(edition, partial_i18n_key)
+    i18n_key = prefix_doctype_field(edition, partial_i18n_key)
     I18n.t!(I18n.exists?(i18n_key) ? i18n_key : doctype_default_key(i18n_key))
   end
 
 private
+
+  def prefix_doctype_field(edition, partial_i18n_key)
+    "document_types.#{edition.document_type.id}.fields.#{partial_i18n_key}"
+  end
 
   def doctype_default_key(i18n_key)
     parts = i18n_key.split(".")

--- a/app/helpers/document_type_helper.rb
+++ b/app/helpers/document_type_helper.rb
@@ -6,8 +6,7 @@ module DocumentTypeHelper
   end
 
   def t_doctype(i18n_key)
-    match = I18n.t!(I18n.exists?(i18n_key) ? i18n_key : doctype_default_key(i18n_key))
-    match.is_a?(String) ? match : match.stringify_keys
+    I18n.t!(I18n.exists?(i18n_key) ? i18n_key : doctype_default_key(i18n_key))
   end
 
 private

--- a/app/models/document_type.rb
+++ b/app/models/document_type.rb
@@ -4,7 +4,7 @@ class DocumentType
   include InitializeWithHash
 
   attr_reader :contents, :id, :label, :managed_elsewhere, :publishing_metadata,
-              :path_prefix, :tags, :guidance_govspeak, :description, :images,
+              :path_prefix, :tags, :guidance_govspeak, :images,
               :topics, :check_path_conflict
 
   def self.find(id)

--- a/app/models/document_type.rb
+++ b/app/models/document_type.rb
@@ -4,7 +4,7 @@ class DocumentType
   include InitializeWithHash
 
   attr_reader :contents, :id, :label, :managed_elsewhere, :publishing_metadata,
-              :path_prefix, :tags, :guidance_govspeak, :description, :hint_govspeak, :images,
+              :path_prefix, :tags, :guidance_govspeak, :description, :images,
               :topics, :check_path_conflict
 
   def self.find(id)

--- a/app/models/document_type.rb
+++ b/app/models/document_type.rb
@@ -18,7 +18,13 @@ class DocumentType
 
       hashes.map do |hash|
         hash["contents"] = hash["contents"].to_a.map(&Field.method(:new))
-        hash["tags"] = hash["tags"].to_a.map(&TagField.method(:new))
+        hash["tags"] = (hash["tags"] || []).map do |tag_config|
+          tag_i18n_data = "document_types.#{hash['id']}.fields.#{tag_config['id']}"
+          if I18n.exists?(tag_i18n_data)
+            TagField.new(tag_config.merge(I18n.t!(tag_i18n_data).stringify_keys))
+          end
+        end
+        hash["tags"] = hash["tags"].compact
         hash["publishing_metadata"] = PublishingMetadata.new(hash["publishing_metadata"].to_h)
         hash["topics"] = true # this feature is only disabled in tests
         new(hash)

--- a/app/models/document_type.rb
+++ b/app/models/document_type.rb
@@ -1,6 +1,8 @@
 # frozen_string_literal: true
 
 class DocumentType
+  extend DocumentTypeHelper # for static methods
+  include DocumentTypeHelper
   include InitializeWithHash
 
   attr_reader :contents, :id, :managed_elsewhere, :publishing_metadata,
@@ -19,8 +21,8 @@ class DocumentType
         hash["contents"] = hash["contents"].to_a.map(&Field.method(:new))
         hash["tags"] = (hash["tags"] || []).map do |tag_config|
           tag_i18n_data = "document_types.#{hash['id']}.fields.#{tag_config['id']}"
-          if I18n.exists?(tag_i18n_data)
-            TagField.new(tag_config.merge(I18n.t!(tag_i18n_data).stringify_keys))
+          if t_doctype_exists?(tag_i18n_data)
+            TagField.new(tag_config.merge(t_doctype(tag_i18n_data)))
           end
         end
         hash["tags"] = hash["tags"].compact
@@ -36,7 +38,7 @@ class DocumentType
   end
 
   def label
-    I18n.t!("document_types.#{id}.label")
+    t_doctype("document_types.#{id}.label")
   end
 
   class TagField

--- a/app/models/document_type.rb
+++ b/app/models/document_type.rb
@@ -3,7 +3,7 @@
 class DocumentType
   include InitializeWithHash
 
-  attr_reader :contents, :id, :label, :managed_elsewhere, :publishing_metadata,
+  attr_reader :contents, :id, :managed_elsewhere, :publishing_metadata,
               :path_prefix, :tags, :guidance_govspeak, :images,
               :topics, :check_path_conflict
 
@@ -28,6 +28,10 @@ class DocumentType
 
   def managed_elsewhere_url
     Plek.new.external_url_for(managed_elsewhere.fetch("hostname")) + managed_elsewhere.fetch("path")
+  end
+
+  def label
+    I18n.t!("document_types.#{id}.label")
   end
 
   class TagField

--- a/app/models/document_type.rb
+++ b/app/models/document_type.rb
@@ -1,8 +1,6 @@
 # frozen_string_literal: true
 
 class DocumentType
-  extend DocumentTypeHelper # for static methods
-  include DocumentTypeHelper
   include InitializeWithHash
 
   attr_reader :contents, :id, :managed_elsewhere, :publishing_metadata, :label,
@@ -19,13 +17,7 @@ class DocumentType
 
       hashes.map do |hash|
         hash["contents"] = hash["contents"].to_a.map(&Field.method(:new))
-        hash["tags"] = (hash["tags"] || []).map do |tag_config|
-          tag_i18n_data = "document_types.#{hash['id']}.fields.#{tag_config['id']}"
-          if t_doctype_exists?(tag_i18n_data)
-            TagField.new(tag_config.merge(t_doctype(tag_i18n_data)))
-          end
-        end
-        hash["tags"] = hash["tags"].compact
+        hash["tags"] = hash["tags"].to_a.map(&TagField.method(:new))
         hash["publishing_metadata"] = PublishingMetadata.new(hash["publishing_metadata"].to_h)
         hash["topics"] = true # this feature is only disabled in tests
         new(hash)

--- a/app/models/document_type.rb
+++ b/app/models/document_type.rb
@@ -4,8 +4,7 @@ class DocumentType
   include InitializeWithHash
 
   attr_reader :contents, :id, :managed_elsewhere, :publishing_metadata,
-              :path_prefix, :tags, :guidance_govspeak, :images,
-              :topics, :check_path_conflict
+              :path_prefix, :tags, :images, :topics, :check_path_conflict
 
   def self.find(id)
     item = all.find { |document_type| document_type.id == id }

--- a/app/models/document_type.rb
+++ b/app/models/document_type.rb
@@ -5,7 +5,7 @@ class DocumentType
   include DocumentTypeHelper
   include InitializeWithHash
 
-  attr_reader :contents, :id, :managed_elsewhere, :publishing_metadata,
+  attr_reader :contents, :id, :managed_elsewhere, :publishing_metadata, :label,
               :path_prefix, :tags, :images, :topics, :check_path_conflict
 
   def self.find(id)
@@ -35,10 +35,6 @@ class DocumentType
 
   def managed_elsewhere_url
     Plek.new.external_url_for(managed_elsewhere.fetch("hostname")) + managed_elsewhere.fetch("path")
-  end
-
-  def label
-    t_doctype("document_types.#{id}.label")
   end
 
   class TagField

--- a/app/models/document_type.rb
+++ b/app/models/document_type.rb
@@ -20,7 +20,6 @@ class DocumentType
         hash["contents"] = hash["contents"].to_a.map(&Field.method(:new))
         hash["tags"] = hash["tags"].to_a.map(&TagField.method(:new))
         hash["publishing_metadata"] = PublishingMetadata.new(hash["publishing_metadata"].to_h)
-        hash["guidance"] = hash["guidance"].to_a.map(&Guidance.method(:new))
         hash["topics"] = true # this feature is only disabled in tests
         new(hash)
       end
@@ -31,18 +30,9 @@ class DocumentType
     Plek.new.external_url_for(managed_elsewhere.fetch("hostname")) + managed_elsewhere.fetch("path")
   end
 
-  def guidance_for(id)
-    @guidance.find { |guidance| guidance.id == id }
-  end
-
   class TagField
     include InitializeWithHash
     attr_reader :id, :label, :type, :document_type, :hint
-  end
-
-  class Guidance
-    include InitializeWithHash
-    attr_reader :id, :title, :body_govspeak
   end
 
   class PublishingMetadata

--- a/app/views/content/edit.html.erb
+++ b/app/views/content/edit.html.erb
@@ -69,7 +69,7 @@
       id: "summary",
       html_for: "summary-field"
     }
-    if @edition.document_type.guidance_for("title")
+    if @edition.document_type.guidance_for("summary")
       summary_contextual_guidance.merge!({
         title: @edition.document_type.guidance_for("summary").title,
         content: @edition.document_type.guidance_for("summary").body_govspeak,

--- a/app/views/content/edit.html.erb
+++ b/app/views/content/edit.html.erb
@@ -20,10 +20,10 @@
       id: "title",
       html_for: "title-field"
     }
-    if I18n.exists?("document_types.#{@edition.document_type.id}.fields.title.guidance")
+    if t_doctype_exists?("document_types.#{@edition.document_type.id}.fields.title.guidance")
       title_contextual_guidance.merge!({
-        title: t("document_types.#{@edition.document_type.id}.fields.title.guidance.title"),
-        content: t("document_types.#{@edition.document_type.id}.fields.title.guidance.body_govspeak"),
+        title: t_doctype("document_types.#{@edition.document_type.id}.fields.title.guidance.title"),
+        content: t_doctype("document_types.#{@edition.document_type.id}.fields.title.guidance.body_govspeak"),
         guidance_id: "title-guidance"
       })
     end
@@ -69,10 +69,10 @@
       id: "summary",
       html_for: "summary-field"
     }
-    if I18n.exists?("document_types.#{@edition.document_type.id}.fields.summary.guidance")
+    if t_doctype_exists?("document_types.#{@edition.document_type.id}.fields.summary.guidance")
       summary_contextual_guidance.merge!({
-        title: t("document_types.#{@edition.document_type.id}.fields.summary.guidance.title"),
-        content: t("document_types.#{@edition.document_type.id}.fields.summary.guidance.body_govspeak"),
+        title: t_doctype("document_types.#{@edition.document_type.id}.fields.summary.guidance.title"),
+        content: t_doctype("document_types.#{@edition.document_type.id}.fields.summary.guidance.body_govspeak"),
         guidance_id: "summary-guidance"
       })
     end

--- a/app/views/content/edit.html.erb
+++ b/app/views/content/edit.html.erb
@@ -20,10 +20,10 @@
       id: "title",
       html_for: "title-field"
     }
-    if @edition.document_type.guidance_for("title")
+    if I18n.exists?("document_types.#{@edition.document_type.id}.fields.title.guidance")
       title_contextual_guidance.merge!({
-        title: @edition.document_type.guidance_for("title").title,
-        content: @edition.document_type.guidance_for("title").body_govspeak,
+        title: t("document_types.#{@edition.document_type.id}.fields.title.guidance.title"),
+        content: t("document_types.#{@edition.document_type.id}.fields.title.guidance.body_govspeak"),
         guidance_id: "title-guidance"
       })
     end
@@ -69,10 +69,10 @@
       id: "summary",
       html_for: "summary-field"
     }
-    if @edition.document_type.guidance_for("summary")
+    if I18n.exists?("document_types.#{@edition.document_type.id}.fields.summary.guidance")
       summary_contextual_guidance.merge!({
-        title: @edition.document_type.guidance_for("summary").title,
-        content: @edition.document_type.guidance_for("summary").body_govspeak,
+        title: t("document_types.#{@edition.document_type.id}.fields.summary.guidance.title"),
+        content: t("document_types.#{@edition.document_type.id}.fields.summary.guidance.body_govspeak"),
         guidance_id: "summary-guidance"
       })
     end

--- a/app/views/content/edit.html.erb
+++ b/app/views/content/edit.html.erb
@@ -20,10 +20,10 @@
       id: "title",
       html_for: "title-field"
     }
-    if t_doctype_exists?("document_types.#{@edition.document_type.id}.fields.title.guidance")
+    if t_doctype_field?(@edition, "title.guidance")
       title_contextual_guidance.merge!({
-        title: t_doctype("document_types.#{@edition.document_type.id}.fields.title.guidance.title"),
-        content: t_doctype("document_types.#{@edition.document_type.id}.fields.title.guidance.body_govspeak"),
+        title: t_doctype_field(@edition, "title.guidance.title"),
+        content: t_doctype_field(@edition, "title.guidance.body_govspeak"),
         guidance_id: "title-guidance"
       })
     end
@@ -69,10 +69,10 @@
       id: "summary",
       html_for: "summary-field"
     }
-    if t_doctype_exists?("document_types.#{@edition.document_type.id}.fields.summary.guidance")
+    if t_doctype_field?(@edition, "summary.guidance")
       summary_contextual_guidance.merge!({
-        title: t_doctype("document_types.#{@edition.document_type.id}.fields.summary.guidance.title"),
-        content: t_doctype("document_types.#{@edition.document_type.id}.fields.summary.guidance.body_govspeak"),
+        title: t_doctype_field(@edition, "summary.guidance.title"),
+        content: t_doctype_field(@edition, "summary.guidance.body_govspeak"),
         guidance_id: "summary-guidance"
       })
     end

--- a/app/views/documents/fields/_govspeak_input.html.erb
+++ b/app/views/documents/fields/_govspeak_input.html.erb
@@ -1,5 +1,5 @@
 <% document_contents_guidance = capture do %>
-  <%= edition.document_type.guidance_for(field.id) ? render_govspeak(edition.document_type.guidance_for(field.id).body_govspeak) : nil %>
+  <%= I18n.exists?("document_types.#{edition.document_type.id}.fields.#{field.id}.guidance") ? render_govspeak(t("document_types.#{edition.document_type.id}.fields.#{field.id}.guidance.body_govspeak")) : nil %>
   <h3 class="govuk-heading-s"><%= t("content.edit.fields.govspeak.title") %></h3>
   <p class="govuk-body">
     <%= link_to t("content.edit.fields.govspeak.guidance"), "https://www.gov.uk/guidance/how-to-publish-on-gov-uk/markdown", class: "govuk-link", target: "_blank" %>
@@ -12,9 +12,9 @@
     id: field.id,
     html_for: "#{field.id}-field"
   }
-  if edition.document_type.guidance_for(field.id)
+  if I18n.exists?("document_types.#{edition.document_type.id}.fields.#{field.id}.guidance")
     field_contextual_guidance.merge!({
-      title: edition.document_type.guidance_for(field.id).title,
+      title: t("document_types.#{edition.document_type.id}.fields.#{field.id}.guidance.title"),
       content: document_contents_guidance,
       guidance_id: "#{field.id}-guidance"
     })

--- a/app/views/documents/fields/_govspeak_input.html.erb
+++ b/app/views/documents/fields/_govspeak_input.html.erb
@@ -1,5 +1,5 @@
 <% document_contents_guidance = capture do %>
-  <%= I18n.exists?("document_types.#{edition.document_type.id}.fields.#{field.id}.guidance") ? render_govspeak(t("document_types.#{edition.document_type.id}.fields.#{field.id}.guidance.body_govspeak")) : nil %>
+  <%= t_doctype_exists?("document_types.#{edition.document_type.id}.fields.#{field.id}.guidance") ? render_govspeak(t_doctype("document_types.#{edition.document_type.id}.fields.#{field.id}.guidance.body_govspeak")) : nil %>
   <h3 class="govuk-heading-s"><%= t("content.edit.fields.govspeak.title") %></h3>
   <p class="govuk-body">
     <%= link_to t("content.edit.fields.govspeak.guidance"), "https://www.gov.uk/guidance/how-to-publish-on-gov-uk/markdown", class: "govuk-link", target: "_blank" %>
@@ -12,9 +12,9 @@
     id: field.id,
     html_for: "#{field.id}-field"
   }
-  if I18n.exists?("document_types.#{edition.document_type.id}.fields.#{field.id}.guidance")
+  if t_doctype_exists?("document_types.#{edition.document_type.id}.fields.#{field.id}.guidance")
     field_contextual_guidance.merge!({
-      title: t("document_types.#{edition.document_type.id}.fields.#{field.id}.guidance.title"),
+      title: t_doctype("document_types.#{edition.document_type.id}.fields.#{field.id}.guidance.title"),
       content: document_contents_guidance,
       guidance_id: "#{field.id}-guidance"
     })

--- a/app/views/documents/fields/_govspeak_input.html.erb
+++ b/app/views/documents/fields/_govspeak_input.html.erb
@@ -1,5 +1,5 @@
 <% document_contents_guidance = capture do %>
-  <%= t_doctype_exists?("document_types.#{edition.document_type.id}.fields.#{field.id}.guidance") ? render_govspeak(t_doctype("document_types.#{edition.document_type.id}.fields.#{field.id}.guidance.body_govspeak")) : nil %>
+  <%= t_doctype_field?(edition, "#{field.id}.guidance") ? render_govspeak(t_doctype_field(edition, "#{field.id}.guidance.body_govspeak")) : nil %>
   <h3 class="govuk-heading-s"><%= t("content.edit.fields.govspeak.title") %></h3>
   <p class="govuk-body">
     <%= link_to t("content.edit.fields.govspeak.guidance"), "https://www.gov.uk/guidance/how-to-publish-on-gov-uk/markdown", class: "govuk-link", target: "_blank" %>
@@ -12,9 +12,9 @@
     id: field.id,
     html_for: "#{field.id}-field"
   }
-  if t_doctype_exists?("document_types.#{edition.document_type.id}.fields.#{field.id}.guidance")
+  if t_doctype_field?(edition, "#{field.id}.guidance")
     field_contextual_guidance.merge!({
-      title: t_doctype("document_types.#{edition.document_type.id}.fields.#{field.id}.guidance.title"),
+      title: t_doctype_field(edition, "#{field.id}.guidance.title"),
       content: document_contents_guidance,
       guidance_id: "#{field.id}-guidance"
     })

--- a/app/views/documents/show/_tags.html.erb
+++ b/app/views/documents/show/_tags.html.erb
@@ -6,7 +6,7 @@
       .map { |content_id| service.by_content_id(content_id) }
 
     {
-      field: tag_field.label,
+      field: t_doctype("document_types.#{@edition.document_type.id}.fields.#{tag_field.id}.label"),
       value: render("documents/tags/#{tag_field.type}", tag_field: tag_field, values: values)
     }
   } %>

--- a/app/views/documents/show/_tags.html.erb
+++ b/app/views/documents/show/_tags.html.erb
@@ -6,7 +6,7 @@
       .map { |content_id| service.by_content_id(content_id) }
 
     {
-      field: t_doctype("document_types.#{@edition.document_type.id}.fields.#{tag_field.id}.label"),
+      field: t_doctype_field(@edition, "#{tag_field.id}.label"),
       value: render("documents/tags/#{tag_field.type}", tag_field: tag_field, values: values)
     }
   } %>

--- a/app/views/new_document/choose_document_type.html.erb
+++ b/app/views/new_document/choose_document_type.html.erb
@@ -18,7 +18,7 @@
               gtm: "choose-document-type",
               "gtm-value": document_type.label,
             },
-            conditional: I18n.exists?("document_types.#{document_type.id}.guidance.body_govspeak") ? render_govspeak(I18n.t!("document_types.#{document_type.id}.guidance.body_govspeak")) : nil,
+            conditional: I18n.exists?("document_types.#{document_type.id}.guidance.body_govspeak") ? render_govspeak(t("document_types.#{document_type.id}.guidance.body_govspeak")) : nil,
             bold: true,
           }
         }

--- a/app/views/new_document/choose_document_type.html.erb
+++ b/app/views/new_document/choose_document_type.html.erb
@@ -13,7 +13,7 @@
           {
             value: document_type.id,
             text: document_type.label,
-            hint_text: document_type.description,
+            hint_text: I18n.exists?("document_types.#{document_type.id}.description") ? t("document_types.#{document_type.id}.description") : nil,
             data_attributes: {
               gtm: "choose-document-type",
               "gtm-value": document_type.label,

--- a/app/views/new_document/choose_document_type.html.erb
+++ b/app/views/new_document/choose_document_type.html.erb
@@ -18,7 +18,7 @@
               gtm: "choose-document-type",
               "gtm-value": document_type.label,
             },
-            conditional: document_type.hint_govspeak ? render_govspeak(document_type.hint_govspeak) : nil,
+            conditional: I18n.exists?("document_types.#{document_type.id}.guidance.body_govspeak") ? render_govspeak(I18n.t!("document_types.#{document_type.id}.guidance.body_govspeak")) : nil,
             bold: true,
           }
         }

--- a/app/views/tags/tags/_multi_tag_input.html.erb
+++ b/app/views/tags/tags/_multi_tag_input.html.erb
@@ -2,10 +2,10 @@
   id: "#{tag_field.id}-field",
   name: "tags[#{tag_field.id}][]",
   label: {
-    text: t_doctype("document_types.#{@edition.document_type.id}.fields.#{tag_field.id}.label"),
+    text: t_doctype_field(@edition, "#{tag_field.id}.label"),
     bold: true
   },
-  hint: t_doctype("document_types.#{@edition.document_type.id}.fields.#{tag_field.id}.hint"),
+  hint: t_doctype_field(@edition, "#{tag_field.id}.hint"),
   select: {
     options: Linkables.new(tag_field.document_type).select_options,
     selected: tags[tag_field.id],

--- a/app/views/tags/tags/_multi_tag_input.html.erb
+++ b/app/views/tags/tags/_multi_tag_input.html.erb
@@ -2,10 +2,10 @@
   id: "#{tag_field.id}-field",
   name: "tags[#{tag_field.id}][]",
   label: {
-    text: tag_field.label,
+    text: t_doctype("document_types.#{@edition.document_type.id}.fields.#{tag_field.id}.label"),
     bold: true
   },
-  hint: tag_field.hint,
+  hint: t_doctype("document_types.#{@edition.document_type.id}.fields.#{tag_field.id}.hint"),
   select: {
     options: Linkables.new(tag_field.document_type).select_options,
     selected: tags[tag_field.id],

--- a/app/views/tags/tags/_single_tag_input.html.erb
+++ b/app/views/tags/tags/_single_tag_input.html.erb
@@ -2,10 +2,10 @@
   id: "#{tag_field.id}-field",
   name: "tags[#{tag_field.id}][]",
   label: {
-    text: tag_field.label,
+    text: t_doctype("document_types.#{@edition.document_type.id}.fields.#{tag_field.id}.label"),
     bold: true,
   },
-  hint: tag_field.hint,
+  hint: t_doctype("document_types.#{@edition.document_type.id}.fields.#{tag_field.id}.hint"),
   select: {
     options: [""] + Linkables.new(tag_field.document_type).select_options,
     selected: tags[tag_field.id],

--- a/app/views/tags/tags/_single_tag_input.html.erb
+++ b/app/views/tags/tags/_single_tag_input.html.erb
@@ -2,10 +2,10 @@
   id: "#{tag_field.id}-field",
   name: "tags[#{tag_field.id}][]",
   label: {
-    text: t_doctype("document_types.#{@edition.document_type.id}.fields.#{tag_field.id}.label"),
+    text: t_doctype_field(@edition, "#{tag_field.id}.label"),
     bold: true,
   },
-  hint: t_doctype("document_types.#{@edition.document_type.id}.fields.#{tag_field.id}.hint"),
+  hint: t_doctype_field(@edition, "#{tag_field.id}.hint"),
   select: {
     options: [""] + Linkables.new(tag_field.document_type).select_options,
     selected: tags[tag_field.id],

--- a/config/document_types.yml
+++ b/config/document_types.yml
@@ -8,23 +8,6 @@
   publishing_metadata:
     schema_name: news_article
     rendering_app: government-frontend
-  guidance:
-    - id: title
-      title: Create a news title
-      body_govspeak: The title must make clear what the content offers users. Use the words your users do to help them find this. Avoid wordplay or teases.
-    - id: summary
-      title: Writing a news summary
-      body_govspeak: The summary explains the main point of the content and it should end with a full stop. Keep it short, possibly under 160 characters, and avoid repeating the first line of the body.
-    - id: body
-      title: Writing news
-      body_govspeak: |
-        Tell the story in the first lines with the most important information at the top. Use short words, short sentences, and short paragraphs. Use subheadings in longer content.
-
-        [Guidance on news stories](https://www.gov.uk/guidance/content-design/content-types#news-story){:target="_blank"}
-
-        [Writing for GOV.UK](https://www.gov.uk/guidance/content-design/writing-for-gov-uk#writing-to-govuk-style){:target="_blank"}
-
-        [The style guide](https://www.gov.uk/guidance/style-guide){:target="_blank"}
   contents:
     - id: body
       label: Body
@@ -65,23 +48,6 @@
   publishing_metadata:
     schema_name: news_article
     rendering_app: government-frontend
-  guidance:
-    - id: title
-      title: Title
-      body_govspeak: The title should be unique and specific. It must make clear what the content offers users. Use the words your users do to help them find this. Avoid wordplay or teases.
-    - id: summary
-      title: Summary
-      body_govspeak: The summary should explain the main point of the story. It is the first line of the story so don’t repeat it in the body and end with a full stop.
-    - id: body
-      title: Writing a press release
-      body_govspeak: |
-        Use short words, short sentences, and short paragraphs. Use subheadings in longer content. Avoid 'notes to editors'.
-
-        [Guidance on press releases](https://www.gov.uk/guidance/content-design/content-types#press-release){:target="_blank"}
-
-        [Writing for GOV.UK](https://www.gov.uk/guidance/content-design/writing-for-gov-uk#writing-to-govuk-style){:target="_blank"}
-
-        [The style guide](https://www.gov.uk/guidance/style-guide){:target="_blank"}
   contents:
     - id: body
       label: Body

--- a/config/document_types.yml
+++ b/config/document_types.yml
@@ -1,6 +1,5 @@
 ---
 - id: news_story
-  label: News story
   path_prefix: /government/news
   images: true
   check_path_conflict: true
@@ -39,7 +38,6 @@
       hint: Tag locations this content is about. If it only relates to the UK you don’t need to use this tag.
 
 - id: press_release
-  label: Press release
   path_prefix: /government/news
   images: true
   check_path_conflict: true
@@ -78,67 +76,56 @@
       hint: Tag locations this content is about. If it only relates to the UK you don’t need to use this tag.
 
 - id: fatality_notice
-  label: Fatality notice
   managed_elsewhere:
     hostname: whitehall-admin
     path: /government/admin/fatalities/new
 
 - id: speech
-  label: Speech
   managed_elsewhere:
     hostname: whitehall-admin
     path: /government/admin/speeches/new
 
 - id: world_news_story
-  label: World news story
   managed_elsewhere:
     hostname: whitehall-admin
     path: /government/admin/news/new
 
 - id: detailed_guide
-  label: Detailed guide
   managed_elsewhere:
     hostname: whitehall-admin
     path: /government/admin/detailed-guides/new
 
 - id: any-whitehall-publication
-  label: Publication
   managed_elsewhere:
     hostname: whitehall-admin
     path: /government/admin/publications/new
 
 - id: manual
-  label: Manual
   managed_elsewhere:
     hostname: manuals-publisher
     path: /
 
 - id: any-mainstream-publication
-  label: Mainstream guide
   managed_elsewhere:
     hostname: support
     path: /content_change_request/new
 
 - id: travel_advice
-  label: Travel advice
   managed_elsewhere:
     hostname: travel-advice-publisher
     path: /admin
 
 - id: statistical-data-set
-  label: Statistical data set
   managed_elsewhere:
     hostname: whitehall-admin
     path: /government/admin/statistical-data-sets/new
 
 - id: case_study
-  label: Case study
   managed_elsewhere:
     hostname: whitehall-admin
     path: /government/admin/case-studies/new
 
 - id: consultation
-  label: Consultation
   managed_elsewhere:
     hostname: whitehall-admin
     path: /government/admin/consultations/new

--- a/config/document_types.yml
+++ b/config/document_types.yml
@@ -2,9 +2,6 @@
 - id: news_story
   label: News story
   description: "News written for GOV.UK which users need, can act on, and cannot get from other sources."
-  hint_govspeak: |
-    Do not include advice in news stories. Do not use to promote other content.
-    Read the full [guidance on news stories](https://www.gov.uk/guidance/content-design/content-types#news-story).
   path_prefix: /government/news
   images: true
   check_path_conflict: true
@@ -62,9 +59,6 @@
 - id: press_release
   label: Press release
   description: "Unedited press releases as sent to the media, and official statements from the organisation."
-  hint_govspeak: |
-    Do not use to promote other content. Statements to Parliament should use the Speech document type.
-    Read the full [guidance on press releases](https://www.gov.uk/guidance/content-design/content-types#press-release).
   path_prefix: /government/news
   images: true
   check_path_conflict: true

--- a/config/document_types.yml
+++ b/config/document_types.yml
@@ -1,7 +1,6 @@
 ---
 - id: news_story
   label: News story
-  description: "News written for GOV.UK which users need, can act on, and cannot get from other sources."
   path_prefix: /government/news
   images: true
   check_path_conflict: true
@@ -41,7 +40,6 @@
 
 - id: press_release
   label: Press release
-  description: "Unedited press releases as sent to the media, and official statements from the organisation."
   path_prefix: /government/news
   images: true
   check_path_conflict: true
@@ -81,77 +79,66 @@
 
 - id: fatality_notice
   label: Fatality notice
-  description: Initial fatality notices and subsequent obituaries of forces and MOD personnel
   managed_elsewhere:
     hostname: whitehall-admin
     path: /government/admin/fatalities/new
 
 - id: speech
   label: Speech
-  description: Public speeches, written statements, or authored articles
   managed_elsewhere:
     hostname: whitehall-admin
     path: /government/admin/speeches/new
 
 - id: world_news_story
   label: World news story
-  description: Announcements specific to one or more world location
   managed_elsewhere:
     hostname: whitehall-admin
     path: /government/admin/news/new
 
 - id: detailed_guide
   label: Detailed guide
-  description: Detailed guidance for specialist users on the steps they need to take to complete a task
   managed_elsewhere:
     hostname: whitehall-admin
     path: /government/admin/detailed-guides/new
 
 - id: any-whitehall-publication
   label: Publication
-  description: Standalone government documents that are issued and not usually updated
   managed_elsewhere:
     hostname: whitehall-admin
     path: /government/admin/publications/new
 
 - id: manual
   label: Manual
-  description: Long and complex guidance broken into chapters and sub-sections for reference
   managed_elsewhere:
     hostname: manuals-publisher
     path: /
 
 - id: any-mainstream-publication
   label: Mainstream guide
-  description: Guidance for the general public on how to do something. Contact GDS to request changes.
   managed_elsewhere:
     hostname: support
     path: /content_change_request/new
 
 - id: travel_advice
   label: Travel advice
-  description: Travel advice by country including entry requirements and safety information
   managed_elsewhere:
     hostname: travel-advice-publisher
     path: /admin
 
 - id: statistical-data-set
   label: Statistical data set
-  description: Frequently updated (“live”) statistical data files.
   managed_elsewhere:
     hostname: whitehall-admin
     path: /government/admin/statistical-data-sets/new
 
 - id: case_study
   label: Case study
-  description: Case studies show someone’s experience of a government process or policy problem
   managed_elsewhere:
     hostname: whitehall-admin
     path: /government/admin/case-studies/new
 
 - id: consultation
   label: Consultation
-  description: A request for views or evidence on an issue
   managed_elsewhere:
     hostname: whitehall-admin
     path: /government/admin/consultations/new

--- a/config/document_types.yml
+++ b/config/document_types.yml
@@ -12,30 +12,20 @@
       type: govspeak
   tags:
     - id: primary_publishing_organisation
-      label: Primary organisation
       type: single_tag
       document_type: organisation
-      hint: The organisation responsible for publishing and maintaining this content.
     - id: organisations
-      label: Organisations
       type: multi_tag
       document_type: organisation
-      hint: Tag organisations associated with this content.
     - id: role_appointments
-      label: Ministers and government appointments
       type: multi_tag
       document_type: role_appointment
-      hint: Tag people who are directly involved.
     - id: topical_events
-      label: Topical events
       type: multi_tag
       document_type: topical_event
-      hint: Tag major events this content is related to. For example, summits or budgets.
     - id: world_locations
-      label: World locations
       type: multi_tag
       document_type: world_location
-      hint: Tag locations this content is about. If it only relates to the UK you don’t need to use this tag.
 
 - id: press_release
   path_prefix: /government/news
@@ -50,30 +40,20 @@
       type: govspeak
   tags:
     - id: primary_publishing_organisation
-      label: Primary organisation
       type: single_tag
       document_type: organisation
-      hint: The organisation responsible for publishing and maintaining this content.
     - id: organisations
-      label: Organisations
       type: multi_tag
       document_type: organisation
-      hint: Tag organisations associated with this content.
     - id: role_appointments
-      label: Ministers and government appointments
       type: multi_tag
       document_type: role_appointment
-      hint: Tag people who are directly involved.
     - id: topical_events
-      label: Topical events
       type: multi_tag
       document_type: topical_event
-      hint: Tag major events this content is related to. For example, summits or budgets.
     - id: world_locations
-      label: World locations
       type: multi_tag
       document_type: world_location
-      hint: Tag locations this content is about. If it only relates to the UK you don’t need to use this tag.
 
 - id: fatality_notice
   managed_elsewhere:

--- a/config/document_types.yml
+++ b/config/document_types.yml
@@ -1,5 +1,6 @@
 ---
 - id: news_story
+  label: News story
   path_prefix: /government/news
   images: true
   check_path_conflict: true
@@ -28,6 +29,7 @@
       document_type: world_location
 
 - id: press_release
+  label: Press release
   path_prefix: /government/news
   images: true
   check_path_conflict: true
@@ -56,56 +58,67 @@
       document_type: world_location
 
 - id: fatality_notice
+  label: Fatality notice
   managed_elsewhere:
     hostname: whitehall-admin
     path: /government/admin/fatalities/new
 
 - id: speech
+  label: Speech
   managed_elsewhere:
     hostname: whitehall-admin
     path: /government/admin/speeches/new
 
 - id: world_news_story
+  label: World news story
   managed_elsewhere:
     hostname: whitehall-admin
     path: /government/admin/news/new
 
 - id: detailed_guide
+  label: Detailed guide
   managed_elsewhere:
     hostname: whitehall-admin
     path: /government/admin/detailed-guides/new
 
 - id: any-whitehall-publication
+  label: Publication
   managed_elsewhere:
     hostname: whitehall-admin
     path: /government/admin/publications/new
 
 - id: manual
+  label: Manual
   managed_elsewhere:
     hostname: manuals-publisher
     path: /
 
 - id: any-mainstream-publication
+  label: Mainstream guide
   managed_elsewhere:
     hostname: support
     path: /content_change_request/new
 
 - id: travel_advice
+  label: Travel advice
   managed_elsewhere:
     hostname: travel-advice-publisher
     path: /admin
 
 - id: statistical-data-set
+  label: Statistical data set
   managed_elsewhere:
     hostname: whitehall-admin
     path: /government/admin/statistical-data-sets/new
 
 - id: case_study
+  label: Case study
   managed_elsewhere:
     hostname: whitehall-admin
     path: /government/admin/case-studies/new
 
 - id: consultation
+  label: Consultation
   managed_elsewhere:
     hostname: whitehall-admin
     path: /government/admin/consultations/new

--- a/config/locales/en/document_types.yml
+++ b/config/locales/en/document_types.yml
@@ -25,7 +25,6 @@ en:
           hint: Tag locations this content is about. If it only relates to the UK you don’t need to use this tag.
 
     news_story:
-      label: News story
       description: "News written for GOV.UK which users need, can act on, and cannot get from other sources."
       guidance:
         body_govspeak: |
@@ -53,7 +52,6 @@ en:
               [The style guide](https://www.gov.uk/guidance/style-guide){:target="_blank"}
 
     press_release:
-      label: Press release
       description: "Unedited press releases as sent to the media, and official statements from the organisation."
       guidance:
         body_govspeak: |
@@ -81,45 +79,34 @@ en:
               [The style guide](https://www.gov.uk/guidance/style-guide){:target="_blank"}
 
     fatality_notice:
-      label: Fatality notice
       description: Initial fatality notices and subsequent obituaries of forces and MOD personnel
       
     speech:
-      label: Speech
       description: Public speeches, written statements, or authored articles
     
     world_news_story:
-      label: World news story
       description: Announcements specific to one or more world location
     
     detailed_guide:
-      label: Detailed guide
       description: Detailed guidance for specialist users on the steps they need to take to complete a task
     
     any-whitehall-publication:
-      label: Publication
       description: Standalone government documents that are issued and not usually updated
     
     manual:
-      label: Manual
       description: Long and complex guidance broken into chapters and sub-sections for reference
     
     any-mainstream-publication:
-      label: Mainstream guide
       description: Guidance for the general public on how to do something. Contact GDS to request changes.
     
     travel_advice:
-      label: Travel advice
       description: Travel advice by country including entry requirements and safety information
     
     statistical-data-set:
-      label: Statistical data set
       description: Frequently updated (“live”) statistical data files.
     
     case_study:
-      label: Case study
       description: Case studies show someone’s experience of a government process or policy problem
     
     consultation:
-      label: Consultation
       description: A request for views or evidence on an issue

--- a/config/locales/en/document_types.yml
+++ b/config/locales/en/document_types.yml
@@ -1,5 +1,29 @@
 en:
   document_types:
+    default:
+      fields:
+        title:
+          label: Title
+        summary:
+          label: Summary
+        body:
+          label: Body
+        primary_publishing_organisation:
+          label: Primary organisation
+          hint: The organisation responsible for publishing and maintaining this content.
+        organisations:
+          label: Organisations
+          hint: Tag organisations associated with this content.
+        role_appointments:
+          label: Ministers and government appointments
+          hint: Tag people who are directly involved.
+        topical_events:
+          label: Topical events
+          hint: Tag major events this content is related to. For example, summits or budgets.
+        world_locations:
+          label: World locations
+          hint: Tag locations this content is about. If it only relates to the UK you don’t need to use this tag.
+
     news_story:
       label: News story
       description: "News written for GOV.UK which users need, can act on, and cannot get from other sources."
@@ -9,17 +33,14 @@ en:
           Read the full [guidance on news stories](https://www.gov.uk/guidance/content-design/content-types#news-story).
       fields:
         title:
-          label: Title
           guidance:
             title: Create a news title
             body_govspeak: The title must make clear what the content offers users. Use the words your users do to help them find this. Avoid wordplay or teases.
         summary:
-          label: Summary
           guidance:
             title: Writing a news summary
             body_govspeak: The summary explains the main point of the content and it should end with a full stop. Keep it short, possibly under 160 characters, and avoid repeating the first line of the body.
         body:
-          label: Body
           guidance:
             title: Writing news
             body_govspeak: |
@@ -30,21 +51,6 @@ en:
               [Writing for GOV.UK](https://www.gov.uk/guidance/content-design/writing-for-gov-uk#writing-to-govuk-style){:target="_blank"}
 
               [The style guide](https://www.gov.uk/guidance/style-guide){:target="_blank"}
-        primary_publishing_organisation:
-          label: Primary organisation
-          hint: The organisation responsible for publishing and maintaining this content.
-        organisations:
-          label: Organisations
-          hint: Tag organisations associated with this content.
-        role_appointments:
-          label: Ministers and government appointments
-          hint: Tag people who are directly involved.
-        topical_events:
-          label: Topical events
-          hint: Tag major events this content is related to. For example, summits or budgets.
-        world_locations:
-          label: World locations
-          hint: Tag locations this content is about. If it only relates to the UK you don’t need to use this tag.
 
     press_release:
       label: Press release
@@ -55,17 +61,14 @@ en:
           Read the full [guidance on press releases](https://www.gov.uk/guidance/content-design/content-types#press-release).
       fields:
         title:
-          label: Title
           guidance:
             title: Title
             body_govspeak: The title should be unique and specific. It must make clear what the content offers users. Use the words your users do to help them find this. Avoid wordplay or teases.
         summary:
-          label: Summary
           guidance:
             title: Summary
             body_govspeak: The summary should explain the main point of the story. It is the first line of the story so don’t repeat it in the body and end with a full stop.
         body:
-          label: Body
           guidance:
             title: Writing a press release
             body_govspeak: |
@@ -76,21 +79,6 @@ en:
               [Writing for GOV.UK](https://www.gov.uk/guidance/content-design/writing-for-gov-uk#writing-to-govuk-style){:target="_blank"}
 
               [The style guide](https://www.gov.uk/guidance/style-guide){:target="_blank"}
-        primary_publishing_organisation:
-          label: Primary organisation
-          hint: The organisation responsible for publishing and maintaining this content.
-        organisations:
-          label: Organisations
-          hint: Tag organisations associated with this content.
-        role_appointments:
-          label: Ministers and government appointments
-          hint: Tag people who are directly involved.
-        topical_events:
-          label: Topical events
-          hint: Tag major events this content is related to. For example, summits or budgets.
-        world_locations:
-          label: World locations
-          hint: Tag locations this content is about. If it only relates to the UK you don’t need to use this tag.
 
     fatality_notice:
       label: Fatality notice

--- a/config/locales/en/document_types.yml
+++ b/config/locales/en/document_types.yml
@@ -30,6 +30,21 @@ en:
               [Writing for GOV.UK](https://www.gov.uk/guidance/content-design/writing-for-gov-uk#writing-to-govuk-style){:target="_blank"}
 
               [The style guide](https://www.gov.uk/guidance/style-guide){:target="_blank"}
+        primary_publishing_organisation:
+          label: Primary organisation
+          hint: The organisation responsible for publishing and maintaining this content.
+        organisations:
+          label: Organisations
+          hint: Tag organisations associated with this content.
+        role_appointments:
+          label: Ministers and government appointments
+          hint: Tag people who are directly involved.
+        topical_events:
+          label: Topical events
+          hint: Tag major events this content is related to. For example, summits or budgets.
+        world_locations:
+          label: World locations
+          hint: Tag locations this content is about. If it only relates to the UK you don’t need to use this tag.
 
     press_release:
       label: Press release
@@ -61,6 +76,21 @@ en:
               [Writing for GOV.UK](https://www.gov.uk/guidance/content-design/writing-for-gov-uk#writing-to-govuk-style){:target="_blank"}
 
               [The style guide](https://www.gov.uk/guidance/style-guide){:target="_blank"}
+        primary_publishing_organisation:
+          label: Primary organisation
+          hint: The organisation responsible for publishing and maintaining this content.
+        organisations:
+          label: Organisations
+          hint: Tag organisations associated with this content.
+        role_appointments:
+          label: Ministers and government appointments
+          hint: Tag people who are directly involved.
+        topical_events:
+          label: Topical events
+          hint: Tag major events this content is related to. For example, summits or budgets.
+        world_locations:
+          label: World locations
+          hint: Tag locations this content is about. If it only relates to the UK you don’t need to use this tag.
 
     fatality_notice:
       label: Fatality notice

--- a/config/locales/en/document_types.yml
+++ b/config/locales/en/document_types.yml
@@ -1,0 +1,107 @@
+en:
+  document_types:
+    news_story:
+      label: News story
+      description: "News written for GOV.UK which users need, can act on, and cannot get from other sources."
+      guidance:
+        body_govspeak: |
+          Do not include advice in news stories. Do not use to promote other content.
+          Read the full [guidance on news stories](https://www.gov.uk/guidance/content-design/content-types#news-story).
+      fields:
+        title:
+          label: Title
+          guidance:
+            title: Create a news title
+            body_govspeak: The title must make clear what the content offers users. Use the words your users do to help them find this. Avoid wordplay or teases.
+        summary:
+          label: Summary
+          guidance:
+            title: Writing a news summary
+            body_govspeak: The summary explains the main point of the content and it should end with a full stop. Keep it short, possibly under 160 characters, and avoid repeating the first line of the body.
+        body:
+          label: Body
+          guidance:
+            title: Writing news
+            body_govspeak: |
+              Tell the story in the first lines with the most important information at the top. Use short words, short sentences, and short paragraphs. Use subheadings in longer content.
+
+              [Guidance on news stories](https://www.gov.uk/guidance/content-design/content-types#news-story){:target="_blank"}
+
+              [Writing for GOV.UK](https://www.gov.uk/guidance/content-design/writing-for-gov-uk#writing-to-govuk-style){:target="_blank"}
+
+              [The style guide](https://www.gov.uk/guidance/style-guide){:target="_blank"}
+
+    press_release:
+      label: Press release
+      description: "Unedited press releases as sent to the media, and official statements from the organisation."
+      guidance:
+        body_govspeak: |
+          Do not use to promote other content. Statements to Parliament should use the Speech document type.
+          Read the full [guidance on press releases](https://www.gov.uk/guidance/content-design/content-types#press-release).
+      fields:
+        title:
+          label: Title
+          guidance:
+            title: Title
+            body_govspeak: The title should be unique and specific. It must make clear what the content offers users. Use the words your users do to help them find this. Avoid wordplay or teases.
+        summary:
+          label: Summary
+          guidance:
+            title: Summary
+            body_govspeak: The summary should explain the main point of the story. It is the first line of the story so don’t repeat it in the body and end with a full stop.
+        body:
+          label: Body
+          guidance:
+            title: Writing a press release
+            body_govspeak: |
+              Use short words, short sentences, and short paragraphs. Use subheadings in longer content. Avoid 'notes to editors'.
+
+              [Guidance on press releases](https://www.gov.uk/guidance/content-design/content-types#press-release){:target="_blank"}
+
+              [Writing for GOV.UK](https://www.gov.uk/guidance/content-design/writing-for-gov-uk#writing-to-govuk-style){:target="_blank"}
+
+              [The style guide](https://www.gov.uk/guidance/style-guide){:target="_blank"}
+
+    fatality_notice:
+      label: Fatality notice
+      description: Initial fatality notices and subsequent obituaries of forces and MOD personnel
+      
+    speech:
+      label: Speech
+      description: Public speeches, written statements, or authored articles
+    
+    world_news_story:
+      label: World news story
+      description: Announcements specific to one or more world location
+    
+    detailed_guide:
+      label: Detailed guide
+      description: Detailed guidance for specialist users on the steps they need to take to complete a task
+    
+    any-whitehall-publication:
+      label: Publication
+      description: Standalone government documents that are issued and not usually updated
+    
+    manual:
+      label: Manual
+      description: Long and complex guidance broken into chapters and sub-sections for reference
+    
+    any-mainstream-publication:
+      label: Mainstream guide
+      description: Guidance for the general public on how to do something. Contact GDS to request changes.
+    
+    travel_advice:
+      label: Travel advice
+      description: Travel advice by country including entry requirements and safety information
+    
+    statistical-data-set:
+      label: Statistical data set
+      description: Frequently updated (“live”) statistical data files.
+    
+    case_study:
+      label: Case study
+      description: Case studies show someone’s experience of a government process or policy problem
+    
+    consultation:
+      label: Consultation
+      description: A request for views or evidence on an issue

--- a/spec/factories/document_type_factory.rb
+++ b/spec/factories/document_type_factory.rb
@@ -10,7 +10,6 @@ FactoryBot.define do
     end
 
     id { SecureRandom.hex(4) }
-    label { SecureRandom.alphanumeric(8) }
     contents { [] }
     tags { [] }
     guidance { [] }
@@ -28,6 +27,8 @@ FactoryBot.define do
     after(:build) do |document_type|
       DocumentType.all << document_type
       Supertype.all.first.document_types << document_type
+      en = { document_types: { document_type.id.to_sym => { label: document_type.id } } }
+      I18n.backend.store_translations(:en, en)
     end
   end
 end

--- a/spec/factories/document_type_factory.rb
+++ b/spec/factories/document_type_factory.rb
@@ -10,6 +10,7 @@ FactoryBot.define do
     end
 
     id { SecureRandom.hex(4) }
+    label { SecureRandom.alphanumeric(8) }
     contents { [] }
     tags { [] }
     guidance { [] }
@@ -27,8 +28,6 @@ FactoryBot.define do
     after(:build) do |document_type|
       DocumentType.all << document_type
       Supertype.all.first.document_types << document_type
-      en = { document_types: { document_type.id.to_sym => { label: document_type.id } } }
-      I18n.backend.store_translations(:en, en)
     end
   end
 end

--- a/spec/factories/tag_field_factory.rb
+++ b/spec/factories/tag_field_factory.rb
@@ -7,5 +7,15 @@ FactoryBot.define do
     id { SecureRandom.hex(4) }
     document_type { SecureRandom.alphanumeric(8) }
     initialize_with { new(attributes) }
+
+    trait :primary_publishing_organisation do
+      id { "primary_publishing_organisation" }
+      type { "single_tag" }
+    end
+
+    trait :world_locations do
+      id { "world_locations" }
+      type { "multi_tag" }
+    end
   end
 end

--- a/spec/features/editing_tags/edit_tags_spec.rb
+++ b/spec/features/editing_tags/edit_tags_spec.rb
@@ -4,6 +4,8 @@ RSpec.feature "Edit tags" do
   let(:initial_tag) { { "content_id" => SecureRandom.uuid, "internal_name" => "Initial tag" } }
   let(:tag_to_select_1) { { "content_id" => SecureRandom.uuid, "internal_name" => "Tag to select 1" } }
   let(:tag_to_select_2) { { "content_id" => SecureRandom.uuid, "internal_name" => "Tag to select 2" } }
+  let(:single_tag_id) { "primary_publishing_organisation" }
+  let(:multi_tag_id) { "world_locations" }
 
   scenario do
     given_there_is_an_edition
@@ -17,8 +19,8 @@ RSpec.feature "Edit tags" do
   end
 
   def given_there_is_an_edition
-    multi_tag_field = build(:tag_field, type: "multi_tag", id: "multi_tag_id")
-    single_tag_field = build(:tag_field, type: "single_tag", id: "single_tag_id")
+    multi_tag_field = build(:tag_field, type: "multi_tag", id: multi_tag_id)
+    single_tag_field = build(:tag_field, type: "single_tag", id: single_tag_id)
     document_type = build(:document_type, tags: [multi_tag_field, single_tag_field])
 
     tag_linkables = [initial_tag, tag_to_select_1, tag_to_select_2]
@@ -45,15 +47,15 @@ RSpec.feature "Edit tags" do
 
   def then_i_see_the_current_selections
     @request = stub_publishing_api_put_content(@edition.content_id, {})
-    expect(page).to have_select("tags[multi_tag_id][]", selected: "Initial tag")
-    expect(page).to have_select("tags[single_tag_id][]", selected: "Initial tag")
+    expect(page).to have_select("tags[#{multi_tag_id}][]", selected: "Initial tag")
+    expect(page).to have_select("tags[#{single_tag_id}][]", selected: "Initial tag")
   end
 
   def when_i_edit_the_tags
-    select "Tag to select 1", from: "tags[multi_tag_id][]"
-    select "Tag to select 2", from: "tags[multi_tag_id][]"
-    unselect "Initial tag", from: "tags[multi_tag_id][]"
-    select "Tag to select 1", from: "tags[single_tag_id][]"
+    select "Tag to select 1", from: "tags[#{multi_tag_id}][]"
+    select "Tag to select 2", from: "tags[#{multi_tag_id}][]"
+    unselect "Initial tag", from: "tags[#{multi_tag_id}][]"
+    select "Tag to select 1", from: "tags[#{single_tag_id}][]"
     click_on "Save"
   end
 
@@ -83,8 +85,8 @@ RSpec.feature "Edit tags" do
 
   def edition_links
     {
-      "multi_tag_id" => [tag_to_select_1["content_id"], tag_to_select_2["content_id"]],
-      "single_tag_id" => [tag_to_select_1["content_id"]],
+      multi_tag_id.to_s => [tag_to_select_1["content_id"], tag_to_select_2["content_id"]],
+      single_tag_id.to_s => [tag_to_select_1["content_id"]],
     }
   end
 end

--- a/spec/helpers/application_helper_spec.rb
+++ b/spec/helpers/application_helper_spec.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-RSpec.describe ApplicationHelper, type: :helper do
+RSpec.describe ApplicationHelper do
   describe "formats a body of text" do
     it "returns a hyper link when given a URI" do
       text = "govuk lives here - https://www.gov.uk/"

--- a/spec/helpers/document_type_helper_spec.rb
+++ b/spec/helpers/document_type_helper_spec.rb
@@ -12,7 +12,7 @@ RSpec.describe DocumentTypeHelper, type: :helper do
             },
           },
         },
-        some_document: {
+        news_story: {
           fields: {
             title: {
               label: "My title",
@@ -20,44 +20,43 @@ RSpec.describe DocumentTypeHelper, type: :helper do
             },
           },
         },
-        some_document_no_fields_specified: {},
       },
     }
     I18n.backend.store_translations(:en, en)
   end
 
-  describe "#t_doctype_exists?" do
+  after { I18n.backend.reload! }
+
+  let(:edition) { build(:edition, document_type_id: "news_story") }
+
+  describe "#t_doctype_field?" do
     it "returns true if explicit i18n value exists" do
-      expect(t_doctype_exists?("document_types.some_document.fields.title.label")).to be true
+      expect(t_doctype_field?(edition, "title.label")).to be true
     end
 
     it "returns true if default i18n value exists" do
-      expect(t_doctype_exists?("document_types.some_document.fields.foo.label")).to be true
+      expect(t_doctype_field?(edition, "foo.label")).to be true
     end
 
     it "returns false if neither explicit nor default i18n value exists" do
-      expect(t_doctype_exists?("document_types.some_document.some_unknown_field")).to be false
+      expect(t_doctype_field?(edition, "some_unknown_field")).to be false
     end
   end
 
-  describe "#t_doctype" do
+  describe "#t_doctype_field" do
     it "returns the explicit i18n value if it exists" do
-      expect(t_doctype("document_types.some_document.fields.title.label")).to eq("My title")
-    end
-
-    it "inherits entire hashes from the default if explicit search has no match" do
-      expect(t_doctype("document_types.some_document_no_fields_specified.fields.foo.label")).to eq("Foo")
+      expect(t_doctype_field(edition, "title.label")).to eq("My title")
     end
 
     it "inherits entire explicit values from the default if explicit search has no match" do
-      expect(t_doctype("document_types.some_document.fields.foo.label")).to eq("Foo")
+      expect(t_doctype_field(edition, "foo.label")).to eq("Foo")
     end
 
     it "raises a I18n::MissingTranslationData exception if no explicit or default matches" do
-      expect { t_doctype("document_types.some_document.some_unknown_field") }
+      expect { t_doctype_field(edition, "some_unknown_field") }
         .to raise_error(
           I18n::MissingTranslationData,
-          "translation missing: en.document_types.default.some_unknown_field",
+          "translation missing: en.document_types.default.fields.some_unknown_field",
         )
     end
   end

--- a/spec/helpers/document_type_helper_spec.rb
+++ b/spec/helpers/document_type_helper_spec.rb
@@ -1,0 +1,71 @@
+# frozen_string_literal: true
+
+RSpec.describe DocumentTypeHelper, type: :helper do
+  before do
+    en = {
+      document_types: {
+        default: {
+          fields: {
+            foo: {
+              label: "Foo",
+              description: "Foo description",
+            },
+          },
+        },
+        some_document: {
+          fields: {
+            title: {
+              label: "My title",
+              description: "...",
+            },
+          },
+        },
+        some_document_no_fields_specified: {},
+      },
+    }
+    I18n.backend.store_translations(:en, en)
+  end
+
+  describe "#t_doctype_exists?" do
+    it "returns true if explicit i18n value exists" do
+      expect(t_doctype_exists?("document_types.some_document.fields.title.label")).to be true
+    end
+
+    it "returns true if default i18n value exists" do
+      expect(t_doctype_exists?("document_types.some_document.fields.foo.label")).to be true
+    end
+
+    it "returns false if neither explicit nor default i18n value exists" do
+      expect(t_doctype_exists?("document_types.some_document.some_unknown_field")).to be false
+    end
+  end
+
+  describe "#t_doctype" do
+    it "returns the explicit i18n value if it exists" do
+      expect(t_doctype("document_types.some_document.fields.title.label")).to eq("My title")
+    end
+
+    it "returns 'stringify_keys' hashes if matching multiple properties" do
+      expect(t_doctype("document_types.some_document.fields.title")).to eq(
+        "label" => "My title",
+        "description" => "...",
+      )
+    end
+
+    it "inherits entire hashes from the default if explicit search has no match" do
+      expect(t_doctype("document_types.some_document_no_fields_specified.fields.foo.label")).to eq("Foo")
+    end
+
+    it "inherits entire explicit values from the default if explicit search has no match" do
+      expect(t_doctype("document_types.some_document.fields.foo.label")).to eq("Foo")
+    end
+
+    it "raises a I18n::MissingTranslationData exception if no explicit or default matches" do
+      expect { t_doctype("document_types.some_document.some_unknown_field") }
+        .to raise_error(
+          I18n::MissingTranslationData,
+          "translation missing: en.document_types.default.some_unknown_field",
+        )
+    end
+  end
+end

--- a/spec/helpers/document_type_helper_spec.rb
+++ b/spec/helpers/document_type_helper_spec.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-RSpec.describe DocumentTypeHelper, type: :helper do
+RSpec.describe DocumentTypeHelper do
   before do
     en = {
       document_types: {

--- a/spec/helpers/document_type_helper_spec.rb
+++ b/spec/helpers/document_type_helper_spec.rb
@@ -45,13 +45,6 @@ RSpec.describe DocumentTypeHelper, type: :helper do
       expect(t_doctype("document_types.some_document.fields.title.label")).to eq("My title")
     end
 
-    it "returns 'stringify_keys' hashes if matching multiple properties" do
-      expect(t_doctype("document_types.some_document.fields.title")).to eq(
-        "label" => "My title",
-        "description" => "...",
-      )
-    end
-
     it "inherits entire hashes from the default if explicit search has no match" do
       expect(t_doctype("document_types.some_document_no_fields_specified.fields.foo.label")).to eq("Foo")
     end

--- a/spec/helpers/edition_url_helper_spec.rb
+++ b/spec/helpers/edition_url_helper_spec.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-RSpec.describe EditionUrlHelper, type: :helper do
+RSpec.describe EditionUrlHelper do
   let(:edition) do
     build(:edition,
           base_path: "/foo",

--- a/spec/lib/requirements/tag_checker_spec.rb
+++ b/spec/lib/requirements/tag_checker_spec.rb
@@ -10,9 +10,7 @@ RSpec.describe Requirements::TagChecker do
 
     context "when the edition supports primary orgs" do
       let(:document_type) do
-        organisation_field = build(:tag_field,
-                                   type: "single_tag",
-                                   id: "primary_publishing_organisation")
+        organisation_field = build(:tag_field, :primary_publishing_organisation)
 
         build(:document_type, tags: [organisation_field])
       end

--- a/spec/requests/access_limit_spec.rb
+++ b/spec/requests/access_limit_spec.rb
@@ -2,9 +2,7 @@
 
 RSpec.describe "Access Limit" do
   let(:document_type) do
-    organisation = build(:tag_field,
-                         type: "single_tag",
-                         id: "primary_publishing_organisation")
+    organisation = build(:tag_field, :primary_publishing_organisation)
     build(:document_type, tags: [organisation])
   end
 

--- a/spec/requests/tags_spec.rb
+++ b/spec/requests/tags_spec.rb
@@ -8,7 +8,7 @@ RSpec.describe "Tags" do
   end
 
   describe "GET /documents/:document/tags" do
-    let(:tag_field) { build(:tag_field, type: "multi_tag", id: "world_locations") }
+    let(:tag_field) { build(:tag_field, :world_locations) }
     let(:edition) do
       document_type = build(:document_type, tags: [tag_field])
       create(:edition, document_type_id: document_type.id)
@@ -49,10 +49,7 @@ RSpec.describe "Tags" do
 
     it "returns an issue and unprocessable response when a primary publishing "\
        "organisation is not selected" do
-      tag_field = build(:tag_field,
-                        type: "single_tag",
-                        id: "primary_publishing_organisation",
-                        document_type: "organisation")
+      tag_field = build(:tag_field, :primary_publishing_organisation)
       document_type = build(:document_type, tags: [tag_field])
       edition = create(:edition, document_type_id: document_type.id)
       stub_publishing_api_has_linkables(

--- a/spec/requests/tags_spec.rb
+++ b/spec/requests/tags_spec.rb
@@ -8,7 +8,7 @@ RSpec.describe "Tags" do
   end
 
   describe "GET /documents/:document/tags" do
-    let(:tag_field) { build(:tag_field, type: "multi_tag") }
+    let(:tag_field) { build(:tag_field, type: "multi_tag", id: "world_locations") }
     let(:edition) do
       document_type = build(:document_type, tags: [tag_field])
       create(:edition, document_type_id: document_type.id)

--- a/spec/services/preview_draft_edition_service/payload_spec.rb
+++ b/spec/services/preview_draft_edition_service/payload_spec.rb
@@ -43,7 +43,7 @@ RSpec.describe PreviewDraftEditionService::Payload do
     end
 
     it "includes primary_publishing_organisation in organisations links" do
-      organisation = build(:tag_field, type: "single_tag", id: "primary_publishing_organisation")
+      organisation = build(:tag_field, :primary_publishing_organisation)
       document_type = build(:document_type, tags: [organisation])
       edition = build(:edition,
                       document_type_id: document_type.id,
@@ -59,7 +59,7 @@ RSpec.describe PreviewDraftEditionService::Payload do
     end
 
     it "ensures the organisation links are unique" do
-      organisation = build(:tag_field, type: "single_tag", id: "primary_publishing_organisation")
+      organisation = build(:tag_field, :primary_publishing_organisation)
       document_type = build(:document_type, tags: [organisation])
       edition = build(:edition,
                       document_type_id: document_type.id,

--- a/spec/views/documents/show.html.erb_spec.rb
+++ b/spec/views/documents/show.html.erb_spec.rb
@@ -23,7 +23,7 @@ RSpec.describe "documents/show.html.erb" do
   end
 
   describe "tags" do
-    let(:tag_field) { build(:tag_field, type: "single_tag", id: "tag_id") }
+    let(:tag_field) { build(:tag_field, type: "single_tag", id: "primary_publishing_organisation") }
     let(:document_type) { build(:document_type, tags: [tag_field]) }
 
     it "shows the tags when a document has tags" do

--- a/spec/views/documents/show.html.erb_spec.rb
+++ b/spec/views/documents/show.html.erb_spec.rb
@@ -23,7 +23,7 @@ RSpec.describe "documents/show.html.erb" do
   end
 
   describe "tags" do
-    let(:tag_field) { build(:tag_field, type: "single_tag", id: "primary_publishing_organisation") }
+    let(:tag_field) { build(:tag_field, :primary_publishing_organisation) }
     let(:document_type) { build(:document_type, tags: [tag_field]) }
 
     it "shows the tags when a document has tags" do

--- a/spec/views/tags/edit.html.erb_spec.rb
+++ b/spec/views/tags/edit.html.erb_spec.rb
@@ -2,10 +2,7 @@
 
 RSpec.describe "tags/edit.html.erb" do
   it "shows a warning when editing the primary organisation tag of an access limited edition" do
-    tag_field = build(:tag_field,
-                      type: "single_tag",
-                      id: "primary_publishing_organisation",
-                      document_type: "organisation")
+    tag_field = build(:tag_field, :primary_publishing_organisation)
     document_type = build(:document_type, tags: [tag_field])
     edition = build(:edition,
                     :access_limited,


### PR DESCRIPTION
This PR rips out copy from `config/document_types.yml` and into a new `config/locales/en/document_types.yml`, so that we can internationalise Content Publisher in the future. `config/document_types.yml` is now solely about the configuration of each document type, which would apply to any language.

The [Trello card](https://trello.com/c/AuzTdQVt/1100-use-i18n-to-manage-copy-for-each-document-type) makes it quite clear that we want to avoid duplicating text/config between similar document types, and proposes a `document_types.default` namespace. The only duplication I've come across so far is in the tagging of the `news_story` and `press_release` document types, whose configurations remain under `config/document_types.yml`; I have used standard YAML inheritance to avoid duplicating the values there. It should be simple enough to use this approach inside the I18n files when the time comes; for now, creating a 'default' doctype copy feels like a premature optimisation.