### PR TITLE
Fix govspeak render in document type description

### DIFF
--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -1,19 +1,13 @@
 # frozen_string_literal: true
 
 module ApplicationHelper
-  def govspeak_to_html(govspeak)
-    # We expect all the govspeak through this to be commited code where we
-    # verify the safety
-    raw(Govspeak::Document.new(govspeak, sanitize: false).to_html) # rubocop:disable Rails/OutputSafety
-  end
-
   def render_back_link(options)
     render("govuk_publishing_components/components/back_link", options)
   end
 
   def render_govspeak(content)
     render "govuk_publishing_components/components/govspeak" do
-      govspeak_to_html(content)
+      raw(Govspeak::Document.new(content, sanitize: false).to_html) # rubocop:disable Rails/OutputSafety
     end
   end
 

--- a/app/views/documents/index.html.erb
+++ b/app/views/documents/index.html.erb
@@ -28,9 +28,7 @@
     </p>
 
     <% if @editions.none? %>
-      <div class="govuk-body">
-        <%= govspeak_to_html t("documents.index.search_results.guidance_govspeak") %>
-      </div>
+      <%= render_govspeak t("documents.index.search_results.guidance_govspeak") %>
     <% else %>
       <%= render "documents/index/results" %>
     <% end %>

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -72,11 +72,7 @@
             "gtm-value" => flash["alert_with_description"]["title"],
             "gtm-visibility-tracking" => true
           },
-          description: capture do
-            render "govuk_publishing_components/components/govspeak" do
-              govspeak_to_html(flash["alert_with_description"].fetch("description_govspeak"))
-            end
-          end
+          description: render_govspeak(flash["alert_with_description"].fetch("description_govspeak"))
         } %>
       <% end %>
 

--- a/app/views/new_document/choose_document_type.html.erb
+++ b/app/views/new_document/choose_document_type.html.erb
@@ -18,7 +18,7 @@
               gtm: "choose-document-type",
               "gtm-value": document_type.label,
             },
-            conditional: document_type.hint_govspeak ? tag.div(govspeak_to_html(document_type.hint_govspeak), class: "govuk-body") : nil,
+            conditional: document_type.hint_govspeak ? render_govspeak(document_type.hint_govspeak) : nil,
             bold: true,
           }
         }


### PR DESCRIPTION
Follow up on https://github.com/alphagov/content-publisher/pull/1642.

Document type description may contain links which means the associated content needs to be rendered as govspeak to be styled properly.

### Before
<img width="1000" alt="Screenshot 2020-01-17 at 08 57 59" src="https://user-images.githubusercontent.com/788096/72598528-ddfb2700-3907-11ea-996f-961314e0a492.png">


### After
<img width="1000" alt="Screenshot 2020-01-17 at 08 55 51" src="https://user-images.githubusercontent.com/788096/72598534-e05d8100-3907-11ea-9aa7-d92416ba4b6e.png">

