### PR TITLE
Allow autocomplete component to be shown only when JavaScript is enabled

### DIFF
--- a/app/views/components/_autocomplete.html.erb
+++ b/app/views/components/_autocomplete.html.erb
@@ -10,10 +10,12 @@
   select ||= {}
   input ||= {}
   search ||= false
+  jsonly ||= false
 
   root_classes = %w(app-c-autocomplete govuk-form-group)
   root_classes << "app-c-autocomplete--#{width}" if width
   root_classes << "app-c-autocomplete--search" if search
+  root_classes << "app-js-only" if jsonly
   root_classes << "govuk-form-group--error" if error_items.any?
 %>
 

--- a/app/views/components/docs/autocomplete.yml
+++ b/app/views/components/docs/autocomplete.yml
@@ -159,3 +159,19 @@ examples:
           - France
           - Germany
           - United Kingdom
+  autocomplete_js_only:
+    description: |
+      Shows an autocomplete component only if JavaScript is enabled.
+      This is used when the search input requires a JavaScript request to return results.
+    data:
+      id: autocomplete-jsonly
+      name: autocomplete-jsonly
+      label:
+        text: Search
+      search: true
+      jsonly: true
+      input:
+        options:
+          - France
+          - Germany
+          - United Kingdom

--- a/app/views/topics/edit.html.erb
+++ b/app/views/topics/edit.html.erb
@@ -68,18 +68,17 @@
   } do %>
     <miller-columns-selected class="miller-columns-selected" id="selected-items" for="miller-columns"></miller-columns-selected>
 
-    <div class="app-js-only">
-      <%= render "components/autocomplete", {
-        id: "topics-autocomplete",
-        name: "topics-autocomplete",
-        label: {
-          text: "Search topics",
-          bold: true
-        },
-        type: "topics",
-        search: true
-      } %>
-    </div>
+    <%= render "components/autocomplete", {
+      id: "topics-autocomplete",
+      name: "topics-autocomplete",
+      label: {
+        text: "Search topics",
+        bold: true
+      },
+      type: "topics",
+      search: true,
+      jsonly: true
+    } %>
 
     <miller-columns id="miller-columns" class="miller-columns" for="taxonomy" selected="selected-items">
     <ul id="taxonomy" class="govuk-list">


### PR DESCRIPTION
The autocomplete component (being an enhanced input), as any other form element rely on `govuk-form-group` class to generate consistent spacing across elements. This class assumes the form elements are at a sibling level (and not nested in unnecessary div wrappers) to style the last element without spacing. This updates the way we apply the `app-js-only` class to this instance of the component by applying the class to the component based on a `jsonly` flag.

### Before
<img width="1000" alt="Screenshot 2020-01-17 at 11 00 51" src="https://user-images.githubusercontent.com/788096/72607907-6b934280-3919-11ea-80ec-33c70abbde7a.png">


### After
<img width="1000" alt="Screenshot 2020-01-17 at 11 00 37" src="https://user-images.githubusercontent.com/788096/72607909-6d5d0600-3919-11ea-9ae1-a4a2aee46c80.png">



[Trello card](https://trello.com/c/rO5ssI8S)