### PR TITLE
Multiple lead orgs

### DIFF
--- a/lib/whitehall_importer/create_revision.rb
+++ b/lib/whitehall_importer/create_revision.rb
@@ -95,10 +95,6 @@ module WhitehallImporter
         raise AbortImportError, "Lead organisation missing"
       end
 
-      if primary_publishing_organisations.count > 1
-        raise AbortImportError, "Cannot have more than one lead organisation"
-      end
-
       primary_publishing_organisation = primary_publishing_organisations.min { |o| o["lead_ordering"] }
 
       [primary_publishing_organisation["content_id"]]

--- a/lib/whitehall_importer/create_revision.rb
+++ b/lib/whitehall_importer/create_revision.rb
@@ -54,8 +54,8 @@ module WhitehallImporter
         ),
         tags_revision: TagsRevision.new(
           tags: {
-            "primary_publishing_organisation" => primary_publishing_organisation(whitehall_edition["organisations"]),
-            "organisations" => supporting_organisations(whitehall_edition["organisations"]),
+            "primary_publishing_organisation" => primary_publishing_organisation,
+            "organisations" => supporting_organisations,
             "role_appointments" => tags(whitehall_edition["role_appointments"]),
             "topical_events" => tags(whitehall_edition["topical_events"]),
             "world_locations" => tags(whitehall_edition["world_locations"]),
@@ -82,30 +82,32 @@ module WhitehallImporter
       @translation || raise(AbortImportError, "Translation #{document.locale} missing")
     end
 
-    def primary_publishing_organisation(organisations)
-      unless organisations
+    def primary_publishing_organisation
+      unless whitehall_edition["organisations"]
         raise AbortImportError, "Must have at least one organisation"
       end
 
-      primary_publishing_organisations = organisations.select do |organisation|
-        organisation["lead"]
-      end
-
-      unless primary_publishing_organisations.any?
+      unless lead_organisations.any?
         raise AbortImportError, "Lead organisation missing"
       end
 
-      primary_publishing_organisation = primary_publishing_organisations.min { |o| o["lead_ordering"] }
-
-      [primary_publishing_organisation["content_id"]]
+      [lead_organisations.first["content_id"]]
     end
 
-    def supporting_organisations(organisations)
-      supporting_organisations = organisations.reject do |organisation|
-        organisation["lead"]
+    def supporting_organisations
+      supporting_organisations = whitehall_edition["organisations"].reject do |organisation|
+        lead_organisations.first == organisation
       end
 
       supporting_organisations.map { |organisation| organisation["content_id"] }
+    end
+
+    def lead_organisations
+      lead_orgs = whitehall_edition["organisations"].select do |organisation|
+        organisation["lead"]
+      end
+
+      lead_orgs.sort_by { |organisation| organisation["lead_ordering"] }
     end
 
     def tags(associations)

--- a/spec/factories/whitehall_migration_factory.rb
+++ b/spec/factories/whitehall_migration_factory.rb
@@ -3,7 +3,7 @@
 FactoryBot.define do
   factory :whitehall_migration do
     sequence(:id)
-    organisation_content_id { "content_id" }
+    organisation_content_id { SecureRandom.uuid }
     document_type { "NewsArticle" }
     created_at { Time.current.rfc3339 }
     updated_at { Time.current.rfc3339 }

--- a/spec/lib/whitehall_importer/create_revision_spec.rb
+++ b/spec/lib/whitehall_importer/create_revision_spec.rb
@@ -181,18 +181,27 @@ RSpec.describe WhitehallImporter::CreateRevision do
         .to eq(lead_organisation["content_id"])
     end
 
-    it "sets the first lead organisation as the primary publishing organisation" do
-      first_lead_organisation = build(:whitehall_export_organisation, :lead)
-      second_lead_organisation = build(:whitehall_export_organisation, :lead, lead_ordering: 2)
-      whitehall_edition = build(
-        :whitehall_export_edition,
-        organisations: [first_lead_organisation, second_lead_organisation],
-      )
+    context "when creating organisations with multiple lead orgs" do
+      let(:first_lead_organisation) { build(:whitehall_export_organisation, :lead) }
+      let(:second_lead_organisation) { build(:whitehall_export_organisation, :lead, lead_ordering: 2) }
+      let(:whitehall_edition) do
+        build(:whitehall_export_edition,
+              organisations: [first_lead_organisation, second_lead_organisation])
+      end
 
-      revision = described_class.call(document_import, whitehall_edition)
+      it "sets the first lead organisation as the primary publishing organisation" do
+        revision = described_class.call(document_import, whitehall_edition)
 
-      expect(revision.primary_publishing_organisation_id)
-        .to eq(first_lead_organisation["content_id"])
+        expect(revision.primary_publishing_organisation_id)
+          .to eq(first_lead_organisation["content_id"])
+      end
+
+      it "sets the remaining lead organisations as supportings organisations" do
+        revision = described_class.call(document_import, whitehall_edition)
+
+        expect(revision.supporting_organisation_ids)
+          .to eq([second_lead_organisation["content_id"]])
+      end
     end
 
     it "sets supporting organisations" do

--- a/spec/lib/whitehall_importer/create_revision_spec.rb
+++ b/spec/lib/whitehall_importer/create_revision_spec.rb
@@ -181,6 +181,20 @@ RSpec.describe WhitehallImporter::CreateRevision do
         .to eq(lead_organisation["content_id"])
     end
 
+    it "sets the first lead organisation as the primary publishing organisation" do
+      first_lead_organisation = build(:whitehall_export_organisation, :lead)
+      second_lead_organisation = build(:whitehall_export_organisation, :lead, lead_ordering: 2)
+      whitehall_edition = build(
+        :whitehall_export_edition,
+        organisations: [first_lead_organisation, second_lead_organisation],
+      )
+
+      revision = described_class.call(document_import, whitehall_edition)
+
+      expect(revision.primary_publishing_organisation_id)
+        .to eq(first_lead_organisation["content_id"])
+    end
+
     it "sets supporting organisations" do
       lead_organisation = build(:whitehall_export_organisation, :lead)
       supporting_organisation = build(:whitehall_export_organisation)
@@ -206,18 +220,6 @@ RSpec.describe WhitehallImporter::CreateRevision do
       whitehall_edition = build(
         :whitehall_export_edition,
         organisations: [build(:whitehall_export_organisation)],
-      )
-
-      expect { described_class.call(document_import, whitehall_edition) }
-        .to raise_error(WhitehallImporter::AbortImportError)
-    end
-
-    it "aborts if there is more than one lead organisation" do
-      first_lead_organisation = build(:whitehall_export_organisation, :lead)
-      second_lead_organisation = build(:whitehall_export_organisation, :lead)
-      whitehall_edition = build(
-        :whitehall_export_edition,
-        organisations: [first_lead_organisation, second_lead_organisation],
       )
 
       expect { described_class.call(document_import, whitehall_edition) }


### PR DESCRIPTION
We now want to import editions which have multiple lead organisations
but use the 'primary' (lowest numerical lead_ordering) to assign to the
edition.

A check is already done [here](https://github.com/alphagov/whitehall/blob/master/app/controllers/admin/export/document_controller.rb#L45) to decipher if the lead organisation passed in matches the primary lead org of the latest edition, this makes sure we are only importing documents which the most current version is owned by the organisation queried in whitehall.

Trello:
https://trello.com/c/7t6Nv8YT/1321-import-editions-with-multiple-lead-organisations