### PR TITLE
Ignore users without a uid when importing users

### DIFF
--- a/lib/whitehall_importer/import.rb
+++ b/lib/whitehall_importer/import.rb
@@ -40,8 +40,11 @@ module WhitehallImporter
     end
 
     def create_users(users)
+      user_keys = %w[uid name email organisation_slug organisation_content_id]
+
       users.each_with_object({}) do |user, memo|
-        user_keys = %w[uid name email organisation_slug organisation_content_id]
+        next if user["uid"].blank?
+
         attributes = user.slice(*user_keys).merge("permissions" => [])
         user_object = User.find_by(uid: user["uid"]) || User.create!(attributes)
         memo[user["id"]] = user_object.id

--- a/spec/lib/whitehall_importer/import_spec.rb
+++ b/spec/lib/whitehall_importer/import_spec.rb
@@ -57,6 +57,14 @@ RSpec.describe WhitehallImporter::Import do
       expect { described_class.call(document_import) }.not_to(change { User.count })
     end
 
+    it "does not create a user who has a nil uid" do
+      user = build(:whitehall_export_user, uid: nil)
+      import_data = build(:whitehall_export_document, users: [user])
+      document_import = build(:whitehall_migration_document_import, payload: import_data)
+
+      expect { described_class.call(document_import) }.not_to(change { User.count })
+    end
+
     it "sets created_by_id as the original author" do
       user = User.create!(uid: whitehall_user["uid"])
       edition = build(


### PR DESCRIPTION
Trello: https://trello.com/c/NhFom5Rj

### Story

- As a GOV.UK developer migrating documents from Whitehall
- I want have edits assigned to the correct users
- So that the document edit history is correct

### What do we need to do and why

On importing some documents from Whitehall, we get the following error:

```bash 
13:49:44 Import failed
13:49:44 Error: #<ActiveRecord::RecordNotUnique: PG::UniqueViolation: ERROR:  duplicate key value violates unique constraint "index_edition_editors_on_edition_id_and_user_id"
13:49:44 DETAIL:  Key (edition_id, user_id)=(3253, 157) already exists.
```

This happens when the assigned user for that incoming document does not have a signon account, i.e they are not a real person, but a system or maintenance user instead.  Users of this type will not have an associated uid.

The current behaviour is to try and locate the user by their uid.  If not found a new user will be created.  Once a user exists (found or created) they are assigned as the creator of the document.  

If a valid user cannot be found or created, the import will fail.  

What we need to happen in these circumstances is that:

- the document is imported
- a new user is not created by the process
- the imported document's `created_by_id` attribute is set to `nil` (no user is assigned)
