### PR TITLE
Wrap miller-columns element in a govuk-form-group

### DIFF
--- a/app/views/topics/edit.html.erb
+++ b/app/views/topics/edit.html.erb
@@ -80,13 +80,15 @@
       jsonly: true
     } %>
 
-    <miller-columns id="miller-columns" class="miller-columns" for="taxonomy" selected="selected-items">
-    <ul id="taxonomy" class="govuk-list">
-      <% Topic.govuk_homepage(@edition.document_topics.index).children.each do |topic| %>
-        <% unroll(topic) %>
-      <% end %>
-    </ul>
-    </miller-columns>
+    <div class="govuk-form-group">
+      <miller-columns id="miller-columns" class="miller-columns" for="taxonomy" selected="selected-items">
+      <ul id="taxonomy" class="govuk-list">
+        <% Topic.govuk_homepage(@edition.document_topics.index).children.each do |topic| %>
+          <% unroll(topic) %>
+        <% end %>
+      </ul>
+      </miller-columns>
+    </div>
   <% end %>
 
   <%= hidden_field_tag :version, @version %>


### PR DESCRIPTION
This aligns the components used within the topics form to be each wrapped in a `govuk-form-group` container. By doing so the miller-columns component will be the last instance of a `govuk-form-group` (instead of the search autocomplete). This will make the spacing between these components consistent.

### Before
<img width="1000" alt="Screenshot 2020-01-17 at 11 00 51" src="https://user-images.githubusercontent.com/788096/72607907-6b934280-3919-11ea-80ec-33c70abbde7a.png">

### After
<img width="1000" alt="Screenshot 2020-01-17 at 11 00 37" src="https://user-images.githubusercontent.com/788096/72607909-6d5d0600-3919-11ea-9ae1-a4a2aee46c80.png">

This is the second attempt at [Trello card](https://trello.com/c/rO5ssI8S) while #1662 did cover it entirely.