### PR TITLE
Fix flakey modal insertion

### DIFF
--- a/app/assets/javascripts/modules/contact-embed-modal.js
+++ b/app/assets/javascripts/modules/contact-embed-modal.js
@@ -34,8 +34,8 @@ ContactEmbedModal.prototype.actionCallback = function (item) {
           if (result.unprocessableEntity) {
             this.workflow.renderSuccess(result)
           } else {
-            this.$modal.close()
             this.editor.insertBlock(result.body)
+            this.$modal.close()
           }
         }.bind(this))
         .catch(this.workflow.renderError)

--- a/app/assets/javascripts/modules/inline-attachment-modal.js
+++ b/app/assets/javascripts/modules/inline-attachment-modal.js
@@ -47,12 +47,12 @@ InlineAttachmentModal.prototype.actionCallback = function (item) {
       this.workflow.render(window.ModalFetch.getLink(item))
     },
     'insert-attachment-block': function () {
-      this.$modal.close()
       this.editor.insertBlock(item.dataset.modalData)
+      this.$modal.close()
     },
     'insert-attachment-link': function () {
-      this.$modal.close()
       this.editor.insertInline(item.dataset.modalData)
+      this.$modal.close()
     }
   }
 

--- a/app/assets/javascripts/modules/inline-image-modal.js
+++ b/app/assets/javascripts/modules/inline-image-modal.js
@@ -59,8 +59,8 @@ InlineImageModal.prototype.actionCallback = function (item) {
           if (result.unprocessableEntity) {
             this.workflow.renderSuccess(result)
           } else {
-            this.$modal.close()
             this.editor.insertBlock(item.dataset.modalData)
+            this.$modal.close()
           }
         }.bind(this))
         .catch(this.workflow.renderError)

--- a/spec/features/editing_content/insert_contact_embed_spec.rb
+++ b/spec/features/editing_content/insert_contact_embed_spec.rb
@@ -67,8 +67,9 @@ RSpec.feature "Insert contact embed" do
   end
 
   def then_i_see_the_snippet_is_inserted
-    snippet = I18n.t("contact_embed.new.contact_markdown", id: @contact["content_id"])
-    expect(find("#body-field").value).to match snippet
+    expect(page).to_not have_selector(".gem-c-modal-dialogue") # wait for modal to close
+    snippet = I18n.t!("contact_embed.new.contact_markdown", id: @contact["content_id"])
+    expect(find("#body-field").value).to include snippet
   end
 
   def and_i_select_a_contact_without_javascript
@@ -77,7 +78,7 @@ RSpec.feature "Insert contact embed" do
   end
 
   def then_i_see_the_contact_markdown_snippet
-    snippet = I18n.t("contact_embed.new.contact_markdown", id: @contact["content_id"])
+    snippet = I18n.t!("contact_embed.new.contact_markdown", id: @contact["content_id"])
     expect(page).to have_content(snippet)
   end
 

--- a/spec/features/editing_content/insert_inline_file_attachment_spec.rb
+++ b/spec/features/editing_content/insert_inline_file_attachment_spec.rb
@@ -63,17 +63,17 @@ RSpec.feature "Insert inline file attachment" do
   end
 
   def then_i_see_the_attachment_snippet_is_inserted
-    expect(page).to_not have_selector(".gem-c-modal-dialogue")
+    expect(page).to_not have_selector(".gem-c-modal-dialogue") # wait for modal to close
     snippet = I18n.t("file_attachments.show.attachment_markdown",
                      filename: @file_attachment_revision.filename)
-    expect(find("#body-field").value).to match snippet
+    expect(find("#body-field").value).to include snippet
   end
 
   def then_i_see_the_attachment_link_snippet_is_inserted
-    expect(page).to_not have_selector(".gem-c-modal-dialogue")
+    expect(page).to_not have_selector(".gem-c-modal-dialogue") # wait for modal to close
     snippet = I18n.t("file_attachments.show.attachment_link_markdown",
                      filename: @file_attachment_revision.filename)
-    expect(find("#body-field").value).to match snippet
+    expect(find("#body-field").value).to include snippet
   end
 
   def then_i_see_the_attachment_markdown_snippet

--- a/spec/features/editing_content/insert_inline_image_spec.rb
+++ b/spec/features/editing_content/insert_inline_image_spec.rb
@@ -36,7 +36,8 @@ RSpec.feature "Insert inline image", js: true do
   end
 
   def then_i_see_the_snippet_is_inserted
+    expect(page).to_not have_selector(".gem-c-modal-dialogue")
     snippet = I18n.t("images.index.meta.inline_code.value", filename: @image_revision.filename)
-    expect(find("#body-field").value).to match snippet
+    expect(find("#body-field").value).to include snippet
   end
 end

--- a/spec/features/editing_content/insert_video_embed_spec.rb
+++ b/spec/features/editing_content/insert_video_embed_spec.rb
@@ -33,7 +33,8 @@ RSpec.describe "Insert video embed", js: true do
   end
 
   def then_i_see_the_snippet_is_inserted
+    expect(page).to_not have_selector(".gem-c-modal-dialogue")
     snippet = "[A title](https://www.youtube.com/watch?v=G8KpPw303PY)"
-    expect(find("#body-field").value).to match snippet
+    expect(find("#body-field").value).to include snippet
   end
 end


### PR DESCRIPTION
This fixes a test issue where the use of 'match' was mis-interpreting
the hyphen characters in a UUID as regex ranges, leading to a

  Regexp error:
     empty range in char class ...

Fixing this then exposed a timing issue, where the JS code had not yet
inserted the expected (contact) snippet into the body field. This adds
missing expectations to ensure we wait for the modal to close before
checking for the inserted snippet, as well as changing the modal
workflows to only close the modal when all its operations are finished.