### PR TITLE
Refactor history mode request tests

### DIFF
--- a/spec/features/editing_content_settings/history_mode_spec.rb
+++ b/spec/features/editing_content_settings/history_mode_spec.rb
@@ -5,6 +5,7 @@ RSpec.feature "History mode" do
     given_there_is_a_past_government
     and_there_is_a_not_political_document
     and_i_am_a_managing_editor
+
     when_i_visit_the_summary_page
     then_i_see_that_the_content_doesnt_get_history_mode
     and_i_do_not_see_the_history_mode_banner

--- a/spec/requests/history_mode_spec.rb
+++ b/spec/requests/history_mode_spec.rb
@@ -1,37 +1,49 @@
 # frozen_string_literal: true
 
 RSpec.describe "History Mode" do
+  it_behaves_like "requests that assert edition state",
+                  "managing history mode on a non editable edition",
+                  routes: { history_mode_path: %i[get patch] } do
+    before { login_as(create(:user, managing_editor: true)) }
+    let(:edition) { create(:edition, :published) }
+  end
+
   describe "GET /documents/:document/history-mode" do
-    it "returns a forbidden status for user without managing editor permission" do
-      @edition = create(:edition)
-      login_as(create(:user))
-      get history_mode_path(@edition.document)
-      expect(response.status).to eq(403)
-      expect(response.body).to include(I18n.t!("history_mode.non_managing_editor.title", title: @edition.title))
+    it "returns successfully for a user with managing editor permission" do
+      edition = create(:edition)
+      login_as(create(:user, managing_editor: true))
+      get history_mode_path(edition.document)
+      expect(response).to have_http_status(:ok)
     end
 
-    it "does not return a forbidden status for user with managing editor permission" do
-      @edition = create(:edition)
-      login_as(create(:user, managing_editor: true))
-      get history_mode_path(@edition.document)
-      expect(response.status).to_not eq(403)
+    it "returns a forbidden status for user without managing editor permission" do
+      edition = create(:edition)
+      login_as(create(:user))
+      get history_mode_path(edition.document)
+      expect(response).to have_http_status(:forbidden)
+      expect(response.body).to have_content(
+        I18n.t!("history_mode.non_managing_editor.title", title: edition.title),
+      )
     end
   end
 
   describe "PATCH /documents/:document/history-mode" do
-    it "returns a forbidden status for user without managing editor permission" do
-      @edition = create(:edition)
-      login_as(create(:user))
-      patch history_mode_path(@edition.document)
-      expect(response.status).to eq(403)
-      expect(response.body).to include(I18n.t!("history_mode.non_managing_editor.title", title: @edition.title))
+    it "redirects to document summary for a user with managing editor permission" do
+      edition = create(:edition)
+      stub_publishing_api_put_content(edition.content_id, {})
+      login_as(create(:user, managing_editor: true))
+      patch history_mode_path(edition.document), params: { "political" => "yes" }
+      expect(response).to redirect_to(document_path(edition.document))
     end
 
-    it "does not return a forbidden status for user with managing editor permission" do
-      @edition = create(:edition)
-      login_as(create(:user, managing_editor: true))
-      patch history_mode_path(@edition.document)
-      expect(response.status).to_not eq(403)
+    it "returns a forbidden status for user without managing editor permission" do
+      edition = create(:edition)
+      login_as(create(:user))
+      patch history_mode_path(edition.document), params: { "political" => "yes" }
+      expect(response).to have_http_status(:forbidden)
+      expect(response.body).to have_content(
+        I18n.t!("history_mode.non_managing_editor.title", title: edition.title),
+      )
     end
   end
 end


### PR DESCRIPTION
Trello: https://trello.com/c/wgkfOJsE/1283-improve-consistency-in-content-publisher-tests

This follows on the test strategy introduced in #1590. Towards this I've done a bunch of writing of request tests and deleting of feature tests. Rather than do one large PR I thought it was best to separate into distinct PR's that are easier to review and thought I'd start with one that covers a few.

This PR does some minor refactoring of the history mode request tests to make them consistent with the other request tests now that conventions have emerged.