### PR TITLE
Consistent withdraw request tests

### DIFF
--- a/app/controllers/withdraw_controller.rb
+++ b/app/controllers/withdraw_controller.rb
@@ -25,9 +25,12 @@ class WithdrawController < ApplicationController
                         issues: issues },
              status: :unprocessable_entity
     elsif api_error
-      redirect_to withdraw_path(params[:document]),
-                  alert_with_description: t("withdraw.new.flashes.publishing_api_error"),
-                  public_explanation: params[:public_explanation]
+      flash.now["alert_with_description"] = t("withdraw.new.flashes.publishing_api_error")
+
+      render :new,
+             assigns: { edition: edition,
+                        public_explanation: params[:public_explanation] },
+             status: :service_unavailable
     else
       redirect_to document_path(edition.document)
     end

--- a/app/interactors/withdraw/create_interactor.rb
+++ b/app/interactors/withdraw/create_interactor.rb
@@ -24,7 +24,7 @@ private
   def find_and_lock_edition
     context.edition = Edition.lock.find_current(document: params[:document])
 
-    assert_edition_state(@edition, assertion: "is published or withdrawn") do
+    assert_edition_state(edition, assertion: "is published or withdrawn") do
       edition.published? || edition.published_but_needs_2i? || edition.withdrawn?
     end
   end

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -65,14 +65,15 @@
       <% end %>
 
       <% if flash["alert_with_description"] %>
+        <% alert = flash["alert_with_description"].stringify_keys %>
         <%= render "govuk_publishing_components/components/error_alert", {
-          message: flash["alert_with_description"].fetch("title"),
+          message: alert.fetch("title"),
           data_attributes: {
             gtm: "alert-with-description",
-            "gtm-value" => flash["alert_with_description"]["title"],
+            "gtm-value" => alert.fetch("title"),
             "gtm-visibility-tracking" => true
           },
-          description: render_govspeak(flash["alert_with_description"].fetch("description_govspeak"))
+          description: render_govspeak(alert.fetch("description_govspeak"))
         } %>
       <% end %>
 

--- a/spec/requests/unwithdraw_spec.rb
+++ b/spec/requests/unwithdraw_spec.rb
@@ -1,8 +1,16 @@
 # frozen_string_literal: true
 
 RSpec.describe "Unwithdraw" do
+  let(:managing_editor) { create(:user, managing_editor: true) }
+
+  it_behaves_like "requests that assert edition state",
+                  "unwithdrawing a non withdrawn edition",
+                  routes: { unwithdraw_path: %i[get post] } do
+    before { login_as(managing_editor) }
+    let(:edition) { create(:edition, :published) }
+  end
+
   describe "POST /documents/:document/unwithdraw" do
-    let(:managing_editor) { create(:user, managing_editor: true) }
     let(:withdrawn_edition) { create(:edition, :withdrawn) }
 
     it "unwithdraws the edition" do
@@ -56,7 +64,6 @@ RSpec.describe "Unwithdraw" do
   end
 
   describe "GET /documents/:document/unwithdraw" do
-    let(:managing_editor) { create(:user, managing_editor: true) }
     let(:withdrawn_edition) { create(:edition, :withdrawn) }
 
     it "fetches unwithdraw page" do

--- a/spec/requests/unwithdraw_spec.rb
+++ b/spec/requests/unwithdraw_spec.rb
@@ -11,104 +11,128 @@ RSpec.describe "Unwithdraw" do
   end
 
   describe "POST /documents/:document/unwithdraw" do
-    let(:withdrawn_edition) { create(:edition, :withdrawn) }
+    let(:edition) { create(:edition, :withdrawn) }
+    before { stub_publishing_api_republish(edition.content_id, {}) }
 
-    it "unwithdraws the edition" do
-      stub_publishing_api_republish(withdrawn_edition.content_id, {})
-      login_as(managing_editor)
+    context "when logged in as a managing editor" do
+      let(:managing_editor) { create(:user, managing_editor: true) }
+      before { login_as(managing_editor) }
 
-      post unwithdraw_path(withdrawn_edition.document)
+      it "redirects to document summary" do
+        post unwithdraw_path(edition.document)
+        expect(response).to redirect_to(document_path(edition.document))
+      end
 
-      expect(response).to redirect_to(document_path(withdrawn_edition.document))
+      it "redirects to document summary with an error when Publishing API is down" do
+        stub_publishing_api_isnt_available
+
+        post unwithdraw_path(edition.document)
+        expect(response).to redirect_to(document_path(edition.document))
+        follow_redirect!
+        expect(response.body).to have_content(
+          I18n.t!("documents.show.flashes.unwithdraw_error.title"),
+        )
+      end
     end
 
-    it "returns an error when publishing-api is down" do
-      stub_publishing_api_isnt_available
-      login_as(managing_editor)
-
-      post unwithdraw_path(withdrawn_edition.document)
-      follow_redirect!
-
-      expect(response.body).to include(I18n.t!("withdraw.new.flashes.publishing_api_error.title"))
-    end
-
-    it "prevents users without managing_editor permission from unwithdrawing the edition" do
-      post unwithdraw_path(withdrawn_edition.document)
-
-      expect(response.body).to include(I18n.t!("unwithdraw.no_managing_editor_permission.title"))
-      expect(response).to have_http_status(:forbidden)
+    context "when not logged in as a managing editor" do
+      it "returns a forbidden response" do
+        post unwithdraw_path(edition.document)
+        expect(response).to have_http_status(:forbidden)
+        expect(response.body)
+          .to have_content(I18n.t!("unwithdraw.no_managing_editor_permission.title"))
+      end
     end
 
     context "when the edition is in history mode" do
-      let(:withdrawn_history_mode_edition) { create(:edition, :withdrawn, :political, government: past_government) }
+      let(:edition) do
+        create(:edition, :withdrawn, :political, government: past_government)
+      end
 
-      it "lets users holding manage_live_history_mode permission unwithdraw the edition" do
-        stub_publishing_api_republish(withdrawn_history_mode_edition.content_id, {})
+      it "allows a managing editor with the manage_live_history_mode permission" do
         user = create(:user, managing_editor: true, manage_live_history_mode: true)
         login_as(user)
 
-        post unwithdraw_path(withdrawn_history_mode_edition.document)
-
-        expect(response).to redirect_to(document_path(withdrawn_history_mode_edition.document))
+        post unwithdraw_path(edition.document)
+        expect(response).to redirect_to(document_path(edition.document))
       end
 
-      it "prevents users without manage_live_history_mode permission from unwithdrawing the edition" do
-        login_as(managing_editor)
-
-        post unwithdraw_path(withdrawn_history_mode_edition.document)
-
-        expect(response.body).to include(I18n.t!("missing_permissions.update_history_mode.title", title: withdrawn_history_mode_edition.title))
+      it "forbids a managing editor without the manage_live_history_mode permission" do
+        user = create(:user, managing_editor: true, manage_live_history_mode: false)
+        login_as(user)
+        post unwithdraw_path(edition.document)
         expect(response).to have_http_status(:forbidden)
+        expect(response.body).to have_content(
+          I18n.t!("missing_permissions.update_history_mode.title", title: edition.title),
+        )
+      end
+
+      it "forbids a user who isn't a managing editor, even with the manage_live_history_mode permission" do
+        user = create(:user, manage_live_history_mode: true)
+        login_as(user)
+        post unwithdraw_path(edition.document)
+        expect(response).to have_http_status(:forbidden)
+        expect(response.body).to have_content(
+          I18n.t!("unwithdraw.no_managing_editor_permission.title"),
+        )
       end
     end
   end
 
   describe "GET /documents/:document/unwithdraw" do
-    let(:withdrawn_edition) { create(:edition, :withdrawn) }
+    let(:edition) { create(:edition, :withdrawn) }
 
-    it "fetches unwithdraw page" do
-      login_as(managing_editor)
+    context "when logged in as a managing editor" do
+      let(:managing_editor) { create(:user, managing_editor: true) }
+      before { login_as(managing_editor) }
 
-      get unwithdraw_path(withdrawn_edition.document)
+      it "returns successfully" do
+        get unwithdraw_path(edition.document)
 
-      expect(response.body).to include(I18n.t!("unwithdraw.confirm.title", title: withdrawn_edition.title_or_fallback))
+        expect(response).to have_http_status(:ok)
+      end
     end
 
-    it "redirects to document summary when the edition is in the wrong state" do
-      published_edition = create(:edition, :published)
-      login_as(managing_editor)
-
-      get unwithdraw_path(published_edition.document)
-
-      expect(response).to redirect_to(document_path(published_edition.document))
-    end
-
-    it "prevents users without managing_editor permission from accessing unwithdraw page" do
-      get unwithdraw_path(withdrawn_edition.document)
-
-      expect(response.body).to include(I18n.t!("unwithdraw.no_managing_editor_permission.title"))
-      expect(response).to have_http_status(:forbidden)
+    context "when not logged in as a managing editor" do
+      it "returns a forbidden response" do
+        get unwithdraw_path(edition.document)
+        expect(response).to have_http_status(:forbidden)
+        expect(response.body).to have_content(
+          I18n.t!("unwithdraw.no_managing_editor_permission.title"),
+        )
+      end
     end
 
     context "when the edition is in history mode" do
-      let(:withdrawn_history_mode_edition) { create(:edition, :withdrawn, :political, government: past_government) }
-
-      it "lets managing_editors holding manage_live_history_mode permission to access unwithdraw page" do
-        user = create(:user, managing_editor: true, manage_live_history_mode: true)
-        login_as(user)
-
-        get unwithdraw_path(withdrawn_history_mode_edition.document)
-
-        expect(response.body).to include(I18n.t!("unwithdraw.confirm.title", title: withdrawn_history_mode_edition.title_or_fallback))
+      let(:edition) do
+        create(:edition, :withdrawn, :political, government: past_government)
       end
 
-      it "prevents users without manage_live_history_mode permission from accessing unwithdraw page" do
-        login_as(managing_editor)
+      it "allows a managing editor with the manage_live_history_mode permission" do
+        user = create(:user, managing_editor: true, manage_live_history_mode: true)
+        login_as(user)
+        get unwithdraw_path(edition.document)
+        expect(response).to have_http_status(:ok)
+      end
 
-        get unwithdraw_path(withdrawn_history_mode_edition.document)
-
-        expect(response.body).to include(I18n.t!("missing_permissions.update_history_mode.title", title: withdrawn_history_mode_edition.title))
+      it "forbids a managing editor without the manage_live_history_mode permission" do
+        user = create(:user, managing_editor: true, manage_live_history_mode: false)
+        login_as(user)
+        get unwithdraw_path(edition.document)
         expect(response).to have_http_status(:forbidden)
+        expect(response.body).to have_content(
+          I18n.t!("missing_permissions.update_history_mode.title", title: edition.title),
+        )
+      end
+
+      it "forbids a user who isn't a managing editor, even with the manage_live_history_mode permission" do
+        user = create(:user, manage_live_history_mode: true)
+        login_as(user)
+        get unwithdraw_path(edition.document)
+        expect(response).to have_http_status(:forbidden)
+        expect(response.body).to have_content(
+          I18n.t!("unwithdraw.no_managing_editor_permission.title"),
+        )
       end
     end
   end

--- a/spec/requests/withdraw_spec.rb
+++ b/spec/requests/withdraw_spec.rb
@@ -28,13 +28,13 @@ RSpec.describe "Withdraw" do
       )
     end
 
-    it "returns an error when publishing-api is down" do
+    it "renders an error when publishing-api is down" do
       stub_publishing_api_isnt_available
       login_as(managing_editor)
 
       post withdraw_path(published_edition.document), params: { public_explanation: "Just cos" }
-      follow_redirect!
 
+      expect(response).to have_http_status(:service_unavailable)
       expect(response.body).to include(I18n.t!("withdraw.new.flashes.publishing_api_error.title"))
     end
 

--- a/spec/requests/withdraw_spec.rb
+++ b/spec/requests/withdraw_spec.rb
@@ -11,124 +11,158 @@ RSpec.describe "Withdraw" do
   end
 
   describe "POST /documents/:document/withdraw" do
-    let(:published_edition) { create(:edition, :published) }
+    let(:edition) { create(:edition, :published) }
+    let(:public_explanation) { SecureRandom.alphanumeric(10) }
 
-    it "withdraws the edition" do
-      stub_publishing_api_unpublish(published_edition.content_id, body: {})
-      login_as(managing_editor)
-
-      post withdraw_path(published_edition.document), params: { public_explanation: "Just cos" }
-      follow_redirect!
-
-      withdrawal = published_edition.reload.status.details
-      expect(response.body).to include(
-        I18n.t!("documents.show.withdrawn.title",
-                document_type: published_edition.document_type.label.downcase,
-                withdrawn_date: withdrawal.created_at.strftime("%-d %B %Y")),
-      )
+    before do
+      stub_publishing_api_unpublish(edition.content_id, body: {})
     end
 
-    it "renders an error when publishing-api is down" do
-      stub_publishing_api_isnt_available
-      login_as(managing_editor)
+    context "when logged in as a managing editor" do
+      let(:managing_editor) { create(:user, managing_editor: true) }
+      before { login_as(managing_editor) }
 
-      post withdraw_path(published_edition.document), params: { public_explanation: "Just cos" }
+      it "allows withdrawing an edtiion" do
+        post withdraw_path(edition.document),
+             params: { public_explanation: public_explanation }
+        expect(response).to redirect_to(document_path(edition.document))
+      end
 
-      expect(response).to have_http_status(:service_unavailable)
-      expect(response.body).to include(I18n.t!("withdraw.new.flashes.publishing_api_error.title"))
-    end
+      it "returns a service unavailable response with error when Publishing API is unavailable" do
+        stub_publishing_api_isnt_available
 
-    it "returns a requirements error when there is a requirements issue" do
-      login_as(managing_editor)
-      post withdraw_path(published_edition.document), params: { public_explanation: "" }
-
-      expect(response.body).to include(I18n.t!("requirements.public_explanation.blank.form_message"))
-    end
-
-    it "prevents users without managing_editor permission from withdrawing the edition" do
-      post withdraw_path(published_edition.document), params: { public_explanation: "just cos" }
-
-      expect(response.body).to include(I18n.t!("withdraw.no_managing_editor_permission.title"))
-      expect(response).to have_http_status(:forbidden)
-    end
-
-    context "when the edition is in history mode" do
-      let(:published_history_mode_edition) { create(:edition, :published, :political, government: past_government) }
-
-      it "lets managing_editors holding manage_live_history_mode permission withdraw the edition" do
-        stub_publishing_api_unpublish(published_history_mode_edition.content_id, body: {})
-        user = create(:user, managing_editor: true, manage_live_history_mode: true)
-        login_as(user)
-
-        post withdraw_path(published_history_mode_edition.document), params: { public_explanation: "Just cos" }
-        follow_redirect!
-
-        withdrawal = published_history_mode_edition.reload.status.details
-        expect(response.body).to include(
-          I18n.t!("documents.show.withdrawn.title",
-                  document_type: published_history_mode_edition.document_type.label.downcase,
-                  withdrawn_date: withdrawal.created_at.strftime("%-d %B %Y")),
+        post withdraw_path(edition.document),
+             params: { public_explanation: public_explanation }
+        expect(response).to have_http_status(:service_unavailable)
+        expect(response.body).to have_content(
+          I18n.t!("withdraw.new.flashes.publishing_api_error.title"),
         )
       end
 
-      it "prevents managing_editors without manage_live_history_mode permission from withdrawing the edition" do
-        login_as(managing_editor)
+      it "returns issues and an unprocessable response when there are requirement issues" do
+        post withdraw_path(edition.document),
+             params: { public_explanation: "" }
+        expect(response).to have_http_status(:unprocessable_entity)
+        expect(response.body).to have_content(
+          I18n.t!("requirements.public_explanation.blank.form_message"),
+        )
+      end
+    end
 
-        post withdraw_path(published_history_mode_edition.document), params: { public_explanation: "Just cos" }
-
-        expect(response.body).to include(I18n.t!("missing_permissions.update_history_mode.title", title: published_history_mode_edition.title))
+    context "when not logged in as a managing editor" do
+      it "returns a forbidden response" do
+        edition = create(:edition, :published)
+        post withdraw_path(edition.document),
+             params: { public_explanation: public_explanation }
         expect(response).to have_http_status(:forbidden)
+        expect(response.body).to have_content(
+          I18n.t!("withdraw.no_managing_editor_permission.title"),
+        )
+      end
+    end
+
+    context "when the edition is in history mode" do
+      let(:edition) do
+        create(:edition, :published, :political, government: past_government)
+      end
+
+      it "allows a managing editor with the manage_live_history_mode permission" do
+        user = create(:user, managing_editor: true, manage_live_history_mode: true)
+        login_as(user)
+        post withdraw_path(edition.document),
+             params: { public_explanation: public_explanation }
+        expect(response).to redirect_to(document_path(edition.document))
+      end
+
+      it "forbids a managing editor without the manage_live_history_mode permission" do
+        user = create(:user, managing_editor: true, manage_live_history_mode: false)
+        login_as(user)
+        post withdraw_path(edition.document),
+             params: { public_explanation: public_explanation }
+        expect(response).to have_http_status(:forbidden)
+        expect(response.body).to have_content(
+          I18n.t!("missing_permissions.update_history_mode.title", title: edition.title),
+        )
+      end
+
+      it "forbids a user who isn't a managing editor, even with the manage_live_history_mode permission" do
+        user = create(:user, manage_live_history_mode: true)
+        login_as(user)
+        post withdraw_path(edition.document),
+             params: { public_explanation: public_explanation }
+        expect(response).to have_http_status(:forbidden)
+        expect(response.body).to have_content(
+          I18n.t!("withdraw.no_managing_editor_permission.title"),
+        )
       end
     end
   end
 
   describe "GET /documents/:document/withdraw" do
-    let(:published_edition) { create(:edition, :published) }
+    context "when logged in as a managing editor" do
+      let(:managing_editor) { create(:user, managing_editor: true) }
+      before { login_as(managing_editor) }
 
-    it "fetches withdraw page" do
-      login_as(managing_editor)
+      it "allows withdrawing a published edtiion" do
+        edition = create(:edition, :published)
+        get withdraw_path(edition.document)
+        expect(response).to have_http_status(:ok)
+      end
 
-      get withdraw_path(published_edition.document)
+      it "allows withdrawing a published but needs 2i edtiion" do
+        edition = create(:edition, :published, state: :published_but_needs_2i)
+        get withdraw_path(edition.document)
+        expect(response).to have_http_status(:ok)
+      end
 
-      expect(response.body).to include(I18n.t!("withdraw.new.title", title: published_edition.title))
+      it "allows re-withdrawing a withdrawn edtiion" do
+        edition = create(:edition, :withdrawn)
+        get withdraw_path(edition.document)
+        expect(response).to have_http_status(:ok)
+      end
     end
 
-    it "redirects to document summary when the edition is in the wrong state" do
-      draft_edition = create(:edition)
-      login_as(managing_editor)
-
-      get withdraw_path(draft_edition.document)
-
-      expect(response).to redirect_to(document_path(draft_edition.document))
-    end
-
-    it "prevents users without managing_editor permission from accessing withdraw page" do
-      get withdraw_path(published_edition.document)
-
-      expect(response.body).to include(I18n.t!("withdraw.no_managing_editor_permission.title"))
-      expect(response).to have_http_status(:forbidden)
+    context "when not logged in as a managing editor" do
+      it "returns a forbidden response" do
+        edition = create(:edition, :published)
+        get withdraw_path(edition.document)
+        expect(response).to have_http_status(:forbidden)
+        expect(response.body).to have_content(
+          I18n.t!("withdraw.no_managing_editor_permission.title"),
+        )
+      end
     end
 
     context "when the edition is in history mode" do
-      let(:published_history_mode_edition) { create(:edition, :published, :political, government: past_government) }
-
-      it "lets managing_editors holding manage_live_history_mode permission to access withdraw page" do
-        stub_publishing_api_unpublish(published_history_mode_edition.content_id, body: {})
-        user = create(:user, managing_editor: true, manage_live_history_mode: true)
-        login_as(user)
-
-        get withdraw_path(published_history_mode_edition.document)
-
-        expect(response.body).to include(I18n.t!("withdraw.new.title", title: published_history_mode_edition.title))
+      let(:edition) do
+        create(:edition, :published, :political, government: past_government)
       end
 
-      it "prevents users without manage_live_history_mode permission from accessing withdraw page" do
-        login_as(managing_editor)
+      it "allows a managing editor with the manage_live_history_mode permission" do
+        user = create(:user, managing_editor: true, manage_live_history_mode: true)
+        login_as(user)
+        get withdraw_path(edition.document)
+        expect(response).to have_http_status(:ok)
+      end
 
-        get withdraw_path(published_history_mode_edition.document)
-
-        expect(response.body).to include(I18n.t!("missing_permissions.update_history_mode.title", title: published_history_mode_edition.title))
+      it "forbids a managing editor without the manage_live_history_mode permission" do
+        user = create(:user, managing_editor: true, manage_live_history_mode: false)
+        login_as(user)
+        get withdraw_path(edition.document)
         expect(response).to have_http_status(:forbidden)
+        expect(response.body).to have_content(
+          I18n.t!("missing_permissions.update_history_mode.title", title: edition.title),
+        )
+      end
+
+      it "forbids a user who isn't a managing editor, even with the manage_live_history_mode permission" do
+        user = create(:user, manage_live_history_mode: true)
+        login_as(user)
+        get withdraw_path(edition.document)
+        expect(response).to have_http_status(:forbidden)
+        expect(response.body).to have_content(
+          I18n.t!("withdraw.no_managing_editor_permission.title"),
+        )
       end
     end
   end

--- a/spec/requests/withdraw_spec.rb
+++ b/spec/requests/withdraw_spec.rb
@@ -1,8 +1,16 @@
 # frozen_string_literal: true
 
 RSpec.describe "Withdraw" do
+  let(:managing_editor) { create(:user, managing_editor: true) }
+
+  it_behaves_like "requests that assert edition state",
+                  "withdrawing a draft edition",
+                  routes: { withdraw_path: %i[get post] } do
+    before { login_as(managing_editor) }
+    let(:edition) { create(:edition) }
+  end
+
   describe "POST /documents/:document/withdraw" do
-    let(:managing_editor) { create(:user, managing_editor: true) }
     let(:published_edition) { create(:edition, :published) }
 
     it "withdraws the edition" do
@@ -75,7 +83,6 @@ RSpec.describe "Withdraw" do
   end
 
   describe "GET /documents/:document/withdraw" do
-    let(:managing_editor) { create(:user, managing_editor: true) }
     let(:published_edition) { create(:edition, :published) }
 
     it "fetches withdraw page" do


### PR DESCRIPTION
Trello: https://trello.com/c/wgkfOJsE/1283-improve-consistency-in-content-publisher-tests

This follows on the test strategy introduced in #1590. Towards this I've done a bunch of writing of request tests and deleting of feature tests. Rather than do one large PR I thought it was best to separate into distinct PR's that are easier to review and thought I'd start with one that covers a few.

This does some refactoring of the existing withdraw and unwithdraw request tests to make them consistent with the conventions of request tests.

They also catch a couple of issues. It allows to return a 503 on an API error rather than redirect for a withdraw that hits a Publishing API error (this required resolving a hash keys issue on the layout) and fixes that the assert edition status on the Withdraw::CreateInteractor wasn't working.