### PR TITLE
Add UID to test user

### DIFF
--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -9,4 +9,5 @@ permissions << User::DEBUG_PERMISSION if Rails.env.development?
 
 user.update!(permissions: permissions,
              organisation_content_id: gds_organisation_content_id,
+             uid: SecureRandom.uuid,
              email: "someone-else@example.com")


### PR DESCRIPTION
There is an assumption that documents within Content Publisher - are always associated with either:

- a valid user - someone who has a signon account and has activated that account by logging into a system; or 
- are un-assigned - where `created_by_id` is nil, in the case of Whitehall documents that are associated with 'system' users.  

However, this assumption is currently not implemented in the test suite, where a seed 'test' user is created without a UID and subsequently widely used in document creation and maintenance.
    
This change re-enforces that assumption within the test suite for consistency.

**Please note** If accepted all developers on Content Publisher will need to re-create their Test database following merge...

```
govuk-docker-run rails db:reset RAILS_ENV=test
```