### PR TITLE
Import Whitehall revision history (History tab in Whitehall) to Content Publisher

### DIFF
--- a/lib/whitehall_importer/create_edition.rb
+++ b/lib/whitehall_importer/create_edition.rb
@@ -33,6 +33,8 @@ module WhitehallImporter
                   create_edition(status: status, current: current, edition_number: edition_number)
                 end
 
+      create_revision_history(edition)
+
       edition.tap { |e| access_limit(e) }
     end
 
@@ -175,6 +177,22 @@ module WhitehallImporter
       )
 
       edition.save!
+    end
+
+    def create_revision_history(edition)
+      whitehall_edition["revision_history"].each do |event|
+        details = TimelineEntry::WhitehallImportedEntry.create!(
+          entry_type: history.imported_entry_type(event, edition_number),
+        )
+        TimelineEntry.create!(
+          entry_type: :whitehall_migration,
+          created_at: event["created_at"],
+          created_by_id: user_ids[event["whodunnit"]],
+          edition: edition,
+          document: edition.document,
+          details: details,
+        )
+      end
     end
   end
 end


### PR DESCRIPTION
Whitehall stores document history in three places.  This PR addresses the import of one of these (revision history, i.e. changes in state) into Content Publisher.

Trello card: https://trello.com/c/PITc94le