### PR TITLE
Controller Reshuffle

### DIFF
--- a/app/controllers/content_controller.rb
+++ b/app/controllers/content_controller.rb
@@ -1,0 +1,39 @@
+# frozen_string_literal: true
+
+class ContentController < ApplicationController
+  def edit
+    @edition = Edition.find_current(document: params[:document])
+    assert_edition_state(@edition, &:editable?)
+    @revision = @edition.revision
+  end
+
+  def update
+    result = Content::UpdateInteractor.call(params: params, user: current_user)
+    edition, revision, issues, = result.to_h.values_at(:edition, :revision, :issues)
+
+    if issues
+      flash.now["requirements"] = {
+        "items" => issues.items(link_options: issues_link_options(edition)),
+      }
+
+      render :edit,
+             assigns: { edition: edition, revision: revision, issues: issues },
+             status: :unprocessable_entity
+    else
+      redirect_to edition.document
+    end
+  end
+
+private
+
+  def issues_link_options(edition)
+    format_specific_options = edition.document_type.contents.each_with_object({}) do |field, memo|
+      memo[field.id.to_sym] = { href: "##{field.id}-field" }
+    end
+
+    {
+      title: { href: "#title-field" },
+      summary: { href: "#summary-field" },
+    }.merge(Hash[format_specific_options])
+  end
+end

--- a/app/controllers/editions_controller.rb
+++ b/app/controllers/editions_controller.rb
@@ -8,6 +8,22 @@ class EditionsController < ApplicationController
     redirect_to edit_document_path(params[:document])
   end
 
+  def destroy
+    result = Editions::DestroyInteractor.call(params: params, user: current_user)
+
+    if result.api_error
+      redirect_to document_path(params[:document]),
+                  alert_with_description: t("documents.show.flashes.delete_draft_error")
+    else
+      redirect_to documents_path
+    end
+  end
+
+  def confirm_delete_draft
+    @edition = Edition.find_current(document: params[:document])
+    assert_edition_state(@edition, &:editable?)
+  end
+
 private
 
   def check_permissions

--- a/app/interactors/content/update_interactor.rb
+++ b/app/interactors/content/update_interactor.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-class Documents::UpdateInteractor < ApplicationInteractor
+class Content::UpdateInteractor < ApplicationInteractor
   delegate :params,
            :user,
            :edition,

--- a/app/interactors/editions/destroy_interactor.rb
+++ b/app/interactors/editions/destroy_interactor.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-class Documents::DestroyInteractor < ApplicationInteractor
+class Editions::DestroyInteractor < ApplicationInteractor
   delegate :params,
            :user,
            :edition,

--- a/app/views/content/edit.html.erb
+++ b/app/views/content/edit.html.erb
@@ -1,9 +1,9 @@
 <% content_for :back_link, render_back_link(href: document_path(@edition.document)) %>
 
 <% if @edition.document.newly_created? %>
-  <% content_for :title, t("documents.edit.title_new", document_type: @edition.document_type.label.downcase) %>
+  <% content_for :title, t("content.edit.title_new", document_type: @edition.document_type.label.downcase) %>
 <% else %>
-  <% content_for :title, t("documents.edit.title", title: @edition.title_or_fallback) %>
+  <% content_for :title, t("content.edit.title", title: @edition.title_or_fallback) %>
 <% end %>
 
 <%= form_for @edition.document,
@@ -32,7 +32,7 @@
   <%= render "govuk_publishing_components/components/contextual_guidance", title_contextual_guidance do %>
     <%= render "govuk_publishing_components/components/textarea", {
       label: {
-        text: t("documents.edit.form_labels.title"),
+        text: t("content.edit.form_labels.title"),
         bold: true
       },
       id: "title-field",
@@ -55,9 +55,9 @@
   <div class="govuk-grid-row">
     <div class="govuk-grid-column-two-thirds">
       <%= render "components/url_preview", {
-        title: t("documents.edit.url_preview.available"),
-        default_message: t("documents.edit.url_preview.no_title"),
-        error_message: t("documents.edit.url_preview.error"),
+        title: t("content.edit.url_preview.available"),
+        default_message: t("content.edit.url_preview.no_title"),
+        error_message: t("content.edit.url_preview.error"),
         website_root: Plek.new.website_root,
         base_path: @revision.base_path
       } %>
@@ -81,7 +81,7 @@
   <%= render "govuk_publishing_components/components/contextual_guidance", summary_contextual_guidance do %>
     <%= render "govuk_publishing_components/components/textarea", {
       label: {
-        text: t("documents.edit.form_labels.summary"),
+        text: t("content.edit.form_labels.summary"),
         bold: true
       },
       id: "summary-field",
@@ -110,7 +110,7 @@
   <% end %>
 
   <% if @edition.document.live_edition %>
-    <%= render "documents/edit/change_notes" %>
+    <%= render "content/edit/change_notes" %>
   <% end %>
 
   <%= render "govuk_publishing_components/components/button", {

--- a/app/views/content/edit/_change_notes.html.erb
+++ b/app/views/content/edit/_change_notes.html.erb
@@ -1,7 +1,7 @@
 <% textarea = capture do %>
     <%= render "govuk_publishing_components/components/textarea", {
       label: {
-        text: t("documents.edit.change_note.title"),
+        text: t("content.edit.change_note.title"),
       },
       id: "revision-change-note",
       name: "revision[change_note]",
@@ -16,31 +16,31 @@
 <%= render "govuk_publishing_components/components/contextual_guidance", {
   id: "change-note",
   html_for: "revision-change-note",
-  title: t("documents.edit.change_note.guidance_title"),
-  content: render_govspeak(t("documents.edit.change_note.guidance"))
+  title: t("content.edit.change_note.guidance_title"),
+  content: render_govspeak(t("content.edit.change_note.guidance"))
 } do %>
   <%= render "govuk_publishing_components/components/radio", {
     name: "revision[update_type]",
-    heading: t("documents.edit.update_type.title"),
+    heading: t("content.edit.update_type.title"),
     heading_size: "s",
     items: [
       {
         value: "major",
-        text: t("documents.edit.update_type.major_name"),
+        text: t("content.edit.update_type.major_name"),
         conditional: textarea,
         checked: @revision.major?,
         data_attributes: {
           gtm: "choose-update-type",
-          "gtm-value": t("documents.edit.update_type.major_name")
+          "gtm-value": t("content.edit.update_type.major_name")
         }
       },
       {
         value: "minor",
-        text: t("documents.edit.update_type.minor_name"),
+        text: t("content.edit.update_type.minor_name"),
         checked: @revision.minor?,
         data_attributes: {
           gtm: "choose-update-type",
-          "gtm-value": t("documents.edit.update_type.minor_name")
+          "gtm-value": t("content.edit.update_type.minor_name")
         }
       }
     ]

--- a/app/views/documents/fields/_govspeak_input.html.erb
+++ b/app/views/documents/fields/_govspeak_input.html.erb
@@ -1,8 +1,8 @@
 <% document_contents_guidance = capture do %>
   <%= edition.document_type.guidance_for(field.id) ? render_govspeak(edition.document_type.guidance_for(field.id).body_govspeak) : nil %>
-  <h3 class="govuk-heading-s"><%= t("documents.edit.fields.govspeak.title") %></h3>
+  <h3 class="govuk-heading-s"><%= t("content.edit.fields.govspeak.title") %></h3>
   <p class="govuk-body">
-    <%= link_to t("documents.edit.fields.govspeak.guidance"), "https://www.gov.uk/guidance/how-to-publish-on-gov-uk/markdown", class: "govuk-link", target: "_blank" %>
+    <%= link_to t("content.edit.fields.govspeak.guidance"), "https://www.gov.uk/guidance/how-to-publish-on-gov-uk/markdown", class: "govuk-link", target: "_blank" %>
   </p>
   <%= render "components/markdown_guidance" %>
 <% end %>

--- a/app/views/editions/confirm_delete_draft.html.erb
+++ b/app/views/editions/confirm_delete_draft.html.erb
@@ -1,4 +1,4 @@
-<% content_for :title, t("documents.confirm_delete_draft.title", title: @edition.title_or_fallback) %>
+<% content_for :title, t("editions.confirm_delete_draft.title", title: @edition.title_or_fallback) %>
 <% content_for :back_link, render_back_link(href: document_path(@edition.document)) %>
 
 <div class="govuk-grid-row">
@@ -6,7 +6,7 @@
     <div class="govuk-grid-row">
       <div class="govuk-grid-column-two-thirds">
         <div class="govuk-body">
-          <%= render_govspeak(t("documents.confirm_delete_draft.description_govspeak")) %>
+          <%= render_govspeak(t("editions.confirm_delete_draft.description_govspeak")) %>
         </div>
       </div>
     </div>

--- a/config/locales/en/content/edit.yml
+++ b/config/locales/en/content/edit.yml
@@ -1,5 +1,5 @@
 en:
-  documents:
+  content:
     edit:
       title: "Edit ‘%{title}’"
       title_new: "New %{document_type}"

--- a/config/locales/en/editions/confirm_delete_draft.yml
+++ b/config/locales/en/editions/confirm_delete_draft.yml
@@ -1,5 +1,5 @@
 en:
-  documents:
+  editions:
     confirm_delete_draft:
       title: Delete the draft of '%{title}'
       description_govspeak: |

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -12,12 +12,14 @@ Rails.application.routes.draw do
 
   scope "/documents/:document" do
     get "" => "documents#show", as: :document
-    patch "" => "documents#update"
-    delete "" => "documents#destroy"
     get "/history" => "documents#history", as: :document_history
-    get "/edit" => "documents#edit", as: :edit_document
     get "/generate-path" => "documents#generate_path", as: :generate_path
-    get "/delete-draft" => "documents#confirm_delete_draft", as: :delete_draft
+
+    patch "" => "content#update"
+    get "/edit" => "content#edit", as: :edit_document
+
+    delete "" => "editions#destroy"
+    get "/delete-draft" => "editions#confirm_delete_draft", as: :delete_draft
 
     get "/publish" => "publish#confirmation", as: :publish_confirmation
     post "/publish" => "publish#publish"

--- a/spec/features/editing_content/url_preview_spec.rb
+++ b/spec/features/editing_content/url_preview_spec.rb
@@ -39,7 +39,7 @@ RSpec.feature "Shows a preview of the URL", js: true do
   end
 
   def then_i_see_a_prompt_to_enter_a_title
-    expect(page).to have_content(I18n.t!("documents.edit.url_preview.no_title"))
+    expect(page).to have_content(I18n.t!("content.edit.url_preview.no_title"))
   end
 
   def and_i_fill_in_the_title

--- a/spec/features/editing_content_settings/enforce_access_limit_spec.rb
+++ b/spec/features/editing_content_settings/enforce_access_limit_spec.rb
@@ -86,7 +86,7 @@ RSpec.feature "Enforce access limit" do
     visit document_path(@edition.document)
     expect(page).to have_content("Change Access limiting")
     visit edit_document_path(@edition.document)
-    expect(page).to have_content(I18n.t!("documents.edit.title", title: @edition.title_or_fallback))
+    expect(page).to have_content(I18n.t!("content.edit.title", title: @edition.title_or_fallback))
   end
 
   def and_the_supporting_user_can_also

--- a/spec/features/workflow/edition_spec.rb
+++ b/spec/features/workflow/edition_spec.rb
@@ -64,7 +64,7 @@ RSpec.feature "Editions" do
   end
 
   def and_i_make_a_minor_change
-    choose I18n.t!("documents.edit.update_type.minor_name")
+    choose I18n.t!("content.edit.update_type.minor_name")
     click_on "Save"
   end
 


### PR DESCRIPTION
Trello - https://trello.com/c/ZTRjP9eT/1099-break-up-the-actions-in-the-documentscontroller

The Documents controller has been largely unchanged since we introduced the concept of editions. This moves functionality from the documents controller into the editions controller and a newly created content controller to better fit with our data models. It also adjusts the copy and tests accordingly.