### PR TITLE
Add bang to internationalisation on supertypes

### DIFF
--- a/spec/models/supertype_spec.rb
+++ b/spec/models/supertype_spec.rb
@@ -6,8 +6,8 @@ RSpec.describe Supertype do
       describe "Supertype #{supertype.id}" do
         it "has the required attributes for #{supertype.id}" do
           expect(supertype.id).to_not be_blank
-          expect(I18n.t("supertypes.#{supertype.id}.label")).to_not be_blank
-          expect(I18n.t("supertypes.#{supertype.id}.description")).to_not be_blank
+          expect(I18n.t!("supertypes.#{supertype.id}.label")).to_not be_blank
+          expect(I18n.t!("supertypes.#{supertype.id}.description")).to_not be_blank
         end
       end
     end


### PR DESCRIPTION
This introduces a bang when calling internationalization in one of our test. This will stop that test from silently failing if a translation doesn't exist. See coomment linked below for introduction of the issue.

https://github.com/alphagov/content-publisher/pull/1658#discussion_r368465923