### PR TITLE
Add body to timeline_entry_whitehall_imported_entries

### DIFF
--- a/db/migrate/20200122110833_add_body_to_timeline_entry_whitehall_imported_entries.rb
+++ b/db/migrate/20200122110833_add_body_to_timeline_entry_whitehall_imported_entries.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+class AddBodyToTimelineEntryWhitehallImportedEntries < ActiveRecord::Migration[6.0]
+  def change
+    add_column :timeline_entry_whitehall_imported_entries, :body, :json, default: "{}", null: false
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2020_01_14_163932) do
+ActiveRecord::Schema.define(version: 2020_01_22_110833) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -324,6 +324,7 @@ ActiveRecord::Schema.define(version: 2020_01_14_163932) do
   create_table "timeline_entry_whitehall_imported_entries", force: :cascade do |t|
     t.string "entry_type", null: false
     t.datetime "created_at"
+    t.json "body", default: "{}", null: false
   end
 
   create_table "users", force: :cascade do |t|


### PR DESCRIPTION
- Required for upcoming implementation of: https://trello.com/c/o8PhjdUc/1312-map-whitehall-fact-check-requests-fact-checking-tab-in-whitehall-to-content-publisher-timeline-entries-on-import and https://trello.com/c/tNsWXZZj/1314-map-whitehall-editorial-remarks-notes-tab-in-whitehall-to-content-publisher-timeline-entries-on-import

- Will allow us to store the notes body content as well as the fact check data

Co-authored-by: Graham Lewis <graham.lewis@digital.cabinet-office.gov.uk>