### PR TITLE
Remove ignored files that no longer exist

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,8 +10,6 @@
   },
   "standard": {
     "ignore": [
-      "/app/assets/javascripts/components/markdown-toolbar.js",
-      "/app/assets/javascripts/vendor/",
       "/spec/javascripts/helpers/jasmine-jquery.js"
     ]
   },


### PR DESCRIPTION
In the past, we added a few vendored files to the ignore list of standard linting configuration. These files don't exist anymore by we forgot to remove them from the list.