### PR TITLE
Add missing translation for Whitehall imported history

### DIFF
--- a/config/locales/en/documents/history.yml
+++ b/config/locales/en/documents/history.yml
@@ -46,6 +46,7 @@ en:
           document_updated: "Document updated"
           fact_check_request: "Fact check pending request"
           fact_check_response: "Fact check response"
+          first_created: "First created"
           imported_from_whitehall: "Imported from Whitehall"
           imported: "First created"
           internal_note: "Internal note"


### PR DESCRIPTION
The `first_created` translation was missed in #1644.