### PR TITLE
Whitehall notes and fact check - import

### DIFF
--- a/lib/whitehall_importer/create_edition.rb
+++ b/lib/whitehall_importer/create_edition.rb
@@ -35,6 +35,7 @@ module WhitehallImporter
 
       create_revision_history(edition)
       create_notes(edition)
+      create_fact_checks(edition)
 
       edition.tap { |e| access_limit(e) }
     end
@@ -202,6 +203,32 @@ module WhitehallImporter
         create_timeline_entry(details,
                               edition, event["created_at"], event["author_id"])
       end
+    end
+
+    def create_fact_checks(edition)
+      whitehall_edition["fact_check_requests"].each do |event|
+        create_fact_check_request(edition, event)
+        create_fact_check_response(edition, event) if event["comments"].present?
+      end
+    end
+
+    def create_fact_check_request(edition, event)
+      contents = {
+        email_address: event["email_address"],
+        instructions: event["instructions"],
+      }
+      details = create_whitehall_imported_entry("fact_check_request", contents)
+      create_timeline_entry(details,
+                            edition, event["created_at"], event["requestor_id"])
+    end
+
+    def create_fact_check_response(edition, event)
+      contents = {
+        email_address: event["email_address"],
+        comments: event["comments"],
+      }
+      details = create_whitehall_imported_entry("fact_check_response", contents)
+      create_timeline_entry(details, edition, event["updated_at"])
     end
 
     def create_whitehall_imported_entry(entry_type, contents = {})

--- a/spec/factories/whitehall_export/edition_factory.rb
+++ b/spec/factories/whitehall_export/edition_factory.rb
@@ -21,6 +21,7 @@ FactoryBot.define do
     contacts { [] }
     images { [] }
     attachments { [] }
+    editorial_remarks { [] }
     revision_history do
       [
         build(:whitehall_export_revision_history_event,
@@ -39,6 +40,7 @@ FactoryBot.define do
       created_at { 3.days.ago.rfc3339 }
       scheduled_publication { Time.current.tomorrow.rfc3339 }
       state { "scheduled" }
+      editorial_remarks { [] }
       revision_history do
         [
           build(:whitehall_export_revision_history_event,
@@ -58,6 +60,7 @@ FactoryBot.define do
     trait :published do
       created_at { 3.days.ago.rfc3339 }
       state { "published" }
+      editorial_remarks { [] }
       revision_history do
         [
           build(:whitehall_export_revision_history_event,

--- a/spec/factories/whitehall_export/edition_factory.rb
+++ b/spec/factories/whitehall_export/edition_factory.rb
@@ -23,7 +23,8 @@ FactoryBot.define do
     attachments { [] }
     revision_history do
       [
-        build(:revision_history_event, created_at: created_at),
+        build(:whitehall_export_revision_history_event,
+              created_at: created_at),
       ]
     end
     unpublishing { nil }
@@ -40,12 +41,13 @@ FactoryBot.define do
       state { "scheduled" }
       revision_history do
         [
-          build(:revision_history_event, created_at: created_at),
-          build(:revision_history_event,
+          build(:whitehall_export_revision_history_event,
+                created_at: created_at),
+          build(:whitehall_export_revision_history_event,
                 event: "update",
                 created_at: 2.days.ago.rfc3339,
                 state: previous_state),
-          build(:revision_history_event,
+          build(:whitehall_export_revision_history_event,
                 event: "update",
                 state: "scheduled",
                 created_at: Time.current.tomorrow.rfc3339),
@@ -58,8 +60,9 @@ FactoryBot.define do
       state { "published" }
       revision_history do
         [
-          build(:revision_history_event, created_at: created_at),
-          build(:revision_history_event,
+          build(:whitehall_export_revision_history_event,
+                created_at: created_at),
+          build(:whitehall_export_revision_history_event,
                 event: "update",
                 state: "published",
                 created_at: 2.days.ago.rfc3339),

--- a/spec/factories/whitehall_export/edition_factory.rb
+++ b/spec/factories/whitehall_export/edition_factory.rb
@@ -22,6 +22,7 @@ FactoryBot.define do
     images { [] }
     attachments { [] }
     editorial_remarks { [] }
+    fact_check_requests { [] }
     revision_history do
       [
         build(:whitehall_export_revision_history_event,
@@ -41,6 +42,7 @@ FactoryBot.define do
       scheduled_publication { Time.current.tomorrow.rfc3339 }
       state { "scheduled" }
       editorial_remarks { [] }
+      fact_check_requests { [] }
       revision_history do
         [
           build(:whitehall_export_revision_history_event,
@@ -61,6 +63,7 @@ FactoryBot.define do
       created_at { 3.days.ago.rfc3339 }
       state { "published" }
       editorial_remarks { [] }
+      fact_check_requests { [] }
       revision_history do
         [
           build(:whitehall_export_revision_history_event,

--- a/spec/factories/whitehall_export/editorial_remark_event.rb
+++ b/spec/factories/whitehall_export/editorial_remark_event.rb
@@ -1,0 +1,14 @@
+# frozen_string_literal: true
+
+FactoryBot.define do
+  factory :whitehall_export_editorial_remark_event, class: Hash do
+    skip_create
+
+    sequence(:id)
+    body { "Note about the revision" }
+    sequence(:author_id)
+    created_at { Time.current.rfc3339 }
+
+    initialize_with { attributes.stringify_keys }
+  end
+end

--- a/spec/factories/whitehall_export/fact_check_event_factory.rb
+++ b/spec/factories/whitehall_export/fact_check_event_factory.rb
@@ -1,0 +1,19 @@
+# frozen_string_literal: true
+
+FactoryBot.define do
+  factory :whitehall_export_fact_check_event, class: Hash do
+    skip_create
+
+    sequence(:id)
+    sequence(:edition_id)
+    key { "redacted-1" }
+    email_address { "someone@somewhere.com" }
+    instructions { "Do something" }
+    comments { "hello" }
+    sequence(:requestor_id)
+    created_at { Time.current.rfc3339 }
+    updated_at { Time.current.rfc3339 }
+
+    initialize_with { attributes.stringify_keys }
+  end
+end

--- a/spec/factories/whitehall_export/revision_history_event.rb
+++ b/spec/factories/whitehall_export/revision_history_event.rb
@@ -4,9 +4,10 @@ FactoryBot.define do
   factory :whitehall_export_revision_history_event, class: Hash do
     skip_create
 
+    sequence(:id)
     event { "create" }
     state { "draft" }
-    whodunnit { 1 }
+    sequence(:whodunnit)
     created_at { Time.current.rfc3339 }
 
     initialize_with { attributes.stringify_keys }

--- a/spec/factories/whitehall_export/revision_history_event.rb
+++ b/spec/factories/whitehall_export/revision_history_event.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 FactoryBot.define do
-  factory :revision_history_event, class: Hash do
+  factory :whitehall_export_revision_history_event, class: Hash do
     skip_create
 
     event { "create" }

--- a/spec/lib/whitehall_importer/create_edition_spec.rb
+++ b/spec/lib/whitehall_importer/create_edition_spec.rb
@@ -50,10 +50,12 @@ RSpec.describe WhitehallImporter::CreateEdition do
         state: "published",
         revision_history: [
           build(:whitehall_export_revision_history_event),
-          build(:whitehall_export_revision_history_event, event: "update", state: "published"),
+          build(:whitehall_export_revision_history_event,
+                event: "update", state: "published"),
         ],
       )
-      edition = described_class.call(document_import: document_import, whitehall_edition: whitehall_edition)
+      edition = described_class.call(document_import: document_import,
+                                     whitehall_edition: whitehall_edition)
 
       expect(edition).to be_live
     end
@@ -99,9 +101,21 @@ RSpec.describe WhitehallImporter::CreateEdition do
         whitehall_edition = build(
           :whitehall_export_edition,
           revision_history: [
-            build(:whitehall_export_revision_history_event, whodunnit: 1, event: "create", state: "draft", created_at: 2.days.ago),
-            build(:whitehall_export_revision_history_event, whodunnit: 2, event: "update", state: "published", created_at: 1.day.ago),
-            build(:whitehall_export_revision_history_event, whodunnit: 1, event: "update", state: "superseded", created_at: 2.days.ago),
+            build(:whitehall_export_revision_history_event,
+                  whodunnit: 1,
+                  event: "create",
+                  state: "draft",
+                  created_at: 2.days.ago),
+            build(:whitehall_export_revision_history_event,
+                  whodunnit: 2,
+                  event: "update",
+                  state: "published",
+                  created_at: 1.day.ago),
+            build(:whitehall_export_revision_history_event,
+                  whodunnit: 1,
+                  event: "update",
+                  state: "superseded",
+                  created_at: 2.days.ago),
           ],
         )
 
@@ -112,12 +126,14 @@ RSpec.describe WhitehallImporter::CreateEdition do
         expect(edition.timeline_entries.first).to be_whitehall_migration
         expect(edition.timeline_entries.first.details).to be_first_created
         expect(edition.timeline_entries.first.created_at).to eq(2.days.ago)
-        expect(edition.timeline_entries.first.created_by_id).to eq(first_user.id)
+        expect(edition.timeline_entries.first.created_by_id)
+          .to eq(first_user.id)
 
         expect(edition.timeline_entries.last).to be_whitehall_migration
         expect(edition.timeline_entries.last.details).to be_published
         expect(edition.timeline_entries.last.created_at).to eq(1.day.ago)
-        expect(edition.timeline_entries.last.created_by_id).to eq(second_user.id)
+        expect(edition.timeline_entries.last.created_by_id)
+          .to eq(second_user.id)
       end
     end
 
@@ -132,14 +148,20 @@ RSpec.describe WhitehallImporter::CreateEdition do
     end
 
     it "attributes the status to the user that created it and at the time that was done" do
-      whitehall_edition = build(:whitehall_export_edition)
+      whitehall_user_id = 1
       user = create(:user)
+      create_event = build(:whitehall_export_revision_history_event,
+                           event: "create", whodunnit: whitehall_user_id)
+      whitehall_edition = build(:whitehall_export_edition,
+                                revision_history: [create_event])
       edition = described_class.call(document_import: document_import,
                                      whitehall_edition: whitehall_edition,
-                                     user_ids: { 1 => user.id })
+                                     user_ids: { whitehall_user_id => user.id })
 
       expect(edition.status.created_by).to eq(user)
-      expect(edition.status.created_at).to eq(whitehall_edition["revision_history"].first["created_at"])
+      expect(edition.status.created_at).to eq(
+        whitehall_edition["revision_history"].first["created_at"],
+      )
     end
 
     context "when the document is withdrawn" do
@@ -148,8 +170,10 @@ RSpec.describe WhitehallImporter::CreateEdition do
               state: "withdrawn",
               revision_history: [
                 build(:whitehall_export_revision_history_event),
-                build(:whitehall_export_revision_history_event, event: "update", state: "published"),
-                build(:whitehall_export_revision_history_event, event: "update", state: "withdrawn"),
+                build(:whitehall_export_revision_history_event,
+                      event: "update", state: "published"),
+                build(:whitehall_export_revision_history_event,
+                      event: "update", state: "withdrawn"),
               ],
               unpublishing: build(:whitehall_export_unpublishing))
       end
@@ -186,9 +210,12 @@ RSpec.describe WhitehallImporter::CreateEdition do
       let(:whitehall_edition) do
         build(:whitehall_export_edition,
               revision_history: [
-                build(:whitehall_export_revision_history_event, created_at: created_at),
-                build(:whitehall_export_revision_history_event, event: "update", state: "published"),
-                build(:whitehall_export_revision_history_event, event: "update", state: "draft", created_at: updated_at),
+                build(:whitehall_export_revision_history_event,
+                      created_at: created_at),
+                build(:whitehall_export_revision_history_event,
+                      event: "update", state: "published"),
+                build(:whitehall_export_revision_history_event,
+                      event: "update", state: "draft", created_at: updated_at),
               ],
               unpublishing: build(:whitehall_export_unpublishing,
                                   alternative_url: "https://www.gov.uk/gators",
@@ -226,9 +253,14 @@ RSpec.describe WhitehallImporter::CreateEdition do
         build(:whitehall_export_edition,
               revision_history: [
                 build(:whitehall_export_revision_history_event),
-                build(:whitehall_export_revision_history_event, event: "update", state: "published"),
-                build(:whitehall_export_revision_history_event, event: "update", state: "draft", created_at: 5.minutes.ago.rfc3339),
-                build(:whitehall_export_revision_history_event, event: "update", state: "draft", created_at: created_at),
+                build(:whitehall_export_revision_history_event,
+                      event: "update", state: "published"),
+                build(:whitehall_export_revision_history_event,
+                      event: "update",
+                      state: "draft",
+                      created_at: 5.minutes.ago.rfc3339),
+                build(:whitehall_export_revision_history_event,
+                      event: "update", state: "draft", created_at: created_at),
               ],
               unpublishing: build(:whitehall_export_unpublishing,
                                   alternative_url: "https://www.gov.uk/flextension",
@@ -278,14 +310,17 @@ RSpec.describe WhitehallImporter::CreateEdition do
         state: "withdrawn",
         revision_history: [
           build(:whitehall_export_revision_history_event),
-          build(:whitehall_export_revision_history_event, event: "update", state: "published"),
-          build(:whitehall_export_revision_history_event, event: "update", state: "withdrawn"),
+          build(:whitehall_export_revision_history_event,
+                event: "update", state: "published"),
+          build(:whitehall_export_revision_history_event,
+                event: "update", state: "withdrawn"),
         ],
         unpublishing: nil,
       )
 
       expect {
-        described_class.call(document_import: document_import, whitehall_edition: whitehall_edition)
+        described_class.call(document_import: document_import,
+                             whitehall_edition: whitehall_edition)
       }.to raise_error(WhitehallImporter::AbortImportError)
     end
   end

--- a/spec/lib/whitehall_importer/create_edition_spec.rb
+++ b/spec/lib/whitehall_importer/create_edition_spec.rb
@@ -49,8 +49,8 @@ RSpec.describe WhitehallImporter::CreateEdition do
         :whitehall_export_edition,
         state: "published",
         revision_history: [
-          build(:revision_history_event),
-          build(:revision_history_event, event: "update", state: "published"),
+          build(:whitehall_export_revision_history_event),
+          build(:whitehall_export_revision_history_event, event: "update", state: "published"),
         ],
       )
       edition = described_class.call(document_import: document_import, whitehall_edition: whitehall_edition)
@@ -74,8 +74,8 @@ RSpec.describe WhitehallImporter::CreateEdition do
       whitehall_edition = build(
         :whitehall_export_edition,
         revision_history: [
-          build(:revision_history_event, whodunnit: 1),
-          build(:revision_history_event, whodunnit: 2),
+          build(:whitehall_export_revision_history_event, whodunnit: 1),
+          build(:whitehall_export_revision_history_event, whodunnit: 2),
         ],
       )
 
@@ -99,9 +99,9 @@ RSpec.describe WhitehallImporter::CreateEdition do
         whitehall_edition = build(
           :whitehall_export_edition,
           revision_history: [
-            build(:revision_history_event, whodunnit: 1, event: "create", state: "draft", created_at: 2.days.ago),
-            build(:revision_history_event, whodunnit: 2, event: "update", state: "published", created_at: 1.day.ago),
-            build(:revision_history_event, whodunnit: 1, event: "update", state: "superseded", created_at: 2.days.ago),
+            build(:whitehall_export_revision_history_event, whodunnit: 1, event: "create", state: "draft", created_at: 2.days.ago),
+            build(:whitehall_export_revision_history_event, whodunnit: 2, event: "update", state: "published", created_at: 1.day.ago),
+            build(:whitehall_export_revision_history_event, whodunnit: 1, event: "update", state: "superseded", created_at: 2.days.ago),
           ],
         )
 
@@ -147,9 +147,9 @@ RSpec.describe WhitehallImporter::CreateEdition do
         build(:whitehall_export_edition,
               state: "withdrawn",
               revision_history: [
-                build(:revision_history_event),
-                build(:revision_history_event, event: "update", state: "published"),
-                build(:revision_history_event, event: "update", state: "withdrawn"),
+                build(:whitehall_export_revision_history_event),
+                build(:whitehall_export_revision_history_event, event: "update", state: "published"),
+                build(:whitehall_export_revision_history_event, event: "update", state: "withdrawn"),
               ],
               unpublishing: build(:whitehall_export_unpublishing))
       end
@@ -186,9 +186,9 @@ RSpec.describe WhitehallImporter::CreateEdition do
       let(:whitehall_edition) do
         build(:whitehall_export_edition,
               revision_history: [
-                build(:revision_history_event, created_at: created_at),
-                build(:revision_history_event, event: "update", state: "published"),
-                build(:revision_history_event, event: "update", state: "draft", created_at: updated_at),
+                build(:whitehall_export_revision_history_event, created_at: created_at),
+                build(:whitehall_export_revision_history_event, event: "update", state: "published"),
+                build(:whitehall_export_revision_history_event, event: "update", state: "draft", created_at: updated_at),
               ],
               unpublishing: build(:whitehall_export_unpublishing,
                                   alternative_url: "https://www.gov.uk/gators",
@@ -225,10 +225,10 @@ RSpec.describe WhitehallImporter::CreateEdition do
       let(:whitehall_edition) do
         build(:whitehall_export_edition,
               revision_history: [
-                build(:revision_history_event),
-                build(:revision_history_event, event: "update", state: "published"),
-                build(:revision_history_event, event: "update", state: "draft", created_at: 5.minutes.ago.rfc3339),
-                build(:revision_history_event, event: "update", state: "draft", created_at: created_at),
+                build(:whitehall_export_revision_history_event),
+                build(:whitehall_export_revision_history_event, event: "update", state: "published"),
+                build(:whitehall_export_revision_history_event, event: "update", state: "draft", created_at: 5.minutes.ago.rfc3339),
+                build(:whitehall_export_revision_history_event, event: "update", state: "draft", created_at: created_at),
               ],
               unpublishing: build(:whitehall_export_unpublishing,
                                   alternative_url: "https://www.gov.uk/flextension",
@@ -277,9 +277,9 @@ RSpec.describe WhitehallImporter::CreateEdition do
         :whitehall_export_edition,
         state: "withdrawn",
         revision_history: [
-          build(:revision_history_event),
-          build(:revision_history_event, event: "update", state: "published"),
-          build(:revision_history_event, event: "update", state: "withdrawn"),
+          build(:whitehall_export_revision_history_event),
+          build(:whitehall_export_revision_history_event, event: "update", state: "published"),
+          build(:whitehall_export_revision_history_event, event: "update", state: "withdrawn"),
         ],
         unpublishing: nil,
       )

--- a/spec/lib/whitehall_importer/edition_history_spec.rb
+++ b/spec/lib/whitehall_importer/edition_history_spec.rb
@@ -239,7 +239,8 @@ RSpec.describe WhitehallImporter::EditionHistory do
                            event: "update")
       instance = described_class.new([first_event, second_event])
 
-      expect(instance.imported_entry_type(second_event, 1)).to eq("document_updated")
+      expect(instance.imported_entry_type(second_event, 1))
+        .to eq("document_updated")
     end
 
     it "returns the Content Publisher event type if the state has changed" do

--- a/spec/lib/whitehall_importer/edition_history_spec.rb
+++ b/spec/lib/whitehall_importer/edition_history_spec.rb
@@ -6,7 +6,7 @@ RSpec.describe WhitehallImporter::EditionHistory do
     let(:bang_method) { "#{method}!".to_sym }
 
     it "delegates to ##{method}" do
-      event = build(:revision_history_event)
+      event = build(:whitehall_export_revision_history_event)
       expect(instance).to receive(method).and_return(event)
       expect(instance.public_send(bang_method, *args)).to be(event)
     end
@@ -20,15 +20,18 @@ RSpec.describe WhitehallImporter::EditionHistory do
 
   describe "#last_state_event" do
     it "returns the last event associated with the state" do
-      first_draft_event = build(:revision_history_event, state: "draft")
-      last_draft_event = build(:revision_history_event, state: "draft")
+      first_draft_event = build(:whitehall_export_revision_history_event,
+                                state: "draft")
+      last_draft_event = build(:whitehall_export_revision_history_event,
+                               state: "draft")
       instance = described_class.new([first_draft_event, last_draft_event])
 
       expect(instance.last_state_event("draft")).to be(last_draft_event)
     end
 
     it "returns nil if the edition is missing a state event" do
-      draft_event = build(:revision_history_event, state: "draft")
+      draft_event = build(:whitehall_export_revision_history_event,
+                          state: "draft")
       expect(described_class.new([draft_event]).last_state_event("published"))
         .to be_nil
     end
@@ -40,15 +43,18 @@ RSpec.describe WhitehallImporter::EditionHistory do
 
   describe "#first_state_event" do
     it "returns the first event associated with the state" do
-      first_draft_event = build(:revision_history_event, state: "draft")
-      last_draft_event = build(:revision_history_event, state: "draft")
+      first_draft_event = build(:whitehall_export_revision_history_event,
+                                state: "draft")
+      last_draft_event = build(:whitehall_export_revision_history_event,
+                               state: "draft")
       instance = described_class.new([first_draft_event, last_draft_event])
 
       expect(instance.first_state_event("draft")).to be(first_draft_event)
     end
 
     it "returns nil if the edition is missing a state event" do
-      draft_event = build(:revision_history_event, state: "draft")
+      draft_event = build(:whitehall_export_revision_history_event,
+                          state: "draft")
       expect(described_class.new([draft_event]).first_state_event("published"))
         .to be_nil
     end
@@ -56,15 +62,15 @@ RSpec.describe WhitehallImporter::EditionHistory do
 
   describe "#previous_event" do
     it "returns the event associated with the state" do
-      first_event = build(:revision_history_event)
-      second_event = build(:revision_history_event)
+      first_event = build(:whitehall_export_revision_history_event)
+      second_event = build(:whitehall_export_revision_history_event)
       instance = described_class.new([first_event, second_event])
 
       expect(instance.previous_event(second_event)).to eq(first_event)
     end
 
     it "returns nil when a previous event is not found" do
-      event = build(:revision_history_event)
+      event = build(:whitehall_export_revision_history_event)
       expect(described_class.new([]).previous_event(event)).to be_nil
     end
   end
@@ -72,20 +78,20 @@ RSpec.describe WhitehallImporter::EditionHistory do
   describe "#previous_event!" do
     it_behaves_like "an event bang method",
                     :previous_event,
-                    [FactoryBot.build(:revision_history_event)]
+                    [FactoryBot.build(:whitehall_export_revision_history_event)]
   end
 
   describe "#next_event" do
     it "returns the event associated with the state" do
-      first_event = build(:revision_history_event)
-      next_event = build(:revision_history_event)
+      first_event = build(:whitehall_export_revision_history_event)
+      next_event = build(:whitehall_export_revision_history_event)
       instance = described_class.new([first_event, next_event])
 
       expect(instance.next_event(first_event)).to be(next_event)
     end
 
     it "returns nil when a next event is not found" do
-      event = build(:revision_history_event)
+      event = build(:whitehall_export_revision_history_event)
       expect(described_class.new([]).next_event(event)).to be_nil
     end
   end
@@ -93,21 +99,26 @@ RSpec.describe WhitehallImporter::EditionHistory do
   describe "#next_event!" do
     it_behaves_like "an event bang method",
                     :next_event,
-                    [FactoryBot.build(:revision_history_event)]
+                    [FactoryBot.build(:whitehall_export_revision_history_event)]
   end
 
   describe "#create_event" do
     it "returns the first create event associated" do
-      first_event = build(:revision_history_event, event: "update")
-      first_create_event = build(:revision_history_event, event: "create")
-      last_create_event = build(:revision_history_event, event: "create")
-      instance = described_class.new([first_event, first_create_event, last_create_event])
+      first_event = build(:whitehall_export_revision_history_event,
+                          event: "update")
+      first_create_event = build(:whitehall_export_revision_history_event,
+                                 event: "create")
+      last_create_event = build(:whitehall_export_revision_history_event,
+                                event: "create")
+      instance = described_class.new([first_event,
+                                      first_create_event,
+                                      last_create_event])
 
       expect(instance.create_event).to be(first_create_event)
     end
 
     it "returns nil if the edition is missing a create event" do
-      event = build(:revision_history_event, event: "update")
+      event = build(:whitehall_export_revision_history_event, event: "update")
       expect(described_class.new([event]).create_event).to be_nil
     end
   end
@@ -118,10 +129,14 @@ RSpec.describe WhitehallImporter::EditionHistory do
 
   describe "#last_unpublishing_event" do
     it "returns the draft that follows a published event" do
-      first_publishing_event = build(:revision_history_event, state: "published")
-      first_unpublishing_event = build(:revision_history_event, state: "draft")
-      last_publishing_event = build(:revision_history_event, state: "published")
-      last_unpublishing_event = build(:revision_history_event, state: "draft")
+      first_publishing_event = build(:whitehall_export_revision_history_event,
+                                     state: "published")
+      first_unpublishing_event = build(:whitehall_export_revision_history_event,
+                                       state: "draft")
+      last_publishing_event = build(:whitehall_export_revision_history_event,
+                                    state: "published")
+      last_unpublishing_event = build(:whitehall_export_revision_history_event,
+                                      state: "draft")
       instance = described_class.new([first_publishing_event,
                                       first_unpublishing_event,
                                       last_publishing_event,
@@ -131,8 +146,10 @@ RSpec.describe WhitehallImporter::EditionHistory do
     end
 
     it "returns nil if there is not a draft update that follows a published event" do
-      publishing_event = build(:revision_history_event, state: "published")
-      next_event = build(:revision_history_event, state: "withdrawn")
+      publishing_event = build(:whitehall_export_revision_history_event,
+                               state: "published")
+      next_event = build(:whitehall_export_revision_history_event,
+                         state: "withdrawn")
       instance = described_class.new([publishing_event, next_event])
 
       expect(instance.last_unpublishing_event).to be_nil
@@ -145,9 +162,11 @@ RSpec.describe WhitehallImporter::EditionHistory do
 
   describe "#edited_after_unpublishing?" do
     it "returns true if there are events after the unpublishing" do
-      publishing_event = build(:revision_history_event, state: "published")
-      unpublishing_event = build(:revision_history_event, state: "draft")
-      edit_event = build(:revision_history_event,
+      publishing_event = build(:whitehall_export_revision_history_event,
+                               state: "published")
+      unpublishing_event = build(:whitehall_export_revision_history_event,
+                                 state: "draft")
+      edit_event = build(:whitehall_export_revision_history_event,
                          state: "draft",
                          created_at: 5.minutes.from_now.rfc3339)
       instance = described_class.new([publishing_event,
@@ -158,8 +177,10 @@ RSpec.describe WhitehallImporter::EditionHistory do
     end
 
     it "returns false if there aren't edits after unpublishing" do
-      publishing_event = build(:revision_history_event, state: "published")
-      unpublishing_event = build(:revision_history_event, state: "draft")
+      publishing_event = build(:whitehall_export_revision_history_event,
+                               state: "published")
+      unpublishing_event = build(:whitehall_export_revision_history_event,
+                                 state: "draft")
       instance = described_class.new([publishing_event, unpublishing_event])
 
       expect(instance.edited_after_unpublishing?).to be(false)
@@ -173,8 +194,10 @@ RSpec.describe WhitehallImporter::EditionHistory do
 
   describe "#editors" do
     it "returns all of the editors who have contributed to an edition" do
-      first_event = build(:revision_history_event, whodunnit: 1)
-      second_event = build(:revision_history_event, whodunnit: 2)
+      first_event = build(:whitehall_export_revision_history_event,
+                          whodunnit: 1)
+      second_event = build(:whitehall_export_revision_history_event,
+                           whodunnit: 2)
 
       instance = described_class.new([first_event, second_event])
 
@@ -183,8 +206,10 @@ RSpec.describe WhitehallImporter::EditionHistory do
     end
 
     it "doesn't return the same editor more than once" do
-      first_event = build(:revision_history_event, whodunnit: 1)
-      second_event = build(:revision_history_event, whodunnit: 1)
+      first_event = build(:whitehall_export_revision_history_event,
+                          whodunnit: 1)
+      second_event = build(:whitehall_export_revision_history_event,
+                           whodunnit: 1)
 
       instance = described_class.new([first_event, second_event])
 
@@ -195,38 +220,43 @@ RSpec.describe WhitehallImporter::EditionHistory do
 
   describe "#timeline_entry" do
     it "returns first_created for create event on first edition" do
-      event = build(:revision_history_event)
+      event = build(:whitehall_export_revision_history_event)
       instance = described_class.new([event])
 
       expect(instance.imported_entry_type(event, 1)).to eq("first_created")
     end
 
     it "returns new_edition for create event on subsequent edition" do
-      event = build(:revision_history_event)
+      event = build(:whitehall_export_revision_history_event)
       instance = described_class.new([event])
 
       expect(instance.imported_entry_type(event, 2)).to eq("new_edition")
     end
 
     it "returns document_updated if there is no change in state" do
-      first_event = build(:revision_history_event)
-      second_event = build(:revision_history_event, event: "update")
+      first_event = build(:whitehall_export_revision_history_event)
+      second_event = build(:whitehall_export_revision_history_event,
+                           event: "update")
       instance = described_class.new([first_event, second_event])
 
       expect(instance.imported_entry_type(second_event, 1)).to eq("document_updated")
     end
 
     it "returns the Content Publisher event type if the state has changed" do
-      first_event = build(:revision_history_event, state: "draft")
-      second_event = build(:revision_history_event, event: "update", state: "published")
+      first_event = build(:whitehall_export_revision_history_event,
+                          state: "draft")
+      second_event = build(:whitehall_export_revision_history_event,
+                           event: "update", state: "published")
       instance = described_class.new([first_event, second_event])
 
       expect(instance.imported_entry_type(second_event, 1)).to eq("published")
     end
 
     it "aborts if the state has changed but the mapping is undefined" do
-      first_event = build(:revision_history_event, state: "draft")
-      second_event = build(:revision_history_event, event: "update", state: "foo")
+      first_event = build(:whitehall_export_revision_history_event,
+                          state: "draft")
+      second_event = build(:whitehall_export_revision_history_event,
+                           event: "update", state: "foo")
       instance = described_class.new([first_event, second_event])
 
       expect { instance.imported_entry_type(second_event, 1) }

--- a/spec/lib/whitehall_importer/import_spec.rb
+++ b/spec/lib/whitehall_importer/import_spec.rb
@@ -85,7 +85,8 @@ RSpec.describe WhitehallImporter::Import do
       import_data = build(:whitehall_export_document,
                           editions: [edition],
                           users: [whitehall_user])
-      document_import = build(:whitehall_migration_document_import, payload: import_data)
+      document_import = build(:whitehall_migration_document_import,
+                              payload: import_data)
       described_class.call(document_import)
 
       expect(document_import.document.created_by).to eq(user)
@@ -107,7 +108,8 @@ RSpec.describe WhitehallImporter::Import do
       import_data = build(:whitehall_export_document,
                           editions: [past_edition, current_edition],
                           users: [whitehall_user])
-      document_import = build(:whitehall_migration_document_import, payload: import_data)
+      document_import = build(:whitehall_migration_document_import,
+                              payload: import_data)
 
       expect(WhitehallImporter::CreateEdition).to receive(:call).with(
         hash_including(current: false),
@@ -145,7 +147,8 @@ RSpec.describe WhitehallImporter::Import do
 
       import_data = build(:whitehall_export_document,
                           editions: [first_edition, second_edition])
-      document_import = build(:whitehall_migration_document_import, payload: import_data)
+      document_import = build(:whitehall_migration_document_import,
+                              payload: import_data)
       described_class.call(document_import)
 
       expect(document_import.document.first_published_at).to eq(first_publish_date)

--- a/spec/lib/whitehall_importer/import_spec.rb
+++ b/spec/lib/whitehall_importer/import_spec.rb
@@ -151,7 +151,8 @@ RSpec.describe WhitehallImporter::Import do
                               payload: import_data)
       described_class.call(document_import)
 
-      expect(document_import.document.first_published_at).to eq(first_publish_date)
+      expect(document_import.document.first_published_at)
+        .to eq(first_publish_date)
     end
 
     it "integrity checks the current and live editions of the imported document" do

--- a/spec/lib/whitehall_importer/import_spec.rb
+++ b/spec/lib/whitehall_importer/import_spec.rb
@@ -78,7 +78,8 @@ RSpec.describe WhitehallImporter::Import do
       user = User.create!(uid: whitehall_user["uid"])
       edition = build(
         :whitehall_export_edition,
-        revision_history: [build(:revision_history_event, whodunnit: whitehall_user["id"])],
+        revision_history: [build(:whitehall_export_revision_history_event,
+                                 whodunnit: whitehall_user["id"])],
       )
 
       import_data = build(:whitehall_export_document,
@@ -94,11 +95,13 @@ RSpec.describe WhitehallImporter::Import do
       past_edition = build(
         :whitehall_export_edition,
         created_at: Time.current.yesterday.rfc3339,
-        revision_history: [build(:revision_history_event, whodunnit: whitehall_user["id"])],
+        revision_history: [build(:whitehall_export_revision_history_event,
+                                 whodunnit: whitehall_user["id"])],
       )
       current_edition = build(
         :whitehall_export_edition,
-        revision_history: [build(:revision_history_event, whodunnit: whitehall_user["id"])],
+        revision_history: [build(:whitehall_export_revision_history_event,
+                                 whodunnit: whitehall_user["id"])],
       )
 
       import_data = build(:whitehall_export_document,
@@ -122,15 +125,21 @@ RSpec.describe WhitehallImporter::Import do
       first_edition = build(
         :whitehall_export_edition,
         revision_history: [
-          build(:revision_history_event),
-          build(:revision_history_event, event: "update", state: "published", created_at: first_publish_date),
+          build(:whitehall_export_revision_history_event),
+          build(:whitehall_export_revision_history_event,
+                event: "update",
+                state: "published",
+                created_at: first_publish_date),
         ],
       )
       second_edition = build(
         :whitehall_export_edition,
         revision_history: [
-          build(:revision_history_event),
-          build(:revision_history_event, event: "update", state: "published", created_at: Time.current),
+          build(:whitehall_export_revision_history_event),
+          build(:whitehall_export_revision_history_event,
+                event: "update",
+                state: "published",
+                created_at: Time.current),
         ],
       )
 


### PR DESCRIPTION
Whitehall stores document history in three places. This PR addresses the import of two of these into Content Publisher:

-  Editorial remarks (Notes tab in Whitehall) 
- Fact check requests (Fact checking tab in Whitehall)

Trello: https://trello.com/c/o8PhjdUc/1312-map-whitehall-editorial-remarks-notes-tab-in-whitehall-and-fact-check-requests-fact-checking-tab-in-whitehall-to-content-publish