### PR TITLE
Ignore superseded revision history state changes from Whitehall

### DIFF
--- a/lib/whitehall_importer/create_edition.rb
+++ b/lib/whitehall_importer/create_edition.rb
@@ -181,8 +181,11 @@ module WhitehallImporter
 
     def create_revision_history(edition)
       whitehall_edition["revision_history"].each do |event|
+        entry_type = history.imported_entry_type(event, edition_number)
+        next if entry_type.nil?
+
         details = TimelineEntry::WhitehallImportedEntry.create!(
-          entry_type: history.imported_entry_type(event, edition_number),
+          entry_type: entry_type,
         )
         TimelineEntry.create!(
           entry_type: :whitehall_migration,

--- a/lib/whitehall_importer/edition_history.rb
+++ b/lib/whitehall_importer/edition_history.rb
@@ -91,6 +91,7 @@ module WhitehallImporter
       when "rejected" then "rejected"
       when "scheduled" then "scheduled"
       when "submitted" then "submitted"
+      when "superseded" then nil
       when "withdrawn" then "withdrawn"
       else
         raise(AbortImportError, "Edition history has an unsupported state #{event['state']}")

--- a/spec/lib/whitehall_importer/create_edition_spec.rb
+++ b/spec/lib/whitehall_importer/create_edition_spec.rb
@@ -101,6 +101,7 @@ RSpec.describe WhitehallImporter::CreateEdition do
           revision_history: [
             build(:revision_history_event, whodunnit: 1, event: "create", state: "draft", created_at: 2.days.ago),
             build(:revision_history_event, whodunnit: 2, event: "update", state: "published", created_at: 1.day.ago),
+            build(:revision_history_event, whodunnit: 1, event: "update", state: "superseded", created_at: 2.days.ago),
           ],
         )
 


### PR DESCRIPTION
Whitehall has a change of state to 'superseded' which happens when an existing published edition is replaced with a new published edition. The existing one is given a new state of superseded, however this is not to be shown to users.

We should therefore skip any history entries that have a state change to superseded, as detailed in https://docs.google.com/spreadsheets/d/1I7TbA9glyFyhyWq5wQJAGykkXFwOJjyd--kLCycXbSY/edit#gid=0.

This fix allows us to import 53 of NDA's documents which are currently failing.

Trello: https://trello.com/c/3AV7mZTG