### PR TITLE
Iterate our route config after a controller reshuffle

### DIFF
--- a/app/controllers/editions_controller.rb
+++ b/app/controllers/editions_controller.rb
@@ -5,10 +5,10 @@ class EditionsController < ApplicationController
 
   def create
     Editions::CreateInteractor.call(params: params, user: current_user)
-    redirect_to edit_document_path(params[:document])
+    redirect_to content_path(params[:document])
   end
 
-  def destroy
+  def destroy_draft
     result = Editions::DestroyInteractor.call(params: params, user: current_user)
 
     if result.api_error

--- a/app/controllers/new_document_controller.rb
+++ b/app/controllers/new_document_controller.rb
@@ -32,7 +32,7 @@ class NewDocumentController < ApplicationController
     elsif result.managed_elsewhere
       redirect_to document_type.managed_elsewhere_url
     else
-      redirect_to edit_document_path(document)
+      redirect_to content_path(document)
     end
   end
 end

--- a/app/helpers/actions_helper.rb
+++ b/app/helpers/actions_helper.rb
@@ -21,7 +21,7 @@ module ActionsHelper
 
   def delete_draft_link(edition, extra_classes = [])
     link_to "Delete draft",
-            delete_draft_path(edition.document),
+            confirm_delete_draft_path(edition.document),
             class: %w(govuk-link app-link--destructive) + Array(extra_classes),
             data: { gtm: "delete-draft" }
   end

--- a/app/views/content/edit.html.erb
+++ b/app/views/content/edit.html.erb
@@ -6,14 +6,17 @@
   <% content_for :title, t("content.edit.title", title: @edition.title_or_fallback) %>
 <% end %>
 
-<%= form_for @edition.document,
-  html: { class: "app-c-contextual-guidance__form" },
-  data: {
-    module: "edit-document-form",
-    "url-preview-path": generate_path_path,
-    "warn-before-unload": "true",
-    gtm: "edit-document-submit"
-  } do |f| %>
+<%= form_tag(
+      content_path(@edition.document),
+      method: :patch,
+      html: { class: "app-c-contextual-guidance__form" },
+      data: {
+        module: "edit-document-form",
+        "url-preview-path": generate_path_path(@edition.document),
+        "warn-before-unload": "true",
+        gtm: "edit-document-submit"
+      }
+    ) do |f| %>
 
   <%
     title_contextual_guidance = {

--- a/app/views/documents/show/_contents.html.erb
+++ b/app/views/documents/show/_contents.html.erb
@@ -27,7 +27,7 @@
   borderless: true,
   edit: (
     if @edition.editable?
-      { href: edit_document_path(@edition.document),
+      { href: content_path(@edition.document),
         data_attributes: { gtm: "edit-summary" } }
     end
   ),

--- a/app/views/documents/show/_requirements.html.erb
+++ b/app/views/documents/show/_requirements.html.erb
@@ -1,10 +1,10 @@
 <% issue_params = {
   style: "summary",
   link_options: {
-    title: { href: edit_document_path(@edition.document, anchor: "title") },
-    summary: { href: edit_document_path(@edition.document, anchor: "summary") },
-    body: { href: edit_document_path(@edition.document, anchor: "body") },
-    change_note: { href: edit_document_path(@edition.document, anchor: "change-note") },
+    title: { href: content_path(@edition.document, anchor: "title") },
+    summary: { href: content_path(@edition.document, anchor: "summary") },
+    body: { href: content_path(@edition.document, anchor: "body") },
+    change_note: { href: content_path(@edition.document, anchor: "change-note") },
     alt_text: -> (context) do
       image_id = context[:image_revision].image_id
       { href: edit_image_path(@edition.document, image_id, anchor: "alt-text") }

--- a/app/views/editions/confirm_delete_draft.html.erb
+++ b/app/views/editions/confirm_delete_draft.html.erb
@@ -13,7 +13,7 @@
 
     <div class="govuk-grid-row">
       <div class="govuk-grid-column-full">
-        <%= form_tag document_path(@edition.document),
+        <%= form_tag destroy_draft_path(@edition.document),
                      method: :delete,
                      data: { gtm: "delete-draft-submit" } do %>
           <%= render "govuk_publishing_components/components/button", {

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -15,11 +15,11 @@ Rails.application.routes.draw do
     get "/history" => "documents#history", as: :document_history
     get "/generate-path" => "documents#generate_path", as: :generate_path
 
-    patch "" => "content#update"
-    get "/edit" => "content#edit", as: :edit_document
+    patch "/content" => "content#update", as: :content
+    get "/content" => "content#edit"
 
-    delete "" => "editions#destroy"
-    get "/delete-draft" => "editions#confirm_delete_draft", as: :delete_draft
+    delete "/draft" => "editions#destroy_draft", as: :destroy_draft
+    get "/delete-draft" => "editions#confirm_delete_draft", as: :confirm_delete_draft
 
     get "/publish" => "publish#confirmation", as: :publish_confirmation
     post "/publish" => "publish#publish"

--- a/spec/features/editing_content/insert_inline_file_attachment_spec.rb
+++ b/spec/features/editing_content/insert_inline_file_attachment_spec.rb
@@ -40,7 +40,7 @@ RSpec.feature "Insert inline file attachment" do
   end
 
   def when_i_go_to_edit_the_edition
-    visit edit_document_path(@edition.document)
+    visit content_path(@edition.document)
   end
 
   def and_i_click_to_insert_a_file_attachment

--- a/spec/features/editing_content/insert_inline_image_spec.rb
+++ b/spec/features/editing_content/insert_inline_image_spec.rb
@@ -28,7 +28,7 @@ RSpec.feature "Insert inline image" do
   end
 
   def when_i_go_to_edit_the_edition
-    visit edit_document_path(@edition.document)
+    visit content_path(@edition.document)
   end
 
   def and_i_click_to_insert_an_image

--- a/spec/features/editing_content/insert_video_embed_spec.rb
+++ b/spec/features/editing_content/insert_video_embed_spec.rb
@@ -16,7 +16,7 @@ RSpec.describe "Insert video embed", js: true do
   end
 
   def when_i_go_to_edit_the_edition
-    visit edit_document_path(@edition.document)
+    visit content_path(@edition.document)
   end
 
   def and_i_click_to_insert_a_video

--- a/spec/features/editing_content_settings/enforce_access_limit_spec.rb
+++ b/spec/features/editing_content_settings/enforce_access_limit_spec.rb
@@ -85,7 +85,7 @@ RSpec.feature "Enforce access limit" do
   def and_i_can_still_edit_the_edition
     visit document_path(@edition.document)
     expect(page).to have_content("Change Access limiting")
-    visit edit_document_path(@edition.document)
+    visit content_path(@edition.document)
     expect(page).to have_content(I18n.t!("content.edit.title", title: @edition.title_or_fallback))
   end
 
@@ -108,7 +108,7 @@ RSpec.feature "Enforce access limit" do
     visit document_path(@edition.document)
     expect(page).to have_content(I18n.t!("documents.forbidden.description"))
     expect(page).to have_content(I18n.t!("documents.forbidden.owner", primary_org: "Primary org"))
-    visit edit_document_path(@edition.document)
+    visit content_path(@edition.document)
     expect(page).to have_content(I18n.t!("documents.forbidden.description"))
     expect(page).to have_content(I18n.t!("documents.forbidden.owner", primary_org: "Primary org"))
   end

--- a/spec/features/editing_file_attachments/delete_file_attachment_spec.rb
+++ b/spec/features/editing_file_attachments/delete_file_attachment_spec.rb
@@ -20,7 +20,7 @@ RSpec.feature "Delete a file attachment", js: true do
   end
 
   def when_i_insert_an_attachment
-    visit edit_document_path(@edition.document)
+    visit content_path(@edition.document)
     find("markdown-toolbar details").click
     click_on "Attachment"
   end

--- a/spec/features/editing_file_attachments/preview_file_attachment_spec.rb
+++ b/spec/features/editing_file_attachments/preview_file_attachment_spec.rb
@@ -24,7 +24,7 @@ RSpec.feature "Preview file attachment", js: true do
   end
 
   def when_i_preview_the_attachment
-    visit edit_document_path(@edition.document)
+    visit content_path(@edition.document)
     within(".app-c-markdown-editor") do
       find("markdown-toolbar details").click
       click_on "Attachment"

--- a/spec/features/editing_file_attachments/replace_file_attachment_file_spec.rb
+++ b/spec/features/editing_file_attachments/replace_file_attachment_file_spec.rb
@@ -24,7 +24,7 @@ RSpec.feature "Replace a file attachment file", js: true do
   end
 
   def when_i_click_to_insert_an_attachment
-    visit edit_document_path(@edition.document)
+    visit content_path(@edition.document)
     find("markdown-toolbar details").click
     click_on "Attachment"
     expect(page).to have_content("74 Bytes")

--- a/spec/features/editing_images/delete_image_spec.rb
+++ b/spec/features/editing_images/delete_image_spec.rb
@@ -32,7 +32,7 @@ RSpec.feature "Delete an image" do
   end
 
   def when_i_insert_an_inline_image
-    visit edit_document_path(@edition.document)
+    visit content_path(@edition.document)
 
     within(".app-c-markdown-editor") do
       find("markdown-toolbar details").click

--- a/spec/features/editing_images/edit_image_spec.rb
+++ b/spec/features/editing_images/edit_image_spec.rb
@@ -60,7 +60,7 @@ RSpec.feature "Edit image", js: true do
   end
 
   def when_i_insert_an_inline_image
-    visit edit_document_path(@edition.document)
+    visit content_path(@edition.document)
 
     within(".app-c-markdown-editor") do
       find("markdown-toolbar details").click

--- a/spec/features/editing_images/upload_image_spec.rb
+++ b/spec/features/editing_images/upload_image_spec.rb
@@ -32,7 +32,7 @@ RSpec.feature "Upload an image", js: true do
   end
 
   def when_i_insert_an_inline_image
-    visit edit_document_path(@edition.document)
+    visit content_path(@edition.document)
 
     within(".app-c-markdown-editor") do
       find("markdown-toolbar details").click

--- a/spec/requests/content_spec.rb
+++ b/spec/requests/content_spec.rb
@@ -1,0 +1,40 @@
+# frozen_string_literal: true
+
+RSpec.describe "Content" do
+  it_behaves_like "requests that assert edition state",
+                  "modifying a non editable edition",
+                  routes: { content_path: %i[patch get] } do
+    let(:edition) { create(:edition, :published) }
+  end
+
+  describe "GET /documents/:document/content" do
+    it "returns successfully" do
+      edition = create(:edition)
+      get content_path(edition.document)
+      expect(response).to have_http_status(:ok)
+    end
+  end
+
+  describe "PATCH /documents/:document/content" do
+    before { stub_any_publishing_api_put_content }
+
+    it "redirects to document summary" do
+      edition = create(:edition)
+      patch content_path(edition.document),
+            params: { revision: { title: "My title" } }
+
+      expect(response).to redirect_to(document_path(edition.document))
+      follow_redirect!
+      expect(response.body).to have_content("My title")
+    end
+
+    it "returns issues and an unprocessable response when there are requirement issues" do
+      edition = create(:edition, title: "Valid title")
+      patch content_path(edition.document),
+            params: { revision: { title: "" } }
+      expect(response).to have_http_status(:unprocessable_entity)
+      expect(response.body)
+        .to have_content(I18n.t!("requirements.title.blank.form_message"))
+    end
+  end
+end

--- a/spec/requests/documents_spec.rb
+++ b/spec/requests/documents_spec.rb
@@ -3,9 +3,7 @@
 RSpec.describe "Documents" do
   it_behaves_like "requests that assert edition state",
                   "modifying a non editable edition",
-                  routes: { document_path: %i[patch delete],
-                            edit_document_path: %i[get],
-                            delete_draft_path: %i[get],
+                  routes: { content_path: %i[patch get],
                             generate_path_path: %i[get] } do
     let(:edition) { create(:edition, :published) }
   end
@@ -41,68 +39,6 @@ RSpec.describe "Documents" do
         get documents_path
         expect(response).to have_http_status(:ok)
       end
-    end
-  end
-
-  describe "GET /documents/:document/edit" do
-    it "returns successfully" do
-      edition = create(:edition)
-      get edit_document_path(edition.document)
-      expect(response).to have_http_status(:ok)
-    end
-  end
-
-  describe "PATCH /documents/:document" do
-    before { stub_any_publishing_api_put_content }
-
-    it "redirects to document summary" do
-      edition = create(:edition)
-      patch document_path(edition.document),
-            params: { revision: { title: "My title" } }
-
-      expect(response).to redirect_to(document_path(edition.document))
-      follow_redirect!
-      expect(response.body).to have_content("My title")
-    end
-
-    it "returns issues and an unprocessable response when there are requirement issues" do
-      edition = create(:edition, title: "Valid title")
-      patch document_path(edition.document),
-            params: { revision: { title: "" } }
-      expect(response).to have_http_status(:unprocessable_entity)
-      expect(response.body)
-        .to have_content(I18n.t!("requirements.title.blank.form_message"))
-    end
-  end
-
-  describe "GET /documents/:document/delete-draft" do
-    it "returns successfully" do
-      edition = create(:edition)
-      get delete_draft_path(edition.document)
-
-      expect(response).to have_http_status(:ok)
-    end
-  end
-
-  describe "DELETE /documents/:document" do
-    let(:edition) { create(:edition) }
-
-    it "redirects to document index on success" do
-      stub_publishing_api_unreserve_path(edition.base_path)
-      stub_publishing_api_discard_draft(edition.content_id)
-
-      delete document_path(edition.document)
-      expect(response).to redirect_to(documents_path)
-    end
-
-    it "redirects to document summary when there is an API error" do
-      stub_publishing_api_isnt_available
-
-      delete document_path(edition.document)
-      expect(response).to redirect_to(document_path(edition.document))
-      follow_redirect!
-      expect(response.body)
-        .to have_content(I18n.t!("documents.show.flashes.delete_draft_error.title"))
     end
   end
 

--- a/spec/requests/new_document_spec.rb
+++ b/spec/requests/new_document_spec.rb
@@ -31,7 +31,7 @@ RSpec.describe "New Document" do
       post create_document_path,
            params: { supertype: supertype_id, document_type: document_type.id }
 
-      expect(response).to redirect_to(edit_document_path(Document.last))
+      expect(response).to redirect_to(content_path(Document.last))
       follow_redirect!
       expect(response.body).to have_content(document_type.label.downcase)
     end


### PR DESCRIPTION
https://github.com/alphagov/content-publisher/pull/1681 introduced some inconsistency with our routes. This fixes that.

The above pull request made it so that we had the same paths going to different controllers based on the request method. This makes paths consistent with controllers and updates the tests accordingly.