### PR TITLE
Ensure document creation is rolled back when an import exception occurs

### DIFF
--- a/lib/whitehall_importer.rb
+++ b/lib/whitehall_importer.rb
@@ -48,8 +48,7 @@ module WhitehallImporter
     raise "Cannot import with a state of #{whitehall_import.state}" unless whitehall_import.importing?
 
     begin
-      document = Import.call(whitehall_import)
-      whitehall_import.update!(document: document, state: "imported")
+      Import.call(whitehall_import)
     rescue IntegrityCheckError => e
       whitehall_import.update!(
         error_log: e.inspect,

--- a/spec/lib/whitehall_importer_spec.rb
+++ b/spec/lib/whitehall_importer_spec.rb
@@ -93,17 +93,6 @@ RSpec.describe WhitehallImporter do
         .to raise_error(RuntimeError, "Cannot import with a state of imported")
     end
 
-    context "when the import is successful" do
-      before do
-        allow(WhitehallImporter::Import).to receive(:call).and_return(build(:document, :with_current_edition))
-      end
-
-      it "marks the import as imported" do
-        WhitehallImporter.import(whitehall_migration_document_import)
-        expect(whitehall_migration_document_import).to be_imported
-      end
-    end
-
     context "when the import fails" do
       before do
         allow(WhitehallImporter::Import).to receive(:call).and_raise(message)


### PR DESCRIPTION
For https://trello.com/c/g0GfY8PF/1364-fix-import-script

Our problem is that we mutate the document_import object during the
import, which conflicts with our 'all or nothing' strategy for
transactions. What happens is that we create a document and various
other models in the database and then, when a transaction fails, roll
them back. However as we set the document attribute on a document_import
the rolled back model still exists in memory and when we save the
document_import it tries to save the document model meaning we at best
get an exception and at worst get a half created document.

An approach to resolve this is to reload the document_import object at
the point of the exception occurring.

A different, more complex context based approach, is considered in
https://github.com/alphagov/content-publisher/compare/atomic-imports?expand=1

Couple of other tweaks this work did:

- Move setting a document as imported to be in the transaction. That way, if
  this step raises an exception we haven't persisted a document but failed to
set the status.
- We no longer need `WhitehallImporter::Import#call` to return a document to
  `WhitehallImporter`, since no longer handle assigning the document to the
document import there. This change caused some tests to fail as they were
relying on receiving the document from `WhitehallImporter::Import#call` to
check various values on the document. These have been updated.