### PR TITLE
Use keyword args for all services

### DIFF
--- a/app/controllers/documents_controller.rb
+++ b/app/controllers/documents_controller.rb
@@ -30,7 +30,8 @@ class DocumentsController < ApplicationController
   def generate_path
     edition = Edition.find_current(document: params[:document])
     assert_edition_state(edition, &:editable?)
-    base_path = GenerateBasePathService.call(edition.document, params[:title])
+    base_path = GenerateBasePathService.call(document: edition.document,
+                                             proposed_title: params[:title])
     render plain: base_path
   end
 

--- a/app/interactors/access_limit/update_interactor.rb
+++ b/app/interactors/access_limit/update_interactor.rb
@@ -31,7 +31,7 @@ private
 
     if LIMIT_TYPES.exclude?(limit_type)
       context.fail! if edition.access_limit.nil?
-      EditDraftEditionService.call(edition, user, access_limit: nil)
+      EditDraftEditionService.call(edition: edition, user: user, access_limit: nil)
       return
     end
 
@@ -42,7 +42,9 @@ private
                                    limit_type: limit_type,
                                    revision_at_creation: edition.revision)
 
-    EditDraftEditionService.call(edition, user, access_limit: access_limit)
+    EditDraftEditionService.call(edition: edition,
+                                 user: user,
+                                 access_limit: access_limit)
   end
 
   def check_for_issues
@@ -72,6 +74,6 @@ private
   end
 
   def update_preview
-    FailsafeDraftPreviewService.call(edition)
+    FailsafeDraftPreviewService.call(edition: edition)
   end
 end

--- a/app/interactors/backdate/destroy_interactor.rb
+++ b/app/interactors/backdate/destroy_interactor.rb
@@ -28,7 +28,9 @@ private
     updater.assign(backdated_to: nil)
     context.fail! unless updater.changed?
 
-    EditDraftEditionService.call(edition, user, revision: updater.next_revision)
+    EditDraftEditionService.call(edition: edition,
+                                 user: user,
+                                 revision: updater.next_revision)
     edition.save!
   end
 
@@ -42,6 +44,6 @@ private
   end
 
   def update_preview
-    FailsafeDraftPreviewService.call(edition)
+    FailsafeDraftPreviewService.call(edition: edition)
   end
 end

--- a/app/interactors/backdate/update_interactor.rb
+++ b/app/interactors/backdate/update_interactor.rb
@@ -32,7 +32,9 @@ private
   def update_edition
     updater = Versioning::RevisionUpdater.new(edition.revision, user)
     updater.assign(backdated_to: date)
-    EditDraftEditionService.call(edition, user, revision: updater.next_revision)
+    EditDraftEditionService.call(edition: edition,
+                                 user: user,
+                                 revision: updater.next_revision)
     edition.save!
 
     context.fail! unless updater.changed?
@@ -66,6 +68,6 @@ private
   end
 
   def update_preview
-    FailsafeDraftPreviewService.call(edition)
+    FailsafeDraftPreviewService.call(edition: edition)
   end
 end

--- a/app/interactors/content/update_interactor.rb
+++ b/app/interactors/content/update_interactor.rb
@@ -45,7 +45,7 @@ private
   end
 
   def update_edition
-    EditDraftEditionService.call(edition, user, revision: revision)
+    EditDraftEditionService.call(edition: edition, user: user, revision: revision)
     edition.save!
   end
 
@@ -54,7 +54,7 @@ private
   end
 
   def update_preview
-    FailsafeDraftPreviewService.call(edition)
+    FailsafeDraftPreviewService.call(edition: edition)
   end
 
   def change_note_params

--- a/app/interactors/editions/create_interactor.rb
+++ b/app/interactors/editions/create_interactor.rb
@@ -52,8 +52,14 @@ private
                   number: edition.document.next_edition_number,
                   created_by: user)
 
-    EditDraftEditionService.call(next_edition, user, current: true, revision: next_revision)
-    AssignEditionStatusService.call(next_edition, user, :draft)
+    EditDraftEditionService.call(edition: next_edition,
+                                 user: user,
+                                 current: true,
+                                 revision: next_revision)
+
+    AssignEditionStatusService.call(edition: next_edition,
+                                    user: user,
+                                    state: :draft)
     next_edition.save!
   end
 
@@ -68,6 +74,6 @@ private
   end
 
   def preview_next_edition
-    FailsafeDraftPreviewService.call(next_edition)
+    FailsafeDraftPreviewService.call(edition: next_edition)
   end
 end

--- a/app/interactors/editions/destroy_interactor.rb
+++ b/app/interactors/editions/destroy_interactor.rb
@@ -23,7 +23,7 @@ private
   end
 
   def discard_draft
-    DeleteDraftEditionService.call(edition.document, user)
+    DeleteDraftEditionService.call(document: edition.document, user: user)
   rescue GdsApi::BaseError => e
     GovukError.notify(e)
     context.fail!(api_error: true)

--- a/app/interactors/file_attachments/create_interactor.rb
+++ b/app/interactors/file_attachments/create_interactor.rb
@@ -55,16 +55,19 @@ private
   def update_edition
     updater = Versioning::RevisionUpdater.new(edition.revision, user)
     updater.add_file_attachment(attachment_revision)
-    EditDraftEditionService.call(edition, user, revision: updater.next_revision)
+    EditDraftEditionService.call(edition: edition,
+                                 user: user,
+                                 revision: updater.next_revision)
     edition.save!
   end
 
   def update_preview
-    FailsafeDraftPreviewService.call(edition)
+    FailsafeDraftPreviewService.call(edition: edition)
   end
 
   def unique_filename
     existing_filenames = edition.revision.file_attachment_revisions.map(&:filename)
-    GenerateUniqueFilenameService.call(existing_filenames, params[:file].original_filename)
+    GenerateUniqueFilenameService.call(existing_filenames: existing_filenames,
+                                       suggested_name: params[:file].original_filename)
   end
 end

--- a/app/interactors/file_attachments/destroy_interactor.rb
+++ b/app/interactors/file_attachments/destroy_interactor.rb
@@ -29,7 +29,9 @@ private
 
     updater = Versioning::RevisionUpdater.new(edition.revision, user)
     updater.remove_file_attachment(attachment_revision)
-    EditDraftEditionService.call(edition, user, revision: updater.next_revision)
+    EditDraftEditionService.call(edition: edition,
+                                 user: user,
+                                 revision: updater.next_revision)
     edition.save!
   end
 
@@ -38,6 +40,6 @@ private
   end
 
   def update_preview
-    FailsafeDraftPreviewService.call(edition)
+    FailsafeDraftPreviewService.call(edition: edition)
   end
 end

--- a/app/interactors/file_attachments/preview_interactor.rb
+++ b/app/interactors/file_attachments/preview_interactor.rb
@@ -31,7 +31,7 @@ private
     asset = attachment_revision.asset
 
     if asset.absent?
-      PreviewAssetService.call(edition, asset)
+      PreviewAssetService.call(edition: edition, asset: asset)
       context.can_preview = false
       return
     end

--- a/app/interactors/file_attachments/update_interactor.rb
+++ b/app/interactors/file_attachments/update_interactor.rb
@@ -56,7 +56,9 @@ private
 
     context.fail!(unchanged: true) unless updater.changed?
 
-    EditDraftEditionService.call(edition, user, revision: updater.next_revision)
+    EditDraftEditionService.call(edition: edition,
+                                 user: user,
+                                 revision: updater.next_revision)
     edition.save!
   end
 
@@ -66,7 +68,7 @@ private
   end
 
   def update_preview
-    FailsafeDraftPreviewService.call(edition)
+    FailsafeDraftPreviewService.call(edition: edition)
   end
 
   def attachment_params
@@ -82,6 +84,7 @@ private
   def unique_filename(file)
     existing_filenames = edition.revision.file_attachment_revisions.map(&:filename)
     existing_filenames.delete(file_attachment_revision.filename)
-    GenerateUniqueFilenameService.call(existing_filenames, file.original_filename)
+    GenerateUniqueFilenameService.call(existing_filenames: existing_filenames,
+                                       suggested_name: file.original_filename)
   end
 end

--- a/app/interactors/history_mode/update_interactor.rb
+++ b/app/interactors/history_mode/update_interactor.rb
@@ -27,7 +27,9 @@ private
     updater = Versioning::RevisionUpdater.new(edition.revision, user)
 
     updater.assign(editor_political: params[:political] == "yes")
-    EditDraftEditionService.call(edition, user, revision: updater.next_revision)
+    EditDraftEditionService.call(edition: edition,
+                                 user: user,
+                                 revision: updater.next_revision)
     edition.save!
   end
 
@@ -41,6 +43,6 @@ private
   end
 
   def update_preview
-    FailsafeDraftPreviewService.call(edition)
+    FailsafeDraftPreviewService.call(edition: edition)
   end
 end

--- a/app/interactors/images/create_interactor.rb
+++ b/app/interactors/images/create_interactor.rb
@@ -42,8 +42,8 @@ private
       user: user,
       temp_image: temp_image,
       filename: GenerateUniqueFilenameService.call(
-        edition.revision.image_revisions.map(&:filename),
-        temp_image.original_filename,
+        existing_filenames: edition.revision.image_revisions.map(&:filename),
+        suggested_name: temp_image.original_filename,
       ),
     )
 
@@ -58,7 +58,9 @@ private
   def update_edition
     updater = Versioning::RevisionUpdater.new(edition.revision, user)
     updater.add_image(image_revision)
-    EditDraftEditionService.call(edition, user, revision: updater.next_revision)
+    EditDraftEditionService.call(edition: edition,
+                                 user: user,
+                                 revision: updater.next_revision)
     edition.save!
   end
 end

--- a/app/interactors/images/destroy_interactor.rb
+++ b/app/interactors/images/destroy_interactor.rb
@@ -28,7 +28,7 @@ private
     context.image_revision = edition.image_revisions.find_by!(image_id: params[:image_id])
     updater = Versioning::RevisionUpdater.new(edition.revision, user)
     updater.remove_image(image_revision)
-    EditDraftEditionService.call(edition, user, revision: updater.next_revision)
+    EditDraftEditionService.call(edition: edition, user: user, revision: updater.next_revision)
     edition.save!
     context.removed_lead_image = updater.removed_lead_image?
   end
@@ -38,6 +38,6 @@ private
   end
 
   def update_preview
-    FailsafeDraftPreviewService.call(edition)
+    FailsafeDraftPreviewService.call(edition: edition)
   end
 end

--- a/app/interactors/images/update_crop_interactor.rb
+++ b/app/interactors/images/update_crop_interactor.rb
@@ -44,7 +44,9 @@ private
     updater = Versioning::RevisionUpdater.new(edition.revision, user)
     updater.update_image(image_revision)
     context.fail! unless updater.changed?
-    EditDraftEditionService.call(edition, user, revision: updater.next_revision)
+    EditDraftEditionService.call(edition: edition,
+                                 user: user,
+                                 revision: updater.next_revision)
     edition.save!
   end
 
@@ -53,6 +55,6 @@ private
   end
 
   def update_preview
-    FailsafeDraftPreviewService.call(edition)
+    FailsafeDraftPreviewService.call(edition: edition)
   end
 end

--- a/app/interactors/images/update_interactor.rb
+++ b/app/interactors/images/update_interactor.rb
@@ -56,7 +56,9 @@ private
 
     context.fail! unless updater.changed?
 
-    EditDraftEditionService.call(edition, user, revision: updater.next_revision)
+    EditDraftEditionService.call(edition: edition,
+                                 user: user,
+                                 revision: updater.next_revision)
     edition.save!
 
     context.selected_lead_image = updater.selected_lead_image?
@@ -76,6 +78,6 @@ private
   end
 
   def update_preview
-    FailsafeDraftPreviewService.call(edition)
+    FailsafeDraftPreviewService.call(edition: edition)
   end
 end

--- a/app/interactors/lead_image/choose_interactor.rb
+++ b/app/interactors/lead_image/choose_interactor.rb
@@ -36,7 +36,9 @@ private
 
     context.fail! unless updater.changed?
 
-    EditDraftEditionService.call(edition, user, revision: updater.next_revision)
+    EditDraftEditionService.call(edition: edition,
+                                 user: user,
+                                 revision: updater.next_revision)
     edition.save!
   end
 
@@ -45,6 +47,6 @@ private
   end
 
   def update_preview
-    FailsafeDraftPreviewService.call(edition)
+    FailsafeDraftPreviewService.call(edition: edition)
   end
 end

--- a/app/interactors/lead_image/remove_interactor.rb
+++ b/app/interactors/lead_image/remove_interactor.rb
@@ -36,7 +36,9 @@ private
     updater = Versioning::RevisionUpdater.new(edition.revision, user)
     updater.assign(lead_image_revision: nil)
 
-    EditDraftEditionService.call(edition, user, revision: updater.next_revision)
+    EditDraftEditionService.call(edition: edition,
+                                 user: user,
+                                 revision: updater.next_revision)
     edition.save!
   end
 
@@ -45,6 +47,6 @@ private
   end
 
   def update_preview
-    FailsafeDraftPreviewService.call(edition)
+    FailsafeDraftPreviewService.call(edition: edition)
   end
 end

--- a/app/interactors/preview/create_interactor.rb
+++ b/app/interactors/preview/create_interactor.rb
@@ -29,7 +29,7 @@ private
   end
 
   def create_preview
-    PreviewDraftEditionService.call(edition)
+    PreviewDraftEditionService.call(edition: edition)
   rescue GdsApi::BaseError => e
     GovukError.notify(e)
     context.fail!(preview_failed: true)

--- a/app/interactors/publish/publish_interactor.rb
+++ b/app/interactors/publish/publish_interactor.rb
@@ -46,7 +46,9 @@ private
   end
 
   def publish_edition
-    PublishDraftEditionService.call(edition, user, with_review: with_review?)
+    PublishDraftEditionService.call(edition: edition,
+                                    user: user,
+                                    with_review: with_review?)
   rescue GdsApi::BaseError
     context.fail!(publish_failed: true)
   end

--- a/app/interactors/review/approve_interactor.rb
+++ b/app/interactors/review/approve_interactor.rb
@@ -23,7 +23,9 @@ private
   end
 
   def approve_edition
-    AssignEditionStatusService.call(edition, user, :published)
+    AssignEditionStatusService.call(edition: edition,
+                                    user: user,
+                                    state: :published)
     edition.save!
   end
 

--- a/app/interactors/review/submit_for2i_interactor.rb
+++ b/app/interactors/review/submit_for2i_interactor.rb
@@ -35,7 +35,9 @@ private
   end
 
   def update_status
-    AssignEditionStatusService.call(edition, user, :submitted_for_review)
+    AssignEditionStatusService.call(edition: edition,
+                                    user: user,
+                                    state: :submitted_for_review)
     edition.save!
   end
 

--- a/app/interactors/schedule/create_interactor.rb
+++ b/app/interactors/schedule/create_interactor.rb
@@ -47,7 +47,9 @@ private
                                 reviewed: params[:review_status] == "reviewed",
                                 publish_time: edition.proposed_publish_time)
 
-    SchedulePublishService.call(edition, user, scheduling)
+    SchedulePublishService.call(edition: edition,
+                                user: user,
+                                scheduling: scheduling)
   rescue GdsApi::BaseError => e
     GovukError.notify(e)
     context.fail!(api_error: true)

--- a/app/interactors/schedule/destroy_interactor.rb
+++ b/app/interactors/schedule/destroy_interactor.rb
@@ -24,14 +24,17 @@ private
 
   def update_edition
     scheduling = edition.status.details
-
     updater = Versioning::RevisionUpdater.new(edition.revision, user)
     updater.assign(proposed_publish_time: scheduling.publish_time)
-
     state = scheduling.reviewed? ? :submitted_for_review : :draft
 
-    EditDraftEditionService.call(edition, user, revision: updater.next_revision)
-    AssignEditionStatusService.call(edition, user, state)
+    EditDraftEditionService.call(edition: edition,
+                                 user: user,
+                                 revision: updater.next_revision)
+
+    AssignEditionStatusService.call(edition: edition,
+                                    user: user,
+                                    state: state)
     edition.save!
   end
 

--- a/app/interactors/schedule/update_interactor.rb
+++ b/app/interactors/schedule/update_interactor.rb
@@ -46,7 +46,9 @@ private
     context.fail! if publish_time == scheduling.publish_time
 
     new_scheduling = scheduling.dup.tap { |s| s.publish_time = publish_time }
-    SchedulePublishService.call(edition, user, new_scheduling)
+    SchedulePublishService.call(edition: edition,
+                                user: user,
+                                scheduling: new_scheduling)
   rescue GdsApi::BaseError => e
     GovukError.notify(e)
     context.fail!(api_error: true)

--- a/app/interactors/schedule_proposal/destroy_interactor.rb
+++ b/app/interactors/schedule_proposal/destroy_interactor.rb
@@ -25,7 +25,9 @@ private
     updater.assign(proposed_publish_time: nil)
 
     if updater.changed?
-      EditDraftEditionService.call(edition, user, revision: updater.next_revision)
+      EditDraftEditionService.call(edition: edition,
+                                   user: user,
+                                   revision: updater.next_revision)
       edition.save!
     end
   end

--- a/app/interactors/schedule_proposal/update_interactor.rb
+++ b/app/interactors/schedule_proposal/update_interactor.rb
@@ -48,7 +48,9 @@ private
     context.fail! unless updater.changed?
 
     context.revision = updater.next_revision
-    EditDraftEditionService.call(edition, user, revision: updater.next_revision)
+    EditDraftEditionService.call(edition: edition,
+                                 user: user,
+                                 revision: updater.next_revision)
     edition.save!
   end
 

--- a/app/interactors/tags/update_interactor.rb
+++ b/app/interactors/tags/update_interactor.rb
@@ -44,7 +44,9 @@ private
   def update_edition
     context.fail! unless revision_updater.changed?
 
-    EditDraftEditionService.call(edition, user, revision: revision)
+    EditDraftEditionService.call(edition: edition,
+                                 user: user,
+                                 revision: revision)
     edition.save!
   end
 
@@ -53,7 +55,7 @@ private
   end
 
   def update_preview
-    FailsafeDraftPreviewService.call(edition)
+    FailsafeDraftPreviewService.call(edition: edition)
   end
 
   def update_params(edition)

--- a/app/interactors/unwithdraw/unwithdraw_interactor.rb
+++ b/app/interactors/unwithdraw/unwithdraw_interactor.rb
@@ -27,7 +27,7 @@ private
     withdrawal = edition.status.details
     published_status = withdrawal.published_status
 
-    AssignEditionStatusService.call(edition, user, published_status.state)
+    AssignEditionStatusService.call(edition: edition, user: user, state: published_status.state)
     edition.save!
   end
 

--- a/app/interactors/withdraw/create_interactor.rb
+++ b/app/interactors/withdraw/create_interactor.rb
@@ -44,7 +44,9 @@ private
   end
 
   def withdraw_edition
-    WithdrawDocumentService.call(edition, params[:public_explanation], user)
+    WithdrawDocumentService.call(edition: edition,
+                                 public_explanation: params[:public_explanation],
+                                 user: user)
   rescue GdsApi::BaseError => e
     GovukError.notify(e)
     context.fail!(api_error: true)

--- a/app/jobs/scheduled_publishing_job.rb
+++ b/app/jobs/scheduled_publishing_job.rb
@@ -4,7 +4,7 @@ class ScheduledPublishingJob < ApplicationJob
   # retry at 3s, 18s, 83s, 258s, 627s
   retry_on(StandardError, wait: :exponentially_longer, attempts: 5) do |job, error|
     GovukError.notify(error)
-    RescueScheduledPublishingService.call(job.arguments.first)
+    RescueScheduledPublishingService.call(edition_id: job.arguments.first)
   end
 
   discard_and_log(ActiveRecord::RecordNotFound)
@@ -18,7 +18,7 @@ class ScheduledPublishingJob < ApplicationJob
 
       user = edition.status.created_by
       reviewed = edition.status.details.reviewed
-      PublishDraftEditionService.call(edition, user, with_review: reviewed)
+      PublishDraftEditionService.call(edition: edition, user: user, with_review: reviewed)
       create_timeline_entry(edition, reviewed)
     end
 

--- a/app/services/assign_edition_status_service.rb
+++ b/app/services/assign_edition_status_service.rb
@@ -1,7 +1,11 @@
 # frozen_string_literal: true
 
 class AssignEditionStatusService < ApplicationService
-  def initialize(edition, user, state, record_edit: true, status_details: nil)
+  def initialize(edition:,
+                 user: nil,
+                 state:,
+                 record_edit: true,
+                 status_details: nil)
     @edition = edition
     @user = user
     @state = state

--- a/app/services/delete_draft_edition_service.rb
+++ b/app/services/delete_draft_edition_service.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 class DeleteDraftEditionService < ApplicationService
-  def initialize(document, user)
+  def initialize(document:, user:)
     @document = document
     @user = user
   end
@@ -58,7 +58,7 @@ private
       end
     end
 
-    AssignEditionStatusService.call(edition, user, :discarded)
+    AssignEditionStatusService.call(edition: edition, user: user, state: :discarded)
     edition.update!(current: false)
   end
 

--- a/app/services/edit_draft_edition_service.rb
+++ b/app/services/edit_draft_edition_service.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 class EditDraftEditionService < ApplicationService
-  def initialize(edition, user, **attributes)
+  def initialize(edition:, user:, **attributes)
     @edition = edition
     @user = user
     @attributes = attributes

--- a/app/services/failsafe_draft_preview_service.rb
+++ b/app/services/failsafe_draft_preview_service.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 class FailsafeDraftPreviewService < ApplicationService
-  def initialize(edition)
+  def initialize(edition:)
     @edition = edition
   end
 
@@ -9,7 +9,7 @@ class FailsafeDraftPreviewService < ApplicationService
     if has_issues?
       edition.update!(revision_synced: false)
     else
-      PreviewDraftEditionService.call(edition)
+      PreviewDraftEditionService.call(edition: edition)
     end
   rescue GdsApi::BaseError => e
     edition.update!(revision_synced: false)

--- a/app/services/generate_base_path_service.rb
+++ b/app/services/generate_base_path_service.rb
@@ -1,7 +1,9 @@
 # frozen_string_literal: true
 
 class GenerateBasePathService < ApplicationService
-  def initialize(document, proposed_title, max_repeated_titles: 1000)
+  def initialize(document:,
+                 proposed_title:,
+                 max_repeated_titles: 1000)
     @document = document
     @proposed_title = proposed_title
     @max_repeated_titles = max_repeated_titles

--- a/app/services/generate_unique_filename_service.rb
+++ b/app/services/generate_unique_filename_service.rb
@@ -3,7 +3,7 @@
 class GenerateUniqueFilenameService < ApplicationService
   MAX_LENGTH = 65
 
-  def initialize(existing_filenames, suggested_name)
+  def initialize(existing_filenames:, suggested_name:)
     @existing_filenames = existing_filenames
     @suggested_name = suggested_name
   end

--- a/app/services/preview_asset_service.rb
+++ b/app/services/preview_asset_service.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 class PreviewAssetService < ApplicationService
-  def initialize(edition, asset)
+  def initialize(edition:, asset:)
     @edition = edition
     @asset = asset
   end

--- a/app/services/preview_draft_edition_service.rb
+++ b/app/services/preview_draft_edition_service.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 class PreviewDraftEditionService < ApplicationService
-  def initialize(edition, republish: false)
+  def initialize(edition:, republish: false)
     @edition = edition
     @republish = republish
   end
@@ -26,6 +26,9 @@ private
 
   def put_draft_assets
     edition.image_revisions.each(&:ensure_assets)
-    edition.assets.each { |asset| PreviewAssetService.call(edition, asset) }
+
+    edition.assets.each do |asset|
+      PreviewAssetService.call(edition: edition, asset: asset)
+    end
   end
 end

--- a/app/services/publish_assets_service.rb
+++ b/app/services/publish_assets_service.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 class PublishAssetsService < ApplicationService
-  def initialize(edition, live_edition)
+  def initialize(edition:, live_edition: nil)
     @edition = edition
     @live_edition = live_edition
   end

--- a/app/services/remove_document_service.rb
+++ b/app/services/remove_document_service.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 class RemoveDocumentService < ApplicationService
-  def initialize(edition, removal)
+  def initialize(edition:, removal:)
     @edition = edition
     @removal = removal
   end
@@ -33,7 +33,9 @@ private
   end
 
   def update_edition_status
-    AssignEditionStatusService.call(edition, nil, :removed, status_details: removal)
+    AssignEditionStatusService.call(edition: edition,
+                                    state: :removed,
+                                    status_details: removal)
     edition.save!
   end
 

--- a/app/services/rescue_scheduled_publishing_service.rb
+++ b/app/services/rescue_scheduled_publishing_service.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 class RescueScheduledPublishingService < ApplicationService
-  def initialize(edition_id)
+  def initialize(edition_id:)
     @edition_id = edition_id
   end
 
@@ -24,9 +24,9 @@ private
   def update_status(edition)
     raise "Expected edition to be scheduled" unless edition.scheduled?
 
-    AssignEditionStatusService.call(edition,
-                                    edition.status.created_by,
-                                    :failed_to_publish,
+    AssignEditionStatusService.call(edition: edition,
+                                    user: edition.status.created_by,
+                                    state: :failed_to_publish,
                                     record_edit: false,
                                     status_details: edition.status.details)
     edition.save!

--- a/app/services/resync_document_service.rb
+++ b/app/services/resync_document_service.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 class ResyncDocumentService < ApplicationService
-  def initialize(document)
+  def initialize(document:)
     @document = document
   end
 
@@ -24,8 +24,8 @@ private
     live_edition.lock!
     set_political_and_government(live_edition)
     reserve_path(live_edition.base_path)
-    PreviewDraftEditionService.call(live_edition, republish: true)
-    PublishAssetsService.call(live_edition, nil)
+    PreviewDraftEditionService.call(edition: live_edition, republish: true)
+    PublishAssetsService.call(edition: live_edition)
 
     if live_edition.withdrawn?
       withdraw
@@ -40,7 +40,7 @@ private
     current_edition.lock!
     set_political_and_government(current_edition)
     reserve_path(current_edition.base_path)
-    FailsafeDraftPreviewService.call(current_edition)
+    FailsafeDraftPreviewService.call(edition: current_edition)
 
     schedule if current_edition.scheduled?
   end

--- a/app/services/schedule_publish_service.rb
+++ b/app/services/schedule_publish_service.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 class SchedulePublishService < ApplicationService
-  def initialize(edition, user, scheduling)
+  def initialize(edition:, user:, scheduling:)
     @edition = edition
     @user = user
     @scheduling = scheduling
@@ -20,9 +20,14 @@ private
   def update_edition(scheduling, user)
     updater = Versioning::RevisionUpdater.new(edition.revision, user)
     updater.assign(proposed_publish_time: nil)
+    EditDraftEditionService.call(edition: edition,
+                                 user: user,
+                                 revision: updater.next_revision)
 
-    EditDraftEditionService.call(edition, user, revision: updater.next_revision)
-    AssignEditionStatusService.call(edition, user, :scheduled, status_details: scheduling)
+    AssignEditionStatusService.call(edition: edition,
+                                    user: user,
+                                    state: :scheduled,
+                                    status_details: scheduling)
     edition.save!
   end
 

--- a/app/services/withdraw_document_service.rb
+++ b/app/services/withdraw_document_service.rb
@@ -1,7 +1,9 @@
 # frozen_string_literal: true
 
 class WithdrawDocumentService < ApplicationService
-  def initialize(edition, public_explanation, user = nil)
+  def initialize(edition:,
+                 public_explanation:,
+                 user:)
     @edition = edition
     @public_explanation = public_explanation
     @user = user
@@ -29,7 +31,10 @@ private
   end
 
   def update_edition(withdrawal)
-    AssignEditionStatusService.call(edition, user, :withdrawn, status_details: withdrawal)
+    AssignEditionStatusService.call(edition: edition,
+                                    user: user,
+                                    state: :withdrawn,
+                                    status_details: withdrawal)
     edition.save!
   end
 

--- a/lib/tasks/resync.rake
+++ b/lib/tasks/resync.rake
@@ -9,13 +9,13 @@ namespace :resync do
 
     raise "No document exists for #{content_id_and_locale}" unless document
 
-    ResyncDocumentService.call(document)
+    ResyncDocumentService.call(document: document)
   end
 
   desc "Resync all documents with the publishing-api e.g. resync:all"
   task all: :environment do
     Document.find_each do |document|
-      ResyncDocumentService.call(document)
+      ResyncDocumentService.call(document: document)
     end
   end
 end

--- a/lib/tasks/unpublish.rake
+++ b/lib/tasks/unpublish.rake
@@ -15,7 +15,7 @@ namespace :unpublish do
     removal = Removal.new(explanatory_note: explanatory_note,
                           alternative_path: alternative_path)
 
-    RemoveDocumentService.call(document.live_edition, removal)
+    RemoveDocumentService.call(edition: document.live_edition, removal: removal)
   end
 
   desc "Remove and redirect a document on GOV.UK e.g. unpublish:remove_and_redirect['a-content-id'] NEW_PATH='/redirect-to-here'"
@@ -34,6 +34,6 @@ namespace :unpublish do
                           explanatory_note: explanatory_note,
                           alternative_path: redirect_path)
 
-    RemoveDocumentService.call(document.live_edition, removal)
+    RemoveDocumentService.call(edition: document.live_edition, removal: removal)
   end
 end

--- a/lib/whitehall_importer.rb
+++ b/lib/whitehall_importer.rb
@@ -67,7 +67,8 @@ module WhitehallImporter
     raise "Cannot sync with a state of #{whitehall_import.state}" unless whitehall_import.imported?
 
     begin
-      ResyncDocumentService.call(whitehall_import.document)
+      whitehall_import.update!(state: "syncing")
+      ResyncDocumentService.call(document: whitehall_import.document)
       ClearLinksetLinks.call(whitehall_import.document.content_id)
       MigrateAssets.call(whitehall_import)
 

--- a/lib/whitehall_importer/create_file_attachment_revision.rb
+++ b/lib/whitehall_importer/create_file_attachment_revision.rb
@@ -42,8 +42,8 @@ module WhitehallImporter
 
     def unique_filename
       @unique_filename ||= GenerateUniqueFilenameService.call(
-        existing_filenames,
-        File.basename(whitehall_file_attachment["url"]),
+        existing_filenames: existing_filenames,
+        suggested_name: File.basename(whitehall_file_attachment["url"]),
       )
     end
 

--- a/lib/whitehall_importer/create_image_revision.rb
+++ b/lib/whitehall_importer/create_image_revision.rb
@@ -47,8 +47,8 @@ module WhitehallImporter
       CreateImageBlobService.call(
         temp_image: temp_image,
         filename: GenerateUniqueFilenameService.call(
-          filenames,
-          File.basename(whitehall_image["url"]),
+          existing_filenames: filenames,
+          suggested_name: File.basename(whitehall_image["url"]),
         ),
       )
     end

--- a/spec/interactors/content/update_interactor_spec.rb
+++ b/spec/interactors/content/update_interactor_spec.rb
@@ -35,7 +35,7 @@ RSpec.describe Content::UpdateInteractor do
     end
 
     it "updates the preview" do
-      expect(FailsafeDraftPreviewService).to receive(:call).with(edition)
+      expect(FailsafeDraftPreviewService).to receive(:call).with(edition: edition)
       Content::UpdateInteractor.call(params: build_params, user: user)
     end
 

--- a/spec/interactors/file_attachments/create_interactor_spec.rb
+++ b/spec/interactors/file_attachments/create_interactor_spec.rb
@@ -37,7 +37,8 @@ RSpec.describe FileAttachments::CreateInteractor do
 
       it "delegates generating a unique filename to GenerateUniqueFilenameService" do
         expect(GenerateUniqueFilenameService).to receive(:call)
-          .with(edition.revision.file_attachment_revisions.map(&:filename), file.original_filename)
+          .with(existing_filenames: edition.revision.file_attachment_revisions.map(&:filename),
+                suggested_name: file.original_filename)
           .and_call_original
         FileAttachments::CreateInteractor.call(**args)
       end
@@ -64,7 +65,7 @@ RSpec.describe FileAttachments::CreateInteractor do
       end
 
       it "updates the preview" do
-        expect(FailsafeDraftPreviewService).to receive(:call).with(edition)
+        expect(FailsafeDraftPreviewService).to receive(:call).with(edition: edition)
         FileAttachments::CreateInteractor.call(**args)
       end
     end

--- a/spec/interactors/schedule/create_interactor_spec.rb
+++ b/spec/interactors/schedule/create_interactor_spec.rb
@@ -21,11 +21,11 @@ RSpec.describe Schedule::CreateInteractor do
       edition = create(:edition, :schedulable, proposed_publish_time: publish_time)
 
       expect(SchedulePublishService)
-        .to receive(:call) do |schedule_edition, schedule_user, new_scheduling|
-          expect(schedule_edition).to eq(edition)
-          expect(schedule_user).to eq(user)
-          expect(new_scheduling.reviewed).to be(false)
-          expect(new_scheduling.publish_time).to eq(publish_time)
+        .to receive(:call) do |args|
+          expect(args[:edition]).to eq(edition)
+          expect(args[:user]).to eq(user)
+          expect(args[:scheduling].reviewed).to be(false)
+          expect(args[:scheduling].publish_time).to eq(publish_time)
         end
 
       params = build_params(document: edition.document,

--- a/spec/interactors/schedule/update_interactor_spec.rb
+++ b/spec/interactors/schedule/update_interactor_spec.rb
@@ -30,11 +30,11 @@ RSpec.describe Schedule::UpdateInteractor do
 
     it "delegates to SchedulePublishService to schedule the edition for publishing" do
       expect(SchedulePublishService)
-        .to receive(:call) do |schedule_edition, schedule_user, new_scheduling|
-          expect(schedule_edition).to eq(edition)
-          expect(schedule_user).to eq(user)
-          expect(new_scheduling.reviewed).to eq(scheduling.reviewed)
-          expect(new_scheduling.publish_time).to eq(publish_time)
+        .to receive(:call) do |args|
+          expect(args[:edition]).to eq(edition)
+          expect(args[:user]).to eq(user)
+          expect(args[:scheduling].reviewed).to eq(scheduling.reviewed)
+          expect(args[:scheduling].publish_time).to eq(publish_time)
         end
 
       Schedule::UpdateInteractor.call(params: build_params, user: user)

--- a/spec/jobs/scheduled_publishing_job_spec.rb
+++ b/spec/jobs/scheduled_publishing_job_spec.rb
@@ -68,7 +68,8 @@ RSpec.describe ScheduledPublishingJob do
     end
 
     it "when it is out of retries it calls the failed service" do
-      expect(RescueScheduledPublishingService).to receive(:call).with(scheduled_edition.id)
+      expect(RescueScheduledPublishingService).to receive(:call)
+        .with(edition_id: scheduled_edition.id)
 
       perform_enqueued_jobs do
         ScheduledPublishingJob.perform_later(scheduled_edition.id)

--- a/spec/lib/tasks/resync_spec.rb
+++ b/spec/lib/tasks/resync_spec.rb
@@ -8,7 +8,7 @@ RSpec.describe "Resync tasks" do
       expect(ResyncDocumentService)
         .to receive(:call)
         .once
-        .with(document)
+        .with(document: document)
 
       Rake::Task["resync:document"].invoke("#{document.content_id}:#{document.locale}")
     end

--- a/spec/lib/whitehall_importer_spec.rb
+++ b/spec/lib/whitehall_importer_spec.rb
@@ -190,14 +190,14 @@ RSpec.describe WhitehallImporter do
 
   describe ".sync" do
     before do
-      allow(ResyncDocumentService).to receive(:call).with(whitehall_migration_document_import.document)
+      allow(ResyncDocumentService).to receive(:call).with(document: whitehall_migration_document_import.document)
       allow(WhitehallImporter::ClearLinksetLinks).to receive(:call).with(whitehall_migration_document_import.document.content_id)
     end
 
     let(:whitehall_migration_document_import) { create(:whitehall_migration_document_import, state: "imported") }
 
     it "syncs the imported document with publishing-api" do
-      expect(ResyncDocumentService).to receive(:call).with(whitehall_migration_document_import.document)
+      expect(ResyncDocumentService).to receive(:call).with(document: whitehall_migration_document_import.document)
       expect(WhitehallImporter::ClearLinksetLinks).to receive(:call).with(whitehall_migration_document_import.document.content_id)
       WhitehallImporter.sync(whitehall_migration_document_import)
     end
@@ -221,7 +221,7 @@ RSpec.describe WhitehallImporter do
     context "when the sync fails" do
       before do
         allow(ResyncDocumentService).to receive(:call)
-          .with(whitehall_migration_document_import.document)
+          .with(document: whitehall_migration_document_import.document)
           .and_raise(GdsApi::HTTPTooManyRequests.new(429, message))
       end
 

--- a/spec/services/assign_edition_status_service_spec.rb
+++ b/spec/services/assign_edition_status_service_spec.rb
@@ -6,14 +6,18 @@ RSpec.describe AssignEditionStatusService do
     let(:user) { build(:user) }
 
     it "assigns a status attributed to a user" do
-      AssignEditionStatusService.call(edition, user, :submitted_for_review)
+      AssignEditionStatusService.call(edition: edition,
+                                      user: user,
+                                      state: :submitted_for_review)
 
       expect(edition.status).to be_submitted_for_review
       expect(edition.status.created_by).to eq(user)
     end
 
     it "does not save the edition" do
-      AssignEditionStatusService.call(edition, user, :submitted_for_review)
+      AssignEditionStatusService.call(edition: edition,
+                                      user: user,
+                                      state: :submitted_for_review)
 
       expect(edition).to be_new_record
     end
@@ -22,7 +26,11 @@ RSpec.describe AssignEditionStatusService do
       freeze_time do
         edition = build(:edition, last_edited_at: 3.weeks.ago)
 
-        expect { AssignEditionStatusService.call(edition, user, :submitted_for_review) }
+        expect {
+          AssignEditionStatusService.call(edition: edition,
+                                          user: user,
+                                          state: :submitted_for_review)
+        }
           .to change { edition.last_edited_by }.to(user)
           .and change { edition.last_edited_at }.to(Time.current)
       end
@@ -31,9 +39,9 @@ RSpec.describe AssignEditionStatusService do
     it "preserves last edited when specified" do
       freeze_time do
         edition = build(:edition, last_edited_at: 3.weeks.ago)
-        AssignEditionStatusService.call(edition,
-                                        user,
-                                        :submitted_for_review,
+        AssignEditionStatusService.call(edition: edition,
+                                        user: user,
+                                        state: :submitted_for_review,
                                         record_edit: false)
 
         expect(edition.last_edited_at).not_to eq(Time.current)
@@ -44,9 +52,9 @@ RSpec.describe AssignEditionStatusService do
 
     it "can set details on the status" do
       removal = build(:removal)
-      AssignEditionStatusService.call(edition,
-                                      user,
-                                      :removed,
+      AssignEditionStatusService.call(edition: edition,
+                                      user: user,
+                                      state: :removed,
                                       status_details: removal)
 
       expect(edition.status.details).to eq(removal)
@@ -56,7 +64,11 @@ RSpec.describe AssignEditionStatusService do
       it "adds an edition user if they are not already listed as an editor" do
         edition = build(:edition)
 
-        expect { AssignEditionStatusService.call(edition, user, :submitted_for_review) }
+        expect {
+          AssignEditionStatusService.call(edition: edition,
+                                          user: user,
+                                          state: :submitted_for_review)
+        }
           .to change { edition.editors.size }
           .by(1)
       end

--- a/spec/services/delete_draft_edition_service_spec.rb
+++ b/spec/services/delete_draft_edition_service_spec.rb
@@ -7,14 +7,14 @@ RSpec.describe DeleteDraftEditionService do
     it "raises an exception if there is not a current edition" do
       document = create :document
 
-      expect { DeleteDraftEditionService.call(document, user) }
+      expect { DeleteDraftEditionService.call(document: document, user: user) }
         .to raise_error "Trying to delete a document without a current edition"
     end
 
     it "raises an exception if the current edition is live" do
       document = create :document, :with_live_edition
 
-      expect { DeleteDraftEditionService.call(document, user) }
+      expect { DeleteDraftEditionService.call(document: document, user: user) }
         .to raise_error "Trying to delete a live document"
     end
 
@@ -22,7 +22,7 @@ RSpec.describe DeleteDraftEditionService do
       document = create :document, :with_current_edition
       stub_publishing_api_unreserve_path(document.current_edition.base_path)
       request = stub_publishing_api_discard_draft(document.content_id)
-      DeleteDraftEditionService.call(document, user)
+      DeleteDraftEditionService.call(document: document, user: user)
       expect(request).to have_been_requested
     end
 
@@ -37,7 +37,7 @@ RSpec.describe DeleteDraftEditionService do
       stub_publishing_api_unreserve_path(edition.base_path)
       delete_request = stub_asset_manager_deletes_any_asset
 
-      DeleteDraftEditionService.call(edition.document, user)
+      DeleteDraftEditionService.call(document: edition.document, user: user)
 
       expect(delete_request).to have_been_requested.at_least_once
       expect(image_revision.reload.assets.map(&:state).uniq).to eq(%w[absent])
@@ -61,7 +61,7 @@ RSpec.describe DeleteDraftEditionService do
         PreviewDraftEditionService::Payload::PUBLISHING_APP,
       )
 
-      DeleteDraftEditionService.call(edition.document, user)
+      DeleteDraftEditionService.call(document: edition.document, user: user)
 
       expect(unreserve_request1).to have_been_requested
       expect(unreserve_request2).to have_been_requested
@@ -70,7 +70,7 @@ RSpec.describe DeleteDraftEditionService do
     it "does not delete path reservations for published documents" do
       document = create :document, :with_current_and_live_editions
       stub_publishing_api_discard_draft(document.content_id)
-      DeleteDraftEditionService.call(document, user)
+      DeleteDraftEditionService.call(document: document, user: user)
       expect(document.reload.current_edition).to eq document.live_edition
     end
 
@@ -78,7 +78,7 @@ RSpec.describe DeleteDraftEditionService do
       document = create :document, :with_current_edition
       stub_publishing_api_unreserve_path(document.current_edition.base_path)
       stub_publishing_api_discard_draft(document.content_id)
-      DeleteDraftEditionService.call(document, user)
+      DeleteDraftEditionService.call(document: document, user: user)
       expect(document.reload.current_edition).to be_nil
     end
 
@@ -87,7 +87,7 @@ RSpec.describe DeleteDraftEditionService do
       live_edition = document.live_edition
       stub_publishing_api_unreserve_path(document.current_edition.base_path)
       stub_publishing_api_discard_draft(document.content_id)
-      DeleteDraftEditionService.call(document, user)
+      DeleteDraftEditionService.call(document: document, user: user)
       expect(document.reload.current_edition).to eq(live_edition)
     end
 
@@ -96,7 +96,7 @@ RSpec.describe DeleteDraftEditionService do
       edition = document.current_edition
       stub_publishing_api_unreserve_path(document.current_edition.base_path)
       stub_publishing_api_discard_draft(document.content_id)
-      DeleteDraftEditionService.call(document, user)
+      DeleteDraftEditionService.call(document: document, user: user)
       expect(edition.status).to be_discarded
     end
 
@@ -104,7 +104,7 @@ RSpec.describe DeleteDraftEditionService do
       document = create :document, :with_current_edition
       stub_publishing_api_unreserve_path(document.current_edition.base_path)
       stub_any_publishing_api_call_to_return_not_found
-      DeleteDraftEditionService.call(document, user)
+      DeleteDraftEditionService.call(document: document, user: user)
       expect(document.reload.current_edition).to be_nil
     end
 
@@ -120,7 +120,7 @@ RSpec.describe DeleteDraftEditionService do
       stub_any_publishing_api_discard_draft
         .to_return(status: 422, body: discard_draft_error.to_json)
 
-      DeleteDraftEditionService.call(document, user)
+      DeleteDraftEditionService.call(document: document, user: user)
       expect(document.reload.current_edition).to be_nil
     end
 
@@ -136,7 +136,7 @@ RSpec.describe DeleteDraftEditionService do
       stub_any_publishing_api_discard_draft
         .to_return(status: 422, body: discard_draft_error.to_json)
 
-      expect { DeleteDraftEditionService.call(document, user) }
+      expect { DeleteDraftEditionService.call(document: document, user: user) }
         .to raise_error(GdsApi::HTTPUnprocessableEntity)
     end
 
@@ -149,7 +149,7 @@ RSpec.describe DeleteDraftEditionService do
 
       stub_publishing_api_unreserve_path(edition.base_path)
       stub_publishing_api_discard_draft(edition.content_id)
-      DeleteDraftEditionService.call(edition.document, user)
+      DeleteDraftEditionService.call(document: edition.document, user: user)
 
       expect(edition.reload.status).to be_discarded
       expect(image_revision.reload.assets.map(&:state).uniq).to eq(%w[absent])
@@ -161,7 +161,7 @@ RSpec.describe DeleteDraftEditionService do
 
       stub_publishing_api_unreserve_path_not_found(edition.base_path)
       stub_publishing_api_discard_draft(edition.content_id)
-      DeleteDraftEditionService.call(edition.document, user)
+      DeleteDraftEditionService.call(document: edition.document, user: user)
 
       expect(edition.reload.status).to be_discarded
     end
@@ -170,7 +170,7 @@ RSpec.describe DeleteDraftEditionService do
       edition = create :edition, base_path: nil
 
       stub_publishing_api_discard_draft(edition.content_id)
-      DeleteDraftEditionService.call(edition.document, user)
+      DeleteDraftEditionService.call(document: edition.document, user: user)
 
       expect(edition.reload.status).to be_discarded
     end
@@ -188,7 +188,7 @@ RSpec.describe DeleteDraftEditionService do
 
       stub_publishing_api_unreserve_path(edition.base_path)
       stub_publishing_api_discard_draft(edition.content_id)
-      DeleteDraftEditionService.call(edition.document, user)
+      DeleteDraftEditionService.call(document: edition.document, user: user)
 
       expect(edition.reload.status).to be_discarded
       expect(image_revision.reload.assets.map(&:state).uniq).to eq(%w[absent])
@@ -201,7 +201,7 @@ RSpec.describe DeleteDraftEditionService do
       stub_publishing_api_discard_draft(edition.content_id)
       stub_publishing_api_unreserve_path_invalid(edition.base_path)
 
-      expect { DeleteDraftEditionService.call(edition.document, user) }
+      expect { DeleteDraftEditionService.call(document: edition.document, user: user) }
         .to raise_error(GdsApi::BaseError)
 
       expect(edition.reload.revision_synced?).to be true
@@ -211,7 +211,7 @@ RSpec.describe DeleteDraftEditionService do
       edition = create :edition
       stub_publishing_api_isnt_available
 
-      expect { DeleteDraftEditionService.call(edition.document, user) }
+      expect { DeleteDraftEditionService.call(document: edition.document, user: user) }
         .to raise_error(GdsApi::BaseError)
 
       expect(edition.reload.revision_synced?).to be false
@@ -226,7 +226,7 @@ RSpec.describe DeleteDraftEditionService do
 
       stub_asset_manager_isnt_available
 
-      expect { DeleteDraftEditionService.call(edition.document, user) }
+      expect { DeleteDraftEditionService.call(document: edition.document, user: user) }
         .to raise_error(GdsApi::BaseError)
 
       expect(edition.reload.revision_synced?).to be false

--- a/spec/services/edit_draft_edition_service_spec.rb
+++ b/spec/services/edit_draft_edition_service_spec.rb
@@ -8,12 +8,16 @@ RSpec.describe EditDraftEditionService do
     it "assigns attributes to an edition" do
       revision = build(:revision)
 
-      expect { EditDraftEditionService.call(edition, user, revision: revision) }
+      expect {
+        EditDraftEditionService.call(edition: edition,
+                                     user: user,
+                                     revision: revision)
+      }
         .to change { edition.revision }.to(revision)
     end
 
     it "does not save the edition" do
-      EditDraftEditionService.call(edition, user, {})
+      EditDraftEditionService.call(edition: edition, user: user)
 
       expect(edition).to be_new_record
     end
@@ -22,7 +26,7 @@ RSpec.describe EditDraftEditionService do
       freeze_time do
         edition = build(:edition, last_edited_at: 3.weeks.ago)
 
-        expect { EditDraftEditionService.call(edition, user) }
+        expect { EditDraftEditionService.call(edition: edition, user: user) }
           .to change { edition.last_edited_by }.to(user)
           .and change { edition.last_edited_at }.to(Time.current)
       end
@@ -31,7 +35,7 @@ RSpec.describe EditDraftEditionService do
     it "raises an error if a live edition is edited" do
       live_edition = build(:edition, live: true)
 
-      expect { EditDraftEditionService.call(live_edition, user) }
+      expect { EditDraftEditionService.call(edition: live_edition, user: user) }
         .to raise_error("cannot edit a live edition")
     end
 
@@ -39,7 +43,7 @@ RSpec.describe EditDraftEditionService do
       it "adds an edition user if they are not already listed as an editor" do
         edition = build(:edition)
 
-        expect { EditDraftEditionService.call(edition, user) }
+        expect { EditDraftEditionService.call(edition: edition, user: user) }
           .to change { edition.editors.size }
           .by(1)
       end
@@ -52,7 +56,7 @@ RSpec.describe EditDraftEditionService do
           .with(edition)
           .and_return(instance_double(PoliticalEditionIdentifier, political?: true))
 
-        expect { EditDraftEditionService.call(edition, user) }
+        expect { EditDraftEditionService.call(edition: edition, user: user) }
           .to change { edition.system_political }
           .to(true)
       end
@@ -65,7 +69,7 @@ RSpec.describe EditDraftEditionService do
           .with(edition)
           .and_return(instance_double(PoliticalEditionIdentifier, political?: false))
 
-        expect { EditDraftEditionService.call(edition, user) }
+        expect { EditDraftEditionService.call(edition: edition, user: user) }
           .to change { edition.system_political }
           .to(false)
       end
@@ -78,7 +82,7 @@ RSpec.describe EditDraftEditionService do
         populate_government_bulk_data(government)
         allow(edition).to receive(:public_first_published_at).and_return(time)
 
-        expect { EditDraftEditionService.call(edition, user) }
+        expect { EditDraftEditionService.call(edition: edition, user: user) }
           .to change { edition.government_id }
           .to(government.content_id)
       end
@@ -89,7 +93,7 @@ RSpec.describe EditDraftEditionService do
         populate_government_bulk_data(government)
         edition = build(:edition, first_published_at: publish_date)
 
-        expect { EditDraftEditionService.call(edition, user) }
+        expect { EditDraftEditionService.call(edition: edition, user: user) }
           .not_to change { edition.government_id }
           .from(nil)
       end
@@ -97,7 +101,7 @@ RSpec.describe EditDraftEditionService do
       it "sets the government to nil when an edition isn't backdated or the document published" do
         edition = build(:edition)
 
-        expect { EditDraftEditionService.call(edition, user) }
+        expect { EditDraftEditionService.call(edition: edition, user: user) }
           .not_to change { edition.government_id }
           .from(nil)
       end

--- a/spec/services/failsafe_preview_service_spec.rb
+++ b/spec/services/failsafe_preview_service_spec.rb
@@ -10,14 +10,14 @@ RSpec.describe FailsafeDraftPreviewService do
     it "delegates to the PreviewDraftEditionService" do
       edition = create(:edition)
       expect(PreviewDraftEditionService).to receive(:call)
-      FailsafeDraftPreviewService.call(edition)
+      FailsafeDraftPreviewService.call(edition: edition)
     end
 
     context "when an external service is down" do
       it "sets revision_synced to false on the edition" do
         allow(PreviewDraftEditionService).to receive(:call).and_raise(GdsApi::BaseError)
         edition = create(:edition, revision_synced: true)
-        FailsafeDraftPreviewService.call(edition)
+        FailsafeDraftPreviewService.call(edition: edition)
         expect(edition.revision_synced).to be(false)
       end
     end
@@ -26,13 +26,13 @@ RSpec.describe FailsafeDraftPreviewService do
       let(:edition) { create(:edition, title: "", revision_synced: true) }
 
       it "sets revision_synced to false on the edition" do
-        FailsafeDraftPreviewService.call(edition)
+        FailsafeDraftPreviewService.call(edition: edition)
         expect(edition.revision_synced).to be(false)
       end
 
       it "doesn't send to the Publishing API" do
         request = stub_publishing_api_put_content(edition.content_id, {})
-        FailsafeDraftPreviewService.call(edition)
+        FailsafeDraftPreviewService.call(edition: edition)
         expect(request).not_to have_been_requested
       end
     end

--- a/spec/services/generate_base_path_service_spec.rb
+++ b/spec/services/generate_base_path_service_spec.rb
@@ -7,9 +7,9 @@ RSpec.describe GenerateBasePathService do
     it "generates a base path which is unique to our database" do
       new_document = build(:document, :with_current_edition)
       stub_publishing_api_has_lookups("#{document.current_edition.base_path}": nil)
-
-      expect(GenerateBasePathService.call(new_document, document.current_edition.title))
-        .to eq("#{document.current_edition.base_path}-1")
+      base_path = GenerateBasePathService.call(document: new_document,
+                                               proposed_title: document.current_edition.title)
+      expect(base_path).to eq("#{document.current_edition.base_path}-1")
     end
 
     it "preserves the base path when the title does not change" do
@@ -22,7 +22,11 @@ RSpec.describe GenerateBasePathService do
       existing_paths = ["#{prefix}/a-title", "#{prefix}/a-title-1", "#{prefix}/a-title-2"]
       existing_paths.each { |path| create(:edition, base_path: path) }
 
-      expect { GenerateBasePathService.call(document, "A title", max_repeated_titles: 2) }
+      expect {
+        GenerateBasePathService.call(document: document,
+                                     proposed_title: "A title",
+                                     max_repeated_titles: 2)
+      }
         .to raise_error("Already >2 paths with same title.")
     end
   end

--- a/spec/services/generate_unique_filename_service_spec.rb
+++ b/spec/services/generate_unique_filename_service_spec.rb
@@ -5,24 +5,28 @@ RSpec.describe GenerateUniqueFilenameService do
 
   describe "#call" do
     it "parameterises the base filename" do
-      name = GenerateUniqueFilenameService.call(existing_filenames, "File $ name.jpg")
+      name = GenerateUniqueFilenameService.call(existing_filenames: existing_filenames,
+                                                suggested_name: "File $ name.jpg")
       expect(name).to eq "file-name.jpg"
     end
 
     it "copes if the file has no extension" do
-      name = GenerateUniqueFilenameService.call(existing_filenames, "file")
+      name = GenerateUniqueFilenameService.call(existing_filenames: existing_filenames,
+                                                suggested_name: "file")
       expect(name).to eq "file"
     end
 
     it "truncates lengthy base filenames" do
       stub_const "GenerateUniqueFilenameService::MAX_LENGTH", 3
-      name = GenerateUniqueFilenameService.call(existing_filenames, "mylongname.jpg")
+      name = GenerateUniqueFilenameService.call(existing_filenames: existing_filenames,
+                                                suggested_name: "mylongname.jpg")
       expect(name).to eq "myl.jpg"
     end
 
     it "ensures the filename is unique for a list of filenames" do
       existing_filenames << "file.jpg"
-      name = GenerateUniqueFilenameService.call(existing_filenames, "file.jpg")
+      name = GenerateUniqueFilenameService.call(existing_filenames: existing_filenames,
+                                                suggested_name: "file.jpg")
       expect(name).to eq "file-1.jpg"
     end
   end

--- a/spec/services/preview_asset_service_spec.rb
+++ b/spec/services/preview_asset_service_spec.rb
@@ -32,7 +32,7 @@ RSpec.describe PreviewAssetService do
         expect(asset).to receive(:update!)
           .with a_hash_including(state: :draft, file_url: file_url)
 
-        PreviewAssetService.call(edition, asset)
+        PreviewAssetService.call(edition: edition, asset: asset)
         expect(request).to have_been_requested.at_least_once
       end
 
@@ -45,7 +45,7 @@ RSpec.describe PreviewAssetService do
           expect(req.body).to include("foo")
         end
 
-        PreviewAssetService.call(edition, asset)
+        PreviewAssetService.call(edition: edition, asset: asset)
         expect(request).to have_been_requested
       end
     end
@@ -61,7 +61,7 @@ RSpec.describe PreviewAssetService do
 
       it "updates the asset" do
         request = stub_asset_manager_update_asset("id")
-        PreviewAssetService.call(edition, asset)
+        PreviewAssetService.call(edition: edition, asset: asset)
         expect(request).to have_been_requested
       end
 
@@ -72,7 +72,7 @@ RSpec.describe PreviewAssetService do
           expect(req.body).to include("foo")
         end
 
-        PreviewAssetService.call(edition, asset)
+        PreviewAssetService.call(edition: edition, asset: asset)
         expect(request).to have_been_requested
       end
     end
@@ -82,7 +82,7 @@ RSpec.describe PreviewAssetService do
         request = stub_asset_manager_update_asset("id")
         allow(asset).to receive(:draft?) { false }
         allow(asset).to receive(:absent?) { false }
-        PreviewAssetService.call(edition, asset)
+        PreviewAssetService.call(edition: edition, asset: asset)
         expect(request).to_not have_been_requested
       end
     end

--- a/spec/services/preview_draft_edition_service_spec.rb
+++ b/spec/services/preview_draft_edition_service_spec.rb
@@ -10,13 +10,13 @@ RSpec.describe PreviewDraftEditionService do
     it "updates the Publishing API" do
       edition = create(:edition)
       request = stub_publishing_api_put_content(edition.content_id, {})
-      PreviewDraftEditionService.call(edition)
+      PreviewDraftEditionService.call(edition: edition)
       expect(request).to have_been_requested
     end
 
     it "marks the edition as 'revision_synced'" do
       edition = create(:edition, revision_synced: false)
-      PreviewDraftEditionService.call(edition)
+      PreviewDraftEditionService.call(edition: edition)
       expect(edition.reload.revision_synced).to be(true)
     end
 
@@ -24,14 +24,14 @@ RSpec.describe PreviewDraftEditionService do
       image_revision = create(:image_revision)
       edition = create(:edition, image_revisions: [image_revision])
       expect(PreviewAssetService).to receive(:call).at_least(:once)
-      PreviewDraftEditionService.call(edition)
+      PreviewDraftEditionService.call(edition: edition)
     end
 
     it "uploads any file attachment assets" do
       file_attachment_revision = create(:file_attachment_revision)
       edition = create(:edition, file_attachment_revisions: [file_attachment_revision])
       expect(PreviewAssetService).to receive(:call).at_least(:once)
-      PreviewDraftEditionService.call(edition)
+      PreviewDraftEditionService.call(edition: edition)
     end
 
     it "sets an update type of republish" do
@@ -42,7 +42,7 @@ RSpec.describe PreviewDraftEditionService do
         .with(edition, republish: true)
         .and_call_original
 
-      PreviewDraftEditionService.call(edition, republish: true)
+      PreviewDraftEditionService.call(edition: edition, republish: true)
     end
 
     context "when Publishing API is down" do
@@ -52,7 +52,7 @@ RSpec.describe PreviewDraftEditionService do
 
       it "sets revision_synced to false on the edition" do
         edition = create(:edition, revision_synced: true)
-        expect { PreviewDraftEditionService.call(edition) }.to raise_error(GdsApi::BaseError)
+        expect { PreviewDraftEditionService.call(edition: edition) }.to raise_error(GdsApi::BaseError)
         expect(edition.revision_synced).to be(false)
       end
     end
@@ -65,7 +65,7 @@ RSpec.describe PreviewDraftEditionService do
       it "sets revision_synced to false on the edition" do
         image_revision = create(:image_revision)
         edition = create(:edition, image_revisions: [image_revision], revision_synced: true)
-        expect { PreviewDraftEditionService.call(edition) }.to raise_error(GdsApi::BaseError)
+        expect { PreviewDraftEditionService.call(edition: edition) }.to raise_error(GdsApi::BaseError)
         expect(edition.revision_synced).to be(false)
       end
     end

--- a/spec/services/publish_assets_service_spec.rb
+++ b/spec/services/publish_assets_service_spec.rb
@@ -12,7 +12,7 @@ RSpec.describe PublishAssetsService do
                        image_revisions: [image_revision])
 
       request = stub_asset_manager_updates_any_asset
-      PublishAssetsService.call(edition, nil)
+      PublishAssetsService.call(edition: edition)
       expect(image_revision.assets.map(&:state).uniq).to eq(%w[live])
       expect(file_attachment_revision.asset).to be_live
       expect(request).to have_been_requested.at_least_once
@@ -34,7 +34,7 @@ RSpec.describe PublishAssetsService do
                        document: live_edition.document)
 
       request = stub_any_asset_manager_call
-      PublishAssetsService.call(edition, live_edition)
+      PublishAssetsService.call(edition: edition, live_edition: live_edition)
       expect(request).to_not have_been_requested
     end
 
@@ -44,7 +44,8 @@ RSpec.describe PublishAssetsService do
                        :publishable,
                        image_revisions: [image_revision])
 
-      expect { PublishAssetsService.call(edition, nil) }.to raise_error("Expected asset to be on asset manager")
+      expect { PublishAssetsService.call(edition: edition) }
+        .to raise_error("Expected asset to be on asset manager")
     end
 
     it "removes an asset not used by the current edition" do
@@ -64,7 +65,7 @@ RSpec.describe PublishAssetsService do
 
       delete_request = stub_asset_manager_deletes_any_asset
 
-      PublishAssetsService.call(edition, live_edition)
+      PublishAssetsService.call(edition: edition, live_edition: live_edition)
       expect(image_revision_to_remove.assets.map(&:state).uniq).to eq(%w[absent])
       expect(file_attachment_revision_to_remove.asset).to be_absent
       expect(delete_request).to have_been_requested.at_least_once
@@ -86,7 +87,7 @@ RSpec.describe PublishAssetsService do
                      file_attachment_revisions: [file_attachment_revision_to_keep],
                      document: live_edition.document)
 
-    PublishAssetsService.call(edition, live_edition)
+    PublishAssetsService.call(edition: edition, live_edition: live_edition)
     expect(image_revision_to_keep.assets.map(&:state).uniq).to eq(%w[live])
     expect(file_attachment_revision_to_keep.asset).to be_live
   end
@@ -109,7 +110,7 @@ RSpec.describe PublishAssetsService do
                      document: live_edition.document)
 
     request = stub_asset_manager_updates_any_asset
-    PublishAssetsService.call(edition, live_edition)
+    PublishAssetsService.call(edition: edition, live_edition: live_edition)
     expect(old_image_revision.assets.map(&:state).uniq).to eq(%w[superseded])
     expect(old_file_attachment_revision.asset).to be_superseded
     expect(request).to have_been_requested.at_least_once

--- a/spec/services/publish_draft_edition_service_spec.rb
+++ b/spec/services/publish_draft_edition_service_spec.rb
@@ -19,7 +19,9 @@ RSpec.describe PublishDraftEditionService do
                                                       update_type: nil,
                                                       locale: edition.locale)
 
-        PublishDraftEditionService.call(edition, user, with_review: true)
+        PublishDraftEditionService.call(edition: edition,
+                                        user: user,
+                                        with_review: true)
         expect(publish_request).to have_been_requested
         expect(edition.document.live_edition).to eq(edition)
         expect(edition).to be_published
@@ -27,7 +29,9 @@ RSpec.describe PublishDraftEditionService do
       end
 
       it "can specify if edition is reviewed" do
-        PublishDraftEditionService.call(edition, user, with_review: false)
+        PublishDraftEditionService.call(edition: edition,
+                                        user: user,
+                                        with_review: false)
         expect(edition).to be_published_but_needs_2i
       end
     end
@@ -38,7 +42,9 @@ RSpec.describe PublishDraftEditionService do
         current_edition = document.current_edition
         live_edition = document.live_edition
 
-        PublishDraftEditionService.call(current_edition, user, with_review: true)
+        PublishDraftEditionService.call(edition: current_edition,
+                                        user: user,
+                                        with_review: true)
         expect(document.live_edition).to eq(current_edition)
         expect(live_edition).to be_superseded
       end
@@ -48,7 +54,9 @@ RSpec.describe PublishDraftEditionService do
       document = create(:document, :with_current_and_live_editions)
       current_edition = document.current_edition
       expect(PublishAssetsService).to receive(:call)
-      PublishDraftEditionService.call(current_edition, user, with_review: true)
+      PublishDraftEditionService.call(edition: current_edition,
+                                      user: user,
+                                      with_review: true)
     end
 
     context "when the edition is not associated with a government" do
@@ -69,7 +77,11 @@ RSpec.describe PublishDraftEditionService do
         allow(edition).to receive(:public_first_published_at)
                       .and_return(Time.zone.yesterday)
 
-        expect { PublishDraftEditionService.call(edition, user, with_review: true) }
+        expect {
+          PublishDraftEditionService.call(edition: edition,
+                                          user: user,
+                                          with_review: true)
+        }
           .to change { edition.government_id }
           .to(past_government.content_id)
       end
@@ -77,15 +89,21 @@ RSpec.describe PublishDraftEditionService do
       it "associates with current government when the edition hasn't been published" do
         edition = create(:edition)
 
-        expect { PublishDraftEditionService.call(edition, user, with_review: true) }
+        expect {
+          PublishDraftEditionService.call(edition: edition,
+                                          user: user,
+                                          with_review: true)
+        }
           .to change { edition.government_id }
           .to(current_government.content_id)
       end
 
       it "updates the preview when a government is associated" do
         edition = create(:edition)
-        expect(PreviewDraftEditionService).to receive(:call).with(edition)
-        PublishDraftEditionService.call(edition, user, with_review: true)
+        expect(PreviewDraftEditionService).to receive(:call).with(edition: edition)
+        PublishDraftEditionService.call(edition: edition,
+                                        user: user,
+                                        with_review: true)
         expect(edition.government_id).to eq(current_government.content_id)
       end
 
@@ -94,7 +112,9 @@ RSpec.describe PublishDraftEditionService do
         edition = create(:edition)
 
         expect(PreviewDraftEditionService).not_to receive(:call).with(edition)
-        PublishDraftEditionService.call(edition, user, with_review: true)
+        PublishDraftEditionService.call(edition: edition,
+                                        user: user,
+                                        with_review: true)
         expect(edition.government_id).to be_nil
       end
     end
@@ -103,20 +123,28 @@ RSpec.describe PublishDraftEditionService do
       let(:edition) { create(:edition, government: past_government) }
 
       it "doesn't change the government on the edition" do
-        expect { PublishDraftEditionService.call(edition, user, with_review: true) }
+        expect {
+          PublishDraftEditionService.call(edition: edition,
+                                          user: user,
+                                          with_review: true)
+        }
           .not_to(change { edition.government_id })
       end
 
       it "doesn't update the preview of the edition" do
         expect(PreviewDraftEditionService).not_to receive(:call)
-        PublishDraftEditionService.call(edition, user, with_review: true)
+        PublishDraftEditionService.call(edition: edition,
+                                        user: user,
+                                        with_review: true)
       end
     end
 
     context "when the edition is access limited" do
       it "removes the access limit" do
         edition = create(:edition, :access_limited)
-        PublishDraftEditionService.call(edition, user, with_review: true)
+        PublishDraftEditionService.call(edition: edition,
+                                        user: user,
+                                        with_review: true)
         expect(edition.access_limit).to be_nil
       end
     end

--- a/spec/services/remove_document_service_spec.rb
+++ b/spec/services/remove_document_service_spec.rb
@@ -11,14 +11,18 @@ RSpec.describe RemoveDocumentService do
         edition.content_id,
         body: hash_including(locale: edition.locale),
       )
-      RemoveDocumentService.call(edition, build(:removal))
+      RemoveDocumentService.call(edition: edition,
+                                 removal: build(:removal))
       expect(request).to have_been_requested
     end
 
     it "creates a timeline entry" do
       removal = build(:removal)
 
-      expect { RemoveDocumentService.call(edition, removal) }
+      expect {
+        RemoveDocumentService.call(edition: edition,
+                                   removal: removal)
+      }
         .to change { TimelineEntry.count }
         .by(1)
 
@@ -30,7 +34,10 @@ RSpec.describe RemoveDocumentService do
     it "updates the edition status" do
       removal = build(:removal)
 
-      expect { RemoveDocumentService.call(edition, removal) }
+      expect {
+        RemoveDocumentService.call(edition: edition,
+                                   removal: removal)
+      }
         .to change { edition.reload.state }
         .to("removed")
 
@@ -53,7 +60,7 @@ RSpec.describe RemoveDocumentService do
             type: "redirect",
           },
         )
-        RemoveDocumentService.call(edition, removal)
+        RemoveDocumentService.call(edition: edition, removal: removal)
         expect(request).to have_been_requested
       end
     end
@@ -74,7 +81,7 @@ RSpec.describe RemoveDocumentService do
             type: "gone",
           },
         )
-        RemoveDocumentService.call(edition, removal)
+        RemoveDocumentService.call(edition: edition, removal: removal)
         expect(request).to have_been_requested
       end
     end
@@ -83,7 +90,10 @@ RSpec.describe RemoveDocumentService do
       before { stub_publishing_api_isnt_available }
 
       it "doesn't change the editions state" do
-        expect { RemoveDocumentService.call(edition, build(:removal)) }
+        expect {
+          RemoveDocumentService.call(edition: edition,
+                                     removal: build(:removal))
+        }
           .to raise_error(GdsApi::BaseError)
         expect(edition.reload.state).to eq("published")
       end
@@ -100,7 +110,8 @@ RSpec.describe RemoveDocumentService do
 
         delete_request = stub_asset_manager_deletes_any_asset
 
-        RemoveDocumentService.call(edition, build(:removal))
+        RemoveDocumentService.call(edition: edition,
+                                   removal: build(:removal))
 
         expect(delete_request).to have_been_requested.at_least_once
         expect(image_revision.assets.map(&:state).uniq).to eq(%w[absent])
@@ -117,7 +128,8 @@ RSpec.describe RemoveDocumentService do
 
         delete_request = stub_asset_manager_deletes_any_asset.to_return(status: 404)
 
-        RemoveDocumentService.call(edition, build(:removal))
+        RemoveDocumentService.call(edition: edition,
+                                   removal: build(:removal))
 
         expect(delete_request).to have_been_requested.at_least_once
         expect(image_revision.assets.map(&:state).uniq).to eq(%w[absent])
@@ -134,7 +146,8 @@ RSpec.describe RemoveDocumentService do
 
         delete_request = stub_asset_manager_deletes_any_asset
 
-        RemoveDocumentService.call(edition, build(:removal))
+        RemoveDocumentService.call(edition: edition,
+                                   removal: build(:removal))
 
         expect(delete_request).not_to have_been_requested
       end
@@ -151,7 +164,10 @@ RSpec.describe RemoveDocumentService do
                          lead_image_revision: image_revision,
                          file_attachment_revisions: [file_attachment_revision])
 
-        expect { RemoveDocumentService.call(edition, build(:removal)) }
+        expect {
+          RemoveDocumentService.call(edition: edition,
+                                     removal: build(:removal))
+        }
           .to raise_error(GdsApi::BaseError)
 
         expect(edition.reload.state).to eq("removed")
@@ -161,7 +177,10 @@ RSpec.describe RemoveDocumentService do
     context "when the given edition is a draft" do
       it "raises an error" do
         draft_edition = create(:edition)
-        expect { RemoveDocumentService.call(draft_edition, build(:removal)) }
+        expect {
+          RemoveDocumentService.call(edition: draft_edition,
+                                     removal: build(:removal))
+        }
           .to raise_error "attempted to remove an edition other than the live edition"
       end
     end
@@ -174,7 +193,10 @@ RSpec.describe RemoveDocumentService do
                               current: false,
                               document: draft_edition.document)
 
-        expect { RemoveDocumentService.call(live_edition, build(:removal)) }
+        expect {
+          RemoveDocumentService.call(edition: live_edition,
+                                     removal: build(:removal))
+        }
           .to raise_error "Publishing API does not support unpublishing while there is a draft"
       end
     end

--- a/spec/services/schedule_publish_service_spec.rb
+++ b/spec/services/schedule_publish_service_spec.rb
@@ -18,24 +18,32 @@ RSpec.describe SchedulePublishService do
     let(:scheduling) { create :scheduling, publish_time: edition.proposed_publish_time }
 
     it "sets an edition's state to 'scheduled'" do
-      SchedulePublishService.call(edition, user, scheduling)
+      SchedulePublishService.call(edition: edition,
+                                  user: user,
+                                  scheduling: scheduling)
       expect(edition).to be_scheduled
     end
 
     it "clears the editions proposed publish time" do
-      SchedulePublishService.call(edition, user, scheduling)
+      SchedulePublishService.call(edition: edition,
+                                  user: user,
+                                  scheduling: scheduling)
       expect(edition.reload.proposed_publish_time).to be_nil
     end
 
     it "creates a publishing intent" do
       request = stub_publishing_api_put_intent(edition.base_path, '"payload"')
-      SchedulePublishService.call(edition, user, scheduling)
+      SchedulePublishService.call(edition: edition,
+                                  user: user,
+                                  scheduling: scheduling)
       expect(request).to have_been_requested
     end
 
     it "schedules the edition to publish" do
       datetime = edition.proposed_publish_time
-      SchedulePublishService.call(edition, user, scheduling)
+      SchedulePublishService.call(edition: edition,
+                                  user: user,
+                                  scheduling: scheduling)
       expect(enqueued_jobs.count).to eq 1
       expect(enqueued_jobs.first[:args].first).to eq edition.id
       expect(enqueued_jobs.first[:at].to_i).to eq datetime.to_i

--- a/spec/services/withdraw_document_service_spec.rb
+++ b/spec/services/withdraw_document_service_spec.rb
@@ -14,7 +14,9 @@ RSpec.describe WithdrawDocumentService do
                                               body: { type: "withdrawal",
                                                       explanation: converted_public_explanation,
                                                       locale: edition.locale })
-      WithdrawDocumentService.call(edition, public_explanation, user)
+      WithdrawDocumentService.call(edition: edition,
+                                   public_explanation: public_explanation,
+                                   user: user)
 
       expect(request).to have_been_requested
     end
@@ -22,7 +24,9 @@ RSpec.describe WithdrawDocumentService do
 
     it "updates the edition status to withdrawn" do
       travel_to(Time.current) do
-        WithdrawDocumentService.call(edition, public_explanation, user)
+        WithdrawDocumentService.call(edition: edition,
+                                     public_explanation: public_explanation,
+                                     user: user)
         edition.reload
         withdrawal = edition.status.details
 
@@ -35,7 +39,9 @@ RSpec.describe WithdrawDocumentService do
     it "saves the published_status to the withdrawal record" do
       previous_published_status = edition.status
 
-      WithdrawDocumentService.call(edition, public_explanation, user)
+      WithdrawDocumentService.call(edition: edition,
+                                   public_explanation: public_explanation,
+                                   user: user)
       edition.reload
 
       withdrawal = edition.status.details
@@ -47,7 +53,9 @@ RSpec.describe WithdrawDocumentService do
       withdrawn_edition = create(:edition, :withdrawn)
       previous_withdrawal = withdrawn_edition.status.details
 
-      WithdrawDocumentService.call(withdrawn_edition, public_explanation, user)
+      WithdrawDocumentService.call(edition: withdrawn_edition,
+                                   public_explanation: public_explanation,
+                                   user: user)
 
       withdrawal = withdrawn_edition.status.details
 
@@ -57,7 +65,11 @@ RSpec.describe WithdrawDocumentService do
     context "when the given edition is a draft" do
       it "raises an error" do
         draft_edition = create(:edition)
-        expect { WithdrawDocumentService.call(draft_edition, public_explanation, user) }
+        expect {
+          WithdrawDocumentService.call(edition: draft_edition,
+                                       public_explanation: public_explanation,
+                                       user: user)
+        }
           .to raise_error "attempted to withdraw an edition other than the live edition"
       end
     end
@@ -70,7 +82,11 @@ RSpec.describe WithdrawDocumentService do
                               current: false,
                               document: draft_edition.document)
 
-        expect { WithdrawDocumentService.call(live_edition, public_explanation, user) }
+        expect {
+          WithdrawDocumentService.call(edition: live_edition,
+                                       public_explanation: public_explanation,
+                                       user: user)
+        }
           .to raise_error "Publishing API does not support unpublishing while there is a draft"
       end
     end
@@ -80,7 +96,9 @@ RSpec.describe WithdrawDocumentService do
         image_revision = create(:image_revision, :on_asset_manager)
         edition = create(:edition, :published, lead_image_revision: image_revision)
         delete_request = stub_asset_manager_deletes_any_asset
-        WithdrawDocumentService.call(edition, public_explanation, user)
+        WithdrawDocumentService.call(edition: edition,
+                                     public_explanation: public_explanation,
+                                     user: user)
         expect(delete_request).not_to have_been_requested
       end
     end
@@ -88,7 +106,11 @@ RSpec.describe WithdrawDocumentService do
     context "when an edition is already withdrawn and public_explanation differs" do
       it "updates public_explanation" do
         withdrawn_edition = create(:edition, :withdrawn)
-        expect { WithdrawDocumentService.call(withdrawn_edition, public_explanation, user) }
+        expect {
+          WithdrawDocumentService.call(edition: withdrawn_edition,
+                                       public_explanation: public_explanation,
+                                       user: user)
+        }
           .to change { withdrawn_edition.reload.status.details.public_explanation }
           .to(public_explanation)
       end
@@ -98,7 +120,11 @@ RSpec.describe WithdrawDocumentService do
         withdrawal = build(:withdrawal, withdrawn_at: withdrawn_at)
         withdrawn_edition = create(:edition, :withdrawn, withdrawal: withdrawal)
 
-        expect { WithdrawDocumentService.call(withdrawn_edition, public_explanation, user) }
+        expect {
+          WithdrawDocumentService.call(edition: withdrawn_edition,
+                                       public_explanation: public_explanation,
+                                       user: user)
+        }
           .not_to change { withdrawn_edition.reload.status.details.withdrawn_at }
           .from(withdrawn_at)
       end


### PR DESCRIPTION
https://github.com/alphagov/content-publisher/issues/1256
https://trello.com/c/f1QaCH7x/231-our-services-directory-is-a-mess

Previously we allowed a mixture of plain and keyword arguments for classes
in 'app/services'. This changes all services to use keyword arguments only,
noting the increase in verbosity in certain places is balanced by the
increased meaning, since we now say what each of the arguments is (for). A
good example of this is:

    job.arguments.first vs. edition_id: job.arguments.first

Please see the commits for more details.