### PR TITLE
Rename 'body' to 'contents' on TimelineEntry::WhitehallImportedEntry

### DIFF
--- a/db/migrate/20200124142150_rename_body_on_timeline_entry_whitehall_imported_entries_to_contents.rb
+++ b/db/migrate/20200124142150_rename_body_on_timeline_entry_whitehall_imported_entries_to_contents.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+class RenameBodyOnTimelineEntryWhitehallImportedEntriesToContents < ActiveRecord::Migration[6.0]
+  def change
+    rename_column :timeline_entry_whitehall_imported_entries, :body, :contents
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2020_01_22_110833) do
+ActiveRecord::Schema.define(version: 2020_01_24_142150) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -324,7 +324,7 @@ ActiveRecord::Schema.define(version: 2020_01_22_110833) do
   create_table "timeline_entry_whitehall_imported_entries", force: :cascade do |t|
     t.string "entry_type", null: false
     t.datetime "created_at"
-    t.json "body", default: "{}", null: false
+    t.json "contents", default: "{}", null: false
   end
 
   create_table "users", force: :cascade do |t|


### PR DESCRIPTION
Trello: https://trello.com/c/o8PhjdUc/1312-map-whitehall-editorial-remarks-notes-tab-in-whitehall-and-fact-check-requests-fact-checking-tab-in-whitehall-to-content-publish

Makes column name consistent with existing naming convention, e.g. 'content_revisions'
