### PR TITLE
Do not report integrity failure for caption nil/empty mismatch

### DIFF
--- a/lib/whitehall_importer/integrity_checker.rb
+++ b/lib/whitehall_importer/integrity_checker.rb
@@ -57,6 +57,8 @@ module WhitehallImporter
 
       %w(alt_text caption).each_with_object([]) do |attribute, problems|
         if publishing_api_image[attribute] != proposed_image_payload[attribute]
+          next if attribute == "caption" && publishing_api_image[attribute].nil? && proposed_image_payload[attribute].empty?
+
           problems << problem_description(
             "image #{attribute} doesn't match",
             publishing_api_image[attribute],

--- a/spec/lib/whitehall_importer/integrity_checker_spec.rb
+++ b/spec/lib/whitehall_importer/integrity_checker_spec.rb
@@ -5,6 +5,7 @@ RSpec.describe WhitehallImporter::IntegrityChecker do
     let(:edition) do
       build(
         :edition,
+        image_revisions: [build(:image_revision, caption: "")],
         tags: {
           primary_publishing_organisation: [SecureRandom.uuid],
           organisations: [SecureRandom.uuid],
@@ -22,6 +23,9 @@ RSpec.describe WhitehallImporter::IntegrityChecker do
         schema_name: edition.document_type.publishing_metadata.schema_name,
         details: {
           body: GovspeakDocument.new(edition.contents["body"], edition).payload_html,
+          image: {
+            caption: nil,
+          },
         },
         links: {
           primary_publishing_organisation: edition.tags["primary_publishing_organisation"].to_a,


### PR DESCRIPTION
When presenting a Whitehall image to Publishing API, empty strings in the caption are replaced with nil values.
https://github.com/alphagov/whitehall/blob/9396ec5a69750bd41c106fa7517d8c3476988d31/app/presenters/lead_image_presenter_helper.rb#L26-L31

Content Publisher does not do this.  Therefore, we need to ignore any mismatch failures on this field for that reason only.

This affects six of NDA's news articles.

Trello card: https://trello.com/c/3AV7mZTG