### PR TITLE
Fix 'translation missing' errors for supertype selection

### DIFF
--- a/app/views/documents/show/_withdrawn_notice.html.erb
+++ b/app/views/documents/show/_withdrawn_notice.html.erb
@@ -1,9 +1,9 @@
 <% withdrawal = @edition.status.details %>
 
 <%= render "govuk_publishing_components/components/notice", {
-  title: I18n.t("documents.show.withdrawn.title",
-                document_type: @edition.document_type.label.downcase,
-                withdrawn_date: format_date(withdrawal.withdrawn_at))
+  title: t("documents.show.withdrawn.title",
+           document_type: @edition.document_type.label.downcase,
+           withdrawn_date: format_date(withdrawal.withdrawn_at))
 } do %>
   <%= render_govspeak(withdrawal.public_explanation) %>
   <%= tag.p link_to("Change public explanation", withdraw_path(@edition.document),

--- a/app/views/file_attachments/show.html.erb
+++ b/app/views/file_attachments/show.html.erb
@@ -17,7 +17,7 @@
             text: "Insert attachment",
             data_attributes: {
               "modal-action": "insert-attachment-block",
-              "modal-data": I18n.t(
+              "modal-data": t(
                 "file_attachments.show.attachment_markdown",
                 filename: @attachment.filename
               ),
@@ -51,7 +51,7 @@
             text: "Insert attachment as link",
             data_attributes: {
               "modal-action": "insert-attachment-link",
-              "modal-data": I18n.t(
+              "modal-data": t(
                 "file_attachments.show.attachment_link_markdown",
                 filename: @attachment.filename
               ),

--- a/app/views/images/_image.html.erb
+++ b/app/views/images/_image.html.erb
@@ -12,7 +12,7 @@
   <% actions << link_to("Insert image markdown", "#",
                         data: {
                           "modal-action": "insert",
-                          "modal-data": I18n.t("images.index.meta.inline_code.value", filename: image.filename),
+                          "modal-data": t("images.index.meta.inline_code.value", filename: image.filename),
                           gtm: "insert-image-markdown"
                         },
                         class: "govuk-link govuk-link--no-visited-state") %>
@@ -56,7 +56,7 @@
   },
   {
     field: t("images.index.meta.inline_code.label"),
-    value: I18n.t("images.index.meta.inline_code.value", filename: image.filename),
+    value: t("images.index.meta.inline_code.value", filename: image.filename),
   },
 ] %>
 

--- a/app/views/images/edit.html.erb
+++ b/app/views/images/edit.html.erb
@@ -28,7 +28,7 @@ content_for :title, t(title_key, title: @edition.title_or_fallback)
   data: {
     "warn-before-unload": true,
     "modal-action": (params[:wizard] == "upload") ? "metaInsert": "meta",
-    "modal-data": I18n.t("images.index.meta.inline_code.value", filename: @image_revision.filename),
+    "modal-data": t("images.index.meta.inline_code.value", filename: @image_revision.filename),
     gtm: "save-image-metadata"
   }
 ) do %>

--- a/app/views/new_document/choose_supertype.html.erb
+++ b/app/views/new_document/choose_supertype.html.erb
@@ -14,11 +14,11 @@
         error_items: @issues&.items_for(:supertype),
         items: Supertype.all.map do |supertype|
           id = supertype.id
-          label = I18n.t("supertypes.#{id}.label")
+          label = t("supertypes.#{id}.label")
           {
             value: id,
             text: label,
-            hint_text: I18n.t("supertypes.#{id}.description"),
+            hint_text: t("supertypes.#{id}.description"),
             bold: true,
             data_attributes: {
               gtm: "choose-supertype",

--- a/app/views/new_document/choose_supertype.html.erb
+++ b/app/views/new_document/choose_supertype.html.erb
@@ -15,7 +15,6 @@
         items: Supertype.all.map do |supertype|
           id = supertype.id
           label = I18n.t("supertypes.#{id}.label")
-          hint = I18n.t("supertypes.#{id}.hint")
           {
             value: id,
             text: label,
@@ -25,7 +24,7 @@
               gtm: "choose-supertype",
               "gtm-value": label,
             },
-            conditional: hint ? tag.p(hint, class: "govuk-body") : nil,
+            conditional: I18n.exists?("supertypes.#{id}.hint") ? tag.p(t("supertypes.#{id}.hint"), class: "govuk-body") : nil,
           }
         end
       } %>


### PR DESCRIPTION
Hint text is only defined for some supertypes, not others.
An attempt was made to only display hint text if it is not
'nil', however it is never 'nil' because the fallback value
is a string 'translation missing: en.supertypes.not-sure.hint'

This commit does an explicit check using 'exists?' and
removes a redundant 'hint' var that is only used in the
ternary.

Fixes this bug:

<img width="669" alt="Screenshot 2020-01-28 at 16 38 15" src="https://user-images.githubusercontent.com/5111927/73285800-78a01380-41ee-11ea-8c9a-e0a5918d589e.png">


