### PR TITLE
Remove syncing state from Document Import

### DIFF
--- a/app/models/whitehall_migration/document_import.rb
+++ b/app/models/whitehall_migration/document_import.rb
@@ -10,15 +10,13 @@ class WhitehallMigration::DocumentImport < ApplicationRecord
   has_many :assets, class_name: "WhitehallMigration::AssetImport"
 
   enum state: { pending: "pending",
-                importing: "importing",
                 imported: "imported",
                 import_aborted: "import_aborted",
                 import_failed: "import_failed",
-                syncing: "syncing",
                 sync_failed: "sync failed",
                 completed: "completed" }
 
-  scope :in_progress, -> { pending.or(importing).or(imported).or(syncing) }
+  scope :in_progress, -> { pending.or(imported) }
 
   def migratable_assets
     assets.select { |a| a.pending? || a.migration_failed? }

--- a/lib/whitehall_importer.rb
+++ b/lib/whitehall_importer.rb
@@ -34,7 +34,6 @@ module WhitehallImporter
     whitehall_import.update!(
       payload: whitehall_document,
       content_id: whitehall_document["content_id"],
-      state: "importing",
     )
 
     import(whitehall_import)
@@ -45,7 +44,7 @@ module WhitehallImporter
   end
 
   def self.import(whitehall_import)
-    raise "Cannot import with a state of #{whitehall_import.state}" unless whitehall_import.importing?
+    raise "Cannot import with a state of #{whitehall_import.state}" unless whitehall_import.pending?
 
     begin
       Import.call(whitehall_import)
@@ -67,8 +66,6 @@ module WhitehallImporter
     raise "Cannot sync with a state of #{whitehall_import.state}" unless whitehall_import.imported?
 
     begin
-      whitehall_import.update!(state: "syncing")
-
       ResyncDocumentService.call(whitehall_import.document)
       ClearLinksetLinks.call(whitehall_import.document.content_id)
       MigrateAssets.call(whitehall_import)

--- a/spec/factories/whitehall_migration_document_import_factory.rb
+++ b/spec/factories/whitehall_migration_document_import_factory.rb
@@ -2,7 +2,7 @@
 
 FactoryBot.define do
   factory :whitehall_migration_document_import, class: WhitehallMigration::DocumentImport do
-    state { "importing" }
+    state { "pending" }
     payload { build(:whitehall_export_document) }
     whitehall_document_id { payload["id"] }
     content_id { payload["content_id"] }

--- a/spec/lib/whitehall_importer_spec.rb
+++ b/spec/lib/whitehall_importer_spec.rb
@@ -73,9 +73,9 @@ RSpec.describe WhitehallImporter do
     end
 
     it "raises if the WhitehallMigration::DocumentImport doesn't have a state of pending" do
-      whitehall_migration_document_import = create(:whitehall_migration_document_import, state: "importing")
+      whitehall_migration_document_import = create(:whitehall_migration_document_import, state: "imported")
       expect { WhitehallImporter.import_and_sync(whitehall_migration_document_import) }
-        .to raise_error(RuntimeError, "Cannot import with a state of importing")
+        .to raise_error(RuntimeError, "Cannot import with a state of imported")
     end
   end
 
@@ -87,7 +87,7 @@ RSpec.describe WhitehallImporter do
       WhitehallImporter.import(whitehall_migration_document_import)
     end
 
-    it "raises if the WhitehallMigration::DocumentImport doesn't have a state of importing" do
+    it "raises if the WhitehallMigration::DocumentImport doesn't have a state of pending" do
       whitehall_migration_document_import = create(:whitehall_migration_document_import, state: "imported")
       expect { WhitehallImporter.import(whitehall_migration_document_import) }
         .to raise_error(RuntimeError, "Cannot import with a state of imported")
@@ -178,9 +178,9 @@ RSpec.describe WhitehallImporter do
     end
 
     it "raises if the WhitehallMigration::DocumentImport doesn't have a state of imported" do
-      whitehall_migration_document_import = create(:whitehall_migration_document_import, state: "importing")
+      whitehall_migration_document_import = create(:whitehall_migration_document_import, state: "pending")
       expect { WhitehallImporter.sync(whitehall_migration_document_import) }
-        .to raise_error(RuntimeError, "Cannot sync with a state of importing")
+        .to raise_error(RuntimeError, "Cannot sync with a state of pending")
     end
 
     context "when the sync fails" do


### PR DESCRIPTION
For https://trello.com/c/Y3hKP4W9/1366-handle-retrying-whitehall-import-job

This removes 'importing' and 'syncing' states from
WhitehallMigration::DocumentImport as they don't provide much value. This also
simplify our approach to retrying the import job, which will be implemented in
a future commit.