### PR TITLE
Remove redundant AccessError subclass

### DIFF
--- a/lib/edition_assertions.rb
+++ b/lib/edition_assertions.rb
@@ -16,12 +16,6 @@ module EditionAssertions
     end
   end
 
-  class AccessError < Error
-    def initialize(edition, limit_type)
-      super(edition, "user is in #{limit_type}")
-    end
-  end
-
   def assert_edition_state(edition, options = {}, &block)
     return if block.call(edition)
 


### PR DESCRIPTION
https://trello.com/c/85gkiigT/1397-enforce-which-features-a-user-can-and-cannot-access-per-document-type-lead-images

This was left over from 79f0fd964.