### PR TITLE
Allow import from Whitehall to be filtered by document subtype

### DIFF
--- a/db/migrate/20200130090021_add_whitehall_migration_subtypes.rb
+++ b/db/migrate/20200130090021_add_whitehall_migration_subtypes.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+class AddWhitehallMigrationSubtypes < ActiveRecord::Migration[6.0]
+  def change
+    add_column :whitehall_migrations, :document_subtypes, :text, array: true
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2020_01_24_142150) do
+ActiveRecord::Schema.define(version: 2020_01_30_090021) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -371,6 +371,7 @@ ActiveRecord::Schema.define(version: 2020_01_24_142150) do
   create_table "whitehall_migrations", force: :cascade do |t|
     t.text "organisation_content_id", null: false
     t.text "document_type", null: false
+    t.text "document_subtypes", array: true
     t.datetime "finished_at"
     t.datetime "created_at", precision: 6, null: false
     t.datetime "updated_at", precision: 6, null: false

--- a/lib/gds_api/whitehall_export.rb
+++ b/lib/gds_api/whitehall_export.rb
@@ -9,12 +9,13 @@ module GdsApi
   end
 
   class WhitehallExport < Base
-    def document_list(organisation_content_id, document_type)
+    def document_list(organisation_content_id, document_type, document_subtypes = [])
       params = {
         lead_organisation: organisation_content_id,
         type: document_type,
         page_number: 1,
         page_count: 100,
+        subtypes: document_subtypes,
       }
       Enumerator.new do |yielder|
         next_link = document_list_url(params)

--- a/lib/tasks/import.rake
+++ b/lib/tasks/import.rake
@@ -3,13 +3,15 @@
 require "gds_api/whitehall_export"
 
 namespace :import do
-  desc "Import all documents matching an organisation and document type from Whitehall Publisher, e.g. import:whitehall_migration[\"cabinet-office\",\"NewsArticle\"]"
-  task :whitehall_migration, %i[organisation_slug document_type] => :environment do |_, args|
+  desc "Import all documents matching an organisation, document type and optional list of document subtypes from Whitehall Publisher, e.g. import:whitehall_migration[\"cabinet-office\",\"NewsArticle\",\"NewsStory,PressRelease\"]"
+  task :whitehall_migration, %i[organisation_slug document_type document_subtypes] => :environment do |_, args|
     organisation_content_id = GdsApi.publishing_api.lookup_content_id(
       base_path: "/government/organisations/#{args.organisation_slug}",
     )
 
-    whitehall_migration = WhitehallImporter.create_migration(organisation_content_id, args.document_type)
+    document_subtypes = args.document_subtypes ? args.document_subtypes.split(",") : []
+
+    whitehall_migration = WhitehallImporter.create_migration(organisation_content_id, args.document_type, document_subtypes)
 
     documents_to_import = WhitehallMigration::DocumentImport.where(whitehall_migration_id: whitehall_migration.id).count
     puts "Identified #{documents_to_import} documents to import"

--- a/lib/tasks/import.rake
+++ b/lib/tasks/import.rake
@@ -3,7 +3,7 @@
 require "gds_api/whitehall_export"
 
 namespace :import do
-  desc "Import all documents matching an organisation, document type and optional list of document subtypes from Whitehall Publisher, e.g. import:whitehall_migration[\"cabinet-office\",\"NewsArticle\",\"NewsStory,PressRelease\"]"
+  desc "Import all documents matching an organisation, document type and optional list of document subtypes from Whitehall Publisher, e.g. import:whitehall_migration[\"cabinet-office\",\"news_article\",\"news_story,press_release\"]"
   task :whitehall_migration, %i[organisation_slug document_type document_subtypes] => :environment do |_, args|
     organisation_content_id = GdsApi.publishing_api.lookup_content_id(
       base_path: "/government/organisations/#{args.organisation_slug}",

--- a/lib/whitehall_importer.rb
+++ b/lib/whitehall_importer.rb
@@ -3,12 +3,13 @@
 require "gds_api/whitehall_export"
 
 module WhitehallImporter
-  def self.create_migration(organisation_content_id, document_type)
+  def self.create_migration(organisation_content_id, document_type, document_subtypes = [])
     whitehall_migration = ActiveRecord::Base.transaction do
       record = WhitehallMigration.create!(organisation_content_id: organisation_content_id,
-                                          document_type: document_type)
+                                          document_type: document_type,
+                                          document_subtypes: document_subtypes)
 
-      whitehall_export = GdsApi.whitehall_export.document_list(organisation_content_id, document_type)
+      whitehall_export = GdsApi.whitehall_export.document_list(organisation_content_id, document_type, document_subtypes)
 
       whitehall_export.each do |page|
         page["documents"].each do |document|

--- a/spec/lib/gds_api/whitehall_export_spec.rb
+++ b/spec/lib/gds_api/whitehall_export_spec.rb
@@ -8,16 +8,16 @@ RSpec.describe GdsApi::WhitehallExport do
     let(:whitehall_export_page_2) { build(:whitehall_export_index, documents: build_list(:whitehall_export_index_document, 10)) }
 
     before do
-      stub_request(:get, "#{whitehall_host}/government/admin/export/document?lead_organisation=123&type=NewsArticle&page_count=100&page_number=1")
+      stub_request(:get, "#{whitehall_host}/government/admin/export/document?lead_organisation=123&type=NewsArticle&subtypes[]=NewsStory&subtypes[]=PressRelease&page_count=100&page_number=1")
         .to_return(status: 200, body: whitehall_export_page_1.to_json)
-      stub_request(:get, "#{whitehall_host}/government/admin/export/document?lead_organisation=123&type=NewsArticle&page_count=100&page_number=2")
+      stub_request(:get, "#{whitehall_host}/government/admin/export/document?lead_organisation=123&type=NewsArticle&subtypes[]=NewsStory&subtypes[]=PressRelease&page_count=100&page_number=2")
         .to_return(status: 200, body: whitehall_export_page_2.to_json)
     end
 
     it "iterates through the correct number of pages" do
-      whitehall_document_list = whitehall_adapter.document_list("123", "NewsArticle")
-      expect(whitehall_document_list.next).to have_requested(:get, "#{whitehall_host}/government/admin/export/document?lead_organisation=123&type=NewsArticle&page_count=100&page_number=1")
-      expect(whitehall_document_list.next).to have_requested(:get, "#{whitehall_host}/government/admin/export/document?lead_organisation=123&type=NewsArticle&page_count=100&page_number=2")
+      whitehall_document_list = whitehall_adapter.document_list("123", "NewsArticle", %w(NewsStory PressRelease))
+      expect(whitehall_document_list.next).to have_requested(:get, "#{whitehall_host}/government/admin/export/document?lead_organisation=123&type=NewsArticle&subtypes[]=NewsStory&subtypes[]=PressRelease&page_count=100&page_number=1")
+      expect(whitehall_document_list.next).to have_requested(:get, "#{whitehall_host}/government/admin/export/document?lead_organisation=123&type=NewsArticle&subtypes[]=NewsStory&subtypes[]=PressRelease&page_count=100&page_number=2")
       expect { whitehall_document_list.next }.to raise_error(StopIteration)
     end
   end

--- a/spec/lib/gds_api/whitehall_export_spec.rb
+++ b/spec/lib/gds_api/whitehall_export_spec.rb
@@ -8,16 +8,16 @@ RSpec.describe GdsApi::WhitehallExport do
     let(:whitehall_export_page_2) { build(:whitehall_export_index, documents: build_list(:whitehall_export_index_document, 10)) }
 
     before do
-      stub_request(:get, "#{whitehall_host}/government/admin/export/document?lead_organisation=123&type=NewsArticle&subtypes[]=NewsStory&subtypes[]=PressRelease&page_count=100&page_number=1")
+      stub_request(:get, "#{whitehall_host}/government/admin/export/document?lead_organisation=123&type=news_article&subtypes[]=news_story&subtypes[]=press_release&page_count=100&page_number=1")
         .to_return(status: 200, body: whitehall_export_page_1.to_json)
-      stub_request(:get, "#{whitehall_host}/government/admin/export/document?lead_organisation=123&type=NewsArticle&subtypes[]=NewsStory&subtypes[]=PressRelease&page_count=100&page_number=2")
+      stub_request(:get, "#{whitehall_host}/government/admin/export/document?lead_organisation=123&type=news_article&subtypes[]=news_story&subtypes[]=press_release&page_count=100&page_number=2")
         .to_return(status: 200, body: whitehall_export_page_2.to_json)
     end
 
     it "iterates through the correct number of pages" do
-      whitehall_document_list = whitehall_adapter.document_list("123", "NewsArticle", %w(NewsStory PressRelease))
-      expect(whitehall_document_list.next).to have_requested(:get, "#{whitehall_host}/government/admin/export/document?lead_organisation=123&type=NewsArticle&subtypes[]=NewsStory&subtypes[]=PressRelease&page_count=100&page_number=1")
-      expect(whitehall_document_list.next).to have_requested(:get, "#{whitehall_host}/government/admin/export/document?lead_organisation=123&type=NewsArticle&subtypes[]=NewsStory&subtypes[]=PressRelease&page_count=100&page_number=2")
+      whitehall_document_list = whitehall_adapter.document_list("123", "news_article", %w(news_story press_release))
+      expect(whitehall_document_list.next).to have_requested(:get, "#{whitehall_host}/government/admin/export/document?lead_organisation=123&type=news_article&subtypes[]=news_story&subtypes[]=press_release&page_count=100&page_number=1")
+      expect(whitehall_document_list.next).to have_requested(:get, "#{whitehall_host}/government/admin/export/document?lead_organisation=123&type=news_article&subtypes[]=news_story&subtypes[]=press_release&page_count=100&page_number=2")
       expect { whitehall_document_list.next }.to raise_error(StopIteration)
     end
   end

--- a/spec/lib/tasks/import_spec.rb
+++ b/spec/lib/tasks/import_spec.rb
@@ -14,13 +14,13 @@ RSpec.describe "Import tasks" do
     end
 
     it "calls WhitehallImporter::create_migration with correct arguments when subtype is specified" do
-      Rake::Task["import:whitehall_migration"].invoke("cabinet-office", "NewsArticle", "PressRelease")
-      expect(WhitehallImporter).to have_received(:create_migration).with("96ae61d6-c2a1-48cb-8e67-da9d105ae381", "NewsArticle", %w(PressRelease))
+      Rake::Task["import:whitehall_migration"].invoke("cabinet-office", "news_article", "press_release")
+      expect(WhitehallImporter).to have_received(:create_migration).with("96ae61d6-c2a1-48cb-8e67-da9d105ae381", "news_article", %w(press_release))
     end
 
     it "calls WhitehallImporter::create_migration with correct arguments when no subtype is specified" do
-      Rake::Task["import:whitehall_migration"].invoke("cabinet-office", "NewsArticle")
-      expect(WhitehallImporter).to have_received(:create_migration).with("96ae61d6-c2a1-48cb-8e67-da9d105ae381", "NewsArticle", [])
+      Rake::Task["import:whitehall_migration"].invoke("cabinet-office", "news_article")
+      expect(WhitehallImporter).to have_received(:create_migration).with("96ae61d6-c2a1-48cb-8e67-da9d105ae381", "news_article", [])
     end
   end
 

--- a/spec/lib/tasks/import_spec.rb
+++ b/spec/lib/tasks/import_spec.rb
@@ -13,9 +13,14 @@ RSpec.describe "Import tasks" do
       allow(WhitehallImporter).to receive(:create_migration).and_return(whitehall_migration_document_import)
     end
 
-    it "calls WhitehallImporter::create_migration with correct arguments" do
+    it "calls WhitehallImporter::create_migration with correct arguments when subtype is specified" do
+      Rake::Task["import:whitehall_migration"].invoke("cabinet-office", "NewsArticle", "PressRelease")
+      expect(WhitehallImporter).to have_received(:create_migration).with("96ae61d6-c2a1-48cb-8e67-da9d105ae381", "NewsArticle", %w(PressRelease))
+    end
+
+    it "calls WhitehallImporter::create_migration with correct arguments when no subtype is specified" do
       Rake::Task["import:whitehall_migration"].invoke("cabinet-office", "NewsArticle")
-      expect(WhitehallImporter).to have_received(:create_migration).with("96ae61d6-c2a1-48cb-8e67-da9d105ae381", "NewsArticle")
+      expect(WhitehallImporter).to have_received(:create_migration).with("96ae61d6-c2a1-48cb-8e67-da9d105ae381", "NewsArticle", [])
     end
   end
 

--- a/spec/lib/whitehall_importer_spec.rb
+++ b/spec/lib/whitehall_importer_spec.rb
@@ -3,33 +3,68 @@
 RSpec.describe WhitehallImporter do
   include ActiveJob::TestHelper
   describe ".create_migration" do
-    let(:whitehall_host) { Plek.new.external_url_for("whitehall-admin") }
-    let(:whitehall_export_page_1) { build(:whitehall_export_index, documents: build_list(:whitehall_export_index_document, 100)) }
-    let(:whitehall_export_page_2) { build(:whitehall_export_index, documents: build_list(:whitehall_export_index_document, 10)) }
+    context "with organisation and type specified" do
+      let(:whitehall_host) { Plek.new.external_url_for("whitehall-admin") }
+      let(:whitehall_export_page_1) { build(:whitehall_export_index, documents: build_list(:whitehall_export_index_document, 100)) }
+      let(:whitehall_export_page_2) { build(:whitehall_export_index, documents: build_list(:whitehall_export_index_document, 10)) }
 
-    before do
-      stub_request(:get, "#{whitehall_host}/government/admin/export/document?lead_organisation=123&page_count=100&page_number=1&type=NewsArticle")
-        .to_return(status: 200, body: whitehall_export_page_1.to_json)
-      stub_request(:get, "#{whitehall_host}/government/admin/export/document?lead_organisation=123&page_count=100&page_number=2&type=NewsArticle")
-        .to_return(status: 200, body: whitehall_export_page_2.to_json)
-    end
+      before do
+        stub_request(:get, "#{whitehall_host}/government/admin/export/document?lead_organisation=123&page_count=100&page_number=1&type=NewsArticle")
+          .to_return(status: 200, body: whitehall_export_page_1.to_json)
+        stub_request(:get, "#{whitehall_host}/government/admin/export/document?lead_organisation=123&page_count=100&page_number=2&type=NewsArticle")
+          .to_return(status: 200, body: whitehall_export_page_2.to_json)
+      end
 
-    it "creates a WhitehallMigration" do
-      freeze_time do
-        expect { WhitehallImporter.create_migration("123", "NewsArticle") }.to change { WhitehallMigration.count }.by(1)
-        expect(WhitehallMigration.last.organisation_content_id).to eq("123")
-        expect(WhitehallMigration.last.document_type).to eq("NewsArticle")
-        expect(WhitehallMigration.last.created_at).to eq(Time.current)
+      it "creates a WhitehallMigration" do
+        freeze_time do
+          expect { WhitehallImporter.create_migration("123", "NewsArticle") }.to change { WhitehallMigration.count }.by(1)
+          expect(WhitehallMigration.last.organisation_content_id).to eq("123")
+          expect(WhitehallMigration.last.document_type).to eq("NewsArticle")
+          expect(WhitehallMigration.last.document_subtypes).to eq([])
+          expect(WhitehallMigration.last.created_at).to eq(Time.current)
+        end
+      end
+
+      it "creates a pending WhitehallMigration::DocumentImport for each listed item" do
+        expect { WhitehallImporter.create_migration("123", "NewsArticle") }.to change { WhitehallMigration::DocumentImport.pending.count }.by(110)
+      end
+
+      it "queues a job for each listed document" do
+        WhitehallImporter.create_migration("123", "NewsArticle")
+        expect(WhitehallDocumentImportJob).to have_been_enqueued.exactly(110).times
       end
     end
 
-    it "creates a pending WhitehallMigration::DocumentImport for each listed item" do
-      expect { WhitehallImporter.create_migration("123", "NewsArticle") }.to change { WhitehallMigration::DocumentImport.pending.count }.by(110)
-    end
+    context "with organisation, type and subtype specified" do
+      let(:whitehall_host) { Plek.new.external_url_for("whitehall-admin") }
+      let(:whitehall_export_page_1) { build(:whitehall_export_index, documents: build_list(:whitehall_export_index_document, 100)) }
+      let(:whitehall_export_page_2) { build(:whitehall_export_index, documents: build_list(:whitehall_export_index_document, 10)) }
 
-    it "queues a job for each listed document" do
-      WhitehallImporter.create_migration("123", "NewsArticle")
-      expect(WhitehallDocumentImportJob).to have_been_enqueued.exactly(110).times
+      before do
+        stub_request(:get, "#{whitehall_host}/government/admin/export/document?lead_organisation=123&page_count=100&page_number=1&type=NewsArticle&subtypes[]=NewsStory&subtypes[]=PressRelease")
+          .to_return(status: 200, body: whitehall_export_page_1.to_json)
+        stub_request(:get, "#{whitehall_host}/government/admin/export/document?lead_organisation=123&page_count=100&page_number=2&type=NewsArticle&subtypes[]=NewsStory&subtypes[]=PressRelease")
+          .to_return(status: 200, body: whitehall_export_page_2.to_json)
+      end
+
+      it "creates a WhitehallMigration" do
+        freeze_time do
+          expect { WhitehallImporter.create_migration("123", "NewsArticle", %w(PressRelease NewsStory)) }.to change { WhitehallMigration.count }.by(1)
+          expect(WhitehallMigration.last.organisation_content_id).to eq("123")
+          expect(WhitehallMigration.last.document_type).to eq("NewsArticle")
+          expect(WhitehallMigration.last.document_subtypes).to eq(%w(PressRelease NewsStory))
+          expect(WhitehallMigration.last.created_at).to eq(Time.current)
+        end
+      end
+
+      it "creates a pending WhitehallMigration::DocumentImport for each listed item" do
+        expect { WhitehallImporter.create_migration("123", "NewsArticle", %w(PressRelease NewsStory)) }.to change { WhitehallMigration::DocumentImport.pending.count }.by(110)
+      end
+
+      it "queues a job for each listed document" do
+        WhitehallImporter.create_migration("123", "NewsArticle", %w(PressRelease NewsStory))
+        expect(WhitehallDocumentImportJob).to have_been_enqueued.exactly(110).times
+      end
     end
   end
 

--- a/spec/lib/whitehall_importer_spec.rb
+++ b/spec/lib/whitehall_importer_spec.rb
@@ -9,28 +9,28 @@ RSpec.describe WhitehallImporter do
       let(:whitehall_export_page_2) { build(:whitehall_export_index, documents: build_list(:whitehall_export_index_document, 10)) }
 
       before do
-        stub_request(:get, "#{whitehall_host}/government/admin/export/document?lead_organisation=123&page_count=100&page_number=1&type=NewsArticle")
+        stub_request(:get, "#{whitehall_host}/government/admin/export/document?lead_organisation=123&page_count=100&page_number=1&type=news_article")
           .to_return(status: 200, body: whitehall_export_page_1.to_json)
-        stub_request(:get, "#{whitehall_host}/government/admin/export/document?lead_organisation=123&page_count=100&page_number=2&type=NewsArticle")
+        stub_request(:get, "#{whitehall_host}/government/admin/export/document?lead_organisation=123&page_count=100&page_number=2&type=news_article")
           .to_return(status: 200, body: whitehall_export_page_2.to_json)
       end
 
       it "creates a WhitehallMigration" do
         freeze_time do
-          expect { WhitehallImporter.create_migration("123", "NewsArticle") }.to change { WhitehallMigration.count }.by(1)
+          expect { WhitehallImporter.create_migration("123", "news_article") }.to change { WhitehallMigration.count }.by(1)
           expect(WhitehallMigration.last.organisation_content_id).to eq("123")
-          expect(WhitehallMigration.last.document_type).to eq("NewsArticle")
+          expect(WhitehallMigration.last.document_type).to eq("news_article")
           expect(WhitehallMigration.last.document_subtypes).to eq([])
           expect(WhitehallMigration.last.created_at).to eq(Time.current)
         end
       end
 
       it "creates a pending WhitehallMigration::DocumentImport for each listed item" do
-        expect { WhitehallImporter.create_migration("123", "NewsArticle") }.to change { WhitehallMigration::DocumentImport.pending.count }.by(110)
+        expect { WhitehallImporter.create_migration("123", "news_article") }.to change { WhitehallMigration::DocumentImport.pending.count }.by(110)
       end
 
       it "queues a job for each listed document" do
-        WhitehallImporter.create_migration("123", "NewsArticle")
+        WhitehallImporter.create_migration("123", "news_article")
         expect(WhitehallDocumentImportJob).to have_been_enqueued.exactly(110).times
       end
     end
@@ -41,28 +41,28 @@ RSpec.describe WhitehallImporter do
       let(:whitehall_export_page_2) { build(:whitehall_export_index, documents: build_list(:whitehall_export_index_document, 10)) }
 
       before do
-        stub_request(:get, "#{whitehall_host}/government/admin/export/document?lead_organisation=123&page_count=100&page_number=1&type=NewsArticle&subtypes[]=NewsStory&subtypes[]=PressRelease")
+        stub_request(:get, "#{whitehall_host}/government/admin/export/document?lead_organisation=123&page_count=100&page_number=1&type=news_article&subtypes[]=news_story&subtypes[]=press_release")
           .to_return(status: 200, body: whitehall_export_page_1.to_json)
-        stub_request(:get, "#{whitehall_host}/government/admin/export/document?lead_organisation=123&page_count=100&page_number=2&type=NewsArticle&subtypes[]=NewsStory&subtypes[]=PressRelease")
+        stub_request(:get, "#{whitehall_host}/government/admin/export/document?lead_organisation=123&page_count=100&page_number=2&type=news_article&subtypes[]=news_story&subtypes[]=press_release")
           .to_return(status: 200, body: whitehall_export_page_2.to_json)
       end
 
       it "creates a WhitehallMigration" do
         freeze_time do
-          expect { WhitehallImporter.create_migration("123", "NewsArticle", %w(PressRelease NewsStory)) }.to change { WhitehallMigration.count }.by(1)
+          expect { WhitehallImporter.create_migration("123", "news_article", %w(press_release news_story)) }.to change { WhitehallMigration.count }.by(1)
           expect(WhitehallMigration.last.organisation_content_id).to eq("123")
-          expect(WhitehallMigration.last.document_type).to eq("NewsArticle")
-          expect(WhitehallMigration.last.document_subtypes).to eq(%w(PressRelease NewsStory))
+          expect(WhitehallMigration.last.document_type).to eq("news_article")
+          expect(WhitehallMigration.last.document_subtypes).to eq(%w(press_release news_story))
           expect(WhitehallMigration.last.created_at).to eq(Time.current)
         end
       end
 
       it "creates a pending WhitehallMigration::DocumentImport for each listed item" do
-        expect { WhitehallImporter.create_migration("123", "NewsArticle", %w(PressRelease NewsStory)) }.to change { WhitehallMigration::DocumentImport.pending.count }.by(110)
+        expect { WhitehallImporter.create_migration("123", "news_article", %w(press_release news_story)) }.to change { WhitehallMigration::DocumentImport.pending.count }.by(110)
       end
 
       it "queues a job for each listed document" do
-        WhitehallImporter.create_migration("123", "NewsArticle", %w(PressRelease NewsStory))
+        WhitehallImporter.create_migration("123", "news_article", %w(press_release news_story))
         expect(WhitehallDocumentImportJob).to have_been_enqueued.exactly(110).times
       end
     end


### PR DESCRIPTION
We may wish to import documents of a single subtype (e.g. only news stories and press releases for the news article type) from Whitehall, since Content Publisher does not yet support the other subtypes of news article.

An optional subtype parameter has been added to the document index endpoint in Whitehall (https://github.com/alphagov/whitehall/pull/5303), so these are the corresponding changes in Content Publisher.

Trello card: https://trello.com/c/dmS7BYoG