### PR TITLE
Ignore missing images on import when organisation default is used

### DIFF
--- a/lib/whitehall_importer/integrity_checker.rb
+++ b/lib/whitehall_importer/integrity_checker.rb
@@ -57,6 +57,7 @@ module WhitehallImporter
 
       %w(alt_text caption).each_with_object([]) do |attribute, problems|
         if publishing_api_image[attribute] != proposed_image_payload[attribute]
+          next if default_image?(proposed_image_payload, publishing_api_image, attribute)
           next if attribute == "caption" && publishing_api_image[attribute].nil? && proposed_image_payload[attribute].empty?
 
           problems << problem_description(
@@ -117,6 +118,12 @@ module WhitehallImporter
 
     def publishing_api_links
       @publishing_api_links ||= GdsApi.publishing_api.get_links(edition.content_id).to_h
+    end
+
+    def default_image?(proposed_image_payload, publishing_api_image, attribute)
+      attribute == "alt_text" &&
+        proposed_image_payload.empty? &&
+        publishing_api_image[attribute] == "placeholder"
     end
   end
 end

--- a/lib/whitehall_importer/integrity_checker.rb
+++ b/lib/whitehall_importer/integrity_checker.rb
@@ -58,7 +58,7 @@ module WhitehallImporter
       %w(alt_text caption).each_with_object([]) do |attribute, problems|
         if publishing_api_image[attribute] != proposed_image_payload[attribute]
           next if default_image?(proposed_image_payload, publishing_api_image, attribute)
-          next if attribute == "caption" && publishing_api_image[attribute].nil? && proposed_image_payload[attribute].empty?
+          next if empty_caption?(proposed_image_payload, publishing_api_image, attribute)
 
           problems << problem_description(
             "image #{attribute} doesn't match",
@@ -118,6 +118,12 @@ module WhitehallImporter
 
     def publishing_api_links
       @publishing_api_links ||= GdsApi.publishing_api.get_links(edition.content_id).to_h
+    end
+
+    def empty_caption?(proposed_image_payload, publishing_api_image, attribute)
+      attribute == "caption" &&
+        publishing_api_image[attribute].nil? &&
+        proposed_image_payload[attribute].empty?
     end
 
     def default_image?(proposed_image_payload, publishing_api_image, attribute)

--- a/spec/lib/whitehall_importer/integrity_checker_spec.rb
+++ b/spec/lib/whitehall_importer/integrity_checker_spec.rb
@@ -22,9 +22,6 @@ RSpec.describe WhitehallImporter::IntegrityChecker do
         schema_name: edition.document_type.publishing_metadata.schema_name,
         details: {
           body: GovspeakDocument.new(edition.contents["body"], edition).payload_html,
-          image: {
-            caption: nil,
-          },
         },
         links: {
           primary_publishing_organisation: edition.tags["primary_publishing_organisation"].to_a,
@@ -45,6 +42,16 @@ RSpec.describe WhitehallImporter::IntegrityChecker do
 
       publishing_api_item[:image] = {
         caption: nil,
+      }
+      stub_publishing_api_has_item(publishing_api_item)
+
+      integrity_check = WhitehallImporter::IntegrityChecker.new(edition)
+      expect(integrity_check.valid?).to be true
+    end
+
+    it "returns true if the Publishing API image is a placeholder and the imported edition has no image" do
+      publishing_api_item[:image] = {
+        alt_text: "placeholder",
       }
       stub_publishing_api_has_item(publishing_api_item)
 


### PR DESCRIPTION
News articles with no user uploaded image were being rejected when importing from Whitehall.  This was because the integrity check was failing.

In the case of no image being specified for a news article, we fall back to the organisation default, or failing that to a placeholder.

Whitehall submits the default organisation or placeholder image to Publishing API as part of the payload, with an alt_text of "placeholder": https://github.com/alphagov/whitehall/blob/9396ec5a69750bd41c106fa7517d8c3476988d31/app/presenters/lead_image_presenter_helper.rb#L18-L24

Content Publisher does not do this.  Instead no images are sent to Publishing API and the image is determined by the frontend application: https://github.com/alphagov/government-frontend/blob/2ef6483d9fb96baf5af0294a07cbddb9c0e4d420/app/presenters/content_item/news_image.rb#L3-L12

Therefore we can ignore failures on these images (identified by the presence of "placeholder" alt_text and no images on the document) since government-frontend will handle the image choice.