### PR TITLE
Remove checks for 'put_content' in features

### DIFF
--- a/spec/features/editing_content/edit_edition_spec.rb
+++ b/spec/features/editing_content/edit_edition_spec.rb
@@ -6,7 +6,6 @@ RSpec.feature "Edit an edition" do
     when_i_go_to_edit_the_edition
     and_i_fill_in_the_content_fields
     then_i_see_the_edition_is_saved
-    and_the_preview_creation_succeeded
     and_i_see_i_was_the_last_user_to_edit_the_edition
     and_i_see_the_timeline_entry
   end
@@ -34,14 +33,6 @@ RSpec.feature "Edit an edition" do
     expect(page).to have_content("Edited body.")
   end
 
-  def and_the_preview_creation_succeeded
-    expect(page).to have_content(I18n.t!("user_facing_states.draft.name"))
-
-    expect(a_request(:put, /content/).with { |req|
-      expect(JSON.parse(req.body)["details"]["body"]).to eq("<p>Edited body.</p>\n")
-    }).to have_been_requested
-  end
-
   def and_i_see_i_was_the_last_user_to_edit_the_edition
     editor = current_user.name
     last_edited = I18n.t!("documents.show.metadata.last_edited_by") + ": #{editor}"
@@ -50,8 +41,6 @@ RSpec.feature "Edit an edition" do
 
   def and_i_see_the_timeline_entry
     click_on "Document history"
-    within first(".app-timeline-entry") do
-      expect(page).to have_content I18n.t!("documents.history.entry_types.updated_content")
-    end
+    expect(page).to have_content I18n.t!("documents.history.entry_types.updated_content")
   end
 end

--- a/spec/features/editing_content_settings/enforce_access_limit_spec.rb
+++ b/spec/features/editing_content_settings/enforce_access_limit_spec.rb
@@ -14,7 +14,6 @@ RSpec.feature "Enforce access limit" do
     and_i_can_still_edit_the_edition
     and_the_supporting_user_cannot
     and_someone_in_another_org_cannot
-    and_the_preview_creation_succeeded
   end
 
   scenario "all organisations" do
@@ -24,7 +23,6 @@ RSpec.feature "Enforce access limit" do
     and_i_can_still_edit_the_edition
     and_the_supporting_user_can_also
     and_someone_in_another_org_cannot
-    and_the_preview_creation_succeeded
   end
 
   def given_there_is_an_edition_in_multiple_orgs
@@ -47,8 +45,8 @@ RSpec.feature "Enforce access limit" do
       ],
     )
 
-    @asset_manager_request = stub_asset_manager_updates_any_asset
-    @publishing_api_request = stub_any_publishing_api_put_content
+    stub_asset_manager_updates_any_asset
+    stub_any_publishing_api_put_content
   end
 
   def and_there_is_a_user_in_a_supporting_org
@@ -111,20 +109,6 @@ RSpec.feature "Enforce access limit" do
     visit content_path(@edition.document)
     expect(page).to have_content(I18n.t!("documents.forbidden.description"))
     expect(page).to have_content(I18n.t!("documents.forbidden.owner", primary_org: "Primary org"))
-  end
-
-  def and_the_preview_creation_succeeded
-    expect(@asset_manager_request).to have_been_requested.at_least_once
-    expect(@publishing_api_request).to have_been_requested
-
-    expect(a_request(:put, /assets/).with { |req|
-      expect(req.body).to include "access_limited_organisation_ids"
-    }).to have_been_requested.at_least_once
-
-    expect(a_request(:put, /content/).with { |req|
-      orgs = JSON.parse(req.body)["access_limited"]["organisations"]
-      expect(orgs).to include @primary_org
-    }).to have_been_requested.at_least_once
   end
 
   def and_i_see_the_timeline_entry

--- a/spec/features/editing_file_attachments/delete_file_attachment_spec.rb
+++ b/spec/features/editing_file_attachments/delete_file_attachment_spec.rb
@@ -6,7 +6,7 @@ RSpec.feature "Delete a file attachment", js: true do
     when_i_insert_an_attachment
     and_i_delete_the_attachment
     then_i_see_the_attachment_is_gone
-    and_the_preview_creation_succeeded
+    and_i_see_the_timeline_entry
   end
 
   def given_there_is_an_edition_with_attachments
@@ -26,7 +26,7 @@ RSpec.feature "Delete a file attachment", js: true do
   end
 
   def and_i_delete_the_attachment
-    @put_content_request = stub_publishing_api_put_content(@edition.content_id, {})
+    stub_publishing_api_put_content(@edition.content_id, {})
     expect(page).to have_selector(".gem-c-attachment__metadata")
     click_on "Delete attachment"
   end
@@ -36,12 +36,8 @@ RSpec.feature "Delete a file attachment", js: true do
     expect(page).to have_content(I18n.t!("file_attachments.index.flashes.deleted", file: @attachment_revision.filename))
   end
 
-  def and_the_preview_creation_succeeded
-    expect(@put_content_request).to have_been_requested
-
+  def and_i_see_the_timeline_entry
     visit document_path(@edition.document)
-    expect(page).to have_content(I18n.t!("user_facing_states.draft.name"))
-
     click_on "Document history"
     expect(page).to have_content(I18n.t!("documents.history.entry_types.file_attachment_deleted"))
   end

--- a/spec/features/editing_file_attachments/replace_file_attachment_file_spec.rb
+++ b/spec/features/editing_file_attachments/replace_file_attachment_file_spec.rb
@@ -7,8 +7,8 @@ RSpec.feature "Replace a file attachment file", js: true do
     and_i_click_on_edit_file
     and_i_upload_a_replacement_attachment_file
     and_i_click_save
-    then_i_see_the_replacement_file_on_the_attachment_index_page
-    and_the_preview_creation_succeeded
+    then_i_see_the_replacement_file
+    and_i_see_the_timeline_entry
   end
 
   def given_there_is_an_edition_with_an_attachment
@@ -35,9 +35,8 @@ RSpec.feature "Replace a file attachment file", js: true do
   end
 
   def and_i_upload_a_replacement_attachment_file
-    @put_content_request = stub_publishing_api_put_content(@edition.content_id, {})
-    @create_new_file_request = stub_asset_manager_receives_an_asset(filename: attachment_filename)
-
+    stub_publishing_api_put_content(@edition.content_id, {})
+    stub_asset_manager_receives_an_asset(filename: attachment_filename)
     find('form input[type="file"]').set(Rails.root.join(file_fixture(attachment_filename)))
   end
 
@@ -45,23 +44,15 @@ RSpec.feature "Replace a file attachment file", js: true do
     click_on "Save"
   end
 
-  def then_i_see_the_replacement_file_on_the_attachment_index_page
+  def then_i_see_the_replacement_file
     expect(page).to have_content("58 Bytes")
     expect(page).not_to have_content("74 Bytes")
   end
 
-  def and_the_preview_creation_succeeded
-    expect(@put_content_request).to have_been_requested
-    expect(@create_new_file_request).to have_been_requested
-
+  def and_i_see_the_timeline_entry
     visit document_path(@edition.document)
     click_on "Document history"
-
-    within first(".app-timeline-entry") do
-      expect(page).to have_content I18n.t!(
-        "documents.history.entry_types.file_attachment_updated",
-      )
-    end
+    expect(page).to have_content I18n.t!("documents.history.entry_types.file_attachment_updated")
   end
 
   def attachment_filename

--- a/spec/features/editing_file_attachments/upload_file_attachment_spec.rb
+++ b/spec/features/editing_file_attachments/upload_file_attachment_spec.rb
@@ -7,7 +7,7 @@ RSpec.feature "Upload file attachment", js: true do
     and_i_go_to_insert_an_attachment
     and_i_upload_a_file_attachment
     then_i_can_see_previews_of_the_attachment
-    and_the_attachment_has_been_uploaded_successfully
+    and_i_see_the_timeline_entry
   end
 
   def given_there_is_an_edition
@@ -30,8 +30,8 @@ RSpec.feature "Upload file attachment", js: true do
     @attachment_filename = "13kb-1-page-attachment.pdf"
     @title = "A title"
 
-    @asset_manager_request = stub_asset_manager_receives_an_asset(filename: @attachment_filename)
-    @publishing_api_request = stub_publishing_api_put_content(@edition.content_id, {})
+    stub_asset_manager_receives_an_asset(filename: @attachment_filename)
+    stub_publishing_api_put_content(@edition.content_id, {})
 
     find('form input[type="file"]').set(Rails.root.join(file_fixture(@attachment_filename)))
     fill_in "title", with: @title
@@ -52,15 +52,9 @@ RSpec.feature "Upload file attachment", js: true do
     end
   end
 
-  def and_the_attachment_has_been_uploaded_successfully
-    expect(@publishing_api_request).to have_been_requested
-    expect(@asset_manager_request).to have_been_requested.at_least_once
-
+  def and_i_see_the_timeline_entry
     visit document_path(@edition.document)
     click_on "Document history"
-
-    within first(".app-timeline-entry") do
-      expect(page).to have_content I18n.t!("documents.history.entry_types.file_attachment_uploaded")
-    end
+    expect(page).to have_content I18n.t!("documents.history.entry_types.file_attachment_uploaded")
   end
 end

--- a/spec/features/editing_images/choose_lead_image_spec.rb
+++ b/spec/features/editing_images/choose_lead_image_spec.rb
@@ -6,7 +6,6 @@ RSpec.feature "Choose a lead image" do
     when_i_visit_the_images_page
     and_i_choose_one_of_the_images
     then_the_edition_has_a_lead_image
-    and_the_preview_creation_succeeded
     and_i_see_the_timeline_entry
   end
 
@@ -16,7 +15,6 @@ RSpec.feature "Choose a lead image" do
     and_i_edit_the_image_metadata
     and_i_tick_the_image_is_the_lead_image
     then_the_edition_has_a_lead_image
-    and_the_preview_creation_succeeded
     and_i_see_the_timeline_entry
   end
 
@@ -33,7 +31,7 @@ RSpec.feature "Choose a lead image" do
   end
 
   def and_i_edit_the_image_metadata
-    @publishing_api_request = stub_publishing_api_put_content(@edition.content_id, {})
+    stub_publishing_api_put_content(@edition.content_id, {})
     stub_asset_manager_updates_any_asset
     visit edit_image_path(@edition.document, @image_revision.image_id)
   end
@@ -45,7 +43,7 @@ RSpec.feature "Choose a lead image" do
   end
 
   def and_i_choose_one_of_the_images
-    @publishing_api_request = stub_publishing_api_put_content(@edition.content_id, {})
+    stub_publishing_api_put_content(@edition.content_id, {})
     stub_asset_manager_updates_any_asset
 
     within("#image-#{@image_revision.image_id}") do
@@ -56,18 +54,6 @@ RSpec.feature "Choose a lead image" do
   def then_the_edition_has_a_lead_image
     expect(find("#lead-image img")["src"]).to include(@image_revision.filename)
     expect(page).to have_content(I18n.t!("documents.show.flashes.lead_image.selected", file: @image_revision.filename))
-  end
-
-  def and_the_preview_creation_succeeded
-    expect(@publishing_api_request).to have_been_requested
-    expect(page).to have_content(I18n.t!("user_facing_states.draft.name"))
-
-    expect(a_request(:put, /content/).with { |req|
-      expect(JSON.parse(req.body)["details"]["image"]["url"])
-        .to eq @image_revision.asset_url("300")
-      expect(JSON.parse(req.body)["details"]["image"]["high_resolution_url"])
-        .to eq @image_revision.asset_url("high_resolution")
-    }).to have_been_requested
   end
 
   def and_i_see_the_timeline_entry

--- a/spec/features/editing_images/delete_image_spec.rb
+++ b/spec/features/editing_images/delete_image_spec.rb
@@ -6,7 +6,7 @@ RSpec.feature "Delete an image" do
     when_i_visit_the_images_page
     and_i_delete_the_non_lead_image
     then_i_see_the_image_is_gone
-    and_the_preview_creation_succeeded
+    and_i_see_the_timeline_entry
   end
 
   scenario "inline image", js: true do
@@ -14,7 +14,7 @@ RSpec.feature "Delete an image" do
     when_i_insert_an_inline_image
     and_i_delete_the_non_lead_image
     then_i_see_the_image_is_gone
-    and_the_preview_creation_succeeded
+    and_i_see_the_timeline_entry
   end
 
   def given_there_is_an_edition_with_images
@@ -41,7 +41,7 @@ RSpec.feature "Delete an image" do
   end
 
   def and_i_delete_the_non_lead_image
-    @put_content_request = stub_publishing_api_put_content(@edition.content_id, {})
+    stub_publishing_api_put_content(@edition.content_id, {})
     click_on "Delete image"
   end
 
@@ -50,12 +50,8 @@ RSpec.feature "Delete an image" do
     expect(page).to have_content(I18n.t!("images.index.flashes.deleted", file: @image_revision.filename))
   end
 
-  def and_the_preview_creation_succeeded
-    expect(@put_content_request).to have_been_requested
-
+  def and_i_see_the_timeline_entry
     visit document_path(@edition.document)
-    expect(page).to have_content(I18n.t!("user_facing_states.draft.name"))
-
     click_on "Document history"
     expect(page).to have_content(I18n.t!("documents.history.entry_types.image_deleted"))
   end

--- a/spec/features/editing_images/delete_lead_image_spec.rb
+++ b/spec/features/editing_images/delete_lead_image_spec.rb
@@ -6,7 +6,6 @@ RSpec.feature "Delete an image" do
     when_i_visit_the_images_page
     when_i_delete_the_lead_image
     then_i_see_the_document_has_no_lead_image
-    and_the_preview_creation_succeeded
     and_i_see_the_timeline_entry
   end
 
@@ -23,7 +22,7 @@ RSpec.feature "Delete an image" do
   end
 
   def when_i_delete_the_lead_image
-    @put_content_request = stub_publishing_api_put_content(@edition.content_id, {})
+    stub_publishing_api_put_content(@edition.content_id, {})
     click_on "Delete lead image"
   end
 
@@ -33,15 +32,6 @@ RSpec.feature "Delete an image" do
 
     visit document_path(@edition.document)
     expect(page).to have_content(I18n.t!("documents.show.lead_image.no_lead_image"))
-  end
-
-  def and_the_preview_creation_succeeded
-    expect(@put_content_request).to have_been_requested
-    expect(page).to have_content(I18n.t!("user_facing_states.draft.name"))
-
-    expect(a_request(:put, /content/).with { |req|
-      expect(JSON.parse(req.body)["details"].keys).to_not include("image")
-    }).to have_been_requested
   end
 
   def and_i_see_the_timeline_entry

--- a/spec/features/editing_images/edit_image_spec.rb
+++ b/spec/features/editing_images/edit_image_spec.rb
@@ -10,8 +10,7 @@ RSpec.feature "Edit image", js: true do
 
     when_i_edit_the_image_metadata
     and_i_see_the_lead_image_is_updated
-    and_the_preview_creation_succeeded
-    and_the_document_history_has_been_updated
+    and_i_see_the_timeline_entry
   end
 
   scenario "inline image" do
@@ -23,8 +22,7 @@ RSpec.feature "Edit image", js: true do
 
     when_i_edit_the_image_metadata
     then_i_see_the_image_is_updated
-    and_the_preview_creation_succeeded
-    and_the_document_history_has_been_updated
+    and_i_see_the_timeline_entry
   end
 
   def given_there_is_an_edition_with_a_lead_image
@@ -78,8 +76,8 @@ RSpec.feature "Edit image", js: true do
     bottom_right_handle = find(".cropper-point.point-se")
     bottom_right_handle.drag_to(find(".govuk-header"))
 
-    @publishing_api_request = stub_any_publishing_api_put_content
-    @new_asset_requests = stub_asset_manager_receives_an_asset
+    stub_any_publishing_api_put_content
+    stub_asset_manager_receives_an_asset
     stub_asset_manager_updates_any_asset
 
     click_on "Crop image"
@@ -109,19 +107,12 @@ RSpec.feature "Edit image", js: true do
     expect(image_revision.crop_height).to eq(640)
   end
 
-  def and_the_preview_creation_succeeded
-    expect(@publishing_api_request).to have_been_requested.at_least_once
-    expect(@new_asset_requests).to have_been_requested.at_least_once
-
-    visit document_path(@edition.document)
-    expect(page).to have_content(I18n.t!("user_facing_states.draft.name"))
-  end
-
   def and_i_see_the_lead_image_is_updated
     within(".app-c-image-meta") { then_i_see_the_image_is_updated }
   end
 
-  def and_the_document_history_has_been_updated
+  def and_i_see_the_timeline_entry
+    visit document_path(@edition.document)
     click_on "Document history"
     expect(page).to have_content I18n.t!("documents.history.entry_types.image_updated")
   end

--- a/spec/features/editing_images/remove_lead_image_spec.rb
+++ b/spec/features/editing_images/remove_lead_image_spec.rb
@@ -6,7 +6,6 @@ RSpec.feature "Remove a lead image" do
     when_i_visit_the_images_page
     and_i_remove_the_lead_image
     then_the_edition_has_no_lead_image
-    and_the_preview_creation_succeeded
     and_i_see_the_timeline_entry
   end
 
@@ -16,7 +15,6 @@ RSpec.feature "Remove a lead image" do
     and_i_edit_the_image_metadata
     and_i_untick_the_image_is_the_lead_image
     then_the_edition_has_no_lead_image
-    and_the_preview_creation_succeeded
     and_i_see_the_timeline_entry
   end
 
@@ -35,13 +33,13 @@ RSpec.feature "Remove a lead image" do
   end
 
   def and_i_remove_the_lead_image
-    @publishing_api_request = stub_publishing_api_put_content(@edition.content_id, {})
+    stub_publishing_api_put_content(@edition.content_id, {})
     stub_asset_manager_updates_any_asset
     click_on "Remove lead image"
   end
 
   def and_i_edit_the_image_metadata
-    @publishing_api_request = stub_publishing_api_put_content(@edition.content_id, {})
+    stub_publishing_api_put_content(@edition.content_id, {})
     stub_asset_manager_updates_any_asset
     visit edit_image_path(@edition.document, @image_revision.image_id)
   end
@@ -56,15 +54,6 @@ RSpec.feature "Remove a lead image" do
     expect(page).to have_content(I18n.t!("images.index.flashes.lead_image.removed", file: @image_revision.filename))
     visit document_path(@edition.document)
     expect(page).to have_content(I18n.t!("documents.show.lead_image.no_lead_image"))
-  end
-
-  def and_the_preview_creation_succeeded
-    expect(@publishing_api_request).to have_been_requested
-    expect(page).to have_content(I18n.t!("user_facing_states.draft.name"))
-
-    expect(a_request(:put, /content/).with { |req|
-      expect(JSON.parse(req.body)["details"].keys).to_not include("image")
-    }).to have_been_requested
   end
 
   def and_i_see_the_timeline_entry

--- a/spec/features/editing_images/upload_image_spec.rb
+++ b/spec/features/editing_images/upload_image_spec.rb
@@ -8,7 +8,7 @@ RSpec.feature "Upload an image", js: true do
     and_i_crop_the_image
     and_i_fill_in_the_metadata
     then_i_see_the_new_image
-    and_the_preview_creation_succeeded
+    and_i_see_the_timeline_entry
   end
 
   scenario "inline image" do
@@ -18,7 +18,7 @@ RSpec.feature "Upload an image", js: true do
     and_i_crop_the_image
     and_i_fill_in_the_metadata
     then_i_see_the_snippet_is_inserted
-    and_the_preview_creation_succeeded
+    and_i_see_the_timeline_entry
   end
 
   def given_there_is_an_edition
@@ -49,12 +49,11 @@ RSpec.feature "Upload an image", js: true do
   def and_i_crop_the_image
     stub_publishing_api_put_content(@edition.content_id, {})
     click_on "Continue"
-    reset_executed_requests!
   end
 
   def and_i_fill_in_the_metadata
-    @publishing_api_request = stub_publishing_api_put_content(@edition.content_id, {})
-    @asset_manager_request = stub_asset_manager_receives_an_asset(filename: @image_filename)
+    stub_publishing_api_put_content(@edition.content_id, {})
+    stub_asset_manager_receives_an_asset(filename: @image_filename)
 
     fill_in "image_revision[alt_text]", with: "Some alt text"
     fill_in "image_revision[caption]", with: "A caption"
@@ -88,13 +87,8 @@ RSpec.feature "Upload an image", js: true do
     expect(find("#body-field").value).to match snippet
   end
 
-  def and_the_preview_creation_succeeded
-    expect(@publishing_api_request).to have_been_requested
-    expect(@asset_manager_request).to have_been_requested.at_least_once
-
+  def and_i_see_the_timeline_entry
     visit document_path(@edition.document)
-
-    expect(page).to have_content(I18n.t!("user_facing_states.draft.name"))
     click_on "Document history"
     expect(page).to have_content(I18n.t!("documents.history.entry_types.image_updated"))
   end

--- a/spec/features/editing_tags/edit_tags_spec.rb
+++ b/spec/features/editing_tags/edit_tags_spec.rb
@@ -14,7 +14,6 @@ RSpec.feature "Edit tags" do
     then_i_see_the_current_selections
     when_i_edit_the_tags
     then_i_can_see_the_tags
-    and_the_preview_creation_succeeded
     and_i_see_the_timeline_entry
   end
 
@@ -69,24 +68,6 @@ RSpec.feature "Edit tags" do
 
   def and_i_see_the_timeline_entry
     click_on "Document history"
-    within first(".app-timeline-entry") do
-      expect(page).to have_content I18n.t!("documents.history.entry_types.updated_tags")
-    end
-  end
-
-  def and_the_preview_creation_succeeded
-    expect(@request).to have_been_requested
-    expect(page).to have_content(I18n.t!("user_facing_states.draft.name"))
-
-    expect(a_request(:put, /content/).with { |req|
-      expect(JSON.parse(req.body)["links"]).to include(edition_links)
-    }).to have_been_requested
-  end
-
-  def edition_links
-    {
-      multi_tag_id.to_s => [tag_to_select_1["content_id"], tag_to_select_2["content_id"]],
-      single_tag_id.to_s => [tag_to_select_1["content_id"]],
-    }
+    expect(page).to have_content I18n.t!("documents.history.entry_types.updated_tags")
   end
 end

--- a/spec/features/formats/news_article_spec.rb
+++ b/spec/features/formats/news_article_spec.rb
@@ -59,24 +59,7 @@ RSpec.describe "News article format" do
   def then_i_can_publish_the_document
     expect(a_request(:put, /content/).with { |req|
              expect(req.body).to be_valid_against_publisher_schema("news_article")
-             expect(JSON.parse(req.body)).to match a_hash_including(content_body)
            }).to have_been_requested
-  end
-
-  def content_body
-    {
-      "links" => hash_including(
-        "topical_events" => [linkable["content_id"]],
-        "world_locations" => [linkable["content_id"]],
-        "organisations" => [linkable["content_id"]],
-        "primary_publishing_organisation" => [linkable["content_id"]],
-        "roles" => role_appointment_links["links"]["role"],
-        "people" => role_appointment_links["links"]["person"],
-      ),
-      "title" => "A great title",
-      "document_type" => "news_story",
-      "description" => "A great summary",
-    }
   end
 
   def role_appointment_links

--- a/spec/features/workflow/create_document_spec.rb
+++ b/spec/features/workflow/create_document_spec.rb
@@ -8,7 +8,6 @@ RSpec.feature "Create a document" do
     and_i_select_a_document_type
     and_i_fill_in_the_contents
     then_i_see_the_document_summary
-    and_the_preview_creation_was_successful
     and_i_see_the_timeline_entry
   end
 
@@ -43,32 +42,10 @@ RSpec.feature "Create a document" do
     expect(page).to have_content("A title")
   end
 
-  def and_the_preview_creation_was_successful
-    expect(a_request(:put, /content/).with { |req|
-      expect(JSON.parse(req.body)).to match a_hash_including(content_body)
-    }).to have_been_requested
-  end
-
   def and_i_see_the_timeline_entry
     click_on "Document history"
     expect(page).to have_content("1st edition")
                 .and have_content(I18n.t!("documents.history.entry_types.created"))
                 .and have_content(I18n.t!("documents.history.entry_types.updated_content"))
-  end
-
-  def content_body
-    {
-      "links" => hash_including(
-        "organisations" => [current_user.organisation_content_id],
-        "primary_publishing_organisation" => [current_user.organisation_content_id],
-      ),
-      "title" => "A title",
-      "document_type" => @document_type.id,
-      "description" => "A summary",
-      "update_type" => "major",
-      "change_note" => "First published.",
-      "base_path" => "/a-title",
-      "locale" => "en",
-    }
   end
 end


### PR DESCRIPTION
https://trello.com/c/u9kRKVsX/1324-extract-title-and-summary-into-classes-views-and-config

Previously we added these steps to many features as a way to check the
tangential outcomes of a user action, including the document state and API
requests to Publishing API and Asset Manager, which arise from the
PreviewDraftEditionService. Checking API requests in features was pragmatic
when we had limited tests at lower levels, and the idea was that each
feature would cover its specific part of the Publishing API payload. Since
then, we've introduced the
'failsafe preview' feature, such that its far less important or
'optional' that a request is made, since a fallback exists. The checker for
draft user state was added with a similar mindset, to ensure that the
edition state is (re)set appropriately on edit, which is now covered by
'editable?' assertions.

This removes the checks for API requests and draft user state, and renames
or removes the associated step method to leave one that checks for a
timeline entry only.