### PR TITLE
Stripped 'news_article_spec.rb' down to its bare essentials

### DIFF
--- a/spec/features/formats/news_article_spec.rb
+++ b/spec/features/formats/news_article_spec.rb
@@ -3,16 +3,10 @@
 RSpec.describe "News article format" do
   include TopicsHelper
 
-  before do
-    stub_any_publishing_api_put_content
-    stub_any_publishing_api_no_links
-  end
-
   scenario do
     when_i_choose_this_document_type
     and_i_fill_in_the_form_fields
-    and_i_add_some_tags
-    then_i_can_publish_the_document
+    then_the_document_should_be_previewable
   end
 
   def when_i_choose_this_document_type
@@ -25,54 +19,15 @@ RSpec.describe "News article format" do
   end
 
   def and_i_fill_in_the_form_fields
-    fill_in "revision[title]", with: "A great title"
-    fill_in "revision[summary]", with: "A great summary"
-
-    document = Document.first
     base_path = Edition.last.document_type.path_prefix + "/a-great-title"
-    stub_publishing_api_has_lookups(base_path => document.content_id)
-
-    click_on "Save"
-    reset_executed_requests!
-  end
-
-  def and_i_add_some_tags
-    stub_publishing_api_has_links(role_appointment_links)
-
-    expect(Edition.last.document_type.tags.count).to eq(5)
-    stub_publishing_api_has_linkables([linkable], document_type: "topical_event")
-    stub_publishing_api_has_linkables([linkable], document_type: "world_location")
-    stub_publishing_api_has_linkables([linkable], document_type: "organisation")
-    stub_publishing_api_has_linkables([linkable], document_type: "role_appointment")
-
-    click_on "Change Tags"
-
-    select linkable["internal_name"], from: "tags[topical_events][]"
-    select linkable["internal_name"], from: "tags[world_locations][]"
-    select linkable["internal_name"], from: "tags[primary_publishing_organisation][]"
-    select linkable["internal_name"], from: "tags[organisations][]"
-    select linkable["internal_name"], from: "tags[role_appointments][]"
-
+    stub_publishing_api_has_lookups(base_path => Document.last.content_id)
+    fill_in "revision[title]", with: "A great title"
     click_on "Save"
   end
 
-  def then_i_can_publish_the_document
+  def then_the_document_should_be_previewable
     expect(a_request(:put, /content/).with { |req|
              expect(req.body).to be_valid_against_publisher_schema("news_article")
            }).to have_been_requested
-  end
-
-  def role_appointment_links
-    @role_appointment_links ||= {
-      "content_id" => linkable["content_id"],
-      "links" => {
-        "person" => [SecureRandom.uuid],
-        "role" => [SecureRandom.uuid],
-      },
-    }
-  end
-
-  def linkable
-    @linkable ||= { "content_id" => SecureRandom.uuid, "internal_name" => "Linkable" }
   end
 end


### PR DESCRIPTION
- Added 'fill_in "revision[contents][body]"' to make this a valid doc
- Checks are made against Document.last, rather than Document.first,
  as this makes more sense
- Avoid stubbing role appointment links, as these aren't required for
  a minimum viable document
- Choose only a primary publishing organisation tag, as the others
  aren't required for a minimum viable document
- Move 'reset_executed_requests!' call to later in the test, so that
  it is more obvious why it is needed
- Assert that the 'Publish' link exists. This isn't strictly necessary
  but is a peace-of-mind quick check that our UI is showing that the
  document is publishable when it is publishable.

...and then simplified further:

- We only care that a user can create a document from scratch and take
  the minimal steps necessary to make the document valid against its
  schema. This validation alone should give us confidence that it can
  preview (and publish) correctly.
- Previewing doesn't require a body (publishing does), so I've removed
  the 'fill_in body' code from the previous commit. It does not need
  any tagging either, and therefore no publishing API stubbing in the
  'before' block.
- This also meant I could remove the 'reset_executed_requests!' hack.

Done as part of https://trello.com/c/ihcpYeWf/1320-iterate-how-we-test-formats

