### PR TITLE
Whitehall notes and fact check - display

### DIFF
--- a/app/views/documents/history/_whitehall_entry.html.erb
+++ b/app/views/documents/history/_whitehall_entry.html.erb
@@ -1,4 +1,10 @@
-<div class="app-timeline-entry">
+<% whitehall_timeline_entry_content = capture do %>
+  <% if entry.details.internal_note? && entry.details.contents["body"].present? %>
+    <%= simple_format(escape_and_link(entry.details.contents["body"])) %>
+  <% end %>
+<% end %>
+
+<div class="app-timeline-entry <%= "app-timeline-entry--highlighted" if whitehall_timeline_entry_content %>">
   <% if entry.details.imported_from_whitehall? %>
     <%= render "govuk_publishing_components/components/notice", {
       title: t("documents.history.entry_types.whitehall_migration.#{entry.details.entry_type}"),
@@ -15,5 +21,11 @@
         <%= t "documents.history.by" %> <%= entry.created_by.name %>
       <% end %>
     </div>
+
+    <% if whitehall_timeline_entry_content %>
+      <div class="app-timeline-entry__content">
+        <%= whitehall_timeline_entry_content %>
+      </div>
+    <% end %>
   <% end %>
 </div>

--- a/app/views/documents/history/_whitehall_entry.html.erb
+++ b/app/views/documents/history/_whitehall_entry.html.erb
@@ -2,6 +2,16 @@
   <% if entry.details.internal_note? && entry.details.contents["body"].present? %>
     <%= simple_format(escape_and_link(entry.details.contents["body"])) %>
   <% end %>
+
+  <% if entry.details.fact_check_request? && entry.details.contents["instructions"].present? %>
+    <%= simple_format(escape_and_link(entry.details.contents["instructions"])) %>
+    <%= simple_format(escape_and_link(entry.details.contents["email_address"])) %>
+  <% end %>
+
+  <% if entry.details.fact_check_response? && entry.details.contents["comments"].present? %>
+    <%= simple_format(escape_and_link(entry.details.contents["comments"])) %>
+    <%= simple_format(escape_and_link(entry.details.contents["email_address"])) %>
+  <% end %>
 <% end %>
 
 <div class="app-timeline-entry <%= "app-timeline-entry--highlighted" if whitehall_timeline_entry_content %>">

--- a/spec/views/documents/history/_whitehall_entry.html.erb_spec.rb
+++ b/spec/views/documents/history/_whitehall_entry.html.erb_spec.rb
@@ -44,4 +44,62 @@ RSpec.describe "documents/history/_whitehall_entry.html.erb" do
     expect(rendered).to have_content(note)
     expect(rendered).to have_selector(".app-timeline-entry--highlighted")
   end
+
+  it "does not highlight an imported fact check request timeline entry without content" do
+    timeline_entry = create(:timeline_entry,
+                            :whitehall_imported,
+                            whitehall_entry_type: :fact_check_request)
+    timeline_entry.details[:contents] = {}
+
+    render partial: "documents/history/whitehall_entry",
+                    locals: { entry: timeline_entry }
+    expect(rendered).to_not have_selector(".app-timeline-entry--highlighted")
+  end
+
+  it "shows the contents of an imported fact check request timeline entry" do
+    email = "someone@somewhere.com"
+    instructions = "Do something, then do something else"
+    timeline_entry = create(:timeline_entry,
+                            :whitehall_imported,
+                            whitehall_entry_type: :fact_check_request)
+    timeline_entry.details[:contents] = {
+      email_address: email,
+      instructions: instructions,
+    }
+
+    render partial: "documents/history/whitehall_entry",
+                    locals: { entry: timeline_entry }
+    expect(rendered).to have_content(email)
+    expect(rendered).to have_content(instructions)
+    expect(rendered).to have_selector(".app-timeline-entry--highlighted")
+  end
+
+  it "does not highlight an imported fact check response timeline entry without content" do
+    timeline_entry = create(:timeline_entry,
+                            :whitehall_imported,
+                            whitehall_entry_type: :fact_check_response)
+    timeline_entry.details[:contents] = {}
+
+    render partial: "documents/history/whitehall_entry",
+                    locals: { entry: timeline_entry }
+    expect(rendered).to_not have_selector(".app-timeline-entry--highlighted")
+  end
+
+  it "shows the contents of an imported fact check response timeline entry" do
+    email = "someone@somewhere.com"
+    comments = "I have done what you requested"
+    timeline_entry = create(:timeline_entry,
+                            :whitehall_imported,
+                            whitehall_entry_type: :fact_check_response)
+    timeline_entry.details[:contents] = {
+      email_address: email,
+      comments: comments,
+    }
+
+    render partial: "documents/history/whitehall_entry",
+                    locals: { entry: timeline_entry }
+    expect(rendered).to have_content(email)
+    expect(rendered).to have_content(comments)
+    expect(rendered).to have_selector(".app-timeline-entry--highlighted")
+  end
 end

--- a/spec/views/documents/history/_whitehall_entry.html.erb_spec.rb
+++ b/spec/views/documents/history/_whitehall_entry.html.erb_spec.rb
@@ -20,4 +20,28 @@ RSpec.describe "documents/history/_whitehall_entry.html.erb" do
     expect(rendered).to have_content(I18n.t!("documents.history.by") + " John Smith")
     expect(rendered).to have_content(I18n.t!("documents.history.entry_types.whitehall_migration.new_edition"))
   end
+
+  it "does not highlight an imported internal note timeline entry without content" do
+    timeline_entry = create(:timeline_entry,
+                            :whitehall_imported,
+                            whitehall_entry_type: :internal_note)
+    timeline_entry.details[:contents] = {}
+
+    render partial: "documents/history/whitehall_entry",
+                    locals: { entry: timeline_entry }
+    expect(rendered).to_not have_selector(".app-timeline-entry--highlighted")
+  end
+
+  it "shows the contents of an imported internal note timeline entry" do
+    note = "This is a note"
+    timeline_entry = create(:timeline_entry,
+                            :whitehall_imported,
+                            whitehall_entry_type: :internal_note)
+    timeline_entry.details[:contents] = { body: note }
+
+    render partial: "documents/history/whitehall_entry",
+                    locals: { entry: timeline_entry }
+    expect(rendered).to have_content(note)
+    expect(rendered).to have_selector(".app-timeline-entry--highlighted")
+  end
 end


### PR DESCRIPTION
Whitehall stores document history in three places. This PR addresses the display of two of these into Content Publisher:

- Editorial remarks (Notes tab in Whitehall)

- Fact check requests (Fact checking tab in Whitehall)

For fact checks, there are two things we need to maintain: a fact check request (i.e. a request sent to a department or individual) and a fact check response (i.e. the response coming back from the recipient(s) of the original request).

In all cases, Whitehall entries with content are highlighted to the user, entries without content are not.

**Before...**

![before](https://user-images.githubusercontent.com/44037625/73659988-344dc100-468f-11ea-95d2-2b9fb3d4a06e.png)

**After...**

![after](https://user-images.githubusercontent.com/44037625/73853582-09977000-4829-11ea-8e4f-dbf67e66a392.png)

Trello: https://trello.com/c/tNsWXZZj/1314-user-interface-display-for-imported-whitehall-editorial-remarks-notes-tab-in-whitehall-and-fact-check-requests-fact-checking-tab