### PR TITLE
Remove redundant flash types / rendering

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -11,8 +11,6 @@ class ApplicationController < ActionController::Base
   before_action :check_user_access
 
   add_flash_types :alert_with_description,
-                  :alert_with_items,
-                  :confirmation,
                   :tried_to_publish,
                   :tried_to_preview
 

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -60,10 +60,6 @@
         } %>
       <% end %>
 
-      <% if flash["confirmation"] %>
-        <%= render flash["confirmation"] %>
-      <% end %>
-
       <% if flash["alert_with_description"] %>
         <% alert = flash["alert_with_description"].stringify_keys %>
         <%= render "govuk_publishing_components/components/error_alert", {


### PR DESCRIPTION
The 'alert_with_items' and 'confirmation' flash types are no longer
used, so we can remove support for them.

https://github.com/alphagov/content-publisher/pull/1611
https://github.com/alphagov/content-publisher/commit/6a3ce564157e8d06a497e149f547781daf60cdf4