### PR TITLE
Restrict content fields to those that exist

### DIFF
--- a/config/schemas/document_type.json
+++ b/config/schemas/document_type.json
@@ -62,7 +62,7 @@
           "type": "array",
           "uniqueItems": true,
           "items": {
-            "type": "string"
+            "$ref": "#/definitions/content_field"
           }
         },
         "tags": {
@@ -129,6 +129,14 @@
     },
     "label": {
       "type": "string"
+    },
+    "content_field": {
+      "type": "string",
+      "enum": [
+        "title_and_base_path",
+        "summary",
+        "body"
+      ]
     },
     "tag_field": {
       "type": "object",


### PR DESCRIPTION
https://trello.com/c/u9kRKVsX/1324-extract-title-and-summary-into-classes-views-and-config

This should make it easier to track down a typo in the config, which
would otherwise lead to less obvious failures elsewhere in the tests.