### PR TITLE
Remove check_path_conflict_flag for base paths

### DIFF
--- a/app/models/document_type.rb
+++ b/app/models/document_type.rb
@@ -4,7 +4,7 @@ class DocumentType
   include InitializeWithHash
 
   attr_reader :contents, :id, :managed_elsewhere, :publishing_metadata, :label,
-              :path_prefix, :tags, :images, :topics, :check_path_conflict
+              :path_prefix, :tags, :images, :topics
 
   def self.find(id)
     item = all.find { |document_type| document_type.id == id }

--- a/app/models/document_type/title_and_base_path_field.rb
+++ b/app/models/document_type/title_and_base_path_field.rb
@@ -62,8 +62,6 @@ class DocumentType::TitleAndBasePathField
 private
 
   def base_path_conflict?(edition, revision)
-    return false unless edition.document_type.check_path_conflict
-
     base_path_owner = GdsApi.publishing_api.lookup_content_id(
       base_path: revision.base_path,
       with_drafts: true,

--- a/config/schemas/document_type.json
+++ b/config/schemas/document_type.json
@@ -17,7 +17,6 @@
         "label",
         "path_prefix",
         "images",
-        "check_path_conflict",
         "publishing_metadata",
         "contents",
         "tags"

--- a/spec/factories/document_type_factory.rb
+++ b/spec/factories/document_type_factory.rb
@@ -16,8 +16,7 @@ FactoryBot.define do
     topics { false }
 
     contents do
-      [DocumentType::TitleAndBasePathField.new,
-       DocumentType::SummaryField.new]
+      [DocumentType::SummaryField.new]
     end
 
     publishing_metadata do

--- a/spec/factories/document_type_factory.rb
+++ b/spec/factories/document_type_factory.rb
@@ -32,5 +32,11 @@ FactoryBot.define do
       DocumentType.all << document_type
       Supertype.all.first.document_types << document_type
     end
+
+    trait :with_body do
+      contents do
+        [DocumentType::BodyField.new]
+      end
+    end
   end
 end

--- a/spec/features/editing_content/edit_edition_spec.rb
+++ b/spec/features/editing_content/edit_edition_spec.rb
@@ -11,8 +11,7 @@ RSpec.feature "Edit an edition" do
   end
 
   def given_there_is_an_edition
-    body_field = DocumentType::BodyField.new
-    document_type = build(:document_type, contents: [body_field])
+    document_type = build(:document_type, :with_body)
     contents = { body: "Existing body" }
     @edition = create(:edition, document_type: document_type, contents: contents)
   end

--- a/spec/features/editing_content/govspeak_preview_spec.rb
+++ b/spec/features/editing_content/govspeak_preview_spec.rb
@@ -10,8 +10,7 @@ RSpec.feature "Shows a preview of Govspeak", js: true do
   end
 
   def given_there_is_an_edition
-    body_field = DocumentType::BodyField.new
-    document_type = build(:document_type, contents: [body_field])
+    document_type = build(:document_type, :with_body)
     @edition = create(:edition, document_type: document_type)
   end
 

--- a/spec/features/editing_content/insert_contact_embed_spec.rb
+++ b/spec/features/editing_content/insert_contact_embed_spec.rb
@@ -23,8 +23,7 @@ RSpec.feature "Insert contact embed" do
   end
 
   def given_there_is_an_edition
-    body_field = DocumentType::BodyField.new
-    document_type = build(:document_type, contents: [body_field])
+    document_type = build(:document_type, :with_body)
     @edition = create(:edition, document_type: document_type)
   end
 

--- a/spec/features/editing_content/insert_inline_file_attachment_spec.rb
+++ b/spec/features/editing_content/insert_inline_file_attachment_spec.rb
@@ -29,13 +29,11 @@ RSpec.feature "Insert inline file attachment" do
   end
 
   def given_there_is_an_edition_with_file_attachments
-    body_field = DocumentType::BodyField.new
-    document_type = build(:document_type, contents: [body_field])
     @file_attachment_revision = create(:file_attachment_revision,
                                        :on_asset_manager,
                                        filename: "foo.pdf")
     @edition = create(:edition,
-                      document_type: document_type,
+                      document_type: build(:document_type, :with_body),
                       file_attachment_revisions: [@file_attachment_revision])
   end
 

--- a/spec/features/editing_content/insert_inline_image_spec.rb
+++ b/spec/features/editing_content/insert_inline_image_spec.rb
@@ -17,13 +17,11 @@ RSpec.feature "Insert inline image" do
   end
 
   def given_there_is_an_edition_with_images
-    body_field = DocumentType::BodyField.new
-    document_type = build(:document_type, contents: [body_field])
     @image_revision = create(:image_revision,
                              :on_asset_manager,
                              filename: "foo.jpg")
     @edition = create(:edition,
-                      document_type: document_type,
+                      document_type: build(:document_type, :with_body),
                       image_revisions: [@image_revision])
   end
 

--- a/spec/features/editing_content/insert_video_embed_spec.rb
+++ b/spec/features/editing_content/insert_video_embed_spec.rb
@@ -10,8 +10,7 @@ RSpec.describe "Insert video embed", js: true do
   end
 
   def given_there_is_an_edition
-    body_field = DocumentType::BodyField.new
-    document_type = build(:document_type, contents: [body_field])
+    document_type = build(:document_type, :with_body)
     @edition = create(:edition, document_type: document_type)
   end
 

--- a/spec/features/editing_content/url_preview_spec.rb
+++ b/spec/features/editing_content/url_preview_spec.rb
@@ -11,7 +11,9 @@ RSpec.feature "Shows a preview of the URL", js: true do
   end
 
   def given_there_is_an_edition
-    @edition = create(:edition)
+    title_field = DocumentType::TitleAndBasePathField.new
+    document_type = build :document_type, contents: [title_field]
+    @edition = create(:edition, document_type: document_type)
     @document_path_prefix = @edition.document_type.path_prefix
     @document_base_path = @edition.base_path
   end

--- a/spec/features/editing_file_attachments/delete_file_attachment_spec.rb
+++ b/spec/features/editing_file_attachments/delete_file_attachment_spec.rb
@@ -10,12 +10,10 @@ RSpec.feature "Delete a file attachment", js: true do
   end
 
   def given_there_is_an_edition_with_attachments
-    body_field = DocumentType::BodyField.new
-    document_type = build(:document_type, contents: [body_field])
     @attachment_revision = create(:file_attachment_revision, :on_asset_manager)
 
     @edition = create(:edition,
-                      document_type: document_type,
+                      document_type: build(:document_type, :with_body),
                       file_attachment_revisions: [@attachment_revision])
   end
 

--- a/spec/features/editing_file_attachments/preview_file_attachment_spec.rb
+++ b/spec/features/editing_file_attachments/preview_file_attachment_spec.rb
@@ -9,13 +9,11 @@ RSpec.feature "Preview file attachment", js: true do
   end
 
   def given_there_is_an_edition_with_attachments
-    body_field = DocumentType::BodyField.new
-    document_type = build(:document_type, contents: [body_field])
     @attachment_revision = create(:file_attachment_revision, :on_asset_manager)
     @asset = @attachment_revision.asset
 
     @edition = create(:edition,
-                      document_type: document_type,
+                      document_type: build(:document_type, :with_body),
                       file_attachment_revisions: [@attachment_revision])
   end
 

--- a/spec/features/editing_file_attachments/replace_file_attachment_file_spec.rb
+++ b/spec/features/editing_file_attachments/replace_file_attachment_file_spec.rb
@@ -16,10 +16,8 @@ RSpec.feature "Replace a file attachment file", js: true do
                                   :on_asset_manager,
                                   filename: attachment_filename)
 
-    body_field = DocumentType::BodyField.new
-    document_type = build(:document_type, contents: [body_field])
     @edition = create(:edition,
-                      document_type: document_type,
+                      document_type: build(:document_type, :with_body),
                       file_attachment_revisions: [@attachment_revision])
   end
 

--- a/spec/features/editing_file_attachments/upload_file_attachment_spec.rb
+++ b/spec/features/editing_file_attachments/upload_file_attachment_spec.rb
@@ -11,8 +11,7 @@ RSpec.feature "Upload file attachment", js: true do
   end
 
   def given_there_is_an_edition
-    body_field = DocumentType::BodyField.new
-    document_type = build(:document_type, contents: [body_field])
+    document_type = build(:document_type, :with_body)
     @edition = create(:edition, document_type: document_type)
   end
 

--- a/spec/features/editing_images/delete_image_spec.rb
+++ b/spec/features/editing_images/delete_image_spec.rb
@@ -18,8 +18,7 @@ RSpec.feature "Delete an image" do
   end
 
   def given_there_is_an_edition_with_images
-    body_field = DocumentType::BodyField.new
-    document_type = build(:document_type, contents: [body_field], images: true)
+    document_type = build(:document_type, :with_body, images: true)
     @image_revision = create(:image_revision, :on_asset_manager)
 
     @edition = create(:edition,

--- a/spec/features/editing_images/edit_image_spec.rb
+++ b/spec/features/editing_images/edit_image_spec.rb
@@ -38,8 +38,7 @@ RSpec.feature "Edit image", js: true do
   end
 
   def given_there_is_an_edition_with_images
-    body_field = DocumentType::BodyField.new
-    document_type = build(:document_type, contents: [body_field], images: true)
+    document_type = build(:document_type, :with_body, images: true)
 
     image_revision = create(:image_revision,
                             :on_asset_manager,

--- a/spec/features/editing_images/upload_image_spec.rb
+++ b/spec/features/editing_images/upload_image_spec.rb
@@ -22,8 +22,7 @@ RSpec.feature "Upload an image", js: true do
   end
 
   def given_there_is_an_edition
-    body_field = DocumentType::BodyField.new
-    document_type = build(:document_type, contents: [body_field], images: true)
+    document_type = build(:document_type, :with_body, images: true)
     @edition = create(:edition, document_type: document_type)
   end
 

--- a/spec/features/workflow/create_document_spec.rb
+++ b/spec/features/workflow/create_document_spec.rb
@@ -32,14 +32,13 @@ RSpec.feature "Create a document" do
 
   def and_i_fill_in_the_contents
     stub_any_publishing_api_put_content
-    fill_in "title", with: "A title"
     fill_in "summary", with: "A summary"
     click_on "Save"
   end
 
   def then_i_see_the_document_summary
     expect(page).to have_content(I18n.t!("user_facing_states.draft.name"))
-    expect(page).to have_content("A title")
+    expect(page).to have_content("A summary")
   end
 
   def and_i_see_the_timeline_entry

--- a/spec/features/workflow/delete_draft_after_publishing_spec.rb
+++ b/spec/features/workflow/delete_draft_after_publishing_spec.rb
@@ -19,10 +19,6 @@ RSpec.feature "Delete draft after publishing" do
     visit document_path(@edition.document)
   end
 
-  def when_i_submit_for_2i_review
-    click_on "Submit for 2i review"
-  end
-
   def and_i_publish_the_edition
     stub_any_publishing_api_put_content
     stub_any_publishing_api_publish

--- a/spec/features/workflow/delete_draft_after_publishing_spec.rb
+++ b/spec/features/workflow/delete_draft_after_publishing_spec.rb
@@ -34,9 +34,9 @@ RSpec.feature "Delete draft after publishing" do
 
   def and_i_create_a_new_draft
     stub_any_publishing_api_put_content
-    @new_title = "New draft"
+    @new_summary = "New summary"
     click_on "Create new edition"
-    fill_in "title", with: @new_title
+    fill_in "summary", with: @new_summary
     click_on "Save"
   end
 
@@ -47,12 +47,12 @@ RSpec.feature "Delete draft after publishing" do
   end
 
   def then_i_see_the_updated_draft
-    expect(page).to have_content @new_title
+    expect(page).to have_content @new_summary
   end
 
   def then_i_see_the_draft_is_gone
     expect(page).to have_current_path(documents_path, ignore_query: true)
-    expect(page).to_not have_content @new_title
+    expect(page).to_not have_content @new_summary
     expect(page).to have_content @edition.title
   end
 end

--- a/spec/features/workflow/submit_for_2i_spec.rb
+++ b/spec/features/workflow/submit_for_2i_spec.rb
@@ -8,9 +8,6 @@ RSpec.feature "Submit for 2i" do
     then_i_see_the_edition_is_submitted
     and_i_see_a_link_to_the_edition
     and_i_see_the_timeline_entry
-
-    when_i_edit_the_edition
-    then_i_see_it_is_still_in_review
   end
 
   def given_there_is_a_draft_edition
@@ -37,22 +34,8 @@ RSpec.feature "Submit for 2i" do
     end
   end
 
-  def then_i_see_it_is_still_in_review
-    expect(page).to have_content I18n.t!("documents.show.submitted_for_review.title")
-    expect(page).to have_content I18n.t!("user_facing_states.submitted_for_review.name")
-  end
-
   def and_i_see_a_link_to_the_edition
     review_url = find_field(I18n.t!("documents.show.submitted_for_review.label")).value
     expect(review_url).to match(document_url(@edition.document))
-  end
-
-  def when_i_edit_the_edition
-    stub_any_publishing_api_put_content
-    click_on "Document summary"
-
-    click_on "Change Content"
-    fill_in "title", with: "a new title"
-    click_on "Save"
   end
 end

--- a/spec/interactors/content/update_interactor_spec.rb
+++ b/spec/interactors/content/update_interactor_spec.rb
@@ -8,7 +8,6 @@ RSpec.describe Content::UpdateInteractor do
 
     let(:params) do
       ActionController::Parameters.new(document: edition.document.to_param,
-                                       title: "New title",
                                        summary: "New summary",
                                        change_note: "New note",
                                        update_type: "minor")
@@ -21,8 +20,7 @@ RSpec.describe Content::UpdateInteractor do
 
     it "updates the edition" do
       expect { Content::UpdateInteractor.call(params: params, user: user) }
-        .to change { edition.reload.title }.to("New title")
-        .and change { edition.reload.summary }.to("New summary")
+        .to change { edition.reload.summary }.to("New summary")
         .and change { edition.reload.change_note }.to("New note")
         .and change { edition.reload.update_type }.to("minor")
     end
@@ -54,8 +52,7 @@ RSpec.describe Content::UpdateInteractor do
     end
 
     it "fails if the content is unchanged" do
-      params.merge!(title: edition.title,
-                    summary: edition.summary,
+      params.merge!(summary: edition.summary,
                     change_note: edition.change_note,
                     update_type: edition.update_type)
       result = Content::UpdateInteractor.call(params: params, user: user)
@@ -63,10 +60,10 @@ RSpec.describe Content::UpdateInteractor do
     end
 
     it "fails if there are issues with the input" do
-      params.merge!(title: "")
+      params.merge!(summary: "new\nline")
       result = Content::UpdateInteractor.call(params: params, user: user)
       expect(result).to be_failure
-      expect(result.issues).to have_issue(:title, :blank)
+      expect(result.issues).to have_issue(:summary, :multiline)
     end
   end
 end

--- a/spec/lib/whitehall_importer/integrity_checker_spec.rb
+++ b/spec/lib/whitehall_importer/integrity_checker_spec.rb
@@ -1,10 +1,19 @@
 # frozen_string_literal: true
 
 RSpec.describe WhitehallImporter::IntegrityChecker do
+  let(:document_type) do
+    build :document_type, contents: [
+      DocumentType::TitleAndBasePathField.new,
+      DocumentType::SummaryField.new,
+      DocumentType::BodyField.new,
+    ]
+  end
+
   describe "#valid?" do
     let(:edition) do
       build(
         :edition,
+        document_type: document_type,
         tags: {
           primary_publishing_organisation: [SecureRandom.uuid],
           organisations: [SecureRandom.uuid],
@@ -86,14 +95,6 @@ RSpec.describe WhitehallImporter::IntegrityChecker do
   end
 
   describe "#problems" do
-    let(:document_type) do
-      build :document_type, contents: [
-        DocumentType::TitleAndBasePathField.new,
-        DocumentType::SummaryField.new,
-        DocumentType::BodyField.new,
-      ]
-    end
-
     let(:edition) do
       build(:edition,
             document_type: document_type,

--- a/spec/models/document_type/title_and_base_path_field_spec.rb
+++ b/spec/models/document_type/title_and_base_path_field_spec.rb
@@ -55,9 +55,7 @@ RSpec.describe DocumentType::TitleAndBasePathField do
   end
 
   describe "pre_update_issues" do
-    let(:edition) do
-      build :edition, document_type: build(:document_type, check_path_conflict: true)
-    end
+    let(:edition) { build :edition }
 
     before do
       stub_publishing_api_has_lookups(edition.base_path => nil)

--- a/spec/requests/contact_embed_spec.rb
+++ b/spec/requests/contact_embed_spec.rb
@@ -2,10 +2,9 @@
 
 RSpec.describe "Contact Embed" do
   let(:edition) do
-    body_field = DocumentType::BodyField.new
-    document_type = build(:document_type, contents: [body_field])
-    create(:edition, document_type: document_type)
+    create(:edition, document_type: build(:document_type, :with_body))
   end
+
   let(:organisation) do
     {
       "content_id" => SecureRandom.uuid,

--- a/spec/requests/content_spec.rb
+++ b/spec/requests/content_spec.rb
@@ -20,18 +20,18 @@ RSpec.describe "Content" do
 
     it "redirects to document summary" do
       edition = create(:edition)
-      patch content_path(edition.document), params: { title: "My title" }
+      patch content_path(edition.document), params: { summary: "My summary" }
       expect(response).to redirect_to(document_path(edition.document))
       follow_redirect!
-      expect(response.body).to have_content("My title")
+      expect(response.body).to have_content("My summary")
     end
 
     it "returns issues and an unprocessable response when there are requirement issues" do
-      edition = create(:edition, title: "Valid title")
-      patch content_path(edition.document), params: { title: "" }
+      edition = create(:edition, summary: "Valid summary")
+      patch content_path(edition.document), params: { summary: "new\nline" }
       expect(response).to have_http_status(:unprocessable_entity)
       expect(response.body)
-        .to have_content(I18n.t!("requirements.title.blank.form_message"))
+        .to have_content(I18n.t!("requirements.summary.multiline.form_message"))
     end
   end
 end

--- a/spec/requests/preview_spec.rb
+++ b/spec/requests/preview_spec.rb
@@ -16,15 +16,15 @@ RSpec.describe "Preview" do
       expect(response).to redirect_to(preview_document_path(edition.document))
     end
 
-    it "redirects to the summary page issues in an error when the document isn't publishable" do
-      edition = create(:edition, title: "", revision_synced: false)
+    it "redirects to the summary page issues in an error when the document isn't previewable" do
+      edition = create(:edition, summary: "new\nline", revision_synced: false)
       post preview_document_path(edition.document)
 
       expect(response).to redirect_to(document_path(edition.document))
       follow_redirect!
       expect(response.body)
         .to have_selector(".gem-c-error-summary",
-                          text: I18n.t!("requirements.title.blank.summary_message"))
+                          text: I18n.t!("requirements.summary.multiline.summary_message"))
     end
 
     it "redirects to the summary page with an error flash when it can't preview the document" do

--- a/spec/services/failsafe_preview_service_spec.rb
+++ b/spec/services/failsafe_preview_service_spec.rb
@@ -23,7 +23,7 @@ RSpec.describe FailsafeDraftPreviewService do
     end
 
     context "when there are pre-preview issues" do
-      let(:edition) { create(:edition, title: "", revision_synced: true) }
+      let(:edition) { create(:edition, summary: "new\nline", revision_synced: true) }
 
       it "sets revision_synced to false on the edition" do
         FailsafeDraftPreviewService.call(edition)

--- a/spec/views/documents/show.html.erb_spec.rb
+++ b/spec/views/documents/show.html.erb_spec.rb
@@ -7,7 +7,6 @@ RSpec.describe "documents/show.html.erb" do
   describe "document summary" do
     it "shows the document and edition metadata" do
       edition = create(:edition,
-                       title: "Title",
                        summary: "Summary",
                        last_edited_by: create(:user, name: "User 1"),
                        created_by: create(:user, name: "User 2"))
@@ -15,8 +14,7 @@ RSpec.describe "documents/show.html.erb" do
       render
 
       expect(rendered)
-        .to include("Title")
-        .and include("Summary")
+        .to include("Summary")
         .and have_content(/#{I18n.t!("documents.show.metadata.created_by")}:\s*User 2/)
         .and have_content(/#{I18n.t!("documents.show.metadata.last_edited_by")}:\s*User 1/)
     end


### PR DESCRIPTION
https://trello.com/c/u9kRKVsX/1324-extract-title-and-summary-into-classes-views-and-config

Previously we added this flag to avoid having extra stubs in many tests,
due to the API call we make in order to check a base path is
(probably) available. This removes the flag, so that the check is always
enabled, noting that we should be able to use the new flexibility of the
TitleAndBasePathField to achieve the same effect.

Please see the commits for further details.