### PR TITLE
Increase test log level to 'warn'

### DIFF
--- a/config/environments/test.rb
+++ b/config/environments/test.rb
@@ -33,6 +33,9 @@ Rails.application.configure do
   # Store uploaded files on the local file system in a temporary directory.
   config.active_storage.service = :local
 
+  # Use a higher log level to avoid unnecessary clutter and disk IO.
+  config.log_level = :warn
+
   config.action_mailer.perform_caching = false
 
   # Tell Action Mailer not to deliver emails to the real world.


### PR DESCRIPTION
This is a shameless tweak to improve performance when running tests
in Docker, which is sensitive to heavy disk IO. I'm pretty sure we
don't have a use case for info-level logs in tests. I'm also open to
making this an environment variable, which might be a more reusable
approach across some of the other apps. I'm seeing about a 30-40s
improvement in test runtime on my machine.

Before

    govuk-docker-run bundle exec rspec  1.59s user 0.27s system 0% cpu 3:44.85 total

After

    govuk-docker-run bundle exec rspec  1.55s user 0.27s system 0% cpu 3:02.77 total