### PR TITLE
Use more keyword args for services

### DIFF
--- a/app/controllers/documents_controller.rb
+++ b/app/controllers/documents_controller.rb
@@ -30,7 +30,7 @@ class DocumentsController < ApplicationController
   def generate_path
     edition = Edition.find_current(document: params[:document])
     assert_edition_state(edition, &:editable?)
-    base_path = GenerateBasePathService.call(edition.document, title: params[:title])
+    base_path = GenerateBasePathService.call(edition, title: params[:title])
     render plain: base_path
   end
 

--- a/app/controllers/documents_controller.rb
+++ b/app/controllers/documents_controller.rb
@@ -30,7 +30,7 @@ class DocumentsController < ApplicationController
   def generate_path
     edition = Edition.find_current(document: params[:document])
     assert_edition_state(edition, &:editable?)
-    base_path = GenerateBasePathService.call(edition.document, params[:title])
+    base_path = GenerateBasePathService.call(edition.document, title: params[:title])
     render plain: base_path
   end
 

--- a/app/interactors/editions/create_interactor.rb
+++ b/app/interactors/editions/create_interactor.rb
@@ -53,7 +53,7 @@ private
                   created_by: user)
 
     EditDraftEditionService.call(next_edition, user, current: true, revision: next_revision)
-    AssignEditionStatusService.call(next_edition, user, :draft)
+    AssignEditionStatusService.call(next_edition, user: user, state: :draft)
     next_edition.save!
   end
 

--- a/app/interactors/file_attachments/create_interactor.rb
+++ b/app/interactors/file_attachments/create_interactor.rb
@@ -65,6 +65,7 @@ private
 
   def unique_filename
     existing_filenames = edition.revision.file_attachment_revisions.map(&:filename)
-    GenerateUniqueFilenameService.call(existing_filenames, params[:file].original_filename)
+    GenerateUniqueFilenameService.call(filename: params[:file].original_filename,
+                                       existing_filenames: existing_filenames)
   end
 end

--- a/app/interactors/file_attachments/update_interactor.rb
+++ b/app/interactors/file_attachments/update_interactor.rb
@@ -82,6 +82,7 @@ private
   def unique_filename(file)
     existing_filenames = edition.revision.file_attachment_revisions.map(&:filename)
     existing_filenames.delete(file_attachment_revision.filename)
-    GenerateUniqueFilenameService.call(existing_filenames, file.original_filename)
+    GenerateUniqueFilenameService.call(filename: file.original_filename,
+                                       existing_filenames: existing_filenames)
   end
 end

--- a/app/interactors/images/create_interactor.rb
+++ b/app/interactors/images/create_interactor.rb
@@ -42,8 +42,8 @@ private
       user: user,
       temp_image: temp_image,
       filename: GenerateUniqueFilenameService.call(
-        edition.revision.image_revisions.map(&:filename),
-        temp_image.original_filename,
+        existing_filenames: edition.revision.image_revisions.map(&:filename),
+        filename: temp_image.original_filename,
       ),
     )
 

--- a/app/interactors/review/approve_interactor.rb
+++ b/app/interactors/review/approve_interactor.rb
@@ -23,7 +23,7 @@ private
   end
 
   def approve_edition
-    AssignEditionStatusService.call(edition, user, :published)
+    AssignEditionStatusService.call(edition, user: user, state: :published)
     edition.save!
   end
 

--- a/app/interactors/review/submit_for2i_interactor.rb
+++ b/app/interactors/review/submit_for2i_interactor.rb
@@ -35,7 +35,7 @@ private
   end
 
   def update_status
-    AssignEditionStatusService.call(edition, user, :submitted_for_review)
+    AssignEditionStatusService.call(edition, user: user, state: :submitted_for_review)
     edition.save!
   end
 

--- a/app/interactors/schedule/destroy_interactor.rb
+++ b/app/interactors/schedule/destroy_interactor.rb
@@ -31,7 +31,7 @@ private
     state = scheduling.reviewed? ? :submitted_for_review : :draft
 
     EditDraftEditionService.call(edition, user, revision: updater.next_revision)
-    AssignEditionStatusService.call(edition, user, state)
+    AssignEditionStatusService.call(edition, user: user, state: state)
     edition.save!
   end
 

--- a/app/interactors/unwithdraw/unwithdraw_interactor.rb
+++ b/app/interactors/unwithdraw/unwithdraw_interactor.rb
@@ -27,7 +27,7 @@ private
     withdrawal = edition.status.details
     published_status = withdrawal.published_status
 
-    AssignEditionStatusService.call(edition, user, published_status.state)
+    AssignEditionStatusService.call(edition, user: user, state: published_status.state)
     edition.save!
   end
 

--- a/app/interactors/withdraw/create_interactor.rb
+++ b/app/interactors/withdraw/create_interactor.rb
@@ -44,7 +44,9 @@ private
   end
 
   def withdraw_edition
-    WithdrawDocumentService.call(edition, params[:public_explanation], user)
+    WithdrawDocumentService.call(edition,
+                                 user,
+                                 public_explanation: params[:public_explanation])
   rescue GdsApi::BaseError => e
     GovukError.notify(e)
     context.fail!(api_error: true)

--- a/app/jobs/scheduled_publishing_job.rb
+++ b/app/jobs/scheduled_publishing_job.rb
@@ -4,7 +4,7 @@ class ScheduledPublishingJob < ApplicationJob
   # retry at 3s, 18s, 83s, 258s, 627s
   retry_on(StandardError, wait: :exponentially_longer, attempts: 5) do |job, error|
     GovukError.notify(error)
-    RescueScheduledPublishingService.call(job.arguments.first)
+    RescueScheduledPublishingService.call(edition_id: job.arguments.first)
   end
 
   discard_and_log(ActiveRecord::RecordNotFound)

--- a/app/models/document_type/title_and_base_path_field.rb
+++ b/app/models/document_type/title_and_base_path_field.rb
@@ -19,7 +19,7 @@ class DocumentType::TitleAndBasePathField
 
   def updater_params(edition, params)
     title = params.dig(:revision, :title)&.strip
-    base_path = GenerateBasePathService.call(edition.document, title)
+    base_path = GenerateBasePathService.call(edition.document, title: title)
     { title: title, base_path: base_path }
   end
 

--- a/app/models/document_type/title_and_base_path_field.rb
+++ b/app/models/document_type/title_and_base_path_field.rb
@@ -19,7 +19,7 @@ class DocumentType::TitleAndBasePathField
 
   def updater_params(edition, params)
     title = params.dig(:revision, :title)&.strip
-    base_path = GenerateBasePathService.call(edition.document, title: title)
+    base_path = GenerateBasePathService.call(edition, title: title)
     { title: title, base_path: base_path }
   end
 

--- a/app/services/assign_edition_status_service.rb
+++ b/app/services/assign_edition_status_service.rb
@@ -1,7 +1,11 @@
 # frozen_string_literal: true
 
 class AssignEditionStatusService < ApplicationService
-  def initialize(edition, user, state, record_edit: true, status_details: nil)
+  def initialize(edition,
+                 user: nil,
+                 state:,
+                 record_edit: true,
+                 status_details: nil)
     @edition = edition
     @user = user
     @state = state

--- a/app/services/delete_draft_edition_service.rb
+++ b/app/services/delete_draft_edition_service.rb
@@ -58,7 +58,7 @@ private
       end
     end
 
-    AssignEditionStatusService.call(edition, user, :discarded)
+    AssignEditionStatusService.call(edition, user: user, state: :discarded)
     edition.update!(current: false)
   end
 

--- a/app/services/generate_base_path_service.rb
+++ b/app/services/generate_base_path_service.rb
@@ -1,15 +1,15 @@
 # frozen_string_literal: true
 
 class GenerateBasePathService < ApplicationService
-  def initialize(document, proposed_title, max_repeated_titles: 1000)
+  def initialize(document, title:, max_repeated_titles: 1000)
     @document = document
-    @proposed_title = proposed_title
+    @title = title
     @max_repeated_titles = max_repeated_titles
   end
 
   def call
     prefix = document.current_edition.document_type.path_prefix
-    slug = proposed_title.parameterize
+    slug = title.parameterize
     base_path = create_path(prefix, slug)
     return base_path unless path_in_use?(base_path)
 
@@ -18,7 +18,7 @@ class GenerateBasePathService < ApplicationService
 
 private
 
-  attr_reader :document, :proposed_title, :max_repeated_titles
+  attr_reader :document, :title, :max_repeated_titles
 
   def find_a_unique_path(prefix, slug)
     (1..max_repeated_titles).each do |appended_count|

--- a/app/services/generate_base_path_service.rb
+++ b/app/services/generate_base_path_service.rb
@@ -1,14 +1,14 @@
 # frozen_string_literal: true
 
 class GenerateBasePathService < ApplicationService
-  def initialize(document, title:, max_repeated_titles: 1000)
-    @document = document
+  def initialize(edition, title:, max_repeated_titles: 1000)
+    @edition = edition
     @title = title
     @max_repeated_titles = max_repeated_titles
   end
 
   def call
-    prefix = document.current_edition.document_type.path_prefix
+    prefix = edition.document_type.path_prefix
     slug = title.parameterize
     base_path = create_path(prefix, slug)
     return base_path unless path_in_use?(base_path)
@@ -18,7 +18,7 @@ class GenerateBasePathService < ApplicationService
 
 private
 
-  attr_reader :document, :title, :max_repeated_titles
+  attr_reader :edition, :title, :max_repeated_titles
 
   def find_a_unique_path(prefix, slug)
     (1..max_repeated_titles).each do |appended_count|
@@ -31,7 +31,7 @@ private
 
   def path_in_use?(base_path)
     Document.using_base_path(base_path)
-            .where.not("documents.id": document.id)
+            .where.not("documents.id": edition.document_id)
             .exists?
   end
 

--- a/app/services/generate_unique_filename_service.rb
+++ b/app/services/generate_unique_filename_service.rb
@@ -3,13 +3,12 @@
 class GenerateUniqueFilenameService < ApplicationService
   MAX_LENGTH = 65
 
-  def initialize(existing_filenames, suggested_name)
+  def initialize(filename:, existing_filenames:)
     @existing_filenames = existing_filenames
-    @suggested_name = suggested_name
+    @filename = ActiveStorage::Filename.new(filename)
   end
 
   def call
-    filename = ActiveStorage::Filename.new(suggested_name)
     base = filename.base.parameterize.slice 0...MAX_LENGTH
     base = ensure_unique(base)
     return base if filename.extension.blank?
@@ -19,7 +18,7 @@ class GenerateUniqueFilenameService < ApplicationService
 
 private
 
-  attr_reader :existing_filenames, :suggested_name
+  attr_reader :existing_filenames, :filename
 
   def ensure_unique(base)
     potential_conflicts = existing_filenames

--- a/app/services/publish_assets_service.rb
+++ b/app/services/publish_assets_service.rb
@@ -1,9 +1,9 @@
 # frozen_string_literal: true
 
 class PublishAssetsService < ApplicationService
-  def initialize(edition, live_edition)
+  def initialize(edition, superseded_edition: nil)
     @edition = edition
-    @live_edition = live_edition
+    @superseded_edition = superseded_edition
   end
 
   def call
@@ -14,7 +14,7 @@ class PublishAssetsService < ApplicationService
 
 private
 
-  attr_reader :edition, :live_edition
+  attr_reader :edition, :superseded_edition
 
   def publish_asset(asset)
     raise "Expected asset to be on asset manager" if asset.absent?
@@ -31,9 +31,9 @@ private
   end
 
   def retire_old_file_attachments
-    return unless live_edition
+    return unless superseded_edition
 
-    live_edition.file_attachment_revisions.each do |live_revision|
+    superseded_edition.file_attachment_revisions.each do |live_revision|
       current_revision = find_file_attachment_revision(edition, live_revision)
 
       if current_revision
@@ -45,9 +45,9 @@ private
   end
 
   def retire_old_images
-    return unless live_edition
+    return unless superseded_edition
 
-    live_edition.image_revisions.each do |live_revision|
+    superseded_edition.image_revisions.each do |live_revision|
       current_revision = find_image_revision(edition, live_revision)
 
       if current_revision

--- a/app/services/publish_draft_edition_service.rb
+++ b/app/services/publish_draft_edition_service.rb
@@ -27,7 +27,7 @@ private
   delegate :document, to: :edition
 
   def publish_assets(live_edition)
-    PublishAssetsService.call(edition, live_edition)
+    PublishAssetsService.call(edition, superseded_edition: live_edition)
   end
 
   def associate_with_government
@@ -56,14 +56,17 @@ private
   def supersede_live_edition(live_edition)
     return unless live_edition
 
-    AssignEditionStatusService.call(live_edition, user, :superseded, record_edit: false)
+    AssignEditionStatusService.call(live_edition,
+                                    user: user,
+                                    state: :superseded,
+                                    record_edit: false)
     live_edition.live = false
     live_edition.save!
   end
 
   def set_new_live_edition
-    status = with_review ? :published : :published_but_needs_2i
-    AssignEditionStatusService.call(edition, user, status)
+    state = with_review ? :published : :published_but_needs_2i
+    AssignEditionStatusService.call(edition, user: user, state: state)
     edition.access_limit = nil
     edition.live = true
     edition.save!

--- a/app/services/remove_document_service.rb
+++ b/app/services/remove_document_service.rb
@@ -33,7 +33,7 @@ private
   end
 
   def update_edition_status
-    AssignEditionStatusService.call(edition, nil, :removed, status_details: removal)
+    AssignEditionStatusService.call(edition, state: :removed, status_details: removal)
     edition.save!
   end
 

--- a/app/services/rescue_scheduled_publishing_service.rb
+++ b/app/services/rescue_scheduled_publishing_service.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 class RescueScheduledPublishingService < ApplicationService
-  def initialize(edition_id)
+  def initialize(edition_id:)
     @edition_id = edition_id
   end
 
@@ -25,8 +25,8 @@ private
     raise "Expected edition to be scheduled" unless edition.scheduled?
 
     AssignEditionStatusService.call(edition,
-                                    edition.status.created_by,
-                                    :failed_to_publish,
+                                    user: edition.status.created_by,
+                                    state: :failed_to_publish,
                                     record_edit: false,
                                     status_details: edition.status.details)
     edition.save!

--- a/app/services/resync_document_service.rb
+++ b/app/services/resync_document_service.rb
@@ -25,7 +25,7 @@ private
     set_political_and_government(live_edition)
     reserve_path(live_edition.base_path)
     PreviewDraftEditionService.call(live_edition, republish: true)
-    PublishAssetsService.call(live_edition, nil)
+    PublishAssetsService.call(live_edition)
 
     if live_edition.withdrawn?
       withdraw

--- a/app/services/schedule_publish_service.rb
+++ b/app/services/schedule_publish_service.rb
@@ -22,7 +22,10 @@ private
     updater.assign(proposed_publish_time: nil)
 
     EditDraftEditionService.call(edition, user, revision: updater.next_revision)
-    AssignEditionStatusService.call(edition, user, :scheduled, status_details: scheduling)
+    AssignEditionStatusService.call(edition,
+                                    user: user,
+                                    state: :scheduled,
+                                    status_details: scheduling)
     edition.save!
   end
 

--- a/app/services/withdraw_document_service.rb
+++ b/app/services/withdraw_document_service.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 class WithdrawDocumentService < ApplicationService
-  def initialize(edition, public_explanation, user = nil)
+  def initialize(edition, user, public_explanation:)
     @edition = edition
     @public_explanation = public_explanation
     @user = user
@@ -29,7 +29,10 @@ private
   end
 
   def update_edition(withdrawal)
-    AssignEditionStatusService.call(edition, user, :withdrawn, status_details: withdrawal)
+    AssignEditionStatusService.call(edition,
+                                    user: user,
+                                    state: :withdrawn,
+                                    status_details: withdrawal)
     edition.save!
   end
 

--- a/lib/whitehall_importer/create_file_attachment_revision.rb
+++ b/lib/whitehall_importer/create_file_attachment_revision.rb
@@ -42,8 +42,8 @@ module WhitehallImporter
 
     def unique_filename
       @unique_filename ||= GenerateUniqueFilenameService.call(
-        existing_filenames,
-        File.basename(whitehall_file_attachment["url"]),
+        existing_filenames: existing_filenames,
+        filename: File.basename(whitehall_file_attachment["url"]),
       )
     end
 

--- a/lib/whitehall_importer/create_image_revision.rb
+++ b/lib/whitehall_importer/create_image_revision.rb
@@ -47,8 +47,8 @@ module WhitehallImporter
       CreateImageBlobService.call(
         temp_image: temp_image,
         filename: GenerateUniqueFilenameService.call(
-          filenames,
-          File.basename(whitehall_image["url"]),
+          existing_filenames: filenames,
+          filename: File.basename(whitehall_image["url"]),
         ),
       )
     end

--- a/spec/interactors/file_attachments/create_interactor_spec.rb
+++ b/spec/interactors/file_attachments/create_interactor_spec.rb
@@ -37,7 +37,8 @@ RSpec.describe FileAttachments::CreateInteractor do
 
       it "delegates generating a unique filename to GenerateUniqueFilenameService" do
         expect(GenerateUniqueFilenameService).to receive(:call)
-          .with(edition.revision.file_attachment_revisions.map(&:filename), file.original_filename)
+          .with(existing_filenames: edition.revision.file_attachment_revisions.map(&:filename),
+                filename: file.original_filename)
           .and_call_original
         FileAttachments::CreateInteractor.call(**args)
       end

--- a/spec/jobs/scheduled_publishing_job_spec.rb
+++ b/spec/jobs/scheduled_publishing_job_spec.rb
@@ -68,7 +68,8 @@ RSpec.describe ScheduledPublishingJob do
     end
 
     it "when it is out of retries it calls the failed service" do
-      expect(RescueScheduledPublishingService).to receive(:call).with(scheduled_edition.id)
+      expect(RescueScheduledPublishingService).to receive(:call)
+        .with(edition_id: scheduled_edition.id)
 
       perform_enqueued_jobs do
         ScheduledPublishingJob.perform_later(scheduled_edition.id)

--- a/spec/models/document_type/title_and_base_path_field_spec.rb
+++ b/spec/models/document_type/title_and_base_path_field_spec.rb
@@ -18,7 +18,7 @@ RSpec.describe DocumentType::TitleAndBasePathField do
     it "returns a hash of the stripped title and base_path" do
       edition = build :edition
       params = ActionController::Parameters.new(revision: { title: "  a title" })
-      allow(GenerateBasePathService).to receive(:call) { "base path" }
+      allow(GenerateBasePathService).to receive(:call).with(edition, title: "a title") { "base path" }
       updater_params = subject.updater_params(edition, params)
       expect(updater_params).to eq(title: "a title", base_path: "base path")
     end

--- a/spec/services/assign_edition_status_service_spec.rb
+++ b/spec/services/assign_edition_status_service_spec.rb
@@ -6,14 +6,18 @@ RSpec.describe AssignEditionStatusService do
     let(:user) { build(:user) }
 
     it "assigns a status attributed to a user" do
-      AssignEditionStatusService.call(edition, user, :submitted_for_review)
+      AssignEditionStatusService.call(edition,
+                                      user: user,
+                                      state: :submitted_for_review)
 
       expect(edition.status).to be_submitted_for_review
       expect(edition.status.created_by).to eq(user)
     end
 
     it "does not save the edition" do
-      AssignEditionStatusService.call(edition, user, :submitted_for_review)
+      AssignEditionStatusService.call(edition,
+                                      user: user,
+                                      state: :submitted_for_review)
 
       expect(edition).to be_new_record
     end
@@ -22,9 +26,12 @@ RSpec.describe AssignEditionStatusService do
       freeze_time do
         edition = build(:edition, last_edited_at: 3.weeks.ago)
 
-        expect { AssignEditionStatusService.call(edition, user, :submitted_for_review) }
-          .to change { edition.last_edited_by }.to(user)
-          .and change { edition.last_edited_at }.to(Time.current)
+        expect {
+          AssignEditionStatusService.call(edition,
+                                          user: user,
+                                          state: :submitted_for_review)
+        }.to change { edition.last_edited_by }.to(user)
+         .and change { edition.last_edited_at }.to(Time.current)
       end
     end
 
@@ -32,8 +39,8 @@ RSpec.describe AssignEditionStatusService do
       freeze_time do
         edition = build(:edition, last_edited_at: 3.weeks.ago)
         AssignEditionStatusService.call(edition,
-                                        user,
-                                        :submitted_for_review,
+                                        user: user,
+                                        state: :submitted_for_review,
                                         record_edit: false)
 
         expect(edition.last_edited_at).not_to eq(Time.current)
@@ -45,8 +52,8 @@ RSpec.describe AssignEditionStatusService do
     it "can set details on the status" do
       removal = build(:removal)
       AssignEditionStatusService.call(edition,
-                                      user,
-                                      :removed,
+                                      user: user,
+                                      state: :removed,
                                       status_details: removal)
 
       expect(edition.status.details).to eq(removal)
@@ -56,9 +63,12 @@ RSpec.describe AssignEditionStatusService do
       it "adds an edition user if they are not already listed as an editor" do
         edition = build(:edition)
 
-        expect { AssignEditionStatusService.call(edition, user, :submitted_for_review) }
-          .to change { edition.editors.size }
-          .by(1)
+        expect {
+          AssignEditionStatusService.call(edition,
+                                          user: user,
+                                          state: :submitted_for_review)
+        }.to change { edition.editors.size }
+         .by(1)
       end
     end
   end

--- a/spec/services/generate_base_path_service_spec.rb
+++ b/spec/services/generate_base_path_service_spec.rb
@@ -8,12 +8,12 @@ RSpec.describe GenerateBasePathService do
       new_document = build(:document, :with_current_edition)
       stub_publishing_api_has_lookups("#{document.current_edition.base_path}": nil)
 
-      expect(GenerateBasePathService.call(new_document, document.current_edition.title))
+      expect(GenerateBasePathService.call(new_document, title: document.current_edition.title))
         .to eq("#{document.current_edition.base_path}-1")
     end
 
     it "preserves the base path when the title does not change" do
-      expect(GenerateBasePathService.call(document, document.current_edition.title))
+      expect(GenerateBasePathService.call(document, title: document.current_edition.title))
         .to eq(document.current_edition.base_path)
     end
 
@@ -22,7 +22,7 @@ RSpec.describe GenerateBasePathService do
       existing_paths = ["#{prefix}/a-title", "#{prefix}/a-title-1", "#{prefix}/a-title-2"]
       existing_paths.each { |path| create(:edition, base_path: path) }
 
-      expect { GenerateBasePathService.call(document, "A title", max_repeated_titles: 2) }
+      expect { GenerateBasePathService.call(document, title: "A title", max_repeated_titles: 2) }
         .to raise_error("Already >2 paths with same title.")
     end
   end

--- a/spec/services/generate_base_path_service_spec.rb
+++ b/spec/services/generate_base_path_service_spec.rb
@@ -2,27 +2,27 @@
 
 RSpec.describe GenerateBasePathService do
   describe ".call" do
-    let(:document) { create(:document, :with_current_edition) }
+    let(:edition) { create(:edition) }
 
     it "generates a base path which is unique to our database" do
-      new_document = build(:document, :with_current_edition)
-      stub_publishing_api_has_lookups("#{document.current_edition.base_path}": nil)
+      new_edition = build(:edition)
+      stub_publishing_api_has_lookups("#{edition.base_path}": nil)
 
-      expect(GenerateBasePathService.call(new_document, title: document.current_edition.title))
-        .to eq("#{document.current_edition.base_path}-1")
+      expect(GenerateBasePathService.call(new_edition, title: edition.title))
+        .to eq("#{edition.base_path}-1")
     end
 
     it "preserves the base path when the title does not change" do
-      expect(GenerateBasePathService.call(document, title: document.current_edition.title))
-        .to eq(document.current_edition.base_path)
+      expect(GenerateBasePathService.call(edition, title: edition.title))
+        .to eq(edition.base_path)
     end
 
     it "raises an error when many variations of that path are in use" do
-      prefix = document.current_edition.document_type.path_prefix
+      prefix = edition.document_type.path_prefix
       existing_paths = ["#{prefix}/a-title", "#{prefix}/a-title-1", "#{prefix}/a-title-2"]
       existing_paths.each { |path| create(:edition, base_path: path) }
 
-      expect { GenerateBasePathService.call(document, title: "A title", max_repeated_titles: 2) }
+      expect { GenerateBasePathService.call(edition, title: "A title", max_repeated_titles: 2) }
         .to raise_error("Already >2 paths with same title.")
     end
   end

--- a/spec/services/generate_unique_filename_service_spec.rb
+++ b/spec/services/generate_unique_filename_service_spec.rb
@@ -5,24 +5,28 @@ RSpec.describe GenerateUniqueFilenameService do
 
   describe "#call" do
     it "parameterises the base filename" do
-      name = GenerateUniqueFilenameService.call(existing_filenames, "File $ name.jpg")
+      name = GenerateUniqueFilenameService.call(filename: "File $ name.jpg",
+                                                existing_filenames: existing_filenames)
       expect(name).to eq "file-name.jpg"
     end
 
     it "copes if the file has no extension" do
-      name = GenerateUniqueFilenameService.call(existing_filenames, "file")
+      name = GenerateUniqueFilenameService.call(filename: "file",
+                                               existing_filenames: existing_filenames)
       expect(name).to eq "file"
     end
 
     it "truncates lengthy base filenames" do
       stub_const "GenerateUniqueFilenameService::MAX_LENGTH", 3
-      name = GenerateUniqueFilenameService.call(existing_filenames, "mylongname.jpg")
+      name = GenerateUniqueFilenameService.call(filename: "mylongname.jpg",
+                                                existing_filenames: existing_filenames)
       expect(name).to eq "myl.jpg"
     end
 
     it "ensures the filename is unique for a list of filenames" do
       existing_filenames << "file.jpg"
-      name = GenerateUniqueFilenameService.call(existing_filenames, "file.jpg")
+      name = GenerateUniqueFilenameService.call(filename: "file.jpg",
+                                               existing_filenames: existing_filenames)
       expect(name).to eq "file-1.jpg"
     end
   end

--- a/spec/services/publish_assets_service_spec.rb
+++ b/spec/services/publish_assets_service_spec.rb
@@ -12,7 +12,7 @@ RSpec.describe PublishAssetsService do
                        image_revisions: [image_revision])
 
       request = stub_asset_manager_updates_any_asset
-      PublishAssetsService.call(edition, nil)
+      PublishAssetsService.call(edition)
       expect(image_revision.assets.map(&:state).uniq).to eq(%w[live])
       expect(file_attachment_revision.asset).to be_live
       expect(request).to have_been_requested.at_least_once
@@ -34,7 +34,7 @@ RSpec.describe PublishAssetsService do
                        document: live_edition.document)
 
       request = stub_any_asset_manager_call
-      PublishAssetsService.call(edition, live_edition)
+      PublishAssetsService.call(edition, superseded_edition: live_edition)
       expect(request).to_not have_been_requested
     end
 
@@ -44,7 +44,7 @@ RSpec.describe PublishAssetsService do
                        :publishable,
                        image_revisions: [image_revision])
 
-      expect { PublishAssetsService.call(edition, nil) }.to raise_error("Expected asset to be on asset manager")
+      expect { PublishAssetsService.call(edition) }.to raise_error("Expected asset to be on asset manager")
     end
 
     it "removes an asset not used by the current edition" do
@@ -64,7 +64,7 @@ RSpec.describe PublishAssetsService do
 
       delete_request = stub_asset_manager_deletes_any_asset
 
-      PublishAssetsService.call(edition, live_edition)
+      PublishAssetsService.call(edition, superseded_edition: live_edition)
       expect(image_revision_to_remove.assets.map(&:state).uniq).to eq(%w[absent])
       expect(file_attachment_revision_to_remove.asset).to be_absent
       expect(delete_request).to have_been_requested.at_least_once
@@ -86,7 +86,7 @@ RSpec.describe PublishAssetsService do
                      file_attachment_revisions: [file_attachment_revision_to_keep],
                      document: live_edition.document)
 
-    PublishAssetsService.call(edition, live_edition)
+    PublishAssetsService.call(edition, superseded_edition: live_edition)
     expect(image_revision_to_keep.assets.map(&:state).uniq).to eq(%w[live])
     expect(file_attachment_revision_to_keep.asset).to be_live
   end
@@ -109,7 +109,7 @@ RSpec.describe PublishAssetsService do
                      document: live_edition.document)
 
     request = stub_asset_manager_updates_any_asset
-    PublishAssetsService.call(edition, live_edition)
+    PublishAssetsService.call(edition, superseded_edition: live_edition)
     expect(old_image_revision.assets.map(&:state).uniq).to eq(%w[superseded])
     expect(old_file_attachment_revision.asset).to be_superseded
     expect(request).to have_been_requested.at_least_once

--- a/spec/services/resync_document_service_spec.rb
+++ b/spec/services/resync_document_service_spec.rb
@@ -92,9 +92,7 @@ RSpec.describe ResyncDocumentService do
       end
 
       it "publishes assets to the live stack" do
-        expect(PublishAssetsService)
-          .to receive(:call).once.with(edition, nil)
-
+        expect(PublishAssetsService).to receive(:call).once.with(edition)
         ResyncDocumentService.call(edition.document)
       end
     end

--- a/spec/services/withdraw_document_service_spec.rb
+++ b/spec/services/withdraw_document_service_spec.rb
@@ -14,7 +14,9 @@ RSpec.describe WithdrawDocumentService do
                                               body: { type: "withdrawal",
                                                       explanation: converted_public_explanation,
                                                       locale: edition.locale })
-      WithdrawDocumentService.call(edition, public_explanation, user)
+      WithdrawDocumentService.call(edition,
+                                   user,
+                                   public_explanation: public_explanation)
 
       expect(request).to have_been_requested
     end
@@ -22,7 +24,9 @@ RSpec.describe WithdrawDocumentService do
 
     it "updates the edition status to withdrawn" do
       travel_to(Time.current) do
-        WithdrawDocumentService.call(edition, public_explanation, user)
+        WithdrawDocumentService.call(edition,
+                                     user,
+                                     public_explanation: public_explanation)
         edition.reload
         withdrawal = edition.status.details
 
@@ -34,8 +38,9 @@ RSpec.describe WithdrawDocumentService do
 
     it "saves the published_status to the withdrawal record" do
       previous_published_status = edition.status
-
-      WithdrawDocumentService.call(edition, public_explanation, user)
+      WithdrawDocumentService.call(edition,
+                                   user,
+                                   public_explanation: public_explanation)
       edition.reload
 
       withdrawal = edition.status.details
@@ -47,7 +52,9 @@ RSpec.describe WithdrawDocumentService do
       withdrawn_edition = create(:edition, :withdrawn)
       previous_withdrawal = withdrawn_edition.status.details
 
-      WithdrawDocumentService.call(withdrawn_edition, public_explanation, user)
+      WithdrawDocumentService.call(withdrawn_edition,
+                                   user,
+                                   public_explanation: public_explanation)
 
       withdrawal = withdrawn_edition.status.details
 
@@ -57,8 +64,11 @@ RSpec.describe WithdrawDocumentService do
     context "when the given edition is a draft" do
       it "raises an error" do
         draft_edition = create(:edition)
-        expect { WithdrawDocumentService.call(draft_edition, public_explanation, user) }
-          .to raise_error "attempted to withdraw an edition other than the live edition"
+        expect {
+          WithdrawDocumentService.call(draft_edition,
+                                       user,
+                                       public_explanation: public_explanation)
+        }.to raise_error "attempted to withdraw an edition other than the live edition"
       end
     end
 
@@ -70,8 +80,11 @@ RSpec.describe WithdrawDocumentService do
                               current: false,
                               document: draft_edition.document)
 
-        expect { WithdrawDocumentService.call(live_edition, public_explanation, user) }
-          .to raise_error "Publishing API does not support unpublishing while there is a draft"
+        expect {
+          WithdrawDocumentService.call(live_edition,
+                                       user,
+                                       public_explanation: public_explanation)
+        }.to raise_error "Publishing API does not support unpublishing while there is a draft"
       end
     end
 
@@ -80,7 +93,9 @@ RSpec.describe WithdrawDocumentService do
         image_revision = create(:image_revision, :on_asset_manager)
         edition = create(:edition, :published, lead_image_revision: image_revision)
         delete_request = stub_asset_manager_deletes_any_asset
-        WithdrawDocumentService.call(edition, public_explanation, user)
+        WithdrawDocumentService.call(edition,
+                                     user,
+                                     public_explanation: public_explanation)
         expect(delete_request).not_to have_been_requested
       end
     end
@@ -88,9 +103,12 @@ RSpec.describe WithdrawDocumentService do
     context "when an edition is already withdrawn and public_explanation differs" do
       it "updates public_explanation" do
         withdrawn_edition = create(:edition, :withdrawn)
-        expect { WithdrawDocumentService.call(withdrawn_edition, public_explanation, user) }
-          .to change { withdrawn_edition.reload.status.details.public_explanation }
-          .to(public_explanation)
+        expect {
+          WithdrawDocumentService.call(withdrawn_edition,
+                                       user,
+                                       public_explanation: public_explanation)
+        }.to change { withdrawn_edition.reload.status.details.public_explanation }
+         .to(public_explanation)
       end
 
       it "maintains the withdrawn timestamp" do
@@ -98,9 +116,12 @@ RSpec.describe WithdrawDocumentService do
         withdrawal = build(:withdrawal, withdrawn_at: withdrawn_at)
         withdrawn_edition = create(:edition, :withdrawn, withdrawal: withdrawal)
 
-        expect { WithdrawDocumentService.call(withdrawn_edition, public_explanation, user) }
-          .not_to change { withdrawn_edition.reload.status.details.withdrawn_at }
-          .from(withdrawn_at)
+        expect {
+          WithdrawDocumentService.call(withdrawn_edition,
+                                       user,
+                                       public_explanation: public_explanation)
+        }.not_to change { withdrawn_edition.reload.status.details.withdrawn_at }
+         .from(withdrawn_at)
       end
     end
   end


### PR DESCRIPTION
https://github.com/alphagov/content-publisher/issues/1256
https://trello.com/c/f1QaCH7x/231-our-services-directory-is-a-mess

This introduces and renames some of the arguments across a few services, in
order to increase readability at the point of use. We agree that it's not
necessary to use keyword args everywhere, as they only seem to add value
where the arguments passed are not self-explanatory:

  nil, false, true, <some_expression>

Some of the arguments renamed include:

  - GenerateBasePathService: proposed_title -> title
 - GenerateUniqueFilenameService: suggested_name -> filename
 - PublishAssetsService: live_edition -> superseded_edition

In the latter case, the previous name of the 'live_edition' argument
conflicted with the resync use case for this service, where the live
edition is passed as the first arg (and the second left blank).