### PR TITLE
Remove 'revision' param for edition checkers

### DIFF
--- a/app/interactors/content/update_interactor.rb
+++ b/app/interactors/content/update_interactor.rb
@@ -38,7 +38,7 @@ private
     issues = Requirements::CheckerIssues.new
 
     edition.document_type.contents.each do |field|
-      issues += field.pre_update_issues(edition, revision)
+      issues += field.pre_update_issues(edition)
     end
 
     context.fail!(issues: issues) if issues.any?

--- a/app/interactors/content/update_interactor.rb
+++ b/app/interactors/content/update_interactor.rb
@@ -32,6 +32,7 @@ private
     updater.assign(change_note_params)
     context.fail! unless updater.changed?
     context.revision = updater.next_revision
+    EditDraftEditionService.call(edition, user, revision: revision)
   end
 
   def check_for_issues
@@ -45,7 +46,6 @@ private
   end
 
   def update_edition
-    EditDraftEditionService.call(edition, user, revision: revision)
     edition.save!
   end
 

--- a/app/interactors/tags/update_interactor.rb
+++ b/app/interactors/tags/update_interactor.rb
@@ -31,7 +31,9 @@ private
   def update_revision
     context.revision_updater = Versioning::RevisionUpdater.new(edition.revision, user)
     revision_updater.assign(tags: update_params(edition))
+    context.fail! unless revision_updater.changed?
     context.revision = revision_updater.next_revision
+    EditDraftEditionService.call(edition, user, revision: revision)
   end
 
   def check_for_issues
@@ -41,9 +43,6 @@ private
   end
 
   def update_edition
-    context.fail! unless revision_updater.changed?
-
-    EditDraftEditionService.call(edition, user, revision: revision)
     edition.save!
   end
 

--- a/app/interactors/tags/update_interactor.rb
+++ b/app/interactors/tags/update_interactor.rb
@@ -35,9 +35,8 @@ private
   end
 
   def check_for_issues
-    checker = Requirements::TagChecker.new(edition, revision)
+    checker = Requirements::TagChecker.new(edition)
     issues = checker.pre_publish_issues
-
     context.fail!(issues: issues) if issues.any?
   end
 

--- a/app/models/document_type/body_field.rb
+++ b/app/models/document_type/body_field.rb
@@ -18,10 +18,10 @@ class DocumentType::BodyField
     { contents: { body: body } }
   end
 
-  def pre_preview_issues(edition, revision)
+  def pre_preview_issues(edition)
     issues = Requirements::CheckerIssues.new
 
-    unless GovspeakDocument.new(revision.contents[id], edition).valid?
+    unless GovspeakDocument.new(edition.contents[id], edition).valid?
       issues << Requirements::Issue.new(id, :invalid_govspeak)
     end
 
@@ -30,10 +30,10 @@ class DocumentType::BodyField
 
   alias_method :pre_update_issues, :pre_preview_issues
 
-  def pre_publish_issues(_edition, revision)
+  def pre_publish_issues(edition)
     issues = Requirements::CheckerIssues.new
 
-    if revision.contents[id].blank?
+    if edition.contents[id].blank?
       issues << Requirements::Issue.new(id, :blank)
     end
 

--- a/app/models/document_type/summary_field.rb
+++ b/app/models/document_type/summary_field.rb
@@ -16,14 +16,14 @@ class DocumentType::SummaryField
     { summary: summary }
   end
 
-  def pre_preview_issues(_edition, revision)
+  def pre_preview_issues(edition)
     issues = Requirements::CheckerIssues.new
 
-    if revision.summary.to_s.size > SUMMARY_MAX_LENGTH
+    if edition.summary.to_s.size > SUMMARY_MAX_LENGTH
       issues << Requirements::Issue.new(:summary, :too_long, max_length: SUMMARY_MAX_LENGTH)
     end
 
-    if revision.summary.to_s.lines.count > 1
+    if edition.summary.to_s.lines.count > 1
       issues << Requirements::Issue.new(:summary, :multiline)
     end
 
@@ -32,10 +32,10 @@ class DocumentType::SummaryField
 
   alias_method :pre_update_issues, :pre_preview_issues
 
-  def pre_publish_issues(_edition, revision)
+  def pre_publish_issues(edition)
     issues = Requirements::CheckerIssues.new
 
-    if revision.summary.blank?
+    if edition.summary.blank?
       issues << Requirements::Issue.new(:summary, :blank)
     end
 

--- a/app/models/document_type/title_and_base_path_field.rb
+++ b/app/models/document_type/title_and_base_path_field.rb
@@ -23,49 +23,49 @@ class DocumentType::TitleAndBasePathField
     { title: title, base_path: base_path }
   end
 
-  def pre_update_issues(edition, revision)
+  def pre_update_issues(edition)
     issues = Requirements::CheckerIssues.new
 
     begin
-      if base_path_conflict?(edition, revision)
+      if base_path_conflict?(edition)
         issues << Requirements::Issue.new(:title, :conflict)
       end
     rescue GdsApi::BaseError => e
       GovukError.notify(e)
     end
 
-    issues + pre_preview_issues(edition, revision)
+    issues + pre_preview_issues(edition)
   end
 
-  def pre_preview_issues(_edition, revision)
+  def pre_preview_issues(edition)
     issues = Requirements::CheckerIssues.new
 
-    if revision.title.blank?
+    if edition.title.blank?
       issues << Requirements::Issue.new(:title, :blank)
     end
 
-    if revision.title.to_s.size > TITLE_MAX_LENGTH
+    if edition.title.to_s.size > TITLE_MAX_LENGTH
       issues << Requirements::Issue.new(:title, :too_long, max_length: TITLE_MAX_LENGTH)
     end
 
-    if revision.title.to_s.lines.count > 1
+    if edition.title.to_s.lines.count > 1
       issues << Requirements::Issue.new(:title, :multiline)
     end
 
     issues
   end
 
-  def pre_publish_issues(_edition, _revision)
+  def pre_publish_issues(_edition)
     Requirements::CheckerIssues.new
   end
 
 private
 
-  def base_path_conflict?(edition, revision)
+  def base_path_conflict?(edition)
     return false unless edition.document_type.check_path_conflict
 
     base_path_owner = GdsApi.publishing_api.lookup_content_id(
-      base_path: revision.base_path,
+      base_path: edition.base_path,
       with_drafts: true,
       exclude_document_types: [],
       exclude_unpublishing_types: [],

--- a/lib/govspeak_document/in_app_options.rb
+++ b/lib/govspeak_document/in_app_options.rb
@@ -14,7 +14,7 @@ class GovspeakDocument::InAppOptions < GovspeakDocument::Options
 private
 
   def in_app_images
-    edition.revision.image_revisions.map(&method(:image_attributes))
+    edition.image_revisions.map(&method(:image_attributes))
   end
 
   def in_app_attachments

--- a/lib/govspeak_document/payload_options.rb
+++ b/lib/govspeak_document/payload_options.rb
@@ -16,7 +16,7 @@ class GovspeakDocument::PayloadOptions < GovspeakDocument::Options
 private
 
   def payload_images
-    edition.revision.image_revisions.map(&method(:image_attributes))
+    edition.image_revisions.map(&method(:image_attributes))
   end
 
   def payload_attachments

--- a/lib/requirements/content_checker.rb
+++ b/lib/requirements/content_checker.rb
@@ -2,18 +2,17 @@
 
 module Requirements
   class ContentChecker
-    attr_reader :edition, :revision
+    attr_reader :edition
 
-    def initialize(edition, revision = nil)
+    def initialize(edition)
       @edition = edition
-      @revision = revision || edition.revision
     end
 
     def pre_preview_issues
       issues = CheckerIssues.new
 
       edition.document_type.contents.each do |field|
-        issues += field.pre_preview_issues(edition, revision)
+        issues += field.pre_preview_issues(edition)
       end
 
       issues
@@ -23,12 +22,12 @@ module Requirements
       issues = CheckerIssues.new
 
       edition.document_type.contents.each do |field|
-        issues += field.pre_publish_issues(edition, revision)
+        issues += field.pre_publish_issues(edition)
       end
 
       if edition.document.live_edition &&
-          revision.update_type == "major" &&
-          revision.change_note.blank?
+          edition.update_type == "major" &&
+          edition.change_note.blank?
         issues << Issue.new(:change_note, :blank)
       end
 

--- a/lib/requirements/edition_checker.rb
+++ b/lib/requirements/edition_checker.rb
@@ -2,29 +2,28 @@
 
 module Requirements
   class EditionChecker
-    attr_reader :edition, :revision
+    attr_reader :edition
 
-    def initialize(edition, revision = nil)
+    def initialize(edition)
       @edition = edition
-      @revision = revision || edition.revision
     end
 
     def pre_preview_issues
       issues = CheckerIssues.new
 
-      revision.image_revisions.each do |image|
+      edition.image_revisions.each do |image|
         issues += ImageRevisionChecker.new(image).pre_preview_issues
       end
 
-      issues += ContentChecker.new(edition, revision).pre_preview_issues
+      issues += ContentChecker.new(edition).pre_preview_issues
       issues
     end
 
     def pre_publish_issues(params = {})
       issues = CheckerIssues.new
-      issues += ContentChecker.new(edition, revision).pre_publish_issues
+      issues += ContentChecker.new(edition).pre_publish_issues
       issues += TopicChecker.new(edition).pre_publish_issues(params)
-      issues += TagChecker.new(edition, revision).pre_publish_issues
+      issues += TagChecker.new(edition).pre_publish_issues
       issues
     end
   end

--- a/lib/requirements/tag_checker.rb
+++ b/lib/requirements/tag_checker.rb
@@ -2,11 +2,10 @@
 
 module Requirements
   class TagChecker
-    attr_reader :edition, :revision
+    attr_reader :edition
 
-    def initialize(edition, revision = nil)
+    def initialize(edition)
       @edition = edition
-      @revision = revision || edition.revision
     end
 
     def pre_publish_issues
@@ -27,7 +26,7 @@ module Requirements
     end
 
     def has_no_primary_org?
-      revision.primary_publishing_organisation_id.blank?
+      edition.primary_publishing_organisation_id.blank?
     end
   end
 end

--- a/spec/models/document_type/body_field_spec.rb
+++ b/spec/models/document_type/body_field_spec.rb
@@ -21,13 +21,13 @@ RSpec.describe DocumentType::BodyField do
   describe "#pre_preview_issues" do
     it "returns no issues when there are none" do
       edition = build :edition, contents: { body: "alert('hi')" }
-      issues = subject.pre_preview_issues(edition, edition.revision)
+      issues = subject.pre_preview_issues(edition)
       expect(issues).to be_empty
     end
 
     it "returns an issue if the a govspeak field contains forbidden HTML" do
       edition = build :edition, contents: { body: "<script>alert('hi')</script>" }
-      issues = subject.pre_preview_issues(edition, edition.revision)
+      issues = subject.pre_preview_issues(edition)
       expect(issues).to have_issue(:body, :invalid_govspeak, styles: %i[form summary])
     end
   end
@@ -35,13 +35,13 @@ RSpec.describe DocumentType::BodyField do
   describe "#pre_publish_issues" do
     it "returns no issues when there are none" do
       edition = build :edition, contents: { body: "alert('hi')" }
-      issues = subject.pre_publish_issues(edition, edition.revision)
+      issues = subject.pre_publish_issues(edition)
       expect(issues).to be_empty
     end
 
     it "returns an issue when the body is empty" do
       edition = build :edition, contents: { body: " " }
-      issues = subject.pre_publish_issues(edition, edition.revision)
+      issues = subject.pre_publish_issues(edition)
       expect(issues).to have_issue(:body, :blank, styles: %i[form summary])
     end
   end

--- a/spec/models/document_type/summary_field_spec.rb
+++ b/spec/models/document_type/summary_field_spec.rb
@@ -22,20 +22,20 @@ RSpec.describe DocumentType::SummaryField do
     let(:edition) { build :edition }
 
     it "returns no issues if there are none" do
-      issues = subject.pre_preview_issues(edition, edition.revision)
+      issues = subject.pre_preview_issues(edition)
       expect(issues).to be_empty
     end
 
     it "returns an issue if the summary is too long" do
       max_length = DocumentType::SummaryField::SUMMARY_MAX_LENGTH
-      revision = build :revision, summary: "a" * (max_length + 1)
-      issues = subject.pre_preview_issues(edition, revision)
+      edition = build :edition, summary: "a" * (max_length + 1)
+      issues = subject.pre_preview_issues(edition)
       expect(issues).to have_issue(:summary, :too_long, styles: %i[form summary], max_length: max_length)
     end
 
     it "returns an issue if the summary has newlines" do
-      revision = build :revision, summary: "a\nb"
-      issues = subject.pre_preview_issues(edition, revision)
+      edition = build :edition, summary: "a\nb"
+      issues = subject.pre_preview_issues(edition)
       expect(issues).to have_issue(:summary, :multiline, styles: %i[form summary])
     end
   end
@@ -44,13 +44,13 @@ RSpec.describe DocumentType::SummaryField do
     let(:edition) { build :edition, summary: "a summary" }
 
     it "returns no issues if there are none" do
-      issues = subject.pre_publish_issues(edition, edition.revision)
+      issues = subject.pre_publish_issues(edition)
       expect(issues).to be_empty
     end
 
     it "returns an issue if the summary is blank" do
-      revision = build :revision, summary: "  "
-      issues = subject.pre_publish_issues(edition, revision)
+      edition = build :edition, summary: "  "
+      issues = subject.pre_publish_issues(edition)
       expect(issues).to have_issue(:summary, :blank, styles: %i[form summary])
     end
   end

--- a/spec/models/document_type/title_and_base_path_field_spec.rb
+++ b/spec/models/document_type/title_and_base_path_field_spec.rb
@@ -28,28 +28,26 @@ RSpec.describe DocumentType::TitleAndBasePathField do
     let(:edition) { build :edition }
 
     it "returns no issues if there are none" do
-      issues = subject.pre_preview_issues(edition, edition.revision)
+      issues = subject.pre_preview_issues(edition)
       expect(issues).to be_empty
     end
 
     it "returns an issue if there is no title" do
-      revision = build :revision, title: nil
-      issues = subject.pre_preview_issues(edition, revision)
+      edition = build :edition, title: nil
+      issues = subject.pre_preview_issues(edition)
       expect(issues).to have_issue(:title, :blank, styles: %i[form summary])
     end
 
     it "returns an issue if the title is too long" do
-      edition = build :edition
       max_length = DocumentType::TitleAndBasePathField::TITLE_MAX_LENGTH
-      revision = build :revision, title: "a" * (max_length + 1)
-      issues = subject.pre_preview_issues(edition, revision)
+      edition = build :edition, title: "a" * (max_length + 1)
+      issues = subject.pre_preview_issues(edition)
       expect(issues).to have_issue(:title, :too_long, styles: %i[form summary], max_length: max_length)
     end
 
     it "returns an issue if the title has newlines" do
-      edition = build :edition
-      revision = build :revision, title: "a\nb"
-      issues = subject.pre_preview_issues(edition, revision)
+      edition = build :edition, title: "a\nb"
+      issues = subject.pre_preview_issues(edition)
       expect(issues).to have_issue(:title, :multiline, styles: %i[form summary])
     end
   end
@@ -64,31 +62,31 @@ RSpec.describe DocumentType::TitleAndBasePathField do
     end
 
     it "returns no issues if there are none" do
-      issues = subject.pre_update_issues(edition, edition.revision)
+      issues = subject.pre_update_issues(edition)
       expect(issues).to be_empty
     end
 
     it "returns any pre_preview_issues" do
-      revision = build :revision, title: nil
-      issues = subject.pre_update_issues(edition, revision)
+      edition = build :edition, title: nil
+      issues = subject.pre_update_issues(edition)
       expect(issues).to have_issue(:title, :blank, styles: %i[form summary])
     end
 
     it "returns no issues if the document owns the path" do
       stub_publishing_api_has_lookups(edition.base_path => edition.content_id)
-      issues = subject.pre_update_issues(edition, edition.revision)
+      issues = subject.pre_update_issues(edition)
       expect(issues).to be_empty
     end
 
     it "returns an issue if the base_path conflicts" do
       stub_publishing_api_has_lookups(edition.base_path => SecureRandom.uuid)
-      issues = subject.pre_update_issues(edition, edition.revision)
+      issues = subject.pre_update_issues(edition)
       expect(issues).to have_issue(:title, :conflict, styles: %i[form summary])
     end
 
     it "returns no issues when the Publishing API is down" do
       stub_publishing_api_isnt_available
-      issues = subject.pre_update_issues(edition, edition.revision)
+      issues = subject.pre_update_issues(edition)
       expect(issues.items_for(:title)).to be_empty
     end
   end
@@ -96,7 +94,7 @@ RSpec.describe DocumentType::TitleAndBasePathField do
   describe "#pre_publish_issues" do
     it "returns no issues" do
       edition = build :edition
-      issues = subject.pre_update_issues(edition, edition.revision)
+      issues = subject.pre_update_issues(edition)
       expect(issues).to be_empty
     end
   end

--- a/spec/requests/tags_spec.rb
+++ b/spec/requests/tags_spec.rb
@@ -51,7 +51,11 @@ RSpec.describe "Tags" do
        "organisation is not selected" do
       tag_field = build(:tag_field, :primary_publishing_organisation)
       document_type = build(:document_type, tags: [tag_field])
-      edition = create(:edition, document_type_id: document_type.id)
+
+      edition = create(:edition,
+                       document_type_id: document_type.id,
+                       tags: { primary_publishing_organisation_ids: %w(id) })
+
       stub_publishing_api_has_linkables(
         [{ "content_id" => SecureRandom.uuid, "internal_name" => "Organisation" }],
         document_type: tag_field.document_type,


### PR DESCRIPTION
https://trello.com/c/u9kRKVsX/1324-extract-title-and-summary-into-classes-views-and-config

Previously we passed the 'edition' and the 'revision' between checkers for
requirements issues, often defaulting the 'revision' to the current one for
the edition. Having both objects available lead to confusion about which to
use to access data, and was originally because the revision had updated
data and was not (yet) assigned to the edition.