### PR TITLE
Add CheckerIssues.create helper method

### DIFF
--- a/app/interactors/contact_embed/create_interactor.rb
+++ b/app/interactors/contact_embed/create_interactor.rb
@@ -20,13 +20,9 @@ private
   end
 
   def check_for_issues
-    return if params[:contact_id].present?
-
-    issues = Requirements::CheckerIssues.new([
-      Requirements::Issue.new(:contact_embed, :blank),
-    ])
-
-    context.fail!(issues: issues)
+    issues = Requirements::CheckerIssues.new
+    issues.create(:contact_embed, :blank) if params[:contact_id].blank?
+    context.fail!(issues: issues) if issues.any?
   end
 
   def generate_markdown_code

--- a/app/interactors/new_document/choose_supertype_interactor.rb
+++ b/app/interactors/new_document/choose_supertype_interactor.rb
@@ -14,18 +14,12 @@ class NewDocument::ChooseSupertypeInteractor < ApplicationInteractor
 private
 
   def check_for_issues
-    return if params[:supertype].present?
-
-    context.fail!(issues: supertype_issues)
+    issues = Requirements::CheckerIssues.new
+    issues.create(:supertype, :not_selected) if params[:supertype].blank?
+    context.fail!(issues: issues) if issues.any?
   end
 
   def find_supertype
     context.supertype = Supertype.find(params[:supertype])
-  end
-
-  def supertype_issues
-    Requirements::CheckerIssues.new([
-      Requirements::Issue.new(:supertype, :not_selected),
-    ])
   end
 end

--- a/app/interactors/new_document/create_interactor.rb
+++ b/app/interactors/new_document/create_interactor.rb
@@ -24,9 +24,9 @@ private
   end
 
   def check_for_issues
-    return if params[:document_type].present?
-
-    context.fail!(issues: document_type_issues)
+    issues = Requirements::CheckerIssues.new
+    issues.create(:document_type, :not_selected) if params[:document_type].blank?
+    context.fail!(issues: issues) if issues.any?
   end
 
   def find_document_type
@@ -46,12 +46,6 @@ private
   def create_timeline_entry
     TimelineEntry.create_for_status_change(entry_type: :created,
                                            status: document.current_edition.status)
-  end
-
-  def document_type_issues
-    Requirements::CheckerIssues.new([
-      Requirements::Issue.new(:document_type, :not_selected),
-    ])
   end
 
   def default_tags

--- a/app/interactors/publish/publish_interactor.rb
+++ b/app/interactors/publish/publish_interactor.rb
@@ -32,13 +32,9 @@ private
   end
 
   def check_for_issues
-    return if params[:review_status].present?
-
-    issues = Requirements::CheckerIssues.new([
-      Requirements::Issue.new(:review_status, :not_selected),
-    ])
-
-    context.fail!(issues: issues)
+    issues = Requirements::CheckerIssues.new
+    issues.create(:review_status, :not_selected) if params[:review_status].blank?
+    context.fail!(issues: issues) if issues.any?
   end
 
   def with_review?

--- a/app/interactors/schedule/create_interactor.rb
+++ b/app/interactors/schedule/create_interactor.rb
@@ -33,13 +33,9 @@ private
   end
 
   def check_for_issues
-    if params[:review_status].blank?
-      issues = Requirements::CheckerIssues.new([
-        Requirements::Issue.new(:schedule_review_status, :not_selected),
-      ])
-    end
-
-    context.fail!(issues: issues) if issues
+    issues = Requirements::CheckerIssues.new
+    issues.create(:schedule_review_status, :not_selected) if params[:review_status].blank?
+    context.fail!(issues: issues) if issues.any?
   end
 
   def schedule_to_publish

--- a/app/interactors/schedule_proposal/update_interactor.rb
+++ b/app/interactors/schedule_proposal/update_interactor.rb
@@ -34,11 +34,9 @@ private
   end
 
   def check_for_issues
-    checker = Requirements::PublishTimeChecker.new(publish_time)
-    issues = checker.issues.to_a
+    issues = Requirements::PublishTimeChecker.new(publish_time).issues
     issues += action_issues if params[:wizard] == "schedule"
-
-    context.fail!(issues: Requirements::CheckerIssues.new(issues)) if issues.any?
+    context.fail!(issues: issues) if issues.any?
   end
 
   def update_edition
@@ -53,9 +51,9 @@ private
   end
 
   def action_issues
-    return [] if schedule_params[:action].present?
-
-    [Requirements::Issue.new(:schedule_action, :not_selected)]
+    issues = Requirements::CheckerIssues.new
+    issues.create(:schedule_action, :not_selected) if schedule_params[:action].blank?
+    issues
   end
 
   def schedule_params

--- a/app/models/document_type/body_field.rb
+++ b/app/models/document_type/body_field.rb
@@ -22,7 +22,7 @@ class DocumentType::BodyField
     issues = Requirements::CheckerIssues.new
 
     unless GovspeakDocument.new(revision.contents[id], edition).valid?
-      issues << Requirements::Issue.new(id, :invalid_govspeak)
+      issues.create(id, :invalid_govspeak)
     end
 
     issues
@@ -32,11 +32,7 @@ class DocumentType::BodyField
 
   def pre_publish_issues(_edition, revision)
     issues = Requirements::CheckerIssues.new
-
-    if revision.contents[id].blank?
-      issues << Requirements::Issue.new(id, :blank)
-    end
-
+    issues.create(id, :blank) if revision.contents[id].blank?
     issues
   end
 end

--- a/app/models/document_type/summary_field.rb
+++ b/app/models/document_type/summary_field.rb
@@ -20,11 +20,11 @@ class DocumentType::SummaryField
     issues = Requirements::CheckerIssues.new
 
     if revision.summary.to_s.size > SUMMARY_MAX_LENGTH
-      issues << Requirements::Issue.new(:summary, :too_long, max_length: SUMMARY_MAX_LENGTH)
+      issues.create(:summary, :too_long, max_length: SUMMARY_MAX_LENGTH)
     end
 
     if revision.summary.to_s.lines.count > 1
-      issues << Requirements::Issue.new(:summary, :multiline)
+      issues.create(:summary, :multiline)
     end
 
     issues
@@ -34,11 +34,7 @@ class DocumentType::SummaryField
 
   def pre_publish_issues(_edition, revision)
     issues = Requirements::CheckerIssues.new
-
-    if revision.summary.blank?
-      issues << Requirements::Issue.new(:summary, :blank)
-    end
-
+    issues.create(:summary, :blank) if revision.summary.blank?
     issues
   end
 end

--- a/app/models/document_type/title_and_base_path_field.rb
+++ b/app/models/document_type/title_and_base_path_field.rb
@@ -28,7 +28,7 @@ class DocumentType::TitleAndBasePathField
 
     begin
       if base_path_conflict?(edition, revision)
-        issues << Requirements::Issue.new(:title, :conflict)
+        issues.create(:title, :conflict)
       end
     rescue GdsApi::BaseError => e
       GovukError.notify(e)
@@ -41,15 +41,15 @@ class DocumentType::TitleAndBasePathField
     issues = Requirements::CheckerIssues.new
 
     if revision.title.blank?
-      issues << Requirements::Issue.new(:title, :blank)
+      issues.create(:title, :blank)
     end
 
     if revision.title.to_s.size > TITLE_MAX_LENGTH
-      issues << Requirements::Issue.new(:title, :too_long, max_length: TITLE_MAX_LENGTH)
+      issues.create(:title, :too_long, max_length: TITLE_MAX_LENGTH)
     end
 
     if revision.title.to_s.lines.count > 1
-      issues << Requirements::Issue.new(:title, :multiline)
+      issues.create(:title, :multiline)
     end
 
     issues

--- a/lib/requirements/access_limit_checker.rb
+++ b/lib/requirements/access_limit_checker.rb
@@ -14,17 +14,17 @@ module Requirements
       return issues if edition.access_limit.nil?
 
       if user.organisation_content_id.blank?
-        issues << Issue.new(:access_limit, :user_has_no_org)
+        issues.create(:access_limit, :user_has_no_org)
         return issues
       end
 
       if edition.primary_publishing_organisation_id.blank?
-        issues << Issue.new(:access_limit, :no_primary_org)
+        issues.create(:access_limit, :no_primary_org)
         return issues
       end
 
       if user_is_not_in_access_limit_orgs?
-        issues << Issue.new(:access_limit, :not_in_orgs)
+        issues.create(:access_limit, :not_in_orgs)
       end
 
       issues

--- a/lib/requirements/backdate_checker.rb
+++ b/lib/requirements/backdate_checker.rb
@@ -12,12 +12,12 @@ module Requirements
       issues = CheckerIssues.new
 
       if in_the_future?
-        issues << Issue.new(:backdate_date, :in_the_future)
+        issues.create(:backdate_date, :in_the_future)
       end
 
       if too_long_ago?
         date = EARLIEST_DATE.strftime("%-d %B %Y")
-        issues << Issue.new(:backdate_date, :too_long_ago, date: date)
+        issues.create(:backdate_date, :too_long_ago, date: date)
       end
 
       issues

--- a/lib/requirements/checker_issues.rb
+++ b/lib/requirements/checker_issues.rb
@@ -15,6 +15,10 @@ module Requirements
       CheckerIssues.new(issues + other.issues)
     end
 
+    def create(*args, **params)
+      self << Issue.new(*args, **params)
+    end
+
     def items(params = {})
       map { |issue| issue.to_item(**issue_item_params(issue, params)) }
     end

--- a/lib/requirements/content_checker.rb
+++ b/lib/requirements/content_checker.rb
@@ -29,7 +29,7 @@ module Requirements
       if edition.document.live_edition &&
           revision.update_type == "major" &&
           revision.change_note.blank?
-        issues << Issue.new(:change_note, :blank)
+        issues.create(:change_note, :blank)
       end
 
       issues

--- a/lib/requirements/file_attachment_checker.rb
+++ b/lib/requirements/file_attachment_checker.rb
@@ -74,13 +74,13 @@ module Requirements
       issues = CheckerIssues.new
 
       if title.blank?
-        issues << Issue.new(:file_attachment_title, :blank)
+        issues.create(:file_attachment_title, :blank)
       end
 
       if title.to_s.size > TITLE_MAX_LENGTH
-        issues << Issue.new(:file_attachment_title,
-                            :too_long,
-                            max_length: TITLE_MAX_LENGTH)
+        issues.create(:file_attachment_title,
+                      :too_long,
+                      max_length: TITLE_MAX_LENGTH)
       end
 
       issues
@@ -90,17 +90,17 @@ module Requirements
       issues = CheckerIssues.new
 
       unless file
-        issues << Issue.new(:file_attachment_upload, :no_file)
+        issues.create(:file_attachment_upload, :no_file)
         return issues
       end
 
       if invalid_zip?
-        issues << Issue.new(:file_attachment_upload, :zip_unsupported_type)
+        issues.create(:file_attachment_upload, :zip_unsupported_type)
         return issues
       end
 
       if unsupported_type?
-        issues << Issue.new(:file_attachment_upload, :unsupported_type)
+        issues.create(:file_attachment_upload, :unsupported_type)
       end
 
       issues

--- a/lib/requirements/image_revision_checker.rb
+++ b/lib/requirements/image_revision_checker.rb
@@ -16,34 +16,34 @@ module Requirements
       issues = CheckerIssues.new
 
       if image_revision.alt_text.blank?
-        issues << Issue.new(:alt_text,
-                            :blank,
-                            filename: image_revision.filename,
-                            image_revision: image_revision)
+        issues.create(:alt_text,
+                      :blank,
+                      filename: image_revision.filename,
+                      image_revision: image_revision)
       end
 
       if image_revision.alt_text.to_s.length > ALT_TEXT_MAX_LENGTH
-        issues << Issue.new(:alt_text,
-                            :too_long,
-                            max_length: ALT_TEXT_MAX_LENGTH,
-                            filename: image_revision.filename,
-                            image_revision: image_revision)
+        issues.create(:alt_text,
+                      :too_long,
+                      max_length: ALT_TEXT_MAX_LENGTH,
+                      filename: image_revision.filename,
+                      image_revision: image_revision)
       end
 
       if image_revision.caption.to_s.length > CAPTION_MAX_LENGTH
-        issues << Issue.new(:caption,
-                            :too_long,
-                            max_length: CAPTION_MAX_LENGTH,
-                            filename: image_revision.filename,
-                            image_revision: image_revision)
+        issues.create(:caption,
+                      :too_long,
+                      max_length: CAPTION_MAX_LENGTH,
+                      filename: image_revision.filename,
+                      image_revision: image_revision)
       end
 
       if image_revision.credit.to_s.length > CREDIT_MAX_LENGTH
-        issues << Issue.new(:credit,
-                            :too_long,
-                            max_length: CREDIT_MAX_LENGTH,
-                            filename: image_revision.filename,
-                            image_revision: image_revision)
+        issues.create(:credit,
+                      :too_long,
+                      max_length: CREDIT_MAX_LENGTH,
+                      filename: image_revision.filename,
+                      image_revision: image_revision)
       end
 
       issues

--- a/lib/requirements/image_upload_checker.rb
+++ b/lib/requirements/image_upload_checker.rb
@@ -19,17 +19,19 @@ module Requirements
       issues = CheckerIssues.new
 
       unless file
-        issues << Issue.new(:image_upload, :no_file)
-        return CheckerIssues.new(issues)
+        issues.create(:image_upload, :no_file)
+        return issues
       end
 
       if unsupported_type?
-        issues << Issue.new(:image_upload, :unsupported_type)
-        return CheckerIssues.new(issues)
+        issues.create(:image_upload, :unsupported_type)
+        return issues
       end
 
       if file.size >= MAX_FILE_SIZE
-        issues << Issue.new(:image_upload, :too_big, max_size: number_to_human_size(MAX_FILE_SIZE))
+        issues.create(:image_upload,
+                      :too_big,
+                      max_size: number_to_human_size(MAX_FILE_SIZE))
       end
 
       issues

--- a/lib/requirements/publish_time_checker.rb
+++ b/lib/requirements/publish_time_checker.rb
@@ -17,20 +17,20 @@ module Requirements
       issues = CheckerIssues.new
 
       if publish_time > MAX_PUBLISH_DELAY.from_now
-        issues << Issue.new(:schedule_date,
-                            :too_far_in_future,
-                            time_period: MAX_PUBLISH_DELAY.inspect)
+        issues.create(:schedule_date,
+                      :too_far_in_future,
+                      time_period: MAX_PUBLISH_DELAY.inspect)
       end
 
       if publish_time > Time.current && publish_time < MIN_PUBLISH_DELAY.from_now
-        issues << Issue.new(:schedule_time,
-                            :too_close_to_now,
-                            time_period: MIN_PUBLISH_DELAY.inspect)
+        issues.create(:schedule_time,
+                      :too_close_to_now,
+                      time_period: MIN_PUBLISH_DELAY.inspect)
       end
 
       if publish_time < Time.current
         field = publish_time.today? ? :schedule_time : :schedule_date
-        issues << Issue.new(field, :in_the_past)
+        issues.create(field, :in_the_past)
       end
 
       issues

--- a/lib/requirements/tag_checker.rb
+++ b/lib/requirements/tag_checker.rb
@@ -13,7 +13,7 @@ module Requirements
       issues = CheckerIssues.new
 
       if should_have_primary_org? && has_no_primary_org?
-        issues << Issue.new(:primary_publishing_organisation, :blank)
+        issues.create(:primary_publishing_organisation, :blank)
       end
 
       issues

--- a/lib/requirements/topic_checker.rb
+++ b/lib/requirements/topic_checker.rb
@@ -13,7 +13,7 @@ module Requirements
 
       begin
         if edition.document_type.topics && edition.topics.none?
-          issues << Issue.new(:topics, :none)
+          issues.create(:topics, :none)
         end
       rescue GdsApi::BaseError => e
         GovukError.notify(e) if rescue_api_errors

--- a/lib/requirements/video_embed_checker.rb
+++ b/lib/requirements/video_embed_checker.rb
@@ -9,13 +9,13 @@ module Requirements
       issues = CheckerIssues.new
 
       if title.blank?
-        issues << Issue.new(:video_embed_title, :blank)
+        issues.create(:video_embed_title, :blank)
       end
 
       if url.blank?
-        issues << Issue.new(:video_embed_url, :blank)
+        issues.create(:video_embed_url, :blank)
       elsif !youtube_url?(url)
-        issues << Issue.new(:video_embed_url, :non_youtube)
+        issues.create(:video_embed_url, :non_youtube)
       end
 
       issues

--- a/lib/requirements/withdrawal_checker.rb
+++ b/lib/requirements/withdrawal_checker.rb
@@ -13,11 +13,11 @@ module Requirements
       issues = CheckerIssues.new
 
       if public_explanation.blank?
-        issues << Issue.new(:public_explanation, :blank)
+        issues.create(:public_explanation, :blank)
       end
 
       unless GovspeakDocument.new(public_explanation, edition).valid?
-        issues << Issue.new(:public_explanation, :invalid_govspeak)
+        issues.create(:public_explanation, :invalid_govspeak)
       end
 
       issues

--- a/spec/interactors/file_attachments/create_interactor_spec.rb
+++ b/spec/interactors/file_attachments/create_interactor_spec.rb
@@ -81,14 +81,13 @@ RSpec.describe FileAttachments::CreateInteractor do
 
     context "when the uploaded file has issues" do
       it "fails with issues returned" do
-        issue = Requirements::Issue.new("file", "example")
         allow(Requirements::FileAttachmentChecker)
-          .to receive(:new).and_return(double(pre_upload_issues: [issue]))
+          .to receive(:new).and_return(double(pre_upload_issues: %w(issue)))
 
         result = FileAttachments::CreateInteractor.call(**args)
 
         expect(result).to be_failure
-        expect(result.issues).to match([issue])
+        expect(result.issues).to eq %w(issue)
       end
     end
   end

--- a/spec/interactors/images/create_interactor_spec.rb
+++ b/spec/interactors/images/create_interactor_spec.rb
@@ -89,15 +89,14 @@ RSpec.describe Images::CreateInteractor do
 
     context "when the image normaliser finds issues" do
       it "fails with issues returned" do
-        issue = Requirements::Issue.new("image", "example")
         allow(ImageNormaliser)
           .to receive(:new)
-          .and_return(double(normalise: nil, issues: [issue]))
+          .and_return(double(normalise: nil, issues: %w(issue)))
 
         result = Images::CreateInteractor.call(**args)
 
         expect(result).to be_failure
-        expect(result.issues).to match([issue])
+        expect(result.issues).to match(%w(issue))
       end
     end
   end

--- a/spec/lib/requirements/content_checker_spec.rb
+++ b/spec/lib/requirements/content_checker_spec.rb
@@ -9,13 +9,12 @@ RSpec.describe Requirements::ContentChecker do
     end
 
     it "delegates to return issues with content fields" do
-      issues = Requirements::CheckerIssues.new
-      issues.create(:body, :blank)
+      issues = Requirements::CheckerIssues.new(%w(issue))
       body_field = double(:body_field, pre_preview_issues: issues)
       document_type = build :document_type, contents: [body_field]
       edition = build :edition, document_type_id: document_type.id
       issues = Requirements::ContentChecker.new(edition).pre_preview_issues
-      expect(issues).to have_issue(:body, :blank, styles: %i[form summary])
+      expect(issues).to eq issues
     end
   end
 
@@ -27,13 +26,12 @@ RSpec.describe Requirements::ContentChecker do
     end
 
     it "delegates to return issues with content fields" do
-      issues = Requirements::CheckerIssues.new
-      issues.create(:body, :blank)
+      issues = Requirements::CheckerIssues.new(%w(issue))
       body_field = double(:body_field, pre_publish_issues: issues)
       document_type = build :document_type, contents: [body_field]
       edition = build :edition, document_type_id: document_type.id
       issues = Requirements::ContentChecker.new(edition).pre_publish_issues
-      expect(issues).to have_issue(:body, :blank, styles: %i[form summary])
+      expect(issues).to eq issues
     end
 
     it "returns an issue if a major change note is blank" do

--- a/spec/lib/requirements/content_checker_spec.rb
+++ b/spec/lib/requirements/content_checker_spec.rb
@@ -10,7 +10,7 @@ RSpec.describe Requirements::ContentChecker do
 
     it "delegates to return issues with content fields" do
       issues = Requirements::CheckerIssues.new
-      issues << Requirements::Issue.new(:body, :blank)
+      issues.create(:body, :blank)
       body_field = double(:body_field, pre_preview_issues: issues)
       document_type = build :document_type, contents: [body_field]
       edition = build :edition, document_type_id: document_type.id
@@ -28,7 +28,7 @@ RSpec.describe Requirements::ContentChecker do
 
     it "delegates to return issues with content fields" do
       issues = Requirements::CheckerIssues.new
-      issues << Requirements::Issue.new(:body, :blank)
+      issues.create(:body, :blank)
       body_field = double(:body_field, pre_publish_issues: issues)
       document_type = build :document_type, contents: [body_field]
       edition = build :edition, document_type_id: document_type.id


### PR DESCRIPTION
https://trello.com/c/u9kRKVsX/1324-extract-title-and-summary-into-classes-views-and-config

Previously the syntax to add an issue was quite verbose, especially when
used outside of the Requirements namespace. This introduces a
'create' method to replace '<< Issue.new' everywhere.

Please see the commits for more details.