### PR TITLE
Fix users_ids bug

### DIFF
--- a/lib/whitehall_importer/create_edition.rb
+++ b/lib/whitehall_importer/create_edition.rb
@@ -201,7 +201,7 @@ module WhitehallImporter
         }
         details = create_whitehall_imported_entry("internal_note", contents)
         create_timeline_entry(details,
-                              edition, event["created_at"], event["author_id"])
+                              edition, event["created_at"], user_ids[event["author_id"]])
       end
     end
 
@@ -219,7 +219,7 @@ module WhitehallImporter
       }
       details = create_whitehall_imported_entry("fact_check_request", contents)
       create_timeline_entry(details,
-                            edition, event["created_at"], event["requestor_id"])
+                            edition, event["created_at"], user_ids[event["requestor_id"]])
     end
 
     def create_fact_check_response(edition, event)

--- a/spec/lib/whitehall_importer/create_edition_spec.rb
+++ b/spec/lib/whitehall_importer/create_edition_spec.rb
@@ -140,7 +140,7 @@ RSpec.describe WhitehallImporter::CreateEdition do
 
       it "imports an editorial remark event" do
         event = build(:whitehall_export_editorial_remark_event,
-                      author_id: user.id,
+                      author_id: whitehall_user_id,
                       body: "Another note",
                       created_at: 1.day.ago.noon)
         whitehall_edition = build(:whitehall_export_edition,
@@ -161,7 +161,7 @@ RSpec.describe WhitehallImporter::CreateEdition do
 
       it "imports a fact check request event" do
         event = build(:whitehall_export_fact_check_event,
-                      requestor_id: user.id,
+                      requestor_id: whitehall_user_id,
                       email_address: "someone@somewhere.com",
                       instructions: "Do something",
                       comments: nil,


### PR DESCRIPTION
There was a bug introduced which meant that when we are importing notes
and editorial remarks for an edition the wrong id is being used to
create the corresponding timeline_entry which was generating
ActiveRecord::InvalidForeignKey: PG::ForeignKeyViolation: ERROR.

We're now using content-publishers user_id instead of whitehall's
local user_id.

Trello:
https://trello.com/c/xZ1B5yf4/1414-investigate-why-draft-with-rejected-status-is-not-exported