### PR TITLE
Update use of user_ids and centralise lookup for consistency

### DIFF
--- a/lib/whitehall_importer/create_edition.rb
+++ b/lib/whitehall_importer/create_edition.rb
@@ -190,7 +190,7 @@ module WhitehallImporter
         create_timeline_entry(details,
                               edition,
                               event["created_at"],
-                              user_ids[event["whodunnit"]])
+                              event["whodunnit"])
       end
     end
 
@@ -238,10 +238,10 @@ module WhitehallImporter
       )
     end
 
-    def create_timeline_entry(details, edition, created_at, created_by = nil)
+    def create_timeline_entry(details, edition, created_at, whitehall_created_by_id = nil)
       TimelineEntry.create!(
         entry_type: :whitehall_migration,
-        created_by_id: created_by,
+        created_by_id: user_ids[whitehall_created_by_id],
         created_at: created_at,
         edition: edition,
         document: edition.document,

--- a/spec/lib/whitehall_importer/create_edition_spec.rb
+++ b/spec/lib/whitehall_importer/create_edition_spec.rb
@@ -90,9 +90,9 @@ RSpec.describe WhitehallImporter::CreateEdition do
     end
 
     context "has editorial remarks" do
-      let(:user) { create(:user) }
+      let(:content_publisher_user) { create(:user) }
       let(:whitehall_user_id) { rand(100) }
-      let(:user_ids) { { whitehall_user_id => user.id } }
+      let(:user_ids) { { whitehall_user_id => content_publisher_user.id } }
       let(:create_event) do
         build(:whitehall_export_revision_history_event,
               event: "create",
@@ -109,7 +109,7 @@ RSpec.describe WhitehallImporter::CreateEdition do
         timeline_entry = edition.timeline_entries.first
         expect(timeline_entry.attributes)
           .to match a_hash_including("entry_type" => "whitehall_migration",
-                                     "created_by_id" => user.id,
+                                     "created_by_id" => content_publisher_user.id,
                                      "created_at" => 1.week.ago.noon)
         expect(timeline_entry.details.attributes)
           .to match a_hash_including("entry_type" => "first_created",
@@ -131,7 +131,7 @@ RSpec.describe WhitehallImporter::CreateEdition do
         timeline_entry = edition.timeline_entries.order(:created_at).last
         expect(timeline_entry.attributes)
           .to match a_hash_including("entry_type" => "whitehall_migration",
-                                     "created_by_id" => user.id,
+                                     "created_by_id" => content_publisher_user.id,
                                      "created_at" => 1.day.ago.noon)
         expect(timeline_entry.details.attributes)
           .to match a_hash_including("entry_type" => "published",
@@ -140,7 +140,7 @@ RSpec.describe WhitehallImporter::CreateEdition do
 
       it "imports an editorial remark event" do
         event = build(:whitehall_export_editorial_remark_event,
-                      author_id: user.id,
+                      author_id: whitehall_user_id,
                       body: "Another note",
                       created_at: 1.day.ago.noon)
         whitehall_edition = build(:whitehall_export_edition,
@@ -152,7 +152,7 @@ RSpec.describe WhitehallImporter::CreateEdition do
         timeline_entry = edition.timeline_entries.order(:created_at).last
         expect(timeline_entry.attributes)
           .to match a_hash_including("entry_type" => "whitehall_migration",
-                                     "created_by_id" => user.id,
+                                     "created_by_id" => content_publisher_user.id,
                                      "created_at" => 1.day.ago.noon)
         expect(timeline_entry.details.attributes)
           .to match a_hash_including("entry_type" => "internal_note",
@@ -161,7 +161,7 @@ RSpec.describe WhitehallImporter::CreateEdition do
 
       it "imports a fact check request event" do
         event = build(:whitehall_export_fact_check_event,
-                      requestor_id: user.id,
+                      requestor_id: whitehall_user_id,
                       email_address: "someone@somewhere.com",
                       instructions: "Do something",
                       comments: nil,
@@ -175,7 +175,7 @@ RSpec.describe WhitehallImporter::CreateEdition do
         timeline_entry = edition.timeline_entries.order(:created_at).last
         expect(timeline_entry.attributes)
           .to match a_hash_including("entry_type" => "whitehall_migration",
-                                     "created_by_id" => user.id,
+                                     "created_by_id" => content_publisher_user.id,
                                      "created_at" => 1.day.ago.noon)
         expect(timeline_entry.details.attributes)
           .to match a_hash_including("entry_type" => "fact_check_request",
@@ -189,7 +189,7 @@ RSpec.describe WhitehallImporter::CreateEdition do
       it "imports a fact check response event" do
         response_received_at = 1.day.ago.noon
         event = build(:whitehall_export_fact_check_event,
-                      requestor_id: user.id,
+                      requestor_id: whitehall_user_id,
                       email_address: "someone@somewhere.com",
                       comments: "Hello World",
                       created_at: 2.days.ago.noon,


### PR DESCRIPTION
The 'user_ids' hash is constructed by mapping a Whitehall user id to the same user's id in Content Publisher via their uid.  

For example:
- Fred Flintstone has a uid of `dce8e3a3-2872-4d45-848e-d1012d8cfd89` in both Whitehall and Content Publisher.  

- In Whitehall their id `615` and in Content Publisher it is `27`.  

The resulting hash to map this user would then be `{ 615 => 27 }`. _Note that the key is the Whitehall user id._
    
On migration the users from the various time line entries from Whitehall need to be mapped to their Content Publisher equivalent in order to avoid miss-matched or nil user id's on migration.
    
This change ensures that the mapping between Whitehall and Content Publisher user is done in one place: inside the `create_timeline_entry` method, and that all user id's passed into that method are Whitehall user ids.
    
The appropriate method parameter has also been renamed for clarity and the tests have been updated to clarify the expectation that a time line entry from Whitehall by a given user is mapped to the correct Content Publisher user when the entry has been migrated.

Related to Trello: https://trello.com/c/xZ1B5yf4/1414-investigate-why-draft-with-rejected-status-is-not-exported
