### PR TITLE
Try a few things to make our JS features faster

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -5,6 +5,7 @@ class ApplicationController < ActionController::Base
   include EditionAssertions
 
   helper_method :rendering_context
+  layout -> { rendering_context }
 
   before_action :authenticate_user!
   before_action { Raven.user_context(id: current_user&.uid) }

--- a/app/controllers/contact_embed_controller.rb
+++ b/app/controllers/contact_embed_controller.rb
@@ -3,12 +3,11 @@
 class ContactEmbedController < ApplicationController
   rescue_from GdsApi::BaseError do |e|
     GovukError.notify(e)
-    render "new_api_down", layout: rendering_context, status: :service_unavailable
+    render "new_api_down", status: :service_unavailable
   end
 
   def new
     @edition = Edition.find_current(document: params[:document])
-    render layout: rendering_context
   end
 
   def create
@@ -23,7 +22,6 @@ class ContactEmbedController < ApplicationController
 
       render :new,
              assigns: { edition: edition, issues: issues },
-             layout: rendering_context,
              status: :unprocessable_entity
     elsif rendering_context == "modal"
       render plain: markdown_code

--- a/app/controllers/file_attachments_controller.rb
+++ b/app/controllers/file_attachments_controller.rb
@@ -6,7 +6,6 @@ class FileAttachmentsController < ApplicationController
   def index
     @edition = Edition.find_current(document: params[:document])
     assert_edition_state(@edition, &:editable?)
-    render layout: rendering_context
   end
 
   def show
@@ -15,8 +14,6 @@ class FileAttachmentsController < ApplicationController
 
     @attachment = @edition.file_attachment_revisions
       .find_by!(file_attachment_id: params[:file_attachment_id])
-
-    render layout: rendering_context
   end
 
   def preview
@@ -51,7 +48,6 @@ class FileAttachmentsController < ApplicationController
       render :index,
              assigns: { edition: edition,
                         issues: issues },
-             layout: rendering_context,
              status: :unprocessable_entity
     else
       redirect_to file_attachment_path(edition.document, attachment_revision.file_attachment)
@@ -73,8 +69,6 @@ class FileAttachmentsController < ApplicationController
 
     @attachment = @edition.file_attachment_revisions
       .find_by!(file_attachment_id: params[:file_attachment_id])
-
-    render layout: rendering_context
   end
 
   def update
@@ -97,7 +91,6 @@ class FileAttachmentsController < ApplicationController
              assigns: { edition: edition,
                         issues: issues,
                         attachment: attachment_revision },
-             layout: rendering_context,
              status: :unprocessable_entity
     elsif unchanged
       redirect_to file_attachments_path(edition.document)

--- a/app/controllers/images_controller.rb
+++ b/app/controllers/images_controller.rb
@@ -4,7 +4,6 @@ class ImagesController < ApplicationController
   def index
     @edition = Edition.find_current(document: params[:document])
     assert_edition_state(@edition, &:editable?)
-    render layout: rendering_context
   end
 
   def create
@@ -18,7 +17,6 @@ class ImagesController < ApplicationController
 
       render :index,
              assigns: { edition: edition },
-             layout: rendering_context,
              status: :unprocessable_entity
     else
       redirect_to crop_image_path(params[:document],
@@ -31,7 +29,6 @@ class ImagesController < ApplicationController
     @edition = Edition.find_current(document: params[:document])
     assert_edition_state(@edition, &:editable?)
     @image_revision = @edition.image_revisions.find_by!(image_id: params[:image_id])
-    render layout: rendering_context
   end
 
   def update_crop
@@ -51,7 +48,6 @@ class ImagesController < ApplicationController
     @edition = Edition.find_current(document: params[:document])
     assert_edition_state(@edition, &:editable?)
     @image_revision = @edition.image_revisions.find_by!(image_id: params[:image_id])
-    render layout: rendering_context
   end
 
   def update
@@ -70,7 +66,6 @@ class ImagesController < ApplicationController
              assigns: { edition: edition,
                         image_revision: image_revision,
                         issues: issues },
-             layout: rendering_context,
              status: :unprocessable_entity
     elsif lead_selected
       redirect_to document_path(params[:document]),

--- a/spec/features/editing_content/insert_contact_embed_spec.rb
+++ b/spec/features/editing_content/insert_contact_embed_spec.rb
@@ -13,7 +13,7 @@ RSpec.feature "Insert contact embed" do
     then_i_see_the_snippet_is_inserted
   end
 
-  scenario "without javascript", js: false do
+  scenario "without javascript" do
     given_there_is_an_edition
     when_i_go_to_edit_the_edition
     and_i_click_to_insert_a_contact

--- a/spec/features/editing_content/insert_inline_file_attachment_spec.rb
+++ b/spec/features/editing_content/insert_inline_file_attachment_spec.rb
@@ -19,7 +19,7 @@ RSpec.feature "Insert inline file attachment" do
     then_i_see_the_attachment_link_snippet_is_inserted
   end
 
-  scenario "Insert attachment without javascript", js: false do
+  scenario "without javascript" do
     given_there_is_an_edition_with_file_attachments
     when_i_go_to_edit_the_edition
     and_i_click_to_insert_a_file_attachment

--- a/spec/features/editing_content/insert_inline_file_attachment_spec.rb
+++ b/spec/features/editing_content/insert_inline_file_attachment_spec.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 RSpec.feature "Insert inline file attachment" do
-  scenario "Insert attachment with javascript", js: true do
+  scenario "block snippet", js: true do
     given_there_is_an_edition_with_file_attachments
     when_i_go_to_edit_the_edition
     and_i_click_to_insert_a_file_attachment
@@ -10,7 +10,7 @@ RSpec.feature "Insert inline file attachment" do
     then_i_see_the_attachment_snippet_is_inserted
   end
 
-  scenario "Insert Attachment link with javascript", js: true do
+  scenario "link snippet", js: true do
     given_there_is_an_edition_with_file_attachments
     when_i_go_to_edit_the_edition
     and_i_click_to_insert_a_file_attachment

--- a/spec/features/editing_content/insert_inline_image_spec.rb
+++ b/spec/features/editing_content/insert_inline_image_spec.rb
@@ -9,7 +9,7 @@ RSpec.feature "Insert inline image" do
     then_i_see_the_snippet_is_inserted
   end
 
-  scenario "without javascript", js: false do
+  scenario "without javascript" do
     given_there_is_an_edition_with_images
     when_i_go_to_edit_the_edition
     and_i_click_to_insert_an_image

--- a/spec/features/editing_file_attachments/delete_file_attachment_spec.rb
+++ b/spec/features/editing_file_attachments/delete_file_attachment_spec.rb
@@ -32,8 +32,8 @@ RSpec.feature "Delete a file attachment", js: true do
   end
 
   def then_i_see_the_attachment_is_gone
-    expect(all("#file-attachment-#{@attachment_revision.file_attachment_id}").count).to be_zero
     expect(page).to have_content(I18n.t!("file_attachments.index.flashes.deleted", file: @attachment_revision.filename))
+    expect(page).to_not have_selector("#file-attachment-#{@attachment_revision.file_attachment_id}")
   end
 
   def and_i_see_the_timeline_entry

--- a/spec/features/editing_file_attachments/delete_file_attachment_spec.rb
+++ b/spec/features/editing_file_attachments/delete_file_attachment_spec.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-RSpec.feature "Delete a file attachment", js: true do
+RSpec.feature "Delete a file attachment" do
   scenario do
     given_there_is_an_edition_with_attachments
     when_i_insert_an_attachment

--- a/spec/features/editing_file_attachments/preview_file_attachment_spec.rb
+++ b/spec/features/editing_file_attachments/preview_file_attachment_spec.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-RSpec.feature "Preview file attachment", js: true do
+RSpec.feature "Preview file attachment" do
   scenario do
     given_there_is_an_edition_with_attachments
     and_the_attachment_is_available
@@ -30,13 +30,10 @@ RSpec.feature "Preview file attachment", js: true do
       click_on "Attachment"
     end
 
-    expect(page).to have_selector(".gem-c-attachment__metadata")
-    @preview_window = window_opened_by { click_on "Preview" }
+    click_on "Preview"
   end
 
   def then_i_should_see_the_attachment
-    within_window @preview_window do
-      expect(current_url).to match(/#{@asset.file_url}\?token=.*/)
-    end
+    expect(current_url).to match(/#{@asset.file_url}\?token=.*/)
   end
 end

--- a/spec/features/editing_file_attachments/replace_file_attachment_file_spec.rb
+++ b/spec/features/editing_file_attachments/replace_file_attachment_file_spec.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-RSpec.feature "Replace a file attachment file", js: true do
+RSpec.feature "Replace a file attachment file" do
   scenario do
     given_there_is_an_edition_with_an_attachment
     when_i_click_to_insert_an_attachment

--- a/spec/features/editing_file_attachments/upload_file_attachment_spec.rb
+++ b/spec/features/editing_file_attachments/upload_file_attachment_spec.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-RSpec.feature "Upload file attachment", js: true do
+RSpec.feature "Upload file attachment" do
   scenario do
     given_there_is_an_edition
     when_i_go_to_edit_the_edition

--- a/spec/features/editing_images/delete_image_spec.rb
+++ b/spec/features/editing_images/delete_image_spec.rb
@@ -9,7 +9,7 @@ RSpec.feature "Delete an image" do
     and_i_see_the_timeline_entry
   end
 
-  scenario "inline image", js: true do
+  scenario "inline image" do
     given_there_is_an_edition_with_images
     when_i_insert_an_inline_image
     and_i_delete_the_non_lead_image

--- a/spec/features/editing_images/delete_image_spec.rb
+++ b/spec/features/editing_images/delete_image_spec.rb
@@ -46,8 +46,8 @@ RSpec.feature "Delete an image" do
   end
 
   def then_i_see_the_image_is_gone
-    expect(all("#image-#{@image_revision.image_id}").count).to be_zero
     expect(page).to have_content(I18n.t!("images.index.flashes.deleted", file: @image_revision.filename))
+    expect(page).to_not have_selector("#image-#{@image_revision.image_id}")
   end
 
   def and_i_see_the_timeline_entry


### PR DESCRIPTION
Please see the commits for more details. We can always drop the last
commit if we're preferring slightly greater coverage for the modal.

## Example of an 'action override'
https://github.com/alphagov/content-publisher/blob/0950e16de6bddf4d67c694275b721799d75a2133/app/views/images/_image.html.erb#L35

## Before

    govuk-docker-run bundle exec rspec  1.63s user 0.28s system 1% cpu 2:48.54 total

## After

    govuk-docker-run bundle exec rspec  1.65s user 0.29s system 1% cpu 2:38.21 total