### PR TITLE
Update single doc import

### DIFF
--- a/db/migrate/20200206153428_remove_null_constraints_from_whitehall_migrations.rb
+++ b/db/migrate/20200206153428_remove_null_constraints_from_whitehall_migrations.rb
@@ -1,0 +1,8 @@
+# frozen_string_literal: true
+
+class RemoveNullConstraintsFromWhitehallMigrations < ActiveRecord::Migration[6.0]
+  def change
+    change_column_null :whitehall_migrations, :document_type, true
+    change_column_null :whitehall_migrations, :organisation_content_id, true
+  end
+end

--- a/db/migrate/20200206162051_add_whitehall_migration_null_constraint_to_document_imports.rb
+++ b/db/migrate/20200206162051_add_whitehall_migration_null_constraint_to_document_imports.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+class AddWhitehallMigrationNullConstraintToDocumentImports < ActiveRecord::Migration[6.0]
+  def change
+    change_column_null :whitehall_migration_document_imports, :whitehall_migration_id, false
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2020_02_06_153428) do
+ActiveRecord::Schema.define(version: 2020_02_06_162051) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -363,7 +363,7 @@ ActiveRecord::Schema.define(version: 2020_02_06_153428) do
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.bigint "document_id"
-    t.bigint "whitehall_migration_id"
+    t.bigint "whitehall_migration_id", null: false
     t.string "integrity_check_problems", default: [], null: false, array: true
     t.json "integrity_check_proposed_payload", default: "{}", null: false
   end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2020_01_30_090021) do
+ActiveRecord::Schema.define(version: 2020_02_06_153428) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -369,8 +369,8 @@ ActiveRecord::Schema.define(version: 2020_01_30_090021) do
   end
 
   create_table "whitehall_migrations", force: :cascade do |t|
-    t.text "organisation_content_id", null: false
-    t.text "document_type", null: false
+    t.text "organisation_content_id"
+    t.text "document_type"
     t.text "document_subtypes", array: true
     t.datetime "finished_at"
     t.datetime "created_at", precision: 6, null: false

--- a/spec/factories/whitehall_migration_document_import_factory.rb
+++ b/spec/factories/whitehall_migration_document_import_factory.rb
@@ -7,5 +7,6 @@ FactoryBot.define do
     whitehall_document_id { payload["id"] }
     content_id { payload["content_id"] }
     document { association :document, imported_from: "whitehall" }
+    whitehall_migration
   end
 end

--- a/spec/lib/tasks/import_spec.rb
+++ b/spec/lib/tasks/import_spec.rb
@@ -1,6 +1,8 @@
 # frozen_string_literal: true
 
 RSpec.describe "Import tasks" do
+  include ActiveJob::TestHelper
+
   describe "import:whitehall_migration" do
     let(:whitehall_migration_document_import) { build(:whitehall_migration_document_import) }
 
@@ -32,80 +34,24 @@ RSpec.describe "Import tasks" do
   end
 
   describe "import:whitehall_document" do
-    let(:whitehall_host) { Plek.new.external_url_for("whitehall-admin") }
-    let(:whitehall_export) { build(:whitehall_export_document) }
-
-    let(:pending_document_import) do
-      build(:whitehall_migration_document_import)
-    end
-
-    let(:integrity_check) do
-      instance_double(
-        WhitehallImporter::IntegrityChecker,
-        valid?: false,
-        problems: ["foo failed"],
-        proposed_payload: { "foo" => "bar" },
-        edition: build(:edition),
-      )
-    end
-
-    before(:each) do
-      Rake::Task["import:whitehall_document"].reenable
+    before do
       allow($stdout).to receive(:puts)
-      allow(WhitehallMigration::DocumentImport).to receive(:create!)
-      .and_return(pending_document_import)
+      Rake::Task["import:whitehall_document"].reenable
     end
 
-    it "imports the export and syncs with publishing-api" do
-      imported_document_import =
-        build(:whitehall_migration_document_import, state: "imported")
-      completed_document_import =
-        build(:whitehall_migration_document_import, state: "completed")
+    it "creates a pending whitehall migration document import" do
+      allow(WhitehallDocumentImportJob).to receive(:perform_later)
 
-      allow(WhitehallImporter::Import).to receive(:call)
-        .and_return(imported_document_import)
-      allow(WhitehallImporter::Sync).to receive(:call)
-        .and_return(completed_document_import)
+      expect { Rake::Task["import:whitehall_document"].invoke("123") }
+        .to change { WhitehallMigration::DocumentImport.pending.exists?(whitehall_document_id: 123) }
+        .to(true)
+    end
 
-      expect(WhitehallImporter::Import).to receive(:call)
-                                       .with(pending_document_import)
-      expect(WhitehallImporter::Sync).to receive(:call)
-                                     .with(imported_document_import)
-
+    it "queues a job for the document to be imported" do
       Rake::Task["import:whitehall_document"].invoke("123")
-    end
-
-    it "aborts if an IntegrityCheckError is raised" do
-      error = WhitehallImporter::IntegrityCheckError.new(integrity_check)
-      allow(WhitehallImporter::Import).to receive(:call)
-                                      .and_raise(error)
-
-      expect($stdout).to receive(:puts).with("Import aborted")
-      expect($stdout).to receive(:puts).with("Error: #{error.inspect}")
-      expect { Rake::Task["import:whitehall_document"].invoke("123") }
-        .to raise_error(SystemExit)
-    end
-
-    it "aborts if an AbortImportError is raised" do
-      error = WhitehallImporter::AbortImportError.new("Aborted")
-      allow(WhitehallImporter::Import).to receive(:call)
-                                      .and_raise(error)
-
-      expect($stdout).to receive(:puts).with("Import aborted")
-      expect($stdout).to receive(:puts).with("Error: #{error.inspect}")
-      expect { Rake::Task["import:whitehall_document"].invoke("123") }
-        .to raise_error(SystemExit)
-    end
-
-    it "aborts if a StandardError exception is raised" do
-      error = StandardError.new
-      allow(WhitehallImporter::Import).to receive(:call)
-                                      .and_raise(error)
-
-      expect($stdout).to receive(:puts).with("Import failed")
-      expect($stdout).to receive(:puts).with("Error: #{error.inspect}")
-      expect { Rake::Task["import:whitehall_document"].invoke("123") }
-        .to raise_error(SystemExit)
+      expect(WhitehallDocumentImportJob).to have_been_enqueued.with(
+        an_instance_of(WhitehallMigration::DocumentImport),
+      )
     end
   end
 end


### PR DESCRIPTION
Updates the single document import task to use a worker instead of being synchronous.

More details in the commits -> 

Trello:
https://trello.com/c/ffU41pHl/1391-adapt-import-single-document-rake-task-to-create-a-migration