### PR TITLE
Ignore .DS_Store

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -19,6 +19,7 @@
 
 /public/assets
 .byebug_history
+.DS_Store
 
 /coverage
 /public/packs


### PR DESCRIPTION
I considered this instruction:
 git config --global core.excludesfile '~/.gitignore_global'

But we ignore .DS_Store in lots of alphagov repos, and can't rely on
everybody to set up their git config in the same way. Ignoring it
explicitly is a common enough convention that it's worth doing here.