### PR TITLE
Update Whitehall document when importing

### DIFF
--- a/app/jobs/whitehall_document_import_job.rb
+++ b/app/jobs/whitehall_document_import_job.rb
@@ -19,6 +19,10 @@ class WhitehallDocumentImportJob < ApplicationJob
   end
 
   def self.handle_error(document_import, error)
+    if document_import.pending?
+      GdsApi.whitehall_export.unlock_document(document_import.whitehall_document_id)
+    end
+
     case error
     when WhitehallImporter::IntegrityCheckError
       document_import.update!(

--- a/app/jobs/whitehall_document_import_job.rb
+++ b/app/jobs/whitehall_document_import_job.rb
@@ -20,7 +20,11 @@ class WhitehallDocumentImportJob < ApplicationJob
 
   def self.handle_error(document_import, error)
     if document_import.pending?
-      GdsApi.whitehall_export.unlock_document(document_import.whitehall_document_id)
+      begin
+        GdsApi.whitehall_export.unlock_document(document_import.whitehall_document_id)
+      rescue StandardError => e
+        logger.warn("Failed to unlock Whitehall document: #{e.inspect}")
+      end
     end
 
     case error

--- a/lib/gds_api/whitehall_export.rb
+++ b/lib/gds_api/whitehall_export.rb
@@ -33,6 +33,10 @@ module GdsApi
       get_json("#{endpoint}/government/admin/export/document/#{document_id}")
     end
 
+    def lock_document(document_id)
+      post_json("#{endpoint}/government/admin/export/document/#{document_id}/lock")
+    end
+
   private
 
     def document_list_url(params)

--- a/lib/gds_api/whitehall_export.rb
+++ b/lib/gds_api/whitehall_export.rb
@@ -41,6 +41,10 @@ module GdsApi
       post_json("#{endpoint}/government/admin/export/document/#{document_id}/unlock")
     end
 
+    def document_migrated(document_id)
+      post_json("#{endpoint}/government/admin/export/document/#{document_id}/migrated")
+    end
+
   private
 
     def document_list_url(params)

--- a/lib/gds_api/whitehall_export.rb
+++ b/lib/gds_api/whitehall_export.rb
@@ -37,6 +37,10 @@ module GdsApi
       post_json("#{endpoint}/government/admin/export/document/#{document_id}/lock")
     end
 
+    def unlock_document(document_id)
+      post_json("#{endpoint}/government/admin/export/document/#{document_id}/unlock")
+    end
+
   private
 
     def document_list_url(params)

--- a/lib/whitehall_importer/import.rb
+++ b/lib/whitehall_importer/import.rb
@@ -17,6 +17,8 @@ module WhitehallImporter
         raise "Cannot import with a state of #{document_import.state}"
       end
 
+      lock_document
+
       document_import.update!(
         payload: whitehall_document,
         content_id: whitehall_document["content_id"],
@@ -55,6 +57,10 @@ module WhitehallImporter
       @whitehall_document ||= GdsApi.whitehall_export
                                     .document_export(document_import.whitehall_document_id)
                                     .to_h
+    end
+
+    def lock_document
+      GdsApi.whitehall_export.lock_document(document_import.whitehall_document_id)
     end
 
     def create_timeline_entry(edition)

--- a/lib/whitehall_importer/sync.rb
+++ b/lib/whitehall_importer/sync.rb
@@ -19,6 +19,9 @@ module WhitehallImporter
 
       ResyncDocumentService.call(whitehall_import.document)
       ClearLinksetLinks.call(whitehall_import.document.content_id)
+      GdsApi.whitehall_export.document_migrated(
+        whitehall_import.whitehall_document_id,
+      )
       MigrateAssets.call(whitehall_import)
 
       whitehall_import.update!(state: "completed")

--- a/spec/jobs/whitehall_document_import_job_spec.rb
+++ b/spec/jobs/whitehall_document_import_job_spec.rb
@@ -184,4 +184,9 @@ RSpec.describe WhitehallDocumentImportJob do
   def stub_whitehall_api_unlock_document(document_id)
     stub_request(:post, "#{whitehall_host}/government/admin/export/document/#{document_id}/unlock")
   end
+
+  def stub_whitehall_api_unlock_document_error(document_id, error)
+    stub_request(:post, "#{whitehall_host}/government/admin/export/document/#{document_id}/unlock")
+      .to_raise(error)
+  end
 end

--- a/spec/jobs/whitehall_document_import_job_spec.rb
+++ b/spec/jobs/whitehall_document_import_job_spec.rb
@@ -26,7 +26,7 @@ RSpec.describe WhitehallDocumentImportJob do
     allow(WhitehallImporter::Sync).to receive(:call)
                                   .and_return(completed_document_import)
     allow(whitehall_migration).to receive(:check_migration_finished)
-    stub_whitehall_api_unlock_document(
+    stub_whitehall_unlock_document(
       whitehall_migration_document_import.whitehall_document_id,
     )
   end
@@ -56,7 +56,7 @@ RSpec.describe WhitehallDocumentImportJob do
     end
 
     it "unlocks the document in Whitehall" do
-      request = stub_whitehall_api_unlock_document(
+      request = stub_whitehall_unlock_document(
         whitehall_migration_document_import.whitehall_document_id,
       )
 
@@ -79,7 +79,7 @@ RSpec.describe WhitehallDocumentImportJob do
     end
 
     it "does not unlock the document in Whitehall" do
-      request = stub_whitehall_api_unlock_document(
+      request = stub_whitehall_unlock_document(
         imported_document_import.whitehall_document_id,
       )
 
@@ -121,7 +121,7 @@ RSpec.describe WhitehallDocumentImportJob do
     let(:error) { StandardError.new }
     before do
       allow(WhitehallImporter::Import).to receive(:call).and_raise(error)
-      stub_whitehall_api_unlock_document(
+      stub_whitehall_unlock_document(
         whitehall_migration_document_import.whitehall_document_id,
       )
     end
@@ -185,7 +185,7 @@ RSpec.describe WhitehallDocumentImportJob do
     let(:error) { StandardError.new }
     before do
       allow(WhitehallImporter::Import).to receive(:call).and_raise("import error")
-      stub_whitehall_api_unlock_document_error(
+      stub_whitehall_unlock_document_error(
         whitehall_migration_document_import.whitehall_document_id, error
       )
     end
@@ -201,11 +201,11 @@ RSpec.describe WhitehallDocumentImportJob do
     end
   end
 
-  def stub_whitehall_api_unlock_document(document_id)
+  def stub_whitehall_unlock_document(document_id)
     stub_request(:post, "#{whitehall_host}/government/admin/export/document/#{document_id}/unlock")
   end
 
-  def stub_whitehall_api_unlock_document_error(document_id, error)
+  def stub_whitehall_unlock_document_error(document_id, error)
     stub_request(:post, "#{whitehall_host}/government/admin/export/document/#{document_id}/unlock")
       .to_raise(error)
   end

--- a/spec/jobs/whitehall_document_import_job_spec.rb
+++ b/spec/jobs/whitehall_document_import_job_spec.rb
@@ -26,6 +26,9 @@ RSpec.describe WhitehallDocumentImportJob do
     allow(WhitehallImporter::Sync).to receive(:call)
                                   .and_return(completed_document_import)
     allow(whitehall_migration).to receive(:check_migration_finished)
+    stub_whitehall_api_unlock_document(
+      whitehall_migration_document_import.whitehall_document_id,
+    )
   end
 
   it "calls WhitehallImporter::Import" do
@@ -44,6 +47,52 @@ RSpec.describe WhitehallDocumentImportJob do
     expect(completed_document_import.whitehall_migration)
       .to receive(:check_migration_finished)
     WhitehallDocumentImportJob.perform_now(whitehall_migration_document_import)
+  end
+
+  context "when the import fails" do
+    let(:error_message) { "import failed error" }
+    before do
+      allow(WhitehallImporter::Import).to receive(:call).and_raise(error_message)
+    end
+
+    it "unlocks the document in Whitehall" do
+      request = stub_whitehall_api_unlock_document(
+        whitehall_migration_document_import.whitehall_document_id,
+      )
+
+      WhitehallDocumentImportJob.perform_now(whitehall_migration_document_import)
+      expect(request).to have_been_requested
+    end
+
+    it "updates the document import state to 'import_failed'" do
+      WhitehallDocumentImportJob.perform_now(whitehall_migration_document_import)
+
+      whitehall_migration_document_import.reload
+      expect(whitehall_migration_document_import).to be_import_failed
+    end
+  end
+
+  context "when the sync fails" do
+    let(:error_message) { "sync failed error" }
+    before do
+      allow(WhitehallImporter::Sync).to receive(:call).and_raise(error_message)
+    end
+
+    it "does not unlock the document in Whitehall" do
+      request = stub_whitehall_api_unlock_document(
+        imported_document_import.whitehall_document_id,
+      )
+
+      WhitehallDocumentImportJob.perform_now(imported_document_import)
+      expect(request).not_to have_been_requested
+    end
+
+    it "updates the document import state to 'sync_failed'" do
+      WhitehallDocumentImportJob.perform_now(imported_document_import)
+
+      imported_document_import.reload
+      expect(imported_document_import).to be_sync_failed
+    end
   end
 
   context "when a GdsApi::BaseError exception is raised" do
@@ -66,41 +115,23 @@ RSpec.describe WhitehallDocumentImportJob do
       whitehall_migration_document_import.reload
       expect(whitehall_migration_document_import.error_log).to eq(error.inspect)
     end
-
-    it "updates the document import state to 'import_failed' if the import failed" do
-      perform_enqueued_jobs do
-        WhitehallDocumentImportJob.perform_now(whitehall_migration_document_import)
-      end
-
-      whitehall_migration_document_import.reload
-      expect(whitehall_migration_document_import).to be_import_failed
-    end
-
-    it "updates the document import state to 'sync_failed' if the sync failed" do
-      whitehall_migration_document_import.update!(state: "imported")
-
-      perform_enqueued_jobs do
-        WhitehallDocumentImportJob.perform_now(whitehall_migration_document_import)
-      end
-
-      whitehall_migration_document_import.reload
-      expect(whitehall_migration_document_import).to be_sync_failed
-    end
   end
 
   context "when a StandardError exception is raised" do
     let(:error) { StandardError.new }
     before do
       allow(WhitehallImporter::Import).to receive(:call).and_raise(error)
+      stub_whitehall_api_unlock_document(
+        whitehall_migration_document_import.whitehall_document_id,
+      )
     end
 
-    it "does not retry the job, logs the error and updates the document import state" do
+    it "does not retry the job and logs the error" do
       WhitehallDocumentImportJob.perform_now(whitehall_migration_document_import)
 
       whitehall_migration_document_import.reload
       expect(WhitehallDocumentImportJob).not_to have_been_enqueued
       expect(whitehall_migration_document_import.error_log).to eq(error.inspect)
-      expect(whitehall_migration_document_import).to be_import_failed
     end
   end
 
@@ -148,5 +179,9 @@ RSpec.describe WhitehallDocumentImportJob do
       expect(whitehall_migration_document_import.integrity_check_proposed_payload)
         .to eq(payload)
     end
+  end
+
+  def stub_whitehall_api_unlock_document(document_id)
+    stub_request(:post, "#{whitehall_host}/government/admin/export/document/#{document_id}/unlock")
   end
 end

--- a/spec/lib/gds_api/whitehall_export_spec.rb
+++ b/spec/lib/gds_api/whitehall_export_spec.rb
@@ -48,6 +48,20 @@ RSpec.describe GdsApi::WhitehallExport do
     end
   end
 
+  describe "#unlock_document" do
+    let(:document_id) { "123" }
+    let(:unlock_endpoint) do
+      "#{whitehall_host}/government/admin/export/document/#{document_id}/unlock"
+    end
+
+    before { stub_request(:post, unlock_endpoint) }
+
+    it "makes a POST request to Whitehall admin export API unlock endpoint" do
+      expect(whitehall_adapter.unlock_document(document_id))
+        .to have_requested(:post, unlock_endpoint)
+    end
+  end
+
   def stub_whitehall_api_has_document_index(lead_organisation, document_type, document_subtypes, page_number, items_on_page)
     whitehall_host = Plek.new.external_url_for("whitehall-admin")
     stub_request(:get, "#{whitehall_host}/government/admin/export/document").

--- a/spec/lib/gds_api/whitehall_export_spec.rb
+++ b/spec/lib/gds_api/whitehall_export_spec.rb
@@ -7,10 +7,15 @@ RSpec.describe GdsApi::WhitehallExport do
 
   describe "#document_list" do
     it "iterates through the correct number of pages" do
-      first_page = stub_whitehall_api_has_document_index("123", "news_article", %w(news_story press_release), 1, 100)
-      second_page = stub_whitehall_api_has_document_index("123", "news_article", %w(news_story press_release), 2, 10)
-
-      whitehall_document_list = whitehall_adapter.document_list("123", "news_article", %w(news_story press_release))
+      first_page = stub_whitehall_has_document_index(
+        document_id, "news_article", %w(news_story press_release), 1, 100
+      )
+      second_page = stub_whitehall_has_document_index(
+        document_id, "news_article", %w(news_story press_release), 2, 10
+      )
+      whitehall_document_list = whitehall_adapter.document_list(
+        document_id, "news_article", %w(news_story press_release)
+      )
 
       whitehall_document_list.next
       expect(first_page).to have_been_requested
@@ -63,7 +68,20 @@ RSpec.describe GdsApi::WhitehallExport do
     end
   end
 
-  def stub_whitehall_api_has_document_index(lead_organisation, document_type, document_subtypes, page_number, items_on_page)
+  describe "#document_migrated" do
+    let(:migrated_endpoint) do
+      "#{whitehall_host}/government/admin/export/document/#{document_id}/migrated"
+    end
+
+    before { stub_request(:post, migrated_endpoint) }
+
+    it "makes a POST request to Whitehall admin export API migrated endpoint" do
+      expect(whitehall_adapter.document_migrated(document_id))
+        .to have_requested(:post, migrated_endpoint)
+    end
+  end
+
+  def stub_whitehall_has_document_index(lead_organisation, document_type, document_subtypes, page_number, items_on_page)
     whitehall_host = Plek.new.external_url_for("whitehall-admin")
     stub_request(:get, "#{whitehall_host}/government/admin/export/document").
       with(query: hash_including(

--- a/spec/lib/gds_api/whitehall_export_spec.rb
+++ b/spec/lib/gds_api/whitehall_export_spec.rb
@@ -1,9 +1,10 @@
 # frozen_string_literal: true
 
 RSpec.describe GdsApi::WhitehallExport do
-  describe "document_list" do
-    let(:whitehall_adapter) { GdsApi::WhitehallExport.new(Plek.find("whitehall-admin")) }
+  let(:whitehall_adapter) { GdsApi::WhitehallExport.new(Plek.find("whitehall-admin")) }
+  let(:whitehall_host) { Plek.new.external_url_for("whitehall-admin") }
 
+  describe "#document_list" do
     it "iterates through the correct number of pages" do
       first_page = stub_whitehall_api_has_document_index("123", "news_article", %w(news_story press_release), 1, 100)
       second_page = stub_whitehall_api_has_document_index("123", "news_article", %w(news_story press_release), 2, 10)
@@ -20,9 +21,7 @@ RSpec.describe GdsApi::WhitehallExport do
     end
   end
 
-  describe "document_export" do
-    let(:whitehall_adapter) { GdsApi::WhitehallExport.new(Plek.find("whitehall-admin")) }
-    let(:whitehall_host) { Plek.new.external_url_for("whitehall-admin") }
+  describe "#document_export" do
     let(:whitehall_export) { build(:whitehall_export_document) }
 
     before do
@@ -32,6 +31,20 @@ RSpec.describe GdsApi::WhitehallExport do
 
     it "makes a GET request to whitehall" do
       expect(whitehall_adapter.document_export("123")).to have_requested(:get, "#{whitehall_host}/government/admin/export/document/123")
+    end
+  end
+
+  describe "#lock_document" do
+    let(:document_id) { "123" }
+    let(:lock_endpoint) do
+      "#{whitehall_host}/government/admin/export/document/#{document_id}/lock"
+    end
+
+    before { stub_request(:post, lock_endpoint) }
+
+    it "makes a POST request to Whitehall admin export API lock endpoint" do
+      expect(whitehall_adapter.lock_document(document_id))
+        .to have_requested(:post, lock_endpoint)
     end
   end
 

--- a/spec/lib/gds_api/whitehall_export_spec.rb
+++ b/spec/lib/gds_api/whitehall_export_spec.rb
@@ -3,6 +3,7 @@
 RSpec.describe GdsApi::WhitehallExport do
   let(:whitehall_adapter) { GdsApi::WhitehallExport.new(Plek.find("whitehall-admin")) }
   let(:whitehall_host) { Plek.new.external_url_for("whitehall-admin") }
+  let(:document_id) { "123" }
 
   describe "#document_list" do
     it "iterates through the correct number of pages" do

--- a/spec/lib/whitehall_importer/sync_spec.rb
+++ b/spec/lib/whitehall_importer/sync_spec.rb
@@ -6,7 +6,7 @@ RSpec.describe WhitehallImporter::Sync do
       allow(ResyncDocumentService).to receive(:call).with(whitehall_document)
       allow(WhitehallImporter::ClearLinksetLinks).to receive(:call)
                                                  .with(whitehall_document.content_id)
-      stub_whitehall_api_document_migrated(
+      stub_whitehall_document_migrated(
         whitehall_migration_document_import.whitehall_document_id,
       )
     end
@@ -29,7 +29,7 @@ RSpec.describe WhitehallImporter::Sync do
     end
 
     it "marks the document as migrated in Whitehall" do
-      request = stub_whitehall_api_document_migrated(
+      request = stub_whitehall_document_migrated(
         whitehall_migration_document_import.whitehall_document_id,
       )
 
@@ -55,7 +55,7 @@ RSpec.describe WhitehallImporter::Sync do
     end
   end
 
-  def stub_whitehall_api_document_migrated(document_id)
+  def stub_whitehall_document_migrated(document_id)
     stub_request(:post, "#{whitehall_host}/government/admin/export/document/#{document_id}/migrated")
   end
 end


### PR DESCRIPTION
For https://trello.com/c/Y3hKP4W9/1366-handle-retrying-whitehall-import-job

This calls the Whitehall export API at various stages of the import and sync job so that Whitehall knows about a document's status.

- We call the lock endpoint before a document is exported from Whitehall
- We call the unlock endpoint if a document import fails, not the sync
- We call the migrated endpoint if the document imports and syncs successfully