### PR TITLE
Introduce government data alert

### DIFF
--- a/app/controllers/healthcheck_controller.rb
+++ b/app/controllers/healthcheck_controller.rb
@@ -1,0 +1,12 @@
+class HealthcheckController < ApplicationController
+  skip_before_action :authenticate_user!
+
+  def index
+    healthcheck = GovukHealthcheck.healthcheck([
+                    GovukHealthcheck::SidekiqRedis,
+                    GovukHealthcheck::ActiveRecord,
+                    Healthcheck::GovernmentDataCheck,
+                  ])
+    render json: healthcheck
+  end
+end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -101,7 +101,7 @@ Rails.application.routes.draw do
     delete "/file-attachments/:file_attachment_id" => "file_attachments#destroy"
   end
 
-  get "/healthcheck", to: proc { [200, {}, %w[OK]] }
+  get "/healthcheck", to: "healthcheck#index"
 
   get "/how-to-use-publisher" => "publisher_information#how_to_use_publisher", as: :how_to_use_publisher
   get "/beta-capabilities" => "publisher_information#beta_capabilities", as: :beta_capabilities

--- a/lib/bulk_data/cache.rb
+++ b/lib/bulk_data/cache.rb
@@ -6,7 +6,7 @@ module BulkData
 
     class << self
       delegate :cache, to: :instance
-      delegate :clear, :middleware, to: :cache
+      delegate :clear, :exist?, :middleware, to: :cache
     end
 
     attr_reader :cache
@@ -36,10 +36,6 @@ module BulkData
     def self.delete(key)
       cache.delete(key)
       cache.delete("#{key}:created")
-    end
-
-    def self.clear
-      cache.clear
     end
 
   private

--- a/lib/bulk_data/government_repository.rb
+++ b/lib/bulk_data/government_repository.rb
@@ -44,5 +44,13 @@ module BulkData
     rescue GdsApi::BaseError
       raise RemoteDataUnavailableError
     end
+
+    def cache_age
+      Time.current - Cache.written_at(CACHE_KEY)
+    end
+
+    def cache_populated?
+      Cache.exist?(CACHE_KEY)
+    end
   end
 end

--- a/lib/healthcheck/government_data_check.rb
+++ b/lib/healthcheck/government_data_check.rb
@@ -1,0 +1,36 @@
+module Healthcheck
+  class GovernmentDataCheck
+    attr_reader :government_repo
+    def initialize
+      @government_repo = BulkData::GovernmentRepository.new
+    end
+
+    def name
+      :government_data_check
+    end
+
+    def status
+      return GovukHealthcheck::CRITICAL unless government_repo.cache_populated?
+      return GovukHealthcheck::WARNING if government_repo.cache_age > 6.hours
+
+      GovukHealthcheck::OK
+    end
+
+    def message
+      return "No government data availible" if status == GovukHealthcheck::CRITICAL
+
+      warning_details_content if status == GovukHealthcheck:: WARNING
+    end
+
+    def enabled?
+      true
+    end
+
+  private
+
+    def warning_details_content
+      data_age = government_repo.cache_age.to_i
+      "Government data not refreshed in #{data_age / 1.hour} hours."
+    end
+  end
+end

--- a/spec/lib/healthcheck/government_data_check_spec.rb
+++ b/spec/lib/healthcheck/government_data_check_spec.rb
@@ -1,0 +1,50 @@
+RSpec.describe Healthcheck::GovernmentDataCheck do
+  let(:gov_data_check) { described_class.new }
+
+  describe "#status" do
+    context "when government data is unavailable" do
+      it "returns critical" do
+        expect(gov_data_check.status).to be(:critical)
+      end
+    end
+
+    context "when government data is set to expire" do
+      it "gives a warning" do
+        populate_default_government_bulk_data
+        travel_to(7.hours.from_now) do
+          expect(gov_data_check.status).to be(:warning)
+        end
+      end
+    end
+
+    context "when everything is fine" do
+      it "returns ok" do
+        populate_default_government_bulk_data
+        expect(gov_data_check.status).to be(:ok)
+      end
+    end
+  end
+
+  describe "#message" do
+    context "when government data is unavailable" do
+      it "displays an appropriate message" do
+        expect(gov_data_check.message).to eq("No government data availible")
+      end
+    end
+
+    context "when government data is set to expire" do
+      it "displays an appropriate message" do
+        populate_default_government_bulk_data
+        travel_to(Time.zone.now + 6.5.hours)
+        expect(gov_data_check.message).to eq("Government data not refreshed in 6 hours.")
+      end
+    end
+
+    context "when everything is fine" do
+      it "displays an appropriate message" do
+        populate_default_government_bulk_data
+        expect(gov_data_check.message).to be_nil
+      end
+    end
+  end
+end

--- a/spec/requests/healthcheck_spec.rb
+++ b/spec/requests/healthcheck_spec.rb
@@ -1,0 +1,17 @@
+RSpec.describe "Healthcheck" do
+  describe "GET /healthcheck" do
+    before do
+      populate_default_government_bulk_data
+    end
+
+    it "returns a 200 HTTP status" do
+      get healthcheck_path
+      expect(response).to have_http_status(:ok)
+    end
+
+    it "includes a status in the response body" do
+      get healthcheck_path
+      expect(JSON.parse(response.body)).to have_key("status")
+    end
+  end
+end


### PR DESCRIPTION
Trello - https://trello.com/c/FaHAEajH/1318-alert-2ndline-when-we-have-no-cached-data-on-governments

This iterates out healthcheck endpoint to include a check for government data, a connection to redis and to the database. This will allow us to alert 2nd line and our slack channel in the event that government data is unavailable. 

### Relies on
https://github.com/alphagov/govuk-developer-docs/pull/2301
https://github.com/alphagov/govuk-puppet/pull/10129