### PR TITLE
Add instructions to navigate topics

### DIFF
--- a/app/views/topics/edit.html.erb
+++ b/app/views/topics/edit.html.erb
@@ -81,12 +81,15 @@
     } %>
 
     <div class="govuk-form-group">
-      <miller-columns id="miller-columns" class="miller-columns" for="taxonomy" selected="selected-items">
-      <ul id="taxonomy" class="govuk-list">
-        <% Topic.govuk_homepage(@edition.document_topics.index).children.each do |topic| %>
-          <% unroll(topic) %>
-        <% end %>
-      </ul>
+      <p id="topics-navigation-instructions" class="govuk-body govuk-visually-hidden">
+        <%= t("topics.edit.navigation_instructions") %>
+      </p>
+      <miller-columns id="miller-columns" class="miller-columns" for="taxonomy" selected="selected-items" aria-describedby="topics-navigation-instructions">
+        <ul id="taxonomy" class="govuk-list">
+          <% Topic.govuk_homepage(@edition.document_topics.index).children.each do |topic| %>
+            <% unroll(topic) %>
+          <% end %>
+        </ul>
       </miller-columns>
     </div>
   <% end %>

--- a/config/locales/en/topics/edit.yml
+++ b/config/locales/en/topics/edit.yml
@@ -6,6 +6,7 @@ en:
         Select topics that describe what your content is about. Topics group content on GOV.UK to make it easier to find.
         You can select any relevant topics. Choose the most specific topics you can.
       selected_title: Selected topics
+      navigation_instructions: Use the right arrow to explore sub-topics, use the up and down arrows to find other topics.
       warning_title: Changes are applied to a live page as soon as you save.
       warning_description: If this content has already been published and you add new topics, then the last published edition will appear on those topic pages immediately, before you publish a new edition.
       link_guidance: Full guidance on topics


### PR DESCRIPTION
Add instructions on how to navigate topics for screen reader users.

co-author: @pollygreen 

Raising this as a draft. It should be merged after the miller-columns-element gets bumped to [1.3.0](https://github.com/alphagov/miller-columns-element/pull/33).

Update: This can now be reviewed and merged as [we're now using the latest version of miller-columns element](https://github.com/alphagov/content-publisher/pull/1750)

