### PR TITLE
Use params directly in requirements checkers

### DIFF
--- a/app/controllers/content_controller.rb
+++ b/app/controllers/content_controller.rb
@@ -4,12 +4,11 @@ class ContentController < ApplicationController
   def edit
     @edition = Edition.find_current(document: params[:document])
     assert_edition_state(@edition, &:editable?)
-    @revision = @edition.revision
   end
 
   def update
     result = Content::UpdateInteractor.call(params: params, user: current_user)
-    edition, revision, issues, = result.to_h.values_at(:edition, :revision, :issues)
+    edition, issues, = result.to_h.values_at(:edition, :issues)
 
     if issues
       flash.now["requirements"] = {
@@ -17,7 +16,7 @@ class ContentController < ApplicationController
       }
 
       render :edit,
-             assigns: { edition: edition, revision: revision, issues: issues },
+             assigns: { edition: edition, issues: issues },
              status: :unprocessable_entity
     else
       redirect_to edition.document

--- a/app/controllers/tags_controller.rb
+++ b/app/controllers/tags_controller.rb
@@ -9,19 +9,18 @@ class TagsController < ApplicationController
   def edit
     @edition = Edition.find_current(document: params[:document])
     assert_edition_state(@edition, &:editable?)
-    @revision = @edition.revision
   end
 
   def update
     results = Tags::UpdateInteractor.call(params: params, user: current_user)
-    edition, revision, issues, = results.to_h.values_at(:edition, :revision, :issues)
+    edition, issues, = results.to_h.values_at(:edition, :issues)
 
     if issues
       flash.now["requirements"] = {
         "items" => issues.items(link_options: issues_link_options(edition)),
       }
       render :edit,
-             assigns: { edition: edition, revision: revision, issues: issues },
+             assigns: { edition: edition, issues: issues },
              status: :unprocessable_entity
     else
       redirect_to document_path(params[:document])

--- a/app/interactors/backdate/update_interactor.rb
+++ b/app/interactors/backdate/update_interactor.rb
@@ -50,9 +50,7 @@ private
   end
 
   def check_for_issues
-    checker = Requirements::BackdateChecker.new(date)
-    issues = checker.pre_submit_issues
-
+    issues = Requirements::BackdateChecker.new.pre_update_issues(date)
     context.fail!(issues: issues) if issues.any?
   end
 

--- a/app/interactors/content/update_interactor.rb
+++ b/app/interactors/content/update_interactor.rb
@@ -38,7 +38,7 @@ private
     issues = Requirements::CheckerIssues.new
 
     edition.document_type.contents.each do |field|
-      issues += field.pre_update_issues(edition, revision)
+      issues += field.pre_update_issues(edition, content_params)
     end
 
     context.fail!(issues: issues) if issues.any?
@@ -64,7 +64,7 @@ private
   end
 
   def content_params
-    edition.document_type.contents.reduce({}) do |hash, field|
+    @content_params ||= edition.document_type.contents.reduce({}) do |hash, field|
       hash.merge!(field.updater_params(edition, params))
     end
   end

--- a/app/interactors/content/update_interactor.rb
+++ b/app/interactors/content/update_interactor.rb
@@ -10,8 +10,8 @@ class Content::UpdateInteractor < ApplicationInteractor
   def call
     Edition.transaction do
       find_and_lock_edition
-      update_revision
       check_for_issues
+      update_revision
 
       update_edition
       create_timeline_entry
@@ -37,7 +37,7 @@ private
   def check_for_issues
     issues = Requirements::CheckerIssues.new
 
-    edition.document_type.contents.each do |field|
+    fields.each do |field|
       issues += field.pre_update_issues(edition, content_params)
     end
 
@@ -64,8 +64,12 @@ private
   end
 
   def content_params
-    @content_params ||= edition.document_type.contents.reduce({}) do |hash, field|
+    @content_params ||= fields.reduce({}) do |hash, field|
       hash.merge!(field.updater_params(edition, params))
     end
+  end
+
+  def fields
+    @fields ||= edition.document_type.contents
   end
 end

--- a/app/interactors/schedule/new_interactor.rb
+++ b/app/interactors/schedule/new_interactor.rb
@@ -31,8 +31,7 @@ class Schedule::NewInteractor < ApplicationInteractor
   end
 
   def check_for_schedule_issues
-    issues = Requirements::PublishTimeChecker.new(edition.proposed_publish_time)
-                                             .issues
+    issues = Requirements::PublishTimeChecker.new.issues(edition.proposed_publish_time)
     context.fail!(schedule_issues: issues) if issues.any?
   end
 end

--- a/app/interactors/schedule/update_interactor.rb
+++ b/app/interactors/schedule/update_interactor.rb
@@ -36,8 +36,7 @@ private
   end
 
   def check_for_issues
-    checker = Requirements::PublishTimeChecker.new(publish_time)
-    issues = checker.issues
+    issues = Requirements::PublishTimeChecker.new.issues(publish_time)
     context.fail!(issues: issues) if issues.any?
   end
 

--- a/app/interactors/schedule_proposal/update_interactor.rb
+++ b/app/interactors/schedule_proposal/update_interactor.rb
@@ -34,7 +34,7 @@ private
   end
 
   def check_for_issues
-    issues = Requirements::PublishTimeChecker.new(publish_time).issues
+    issues = Requirements::PublishTimeChecker.new.issues(publish_time)
     issues += action_issues if params[:wizard] == "schedule"
     context.fail!(issues: issues) if issues.any?
   end

--- a/app/interactors/tags/update_interactor.rb
+++ b/app/interactors/tags/update_interactor.rb
@@ -30,14 +30,12 @@ private
 
   def update_revision
     context.revision_updater = Versioning::RevisionUpdater.new(edition.revision, user)
-    revision_updater.assign(tags: update_params(edition))
+    revision_updater.assign(tags: update_params)
     context.revision = revision_updater.next_revision
   end
 
   def check_for_issues
-    checker = Requirements::TagChecker.new(edition, revision)
-    issues = checker.pre_publish_issues
-
+    issues = Requirements::TagChecker.new(edition).pre_update_issues(update_params)
     context.fail!(issues: issues) if issues.any?
   end
 
@@ -56,7 +54,7 @@ private
     FailsafeDraftPreviewService.call(edition)
   end
 
-  def update_params(edition)
+  def update_params
     permits = edition.document_type.tags.map do |tag_field|
       [tag_field.id, []]
     end

--- a/app/interactors/withdraw/create_interactor.rb
+++ b/app/interactors/withdraw/create_interactor.rb
@@ -30,8 +30,10 @@ private
   end
 
   def check_for_issues
-    issues = Requirements::WithdrawalChecker.new(params[:public_explanation], edition)
-                                            .pre_withdrawal_issues
+    issues = Requirements::WithdrawalChecker
+      .new(edition)
+      .pre_withdrawal_issues(params[:public_explanation])
+
     context.fail!(issues: issues) if issues.any?
   end
 

--- a/app/models/document_type/body_field.rb
+++ b/app/models/document_type/body_field.rb
@@ -17,17 +17,19 @@ class DocumentType::BodyField
     { contents: { body: params[:body] } }
   end
 
-  def pre_preview_issues(edition, revision)
+  def pre_update_issues(edition, params)
     issues = Requirements::CheckerIssues.new
 
-    unless GovspeakDocument.new(revision.contents[id], edition).valid?
+    unless GovspeakDocument.new(params[:contents][:body], edition).valid?
       issues.create(id, :invalid_govspeak)
     end
 
     issues
   end
 
-  alias_method :pre_update_issues, :pre_preview_issues
+  def pre_preview_issues(edition)
+    pre_update_issues(edition, contents: edition.contents.symbolize_keys)
+  end
 
   def pre_publish_issues(_edition, revision)
     issues = Requirements::CheckerIssues.new

--- a/app/models/document_type/body_field.rb
+++ b/app/models/document_type/body_field.rb
@@ -31,9 +31,9 @@ class DocumentType::BodyField
     pre_update_issues(edition, contents: edition.contents.symbolize_keys)
   end
 
-  def pre_publish_issues(_edition, revision)
+  def pre_publish_issues(edition)
     issues = Requirements::CheckerIssues.new
-    issues.create(id, :blank) if revision.contents[id].blank?
+    issues.create(id, :blank) if edition.contents[id].blank?
     issues
   end
 end

--- a/app/models/document_type/summary_field.rb
+++ b/app/models/document_type/summary_field.rb
@@ -15,21 +15,23 @@ class DocumentType::SummaryField
     { summary: params[:summary]&.strip }
   end
 
-  def pre_preview_issues(_edition, revision)
+  def pre_update_issues(_edition, params)
     issues = Requirements::CheckerIssues.new
 
-    if revision.summary.to_s.size > SUMMARY_MAX_LENGTH
+    if params[:summary].to_s.size > SUMMARY_MAX_LENGTH
       issues.create(:summary, :too_long, max_length: SUMMARY_MAX_LENGTH)
     end
 
-    if revision.summary.to_s.lines.count > 1
+    if params[:summary].to_s.lines.count > 1
       issues.create(:summary, :multiline)
     end
 
     issues
   end
 
-  alias_method :pre_update_issues, :pre_preview_issues
+  def pre_preview_issues(edition)
+    pre_update_issues(edition, summary: edition.summary)
+  end
 
   def pre_publish_issues(_edition, revision)
     issues = Requirements::CheckerIssues.new

--- a/app/models/document_type/summary_field.rb
+++ b/app/models/document_type/summary_field.rb
@@ -33,9 +33,9 @@ class DocumentType::SummaryField
     pre_update_issues(edition, summary: edition.summary)
   end
 
-  def pre_publish_issues(_edition, revision)
+  def pre_publish_issues(edition)
     issues = Requirements::CheckerIssues.new
-    issues.create(:summary, :blank) if revision.summary.blank?
+    issues.create(:summary, :blank) if edition.summary.blank?
     issues
   end
 end

--- a/app/models/document_type/title_and_base_path_field.rb
+++ b/app/models/document_type/title_and_base_path_field.rb
@@ -31,7 +31,7 @@ class DocumentType::TitleAndBasePathField
     title_issues(edition.title)
   end
 
-  def pre_publish_issues(_edition, _revision)
+  def pre_publish_issues(_edition)
     Requirements::CheckerIssues.new
   end
 

--- a/app/views/content/edit.html.erb
+++ b/app/views/content/edit.html.erb
@@ -27,7 +27,7 @@
   <% end %>
 
   <% if @edition.document.live_edition %>
-    <%= render "content/edit/change_notes" %>
+    <%= render "content/edit/change_notes", revision: @revision %>
   <% end %>
 
   <%= render "govuk_publishing_components/components/button", {

--- a/app/views/content/edit.html.erb
+++ b/app/views/content/edit.html.erb
@@ -19,15 +19,11 @@
     ) do |f| %>
 
   <% @edition.document_type.contents.each do |field| %>
-    <%= render "content/edit/#{field.id}_field",
-      edition: @edition,
-      revision: @revision,
-      issues: @issues
-    %>
+    <%= render "content/edit/#{field.id}_field", edition: @edition, issues: @issues %>
   <% end %>
 
   <% if @edition.document.live_edition %>
-    <%= render "content/edit/change_notes", revision: @revision %>
+    <%= render "content/edit/change_notes", edition: @edition %>
   <% end %>
 
   <%= render "govuk_publishing_components/components/button", {

--- a/app/views/content/edit/_body_field.html.erb
+++ b/app/views/content/edit/_body_field.html.erb
@@ -35,7 +35,7 @@
       },
       id: "body-field",
       name: "body",
-      value: revision.contents["body"],
+      value: params[:body] || edition.contents["body"],
       rows: 20,
       spellcheck: "false",
       describedby: "body-guidance"

--- a/app/views/content/edit/_change_notes.html.erb
+++ b/app/views/content/edit/_change_notes.html.erb
@@ -3,9 +3,9 @@
       label: {
         text: t("content.edit.change_note.title"),
       },
-      id: "revision-change-note",
+      id: "edition-change-note",
       name: "change_note",
-      value: revision.change_note,
+      value: params[:change_note] || edition.change_note,
       rows: 4,
       data: {
         "contextual-guidance": "change-note-guidance"
@@ -15,10 +15,12 @@
 
 <%= render "govuk_publishing_components/components/contextual_guidance", {
   id: "change-note",
-  html_for: "revision-change-note",
+  html_for: "edition-change-note",
   title: t("content.edit.change_note.guidance_title"),
   content: render_govspeak(t("content.edit.change_note.guidance"))
 } do %>
+  <% update_type = params[:update_type] || edition.update_type %>
+
   <%= render "govuk_publishing_components/components/radio", {
     name: "update_type",
     heading: t("content.edit.update_type.title"),
@@ -28,7 +30,7 @@
         value: "major",
         text: t("content.edit.update_type.major_name"),
         conditional: textarea,
-        checked: revision.major?,
+        checked: update_type == "major",
         data_attributes: {
           gtm: "choose-update-type",
           "gtm-value": t("content.edit.update_type.major_name")
@@ -37,7 +39,7 @@
       {
         value: "minor",
         text: t("content.edit.update_type.minor_name"),
-        checked: revision.minor?,
+        checked: update_type == "minor",
         data_attributes: {
           gtm: "choose-update-type",
           "gtm-value": t("content.edit.update_type.minor_name")

--- a/app/views/content/edit/_change_notes.html.erb
+++ b/app/views/content/edit/_change_notes.html.erb
@@ -5,7 +5,7 @@
       },
       id: "revision-change-note",
       name: "change_note",
-      value: @revision.change_note,
+      value: revision.change_note,
       rows: 4,
       data: {
         "contextual-guidance": "change-note-guidance"
@@ -28,7 +28,7 @@
         value: "major",
         text: t("content.edit.update_type.major_name"),
         conditional: textarea,
-        checked: @revision.major?,
+        checked: revision.major?,
         data_attributes: {
           gtm: "choose-update-type",
           "gtm-value": t("content.edit.update_type.major_name")
@@ -37,7 +37,7 @@
       {
         value: "minor",
         text: t("content.edit.update_type.minor_name"),
-        checked: @revision.minor?,
+        checked: revision.minor?,
         data_attributes: {
           gtm: "choose-update-type",
           "gtm-value": t("content.edit.update_type.minor_name")

--- a/app/views/content/edit/_summary_field.html.erb
+++ b/app/views/content/edit/_summary_field.html.erb
@@ -20,7 +20,7 @@
     },
     id: "summary-field",
     name: "summary",
-    value: revision.summary,
+    value: params[:summary] || edition.summary,
     error_items: issues&.items_for(:summary),
     rows: 4,
     maxlength: DocumentType::SummaryField::SUMMARY_MAX_LENGTH,

--- a/app/views/content/edit/_summary_field.html.erb
+++ b/app/views/content/edit/_summary_field.html.erb
@@ -3,10 +3,10 @@
     id: "summary",
     html_for: "summary-field"
   }
-  if t_doctype_field?(@edition, "summary.guidance")
+  if t_doctype_field?(edition, "summary.guidance")
     summary_contextual_guidance.merge!({
-      title: t_doctype_field(@edition, "summary.guidance.title"),
-      content: t_doctype_field(@edition, "summary.guidance.body_govspeak"),
+      title: t_doctype_field(edition, "summary.guidance.title"),
+      content: t_doctype_field(edition, "summary.guidance.body_govspeak"),
       guidance_id: "summary-guidance"
     })
   end
@@ -20,8 +20,8 @@
     },
     id: "summary-field",
     name: "summary",
-    value: @revision.summary,
-    error_items: @issues&.items_for(:summary),
+    value: revision.summary,
+    error_items: issues&.items_for(:summary),
     rows: 4,
     maxlength: DocumentType::SummaryField::SUMMARY_MAX_LENGTH,
     describedby: "summary-guidance"

--- a/app/views/content/edit/_title_and_base_path_field.html.erb
+++ b/app/views/content/edit/_title_and_base_path_field.html.erb
@@ -3,10 +3,10 @@
     id: "title",
     html_for: "title-field"
   }
-  if t_doctype_field?(@edition, "title.guidance")
+  if t_doctype_field?(edition, "title.guidance")
     title_contextual_guidance.merge!({
-      title: t_doctype_field(@edition, "title.guidance.title"),
-      content: t_doctype_field(@edition, "title.guidance.body_govspeak"),
+      title: t_doctype_field(edition, "title.guidance.title"),
+      content: t_doctype_field(edition, "title.guidance.body_govspeak"),
       guidance_id: "title-guidance"
     })
   end
@@ -20,8 +20,8 @@
     },
     id: "title-field",
     name: "title",
-    value: @revision.title,
-    error_items: @issues&.items_for(:title),
+    value: revision.title,
+    error_items: issues&.items_for(:title),
     rows: 2,
     maxlength: DocumentType::TitleAndBasePathField::TITLE_MAX_LENGTH,
     data: { "url-preview": "input" },
@@ -42,7 +42,7 @@
       default_message: t("content.edit.url_preview.no_title"),
       error_message: t("content.edit.url_preview.error"),
       website_root: Plek.new.website_root,
-      base_path: @revision.base_path
+      base_path: revision.base_path
     } %>
   </div>
 </div>

--- a/app/views/content/edit/_title_and_base_path_field.html.erb
+++ b/app/views/content/edit/_title_and_base_path_field.html.erb
@@ -20,7 +20,7 @@
     },
     id: "title-field",
     name: "title",
-    value: revision.title,
+    value: params[:title] || edition.title,
     error_items: issues&.items_for(:title),
     rows: 2,
     maxlength: DocumentType::TitleAndBasePathField::TITLE_MAX_LENGTH,
@@ -42,7 +42,7 @@
       default_message: t("content.edit.url_preview.no_title"),
       error_message: t("content.edit.url_preview.error"),
       website_root: Plek.new.website_root,
-      base_path: revision.base_path
+      base_path: edition.base_path
     } %>
   </div>
 </div>

--- a/app/views/documents/show/_proposed_scheduling_notice.html.erb
+++ b/app/views/documents/show/_proposed_scheduling_notice.html.erb
@@ -1,6 +1,6 @@
 <%
   publish_time = @edition.proposed_publish_time
-  issues = Requirements::PublishTimeChecker.new(publish_time).issues
+  issues = Requirements::PublishTimeChecker.new.issues(publish_time)
 %>
 <% proposed_scheduling_description = capture do %>
   <p class="govuk-body govuk-!-margin-bottom-1">

--- a/app/views/documents/show/contents/_body_field.html.erb
+++ b/app/views/documents/show/contents/_body_field.html.erb
@@ -1,4 +1,4 @@
 <%= render "components/formatted_text", {
-  text: @edition.contents["body"].to_s,
+  text: edition.contents["body"].to_s,
   chars: 150
 } %>

--- a/app/views/documents/show/contents/_summary_field.html.erb
+++ b/app/views/documents/show/contents/_summary_field.html.erb
@@ -1,1 +1,1 @@
-<%= @edition.summary %>
+<%= edition.summary %>

--- a/app/views/documents/show/contents/_title_and_base_path_field.html.erb
+++ b/app/views/documents/show/contents/_title_and_base_path_field.html.erb
@@ -1,1 +1,1 @@
-<%= @edition.title %>
+<%= edition.title %>

--- a/app/views/tags/edit.html.erb
+++ b/app/views/tags/edit.html.erb
@@ -22,7 +22,7 @@
         <div id="<%= tag_field.id %>">
           <%= render "tags/tags/#{tag_field.type}_input",
             tag_field: tag_field,
-            tags: @revision.tags,
+            tags: params[:tags] || @edition.tags,
             issues: @issues %>
         </div>
       <% end %>

--- a/lib/requirements/backdate_checker.rb
+++ b/lib/requirements/backdate_checker.rb
@@ -4,35 +4,19 @@ module Requirements
   class BackdateChecker
     EARLIEST_DATE = Date.new(1995, 1, 1)
 
-    def initialize(backdate)
-      @backdate = backdate
-    end
-
-    def pre_submit_issues
+    def pre_update_issues(backdate)
       issues = CheckerIssues.new
 
-      if in_the_future?
+      if backdate > Time.zone.today
         issues.create(:backdate_date, :in_the_future)
       end
 
-      if too_long_ago?
+      if backdate < EARLIEST_DATE
         date = EARLIEST_DATE.strftime("%-d %B %Y")
         issues.create(:backdate_date, :too_long_ago, date: date)
       end
 
       issues
-    end
-
-  private
-
-    attr_reader :backdate
-
-    def in_the_future?
-      backdate > Time.zone.today
-    end
-
-    def too_long_ago?
-      backdate < EARLIEST_DATE
     end
   end
 end

--- a/lib/requirements/content_checker.rb
+++ b/lib/requirements/content_checker.rb
@@ -9,11 +9,21 @@ module Requirements
       @revision = revision || edition.revision
     end
 
+    def pre_update_issues(params)
+      issues = CheckerIssues.new
+
+      edition.document_type.contents.each do |field|
+        issues += field.pre_update_issues(edition, params)
+      end
+
+      issues
+    end
+
     def pre_preview_issues
       issues = CheckerIssues.new
 
       edition.document_type.contents.each do |field|
-        issues += field.pre_preview_issues(edition, revision)
+        issues += field.pre_preview_issues(edition)
       end
 
       issues

--- a/lib/requirements/content_checker.rb
+++ b/lib/requirements/content_checker.rb
@@ -2,11 +2,10 @@
 
 module Requirements
   class ContentChecker
-    attr_reader :edition, :revision
+    attr_reader :edition
 
-    def initialize(edition, revision = nil)
+    def initialize(edition)
       @edition = edition
-      @revision = revision || edition.revision
     end
 
     def pre_update_issues(params)
@@ -33,12 +32,12 @@ module Requirements
       issues = CheckerIssues.new
 
       edition.document_type.contents.each do |field|
-        issues += field.pre_publish_issues(edition, revision)
+        issues += field.pre_publish_issues(edition)
       end
 
       if edition.document.live_edition &&
-          revision.update_type == "major" &&
-          revision.change_note.blank?
+          edition.update_type == "major" &&
+          edition.change_note.blank?
         issues.create(:change_note, :blank)
       end
 

--- a/lib/requirements/edition_checker.rb
+++ b/lib/requirements/edition_checker.rb
@@ -2,17 +2,16 @@
 
 module Requirements
   class EditionChecker
-    attr_reader :edition, :revision
+    attr_reader :edition
 
-    def initialize(edition, revision = nil)
+    def initialize(edition)
       @edition = edition
-      @revision = revision || edition.revision
     end
 
     def pre_preview_issues
       issues = CheckerIssues.new
 
-      revision.image_revisions.each do |image|
+      edition.image_revisions.each do |image|
         issues += ImageRevisionChecker.new(image).pre_preview_issues
       end
 
@@ -22,9 +21,9 @@ module Requirements
 
     def pre_publish_issues(params = {})
       issues = CheckerIssues.new
-      issues += ContentChecker.new(edition, revision).pre_publish_issues
+      issues += ContentChecker.new(edition).pre_publish_issues
       issues += TopicChecker.new(edition).pre_publish_issues(params)
-      issues += TagChecker.new(edition, revision).pre_publish_issues
+      issues += TagChecker.new(edition).pre_publish_issues
       issues
     end
   end

--- a/lib/requirements/edition_checker.rb
+++ b/lib/requirements/edition_checker.rb
@@ -16,7 +16,7 @@ module Requirements
         issues += ImageRevisionChecker.new(image).pre_preview_issues
       end
 
-      issues += ContentChecker.new(edition, revision).pre_preview_issues
+      issues += ContentChecker.new(edition).pre_preview_issues
       issues
     end
 

--- a/lib/requirements/publish_time_checker.rb
+++ b/lib/requirements/publish_time_checker.rb
@@ -4,16 +4,10 @@ module Requirements
   class PublishTimeChecker
     include ActionView::Helpers::DateHelper
 
-    attr_reader :publish_time
-
     MAX_PUBLISH_DELAY = 14.months
     MIN_PUBLISH_DELAY = 15.minutes
 
-    def initialize(publish_time)
-      @publish_time = publish_time
-    end
-
-    def issues
+    def issues(publish_time)
       issues = CheckerIssues.new
 
       if publish_time > MAX_PUBLISH_DELAY.from_now

--- a/lib/requirements/tag_checker.rb
+++ b/lib/requirements/tag_checker.rb
@@ -9,14 +9,18 @@ module Requirements
       @revision = revision || edition.revision
     end
 
-    def pre_publish_issues
+    def pre_update_issues(params)
       issues = CheckerIssues.new
 
-      if should_have_primary_org? && has_no_primary_org?
+      if missing_primary_org?(params)
         issues.create(:primary_publishing_organisation, :blank)
       end
 
       issues
+    end
+
+    def pre_publish_issues
+      pre_update_issues(edition.tags.symbolize_keys)
     end
 
   private
@@ -26,8 +30,10 @@ module Requirements
        .include?("primary_publishing_organisation")
     end
 
-    def has_no_primary_org?
-      revision.primary_publishing_organisation_id.blank?
+    def missing_primary_org?(params)
+      return false unless should_have_primary_org?
+
+      params[:primary_publishing_organisation].blank?
     end
   end
 end

--- a/lib/requirements/tag_checker.rb
+++ b/lib/requirements/tag_checker.rb
@@ -2,11 +2,10 @@
 
 module Requirements
   class TagChecker
-    attr_reader :edition, :revision
+    attr_reader :edition
 
-    def initialize(edition, revision = nil)
+    def initialize(edition)
       @edition = edition
-      @revision = revision || edition.revision
     end
 
     def pre_update_issues(params)

--- a/lib/requirements/withdrawal_checker.rb
+++ b/lib/requirements/withdrawal_checker.rb
@@ -2,14 +2,13 @@
 
 module Requirements
   class WithdrawalChecker
-    attr_reader :public_explanation, :edition
+    attr_reader :edition
 
-    def initialize(public_explanation, edition)
-      @public_explanation = public_explanation
+    def initialize(edition)
       @edition = edition
     end
 
-    def pre_withdrawal_issues
+    def pre_withdrawal_issues(public_explanation)
       issues = CheckerIssues.new
 
       if public_explanation.blank?

--- a/spec/lib/requirements/backdate_checker_spec.rb
+++ b/spec/lib/requirements/backdate_checker_spec.rb
@@ -4,19 +4,19 @@ RSpec.describe Requirements::BackdateChecker do
   describe "#pre_submit_issues" do
     it "returns no issues if there are none" do
       date = Time.current.change(day: 1, month: 1, year: 2019)
-      issues = Requirements::BackdateChecker.new(date).pre_submit_issues
+      issues = subject.pre_update_issues(date)
       expect(issues).to be_empty
     end
 
     it "returns an issue if the date is in the future" do
       date = 1.year.from_now
-      issues = Requirements::BackdateChecker.new(date).pre_submit_issues
+      issues = subject.pre_update_issues(date)
       expect(issues).to have_issue(:backdate_date, :in_the_future)
     end
 
     it "returns an issue if the date is too long ago" do
       earliest_date = Requirements::BackdateChecker::EARLIEST_DATE
-      issues = Requirements::BackdateChecker.new(earliest_date - 1).pre_submit_issues
+      issues = subject.pre_update_issues(earliest_date - 1)
 
       expect(issues).to have_issue(:backdate_date,
                                    :too_long_ago,

--- a/spec/lib/requirements/publish_time_checker_spec.rb
+++ b/spec/lib/requirements/publish_time_checker_spec.rb
@@ -3,24 +3,24 @@
 RSpec.describe Requirements::PublishTimeChecker do
   describe "#issues" do
     it "returns no issues if there are none" do
-      issues = Requirements::PublishTimeChecker.new(1.day.from_now).issues
+      issues = subject.issues(1.day.from_now)
       expect(issues).to be_empty
     end
 
     it "returns a date issue if the date is in the past" do
-      issues = Requirements::PublishTimeChecker.new(1.day.ago).issues
+      issues = subject.issues(1.day.ago)
       expect(issues).to have_issue(:schedule_date, :in_the_past, styles: %i[form summary])
     end
 
     it "returns a time issue if just the time is in the past" do
       travel_to(Time.zone.parse("2019-06-17 15:00")) do
-        issues = Requirements::PublishTimeChecker.new(1.hour.ago).issues
+        issues = subject.issues(1.hour.ago)
         expect(issues).to have_issue(:schedule_time, :in_the_past, styles: %i[form summary])
       end
     end
 
     it "returns an issue if the time is too close to now" do
-      issues = Requirements::PublishTimeChecker.new(5.minutes.from_now).issues
+      issues = subject.issues(5.minutes.from_now)
 
       expect(issues).to have_issue(:schedule_time,
                                    :too_close_to_now,
@@ -29,7 +29,7 @@ RSpec.describe Requirements::PublishTimeChecker do
     end
 
     it "returns an issue if the date is too far into the future" do
-      issues = Requirements::PublishTimeChecker.new(10.years.from_now).issues
+      issues = subject.issues(10.years.from_now)
 
       expect(issues).to have_issue(:schedule_date,
                                    :too_far_in_future,

--- a/spec/lib/requirements/withdrawal_checker_spec.rb
+++ b/spec/lib/requirements/withdrawal_checker_spec.rb
@@ -3,21 +3,22 @@
 RSpec.describe Requirements::WithdrawalChecker do
   describe "#pre_withdrawal_issues" do
     let(:edition) { build(:edition) }
+    subject { Requirements::WithdrawalChecker.new(edition) }
 
     it "returns no issues if there are none" do
       explanation = SecureRandom.alphanumeric
-      issues = Requirements::WithdrawalChecker.new(explanation, edition).pre_withdrawal_issues
+      issues = subject.pre_withdrawal_issues(explanation)
       expect(issues).to be_empty
     end
 
     it "returns an issue if there is no public explanation" do
-      issues = Requirements::WithdrawalChecker.new(nil, edition).pre_withdrawal_issues
+      issues = subject.pre_withdrawal_issues(nil)
       expect(issues).to have_issue(:public_explanation, :blank)
     end
 
     it "returns an issue if there is invalid govspeak in the public explanation" do
       explanation = "<script>alert('123')</script>"
-      issues = Requirements::WithdrawalChecker.new(explanation, edition).pre_withdrawal_issues
+      issues = subject.pre_withdrawal_issues(explanation)
       expect(issues).to have_issue(:public_explanation, :invalid_govspeak)
     end
   end

--- a/spec/models/document_type/body_field_spec.rb
+++ b/spec/models/document_type/body_field_spec.rb
@@ -46,13 +46,13 @@ RSpec.describe DocumentType::BodyField do
   describe "#pre_publish_issues" do
     it "returns no issues when there are none" do
       edition = build :edition, contents: { body: "alert('hi')" }
-      issues = subject.pre_publish_issues(edition, edition.revision)
+      issues = subject.pre_publish_issues(edition)
       expect(issues).to be_empty
     end
 
     it "returns an issue when the body is empty" do
       edition = build :edition, contents: { body: " " }
-      issues = subject.pre_publish_issues(edition, edition.revision)
+      issues = subject.pre_publish_issues(edition)
       expect(issues).to have_issue(:body, :blank, styles: %i[form summary])
     end
   end

--- a/spec/models/document_type/body_field_spec.rb
+++ b/spec/models/document_type/body_field_spec.rb
@@ -18,17 +18,28 @@ RSpec.describe DocumentType::BodyField do
     end
   end
 
-  describe "#pre_preview_issues" do
+  describe "#pre_update_issues" do
+    let(:edition) { build :edition }
+
     it "returns no issues when there are none" do
-      edition = build :edition, contents: { body: "alert('hi')" }
-      issues = subject.pre_preview_issues(edition, edition.revision)
+      params = { contents: { body: "alert('hi')" } }
+      issues = subject.pre_update_issues(edition, params)
       expect(issues).to be_empty
     end
 
     it "returns an issue if the a govspeak field contains forbidden HTML" do
-      edition = build :edition, contents: { body: "<script>alert('hi')</script>" }
-      issues = subject.pre_preview_issues(edition, edition.revision)
+      params = { contents: { body: "<script>alert('hi')</script>" } }
+      issues = subject.pre_update_issues(edition, params)
       expect(issues).to have_issue(:body, :invalid_govspeak, styles: %i[form summary])
+    end
+  end
+
+  describe "#pre_preview_issues" do
+    it "delegates to #pre_update_issues" do
+      edition = build :edition, contents: { body: "body" }
+      params = { contents: { body: edition.contents["body"] } }
+      expect(subject).to receive(:pre_update_issues).with(edition, params)
+      subject.pre_preview_issues(edition)
     end
   end
 

--- a/spec/models/document_type/summary_field_spec.rb
+++ b/spec/models/document_type/summary_field_spec.rb
@@ -18,25 +18,35 @@ RSpec.describe DocumentType::SummaryField do
     end
   end
 
-  describe "#pre_preview_issues" do
+  describe "#pre_update_issues" do
     let(:edition) { build :edition }
 
     it "returns no issues if there are none" do
-      issues = subject.pre_preview_issues(edition, edition.revision)
+      params = { summary: edition.summary }
+      issues = subject.pre_update_issues(edition, params)
       expect(issues).to be_empty
     end
 
     it "returns an issue if the summary is too long" do
       max_length = DocumentType::SummaryField::SUMMARY_MAX_LENGTH
-      revision = build :revision, summary: "a" * (max_length + 1)
-      issues = subject.pre_preview_issues(edition, revision)
+      params = { summary: "a" * (max_length + 1) }
+      issues = subject.pre_update_issues(edition, params)
       expect(issues).to have_issue(:summary, :too_long, styles: %i[form summary], max_length: max_length)
     end
 
     it "returns an issue if the summary has newlines" do
-      revision = build :revision, summary: "a\nb"
-      issues = subject.pre_preview_issues(edition, revision)
+      params = { summary: "a\nb" }
+      issues = subject.pre_update_issues(edition, params)
       expect(issues).to have_issue(:summary, :multiline, styles: %i[form summary])
+    end
+  end
+
+  describe "#pre_preview_issues" do
+    let(:edition) { build :edition }
+
+    it "delegates to #pre_update_issues" do
+      expect(subject).to receive(:pre_update_issues).with(edition, summary: edition.summary)
+      subject.pre_preview_issues(edition)
     end
   end
 

--- a/spec/models/document_type/summary_field_spec.rb
+++ b/spec/models/document_type/summary_field_spec.rb
@@ -54,13 +54,13 @@ RSpec.describe DocumentType::SummaryField do
     let(:edition) { build :edition, summary: "a summary" }
 
     it "returns no issues if there are none" do
-      issues = subject.pre_publish_issues(edition, edition.revision)
+      issues = subject.pre_publish_issues(edition)
       expect(issues).to be_empty
     end
 
     it "returns an issue if the summary is blank" do
-      revision = build :revision, summary: "  "
-      issues = subject.pre_publish_issues(edition, revision)
+      edition = build :edition, summary: "  "
+      issues = subject.pre_publish_issues(edition)
       expect(issues).to have_issue(:summary, :blank, styles: %i[form summary])
     end
   end

--- a/spec/models/document_type/title_and_base_path_field_spec.rb
+++ b/spec/models/document_type/title_and_base_path_field_spec.rb
@@ -28,28 +28,26 @@ RSpec.describe DocumentType::TitleAndBasePathField do
     let(:edition) { build :edition }
 
     it "returns no issues if there are none" do
-      issues = subject.pre_preview_issues(edition, edition.revision)
+      issues = subject.pre_preview_issues(edition)
       expect(issues).to be_empty
     end
 
     it "returns an issue if there is no title" do
-      revision = build :revision, title: nil
-      issues = subject.pre_preview_issues(edition, revision)
+      edition = build :edition, title: nil
+      issues = subject.pre_preview_issues(edition)
       expect(issues).to have_issue(:title, :blank, styles: %i[form summary])
     end
 
     it "returns an issue if the title is too long" do
-      edition = build :edition
       max_length = DocumentType::TitleAndBasePathField::TITLE_MAX_LENGTH
-      revision = build :revision, title: "a" * (max_length + 1)
-      issues = subject.pre_preview_issues(edition, revision)
+      edition = build :edition, title: "a" * (max_length + 1)
+      issues = subject.pre_preview_issues(edition)
       expect(issues).to have_issue(:title, :too_long, styles: %i[form summary], max_length: max_length)
     end
 
     it "returns an issue if the title has newlines" do
-      edition = build :edition
-      revision = build :revision, title: "a\nb"
-      issues = subject.pre_preview_issues(edition, revision)
+      edition = build :edition, title: "a\nb"
+      issues = subject.pre_preview_issues(edition)
       expect(issues).to have_issue(:title, :multiline, styles: %i[form summary])
     end
   end
@@ -62,31 +60,35 @@ RSpec.describe DocumentType::TitleAndBasePathField do
     end
 
     it "returns no issues if there are none" do
-      issues = subject.pre_update_issues(edition, edition.revision)
+      params = { title: edition.title }
+      issues = subject.pre_update_issues(edition, params)
       expect(issues).to be_empty
     end
 
     it "returns any pre_preview_issues" do
-      revision = build :revision, title: nil
-      issues = subject.pre_update_issues(edition, revision)
+      params = { title: nil }
+      issues = subject.pre_update_issues(edition, params)
       expect(issues).to have_issue(:title, :blank, styles: %i[form summary])
     end
 
     it "returns no issues if the document owns the path" do
       stub_publishing_api_has_lookups(edition.base_path => edition.content_id)
-      issues = subject.pre_update_issues(edition, edition.revision)
+      params = { title: edition.title, base_path: edition.base_path }
+      issues = subject.pre_update_issues(edition, params)
       expect(issues).to be_empty
     end
 
     it "returns an issue if the base_path conflicts" do
       stub_publishing_api_has_lookups(edition.base_path => SecureRandom.uuid)
-      issues = subject.pre_update_issues(edition, edition.revision)
+      params = { title: edition.title, base_path: edition.base_path }
+      issues = subject.pre_update_issues(edition, params)
       expect(issues).to have_issue(:title, :conflict, styles: %i[form summary])
     end
 
     it "returns no issues when the Publishing API is down" do
       stub_publishing_api_isnt_available
-      issues = subject.pre_update_issues(edition, edition.revision)
+      params = { title: edition.title, base_path: edition.base_path }
+      issues = subject.pre_update_issues(edition, params)
       expect(issues.items_for(:title)).to be_empty
     end
   end

--- a/spec/models/document_type/title_and_base_path_field_spec.rb
+++ b/spec/models/document_type/title_and_base_path_field_spec.rb
@@ -96,7 +96,7 @@ RSpec.describe DocumentType::TitleAndBasePathField do
   describe "#pre_publish_issues" do
     it "returns no issues" do
       edition = build :edition
-      issues = subject.pre_publish_issues(edition, edition.revision)
+      issues = subject.pre_publish_issues(edition)
       expect(issues).to be_empty
     end
   end


### PR DESCRIPTION
https://trello.com/c/u9kRKVsX/1324-extract-title-and-summary-into-classes-views-and-config

This resolves a pain point from the work to implement
flexible fields, where we redundantly pass an edition
and a revision as part of requirements checks.

Resolving this was more involved than I expected, since
it meant changing the approach we have for checking
requirements to avoid relying on an in-memory revision.

Please see the commits for more details. There's still
some remaining work to do in order to make our approach
consistent for file attachments and images.