### PR TITLE
Removals: support absolute URLs and allow attributing users

### DIFF
--- a/app/services/remove_document_service.rb
+++ b/app/services/remove_document_service.rb
@@ -27,7 +27,7 @@ private
       edition.content_id,
       type: removal.redirect? ? "redirect" : "gone",
       explanation: removal.explanatory_note,
-      alternative_path: removal.alternative_path,
+      alternative_path: removal.alternative_url,
       locale: edition.locale,
     )
   end

--- a/app/services/remove_document_service.rb
+++ b/app/services/remove_document_service.rb
@@ -50,13 +50,11 @@ private
   end
 
   def check_removeable
-    document = edition.document
-
-    if edition != document.live_edition
+    unless edition.live?
       raise "attempted to remove an edition other than the live edition"
     end
 
-    if document.current_edition != document.live_edition
+    unless edition.current?
       raise "Publishing API does not support unpublishing while there is a draft"
     end
   end

--- a/app/services/remove_document_service.rb
+++ b/app/services/remove_document_service.rb
@@ -1,9 +1,10 @@
 # frozen_string_literal: true
 
 class RemoveDocumentService < ApplicationService
-  def initialize(edition, removal)
+  def initialize(edition, removal, user: nil)
     @edition = edition
     @removal = removal
+    @user = user
   end
 
   def call
@@ -20,7 +21,7 @@ class RemoveDocumentService < ApplicationService
 
 private
 
-  attr_reader :edition, :removal
+  attr_reader :edition, :removal, :user
 
   def unpublish_edition
     GdsApi.publishing_api.unpublish(
@@ -33,7 +34,10 @@ private
   end
 
   def update_edition_status
-    AssignEditionStatusService.call(edition, state: :removed, status_details: removal)
+    AssignEditionStatusService.call(edition,
+                                    state: :removed,
+                                    status_details: removal,
+                                    user: user)
     edition.save!
   end
 

--- a/app/services/resync_document_service.rb
+++ b/app/services/resync_document_service.rb
@@ -92,7 +92,7 @@ private
       live_edition.content_id,
       type: removal.redirect? ? "redirect" : "gone",
       explanation: removal.explanatory_note,
-      alternative_path: removal.alternative_path,
+      alternative_path: removal.alternative_url,
       locale: live_edition.locale,
       unpublished_at: removal.created_at,
       allow_draft: true,

--- a/app/views/documents/history/_content_publisher_entry.html.erb
+++ b/app/views/documents/history/_content_publisher_entry.html.erb
@@ -17,18 +17,18 @@
     <% if removal.explanatory_note.present? %>
       <p><%= removal.explanatory_note %></p>
     <% end %>
-    <% if removal.alternative_path.present? %>
+    <% if removal.alternative_url.present? %>
       <% if removal.redirect? %>
         <p>
           Redirected to
-          <%= link_to(Plek.new.website_root + removal.alternative_path,
+          <%= link_to(Plek.new.website_root + removal.alternative_url,
                       nil,
                       class: "govuk-link") %>
         </p>
       <% else %>
         <p>
-          Alternative path
-          <%= link_to(Plek.new.website_root + removal.alternative_path,
+          Alternative URL
+          <%= link_to(Plek.new.website_root + removal.alternative_url,
                       nil,
                       class: "govuk-link") %>
         </p>

--- a/app/views/documents/history/_content_publisher_entry.html.erb
+++ b/app/views/documents/history/_content_publisher_entry.html.erb
@@ -20,9 +20,9 @@
     <% if removal.alternative_url.present? %>
       <p>
         <% if removal.redirect? %>
-          Redirected to
+          <%= t "documents.history.entry_content.redirected_to" %>
         <% else %>
-          Alternative URL
+          <%= t "documents.history.entry_content.alternative_url" %>
         <% end %>
         <%= link_to(nil,
                     URI.join(Plek.new.website_root, removal.alternative_url).to_s,

--- a/app/views/documents/history/_content_publisher_entry.html.erb
+++ b/app/views/documents/history/_content_publisher_entry.html.erb
@@ -18,21 +18,16 @@
       <p><%= removal.explanatory_note %></p>
     <% end %>
     <% if removal.alternative_url.present? %>
-      <% if removal.redirect? %>
-        <p>
+      <p>
+        <% if removal.redirect? %>
           Redirected to
-          <%= link_to(Plek.new.website_root + removal.alternative_url,
-                      nil,
-                      class: "govuk-link") %>
-        </p>
-      <% else %>
-        <p>
+        <% else %>
           Alternative URL
-          <%= link_to(Plek.new.website_root + removal.alternative_url,
-                      nil,
-                      class: "govuk-link") %>
-        </p>
-      <% end %>
+        <% end %>
+        <%= link_to(nil,
+                    URI.join(Plek.new.website_root, removal.alternative_url).to_s,
+                    class: "govuk-link") %>
+      </p>
     <% end %>
   <% end %>
 <% end %>

--- a/config/locales/en/documents/history.yml
+++ b/config/locales/en/documents/history.yml
@@ -59,3 +59,5 @@ en:
           withdrawn: "Withdrawn"
       entry_content:
         backdated: "First published date backdated to %{date}"
+        alternative_url: "Alternative URL"
+        redirected_to: "Redirected to"

--- a/db/migrate/20200207224528_rename_removal_alternative_path_to_alternative_url.rb
+++ b/db/migrate/20200207224528_rename_removal_alternative_path_to_alternative_url.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+class RenameRemovalAlternativePathToAlternativeUrl < ActiveRecord::Migration[6.0]
+  def change
+    rename_column :removals, :alternative_path, :alternative_url
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2020_02_06_162051) do
+ActiveRecord::Schema.define(version: 2020_02_07_224528) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -225,7 +225,7 @@ ActiveRecord::Schema.define(version: 2020_02_06_162051) do
 
   create_table "removals", force: :cascade do |t|
     t.string "explanatory_note"
-    t.string "alternative_path"
+    t.string "alternative_url"
     t.boolean "redirect", default: false
     t.datetime "created_at", null: false
   end

--- a/docs/removing-documents.md
+++ b/docs/removing-documents.md
@@ -1,6 +1,6 @@
 # Removing or removing and redirecting a document
 
-We need to allow users to unpublish content from GOV.UK. Currently, a user can't
+We need to allow users to remove content from GOV.UK. Currently, a user can't
 remove a document from the UI so a developer needs to run a rake task to
 achieve this.
 
@@ -25,7 +25,7 @@ Optional parameters:
 - URL
 
 ```
-rake unpublish:remove['a-content-id']
+rake remove:gone['a-content-id']
 ```
 
 ## Redirect removed documents to another page on GOV.UK
@@ -41,5 +41,5 @@ Optional parameters:
 - NOTE
 
 ```
-rake unpublish:remove_and_redirect['a-content-id'] URL='/redirect-to-here'
+rake remove:redirect['a-content-id'] URL='/redirect-to-here'
 ```

--- a/docs/removing-documents.md
+++ b/docs/removing-documents.md
@@ -12,6 +12,12 @@ Removed and redirected content redirects users to another page on GOV.UK
 
 Environment variables are being used to pass parameters to the rake tasks.
 
+When calling these tasks the USER_EMAIL variable should be passed in with your
+email address, for example:
+`rake remove:gone['a-content-id'] USER_EMAIL=me@example.com`. This is so
+the change can be associated with you, the developer that performed the task,
+and attributed correctly in the document history.
+
 ## Removing documents
 
 Required parameters:
@@ -23,6 +29,7 @@ Optional parameters:
 - LOCALE (set to "en" by default)
 - NOTE
 - URL
+- USER_EMAIL
 
 ```
 rake remove:gone['a-content-id']
@@ -39,6 +46,7 @@ Optional parameters:
 
 - LOCALE (set to "en" by default)
 - NOTE
+- USER_EMAIL
 
 ```
 rake remove:redirect['a-content-id'] URL='/redirect-to-here'

--- a/docs/removing-documents.md
+++ b/docs/removing-documents.md
@@ -22,7 +22,7 @@ Optional parameters:
 
 - LOCALE (set to "en" by default)
 - NOTE
-- NEW_PATH
+- URL
 
 ```
 rake unpublish:remove['a-content-id']
@@ -33,7 +33,7 @@ rake unpublish:remove['a-content-id']
 Required parameters:
 
 - content_id
-- NEW_PATH
+- URL
 
 Optional parameters:
 
@@ -41,5 +41,5 @@ Optional parameters:
 - NOTE
 
 ```
-rake unpublish:remove_and_redirect['a-content-id'] NEW_PATH='/redirect-to-here'
+rake unpublish:remove_and_redirect['a-content-id'] URL='/redirect-to-here'
 ```

--- a/lib/tasks/remove.rake
+++ b/lib/tasks/remove.rake
@@ -8,6 +8,7 @@ namespace :remove do
     explanatory_note = ENV["NOTE"]
     alternative_url = ENV["URL"]
     locale = ENV["LOCALE"] || "en"
+    user = User.find_by!(email: ENV["USER_EMAIL"]) if ENV["USER_EMAIL"]
 
     document = Document.find_by!(content_id: args.content_id, locale: locale)
     raise "Document must have a published version before it can be removed" unless document.live_edition
@@ -15,7 +16,7 @@ namespace :remove do
     removal = Removal.new(explanatory_note: explanatory_note,
                           alternative_url: alternative_url)
 
-    RemoveDocumentService.call(document.live_edition, removal)
+    RemoveDocumentService.call(document.live_edition, removal, user: user)
   end
 
   desc "Remove a document with a redirect on GOV.UK e.g. remove:redirect['a-content-id'] URL='/redirect-to-here'"
@@ -26,6 +27,7 @@ namespace :remove do
     explanatory_note = ENV["NOTE"]
     redirect_url = ENV["URL"]
     locale = ENV["LOCALE"] || "en"
+    user = User.find_by!(email: ENV["USER_EMAIL"]) if ENV["USER_EMAIL"]
 
     document = Document.find_by!(content_id: args.content_id, locale: locale)
     raise "Document must have a published version before it can be redirected" unless document.live_edition
@@ -34,6 +36,6 @@ namespace :remove do
                           explanatory_note: explanatory_note,
                           alternative_url: redirect_url)
 
-    RemoveDocumentService.call(document.live_edition, removal)
+    RemoveDocumentService.call(document.live_edition, removal, user: user)
   end
 end

--- a/lib/tasks/remove.rake
+++ b/lib/tasks/remove.rake
@@ -1,8 +1,8 @@
 # frozen_string_literal: true
 
-namespace :unpublish do
-  desc "Remove a document from GOV.UK e.g. unpublish:remove['a-content-id']"
-  task :remove, [:content_id] => :environment do |_, args|
+namespace :remove do
+  desc "Remove a document with a gone on GOV.UK e.g. remove:gone['a-content-id']"
+  task :gone, [:content_id] => :environment do |_, args|
     raise "Missing content_id parameter" unless args.content_id
 
     explanatory_note = ENV["NOTE"]
@@ -18,8 +18,8 @@ namespace :unpublish do
     RemoveDocumentService.call(document.live_edition, removal)
   end
 
-  desc "Remove and redirect a document on GOV.UK e.g. unpublish:remove_and_redirect['a-content-id'] URL='/redirect-to-here'"
-  task :remove_and_redirect, [:content_id] => :environment do |_, args|
+  desc "Remove a document with a redirect on GOV.UK e.g. remove:redirect['a-content-id'] URL='/redirect-to-here'"
+  task :redirect, [:content_id] => :environment do |_, args|
     raise "Missing content_id parameter" unless args.content_id
     raise "Missing URL value" if ENV["URL"].blank?
 

--- a/lib/tasks/unpublish.rake
+++ b/lib/tasks/unpublish.rake
@@ -6,25 +6,25 @@ namespace :unpublish do
     raise "Missing content_id parameter" unless args.content_id
 
     explanatory_note = ENV["NOTE"]
-    alternative_path = ENV["NEW_PATH"]
+    alternative_url = ENV["URL"]
     locale = ENV["LOCALE"] || "en"
 
     document = Document.find_by!(content_id: args.content_id, locale: locale)
     raise "Document must have a published version before it can be removed" unless document.live_edition
 
     removal = Removal.new(explanatory_note: explanatory_note,
-                          alternative_path: alternative_path)
+                          alternative_url: alternative_url)
 
     RemoveDocumentService.call(document.live_edition, removal)
   end
 
-  desc "Remove and redirect a document on GOV.UK e.g. unpublish:remove_and_redirect['a-content-id'] NEW_PATH='/redirect-to-here'"
+  desc "Remove and redirect a document on GOV.UK e.g. unpublish:remove_and_redirect['a-content-id'] URL='/redirect-to-here'"
   task :remove_and_redirect, [:content_id] => :environment do |_, args|
     raise "Missing content_id parameter" unless args.content_id
-    raise "Missing NEW_PATH value" if ENV["NEW_PATH"].blank?
+    raise "Missing URL value" if ENV["URL"].blank?
 
     explanatory_note = ENV["NOTE"]
-    redirect_path = ENV["NEW_PATH"]
+    redirect_url = ENV["URL"]
     locale = ENV["LOCALE"] || "en"
 
     document = Document.find_by!(content_id: args.content_id, locale: locale)
@@ -32,7 +32,7 @@ namespace :unpublish do
 
     removal = Removal.new(redirect: true,
                           explanatory_note: explanatory_note,
-                          alternative_path: redirect_path)
+                          alternative_url: redirect_url)
 
     RemoveDocumentService.call(document.live_edition, removal)
   end

--- a/lib/whitehall_importer/create_edition.rb
+++ b/lib/whitehall_importer/create_edition.rb
@@ -128,7 +128,7 @@ module WhitehallImporter
 
       Removal.new(
         explanatory_note: unpublishing["explanation"],
-        alternative_path: unpublishing["alternative_url"],
+        alternative_url: unpublishing["alternative_url"],
         redirect: unpublishing["alternative_url"].present?,
       )
     end

--- a/spec/factories/user_factory.rb
+++ b/spec/factories/user_factory.rb
@@ -4,7 +4,7 @@ FactoryBot.define do
   factory :user do
     name { "John Smith" }
     uid { SecureRandom.uuid }
-    email { "someone@example.com" }
+    sequence(:email) { |n| "user#{n}@example.com" }
     transient do
       managing_editor { false }
       manage_live_history_mode { false }

--- a/spec/lib/tasks/notify_spec.rb
+++ b/spec/lib/tasks/notify_spec.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-RSpec.describe "Notify rake tasks" do
+RSpec.describe "Notify tasks" do
   describe "notify:send_email" do
     let(:email_address) { "x@y.com" }
     before { Rake::Task["notify:send_email"].reenable }

--- a/spec/lib/tasks/remove_spec.rb
+++ b/spec/lib/tasks/remove_spec.rb
@@ -1,11 +1,11 @@
 # frozen_string_literal: true
 
-RSpec.describe "Unpublish tasks" do
+RSpec.describe "Remove tasks" do
   let(:edition) { create(:edition, :published, locale: "en") }
 
-  describe "unpublish:remove" do
+  describe "remove:gone" do
     before do
-      Rake::Task["unpublish:remove"].reenable
+      Rake::Task["remove:gone"].reenable
     end
 
     it "removes the edition" do
@@ -23,7 +23,7 @@ RSpec.describe "Unpublish tasks" do
       )
 
       ClimateControl.modify URL: alternative_url, NOTE: explanatory_note do
-        Rake::Task["unpublish:remove"].invoke(edition.content_id)
+        Rake::Task["remove:gone"].invoke(edition.content_id)
       end
 
       expect(unpublish_request).to have_been_requested
@@ -31,21 +31,21 @@ RSpec.describe "Unpublish tasks" do
     end
 
     it "raises an error if a content_id is not present" do
-      expect { Rake::Task["unpublish:remove"].invoke }
+      expect { Rake::Task["remove:gone"].invoke }
         .to raise_error("Missing content_id parameter")
     end
 
     it "raises an error if the document does not have a live version on GOV.uk" do
       draft = create(:edition, locale: "en")
 
-      expect { Rake::Task["unpublish:remove"].invoke(draft.content_id) }
+      expect { Rake::Task["remove:gone"].invoke(draft.content_id) }
         .to raise_error("Document must have a published version before it can be removed")
     end
   end
 
-  describe "unpublish:remove_and_redirect" do
+  describe "remove:redirect" do
     before do
-      Rake::Task["unpublish:remove_and_redirect"].reenable
+      Rake::Task["remove:redirect"].reenable
     end
 
     it "removes the edition with a redirect" do
@@ -62,7 +62,7 @@ RSpec.describe "Unpublish tasks" do
         },
       )
       ClimateControl.modify URL: redirect_url, NOTE: explanatory_note do
-        Rake::Task["unpublish:remove_and_redirect"].invoke(edition.content_id)
+        Rake::Task["remove:redirect"].invoke(edition.content_id)
       end
 
       expect(unpublish_request).to have_been_requested
@@ -70,12 +70,12 @@ RSpec.describe "Unpublish tasks" do
     end
 
     it "raises an error if a content_id is not present" do
-      expect { Rake::Task["unpublish:remove_and_redirect"].invoke }
+      expect { Rake::Task["remove:redirect"].invoke }
         .to raise_error("Missing content_id parameter")
     end
 
     it "raises an error if a URL is not present" do
-      expect { Rake::Task["unpublish:remove_and_redirect"].invoke("a-content-id") }
+      expect { Rake::Task["remove:redirect"].invoke("a-content-id") }
         .to raise_error("Missing URL value")
     end
 
@@ -83,7 +83,7 @@ RSpec.describe "Unpublish tasks" do
       draft = create(:edition, locale: "en")
 
       ClimateControl.modify URL: "/redirect" do
-        expect { Rake::Task["unpublish:remove_and_redirect"].invoke(draft.content_id) }
+        expect { Rake::Task["remove:redirect"].invoke(draft.content_id) }
           .to raise_error("Document must have a published version before it can be redirected")
       end
     end

--- a/spec/lib/tasks/remove_spec.rb
+++ b/spec/lib/tasks/remove_spec.rb
@@ -36,6 +36,18 @@ RSpec.describe "Remove tasks" do
       end
     end
 
+    it "accepts a user email" do
+      user = create(:user, email: "editor@example.com")
+
+      ClimateControl.modify NOTE: "My note", USER_EMAIL: user.email do
+        Rake::Task["remove:gone"].invoke(edition.content_id)
+      end
+
+      expect(RemoveDocumentService)
+        .to have_received(:call).with(anything, anything, user: user)
+    end
+
+
     it "raises an error if a content_id is not present" do
       expect { Rake::Task["remove:gone"].invoke }
         .to raise_error("Missing content_id parameter")
@@ -71,6 +83,17 @@ RSpec.describe "Remove tasks" do
             ),
           )
       end
+    end
+
+    it "accepts a user uid" do
+      user = create(:user, email: "editor@example.com")
+
+      ClimateControl.modify NOTE: "My note", URL: "/url", USER_EMAIL: user.email do
+        Rake::Task["remove:redirect"].invoke(edition.content_id)
+      end
+
+      expect(RemoveDocumentService)
+        .to have_received(:call).with(anything, anything, user: user)
     end
 
     it "raises an error if a content_id is not present" do

--- a/spec/lib/tasks/remove_spec.rb
+++ b/spec/lib/tasks/remove_spec.rb
@@ -86,7 +86,7 @@ RSpec.describe "Remove tasks" do
     end
 
     it "accepts a user uid" do
-      user = create(:user, email: "editor@example.com")
+      user = create(:user)
 
       ClimateControl.modify NOTE: "My note", URL: "/url", USER_EMAIL: user.email do
         Rake::Task["remove:redirect"].invoke(edition.content_id)

--- a/spec/lib/tasks/unpublish_spec.rb
+++ b/spec/lib/tasks/unpublish_spec.rb
@@ -10,19 +10,19 @@ RSpec.describe "Unpublish tasks" do
 
     it "removes the edition" do
       explanatory_note = "The reason the edition is being removed"
-      alternative_path = "/path"
+      alternative_url = "/path"
 
       unpublish_request = stub_publishing_api_unpublish(
         edition.content_id,
         body: {
-          alternative_path: alternative_path,
+          alternative_path: alternative_url,
           explanation: explanatory_note,
           locale: edition.locale,
           type: "gone",
         },
       )
 
-      ClimateControl.modify NEW_PATH: alternative_path, NOTE: explanatory_note do
+      ClimateControl.modify URL: alternative_url, NOTE: explanatory_note do
         Rake::Task["unpublish:remove"].invoke(edition.content_id)
       end
 
@@ -50,18 +50,18 @@ RSpec.describe "Unpublish tasks" do
 
     it "removes the edition with a redirect" do
       explanatory_note = "The reason the edition is being redirected"
-      redirect_path = "/redirect-path"
+      redirect_url = "/redirect-url"
 
       unpublish_request = stub_publishing_api_unpublish(
         edition.content_id,
         body: {
-          alternative_path: redirect_path,
+          alternative_path: redirect_url,
           explanation: explanatory_note,
           locale: edition.locale,
           type: "redirect",
         },
       )
-      ClimateControl.modify NEW_PATH: redirect_path, NOTE: explanatory_note do
+      ClimateControl.modify URL: redirect_url, NOTE: explanatory_note do
         Rake::Task["unpublish:remove_and_redirect"].invoke(edition.content_id)
       end
 
@@ -74,15 +74,15 @@ RSpec.describe "Unpublish tasks" do
         .to raise_error("Missing content_id parameter")
     end
 
-    it "raises an error if a NEW_PATH is not present" do
+    it "raises an error if a URL is not present" do
       expect { Rake::Task["unpublish:remove_and_redirect"].invoke("a-content-id") }
-        .to raise_error("Missing NEW_PATH value")
+        .to raise_error("Missing URL value")
     end
 
     it "raises an error if the document does not have a live version on GOV.uk" do
       draft = create(:edition, locale: "en")
 
-      ClimateControl.modify NEW_PATH: "/redirect" do
+      ClimateControl.modify URL: "/redirect" do
         expect { Rake::Task["unpublish:remove_and_redirect"].invoke(draft.content_id) }
           .to raise_error("Document must have a published version before it can be redirected")
       end

--- a/spec/lib/tasks/unpublish_spec.rb
+++ b/spec/lib/tasks/unpublish_spec.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-RSpec.describe "Unpublish rake tasks" do
+RSpec.describe "Unpublish tasks" do
   let(:edition) { create(:edition, :published, locale: "en") }
 
   describe "unpublish:remove" do

--- a/spec/lib/whitehall_importer/create_edition_spec.rb
+++ b/spec/lib/whitehall_importer/create_edition_spec.rb
@@ -315,7 +315,7 @@ RSpec.describe WhitehallImporter::CreateEdition do
 
         removal = edition.status.details
         expect(removal.explanatory_note).to eq(whitehall_edition["unpublishing"]["explanation"])
-        expect(removal.alternative_path).to eq(whitehall_edition["unpublishing"]["alternative_url"])
+        expect(removal.alternative_url).to eq(whitehall_edition["unpublishing"]["alternative_url"])
         expect(removal.redirect).to be_truthy
       end
 
@@ -366,7 +366,7 @@ RSpec.describe WhitehallImporter::CreateEdition do
 
         removal = document.editions.first.status.details
         expect(removal.explanatory_note).to eq(whitehall_edition["unpublishing"]["explanation"])
-        expect(removal.alternative_path).to eq(whitehall_edition["unpublishing"]["alternative_url"])
+        expect(removal.alternative_url).to eq(whitehall_edition["unpublishing"]["alternative_url"])
         expect(removal.redirect).to be_truthy
       end
 

--- a/spec/services/remove_document_service_spec.rb
+++ b/spec/services/remove_document_service_spec.rb
@@ -37,6 +37,14 @@ RSpec.describe RemoveDocumentService do
       expect(edition.status.details).to eq(removal)
     end
 
+    it "can assign a user to the status" do
+      removal = build(:removal)
+      user = build(:user)
+
+      RemoveDocumentService.call(edition, removal, user: user)
+      expect(edition.status.created_by).to eq(user)
+    end
+
     context "when the removal is a redirect" do
       it "unpublishes in the Publishing API with a type of redirect" do
         removal = build(:removal,

--- a/spec/services/remove_document_service_spec.rb
+++ b/spec/services/remove_document_service_spec.rb
@@ -41,7 +41,7 @@ RSpec.describe RemoveDocumentService do
       it "unpublishes in the Publishing API with a type of redirect" do
         removal = build(:removal,
                         redirect: true,
-                        alternative_path: "/path",
+                        alternative_url: "/path",
                         explanatory_note: "explanation")
 
         request = stub_publishing_api_unpublish(
@@ -62,7 +62,7 @@ RSpec.describe RemoveDocumentService do
       it "unpublishes in the Publishing API with a type of gone" do
         removal = build(:removal,
                         redirect: false,
-                        alternative_path: "/path",
+                        alternative_url: "/path",
                         explanatory_note: "explanation")
 
         request = stub_publishing_api_unpublish(

--- a/spec/services/remove_document_service_spec.rb
+++ b/spec/services/remove_document_service_spec.rb
@@ -31,7 +31,7 @@ RSpec.describe RemoveDocumentService do
       removal = build(:removal)
 
       expect { RemoveDocumentService.call(edition, removal) }
-        .to change { edition.reload.state }
+        .to change { edition.state }
         .to("removed")
 
       expect(edition.status.details).to eq(removal)

--- a/spec/services/resync_document_service_spec.rb
+++ b/spec/services/resync_document_service_spec.rb
@@ -138,7 +138,7 @@ RSpec.describe ResyncDocumentService do
           build(
             :removal,
             redirect: true,
-            alternative_path: "/foo/bar",
+            alternative_url: "/foo/bar",
             explanatory_note: explanation,
           )
         end
@@ -149,7 +149,7 @@ RSpec.describe ResyncDocumentService do
           remove_params = {
             type: "redirect",
             explanation: explanation,
-            alternative_path: removal.alternative_path,
+            alternative_path: removal.alternative_url,
             locale: edition.locale,
             unpublished_at: removal.created_at,
             allow_draft: true,

--- a/spec/views/documents/history/_content_publisher_entry.html.erb_spec.rb
+++ b/spec/views/documents/history/_content_publisher_entry.html.erb_spec.rb
@@ -25,4 +25,51 @@ RSpec.describe "documents/history/_content_publisher_entry.html.erb" do
                                       text: "Amazing internal note")
     expect(rendered).to have_content(I18n.t!("documents.history.entry_types.internal_note"))
   end
+
+  context "when the timeline entry is for a removal" do
+    it "can show an explanatory_note" do
+      removal = create(:removal, explanatory_note: "My note")
+      timeline_entry = create(:timeline_entry,
+                              entry_type: :removed,
+                              details: removal)
+      render partial: "documents/history/content_publisher_entry",
+             locals: { entry: timeline_entry }
+      expect(rendered).to have_content("My note")
+    end
+
+    it "can show a link to an alternative URL" do
+      removal = create(:removal, alternative_url: "https://example.com")
+      timeline_entry = create(:timeline_entry,
+                              entry_type: :removed,
+                              details: removal)
+      render partial: "documents/history/content_publisher_entry",
+             locals: { entry: timeline_entry }
+      expect(rendered).to have_content("Alternative URL https://example.com",
+                                       normalize_ws: true)
+      expect(rendered).to have_link("https://example.com",
+                                    href: "https://example.com")
+    end
+
+    it "can show a link to an alternative URL that is a path" do
+      removal = create(:removal, alternative_url: "/path")
+      timeline_entry = create(:timeline_entry,
+                              entry_type: :removed,
+                              details: removal)
+      render partial: "documents/history/content_publisher_entry",
+             locals: { entry: timeline_entry }
+      expect(rendered).to have_link("https://www.test.gov.uk/path",
+                                    href: "https://www.test.gov.uk/path")
+    end
+
+    it "can show a redirect" do
+      removal = create(:removal, redirect: true, alternative_url: "https://example.com")
+      timeline_entry = create(:timeline_entry,
+                              entry_type: :removed,
+                              details: removal)
+      render partial: "documents/history/content_publisher_entry",
+             locals: { entry: timeline_entry }
+      expect(rendered).to have_content("Redirected to https://example.com",
+                                       normalize_ws: true)
+    end
+  end
 end

--- a/spec/views/documents/history/_content_publisher_entry.html.erb_spec.rb
+++ b/spec/views/documents/history/_content_publisher_entry.html.erb_spec.rb
@@ -44,7 +44,8 @@ RSpec.describe "documents/history/_content_publisher_entry.html.erb" do
                               details: removal)
       render partial: "documents/history/content_publisher_entry",
              locals: { entry: timeline_entry }
-      expect(rendered).to have_content("Alternative URL https://example.com",
+      alternative_url = I18n.t!("documents.history.entry_content.alternative_url")
+      expect(rendered).to have_content("#{alternative_url} https://example.com",
                                        normalize_ws: true)
       expect(rendered).to have_link("https://example.com",
                                     href: "https://example.com")
@@ -68,7 +69,8 @@ RSpec.describe "documents/history/_content_publisher_entry.html.erb" do
                               details: removal)
       render partial: "documents/history/content_publisher_entry",
              locals: { entry: timeline_entry }
-      expect(rendered).to have_content("Redirected to https://example.com",
+      redirected_to = I18n.t!("documents.history.entry_content.redirected_to")
+      expect(rendered).to have_content("#{redirected_to} https://example.com",
                                        normalize_ws: true)
     end
   end


### PR DESCRIPTION
Trello: https://trello.com/c/yqXt0RGc/1417-remove-documents-at-dwps-request

Following the first request to remove documents from Content Publisher we have learnt that there are some issues to resolve.

Firstly Content Publisher uses misleadingly named terminology from the Publishing API of `alternative_path`to describe the redirect destination. This is actually a URL rather than a path, however Content Publisher had assumed it could only be a path which caused some poor rendering:

<img width="1038" alt="Screenshot 2020-02-07 at 17 58 47" src="https://user-images.githubusercontent.com/282717/74153586-dd089d00-4c08-11ea-85c1-a444203c5c55.png">

To resolve this I've switched our naming to follow the Whitehall precedent of `alternative_url` throughout the app.

Secondly, it turned out the links we are showing users in the document history for a removal or incorrect. This is because we passed in nil as the wrong parameter of `link_to`. Passing a url as the first parameter and nil as the second means we get a link like: `<a href="">https://my.url</a>`, whereas we actually want to use [nil as the first parameter](https://github.com/rails/rails/blob/c77a949299fcddd0f6f35d9bc21888b862ff665c/actionview/lib/action_view/helpers/url_helper.rb#L144-L145).

Thirdly, it seemed a shame that our task doesn't allow the attribution of users to removing, leaving unattributed actions in the history. With me intending to remove a document for a publisher I want to say in the history that I did the change which should offer people more clues if they ever question how the change came to be. In adding this in I noticed that we create all users with the same email address in our factories so I resolved that.

And finally I fixed some inconsistencies with copy in the views that would normally be in I18n files.