### PR TITLE
Fix discarded draft attribution in timeline entries

### DIFF
--- a/app/interactors/editions/destroy_interactor.rb
+++ b/app/interactors/editions/destroy_interactor.rb
@@ -23,7 +23,7 @@ private
   end
 
   def discard_draft
-    DeleteDraftEditionService.call(edition.document, user)
+    DeleteDraftEditionService.call(edition, user)
   rescue GdsApi::BaseError => e
     GovukError.notify(e)
     context.fail!(api_error: true)

--- a/spec/interactors/editions/destroy_interactor_spec.rb
+++ b/spec/interactors/editions/destroy_interactor_spec.rb
@@ -23,7 +23,7 @@ RSpec.describe Editions::DestroyInteractor do
     it "delegates to the DeleteDraftEditionService" do
       expect(DeleteDraftEditionService)
         .to receive(:call)
-        .with(edition.document, user)
+        .with(edition, user)
       Editions::DestroyInteractor.call(params: params, user: user)
     end
 

--- a/spec/interactors/editions/destroy_interactor_spec.rb
+++ b/spec/interactors/editions/destroy_interactor_spec.rb
@@ -1,0 +1,55 @@
+# frozen_string_literal: true
+
+RSpec.describe Editions::DestroyInteractor do
+  describe ".call" do
+    let(:edition) { create(:edition) }
+    let(:user) { create :user }
+
+    let(:params) do
+      ActionController::Parameters.new(document: edition.document.to_param)
+    end
+
+    before do
+      stub_publishing_api_unreserve_path(edition.base_path)
+      stub_publishing_api_discard_draft(edition.content_id)
+    end
+
+    it "discards an edition" do
+      result = Editions::DestroyInteractor.call(params: params, user: user)
+      expect(result).to be_success
+      expect(result.edition).to be_discarded
+    end
+
+    it "delegates to the DeleteDraftEditionService" do
+      expect(DeleteDraftEditionService)
+        .to receive(:call)
+        .with(edition.document, user)
+      Editions::DestroyInteractor.call(params: params, user: user)
+    end
+
+    it "creates a timeline entry" do
+      expect { Editions::DestroyInteractor.call(params: params, user: user) }
+        .to change { TimelineEntry.where(entry_type: :draft_discarded).count }
+        .by(1)
+    end
+
+    context "when the Publishing API is down" do
+      before { stub_publishing_api_isnt_available }
+
+      it "fails with an api_error flag" do
+        result = Editions::DestroyInteractor.call(params: params, user: user)
+        expect(result).to be_failure
+        expect(result.api_error).to be(true)
+      end
+    end
+
+    context "when the edition isn't editable" do
+      let(:edition) { create(:edition, :published) }
+
+      it "raises a state error" do
+        expect { Editions::DestroyInteractor.call(params: params, user: user) }
+          .to raise_error(EditionAssertions::StateError)
+      end
+    end
+  end
+end


### PR DESCRIPTION
Trello: https://trello.com/c/yqXt0RGc/1417-remove-documents-at-dwps-request

It turns out that we have a bug in the code used to assign the status of a timeline entry. The `DeleteDraftEditionService` accepts a document as input and modifies the current_edition of that. As the edition that is used in the interactor is not the same object as `document.current_edition` the edition in the interactor becomes stale and using that to populate the timeline entry uses an out of date status.

Looking on production we have 175 discarded timeline entries and only 32 of those are attributed to the correct status:

```
irb(main):010:0> TimelineEntry.draft_discarded.map { |te| te.status.state }.each_with_object(Hash.new(0)) { |state, memo| memo[state] += 1 }
=> {"discarded"=>32, "draft"=>129, "submitted_for_review"=>14}
```
The problems seem to kick in between March 20th to 25th this year - which makes [this change (by me)](https://github.com/alphagov/content-publisher/commit/62871d94412d6c4cbb9d0dc28411128bb08d0a5e) the likely culprit. Once this is merged I plan to fix those in the DB manually.

To resolve this I've changed the `DeleteDraftEditionService` to operate on an edition, which felt more natural anyway given the naming the class.