### PR TITLE
Fix import of embedded files in news articles

### DIFF
--- a/spec/lib/whitehall_importer/embed_body_references_spec.rb
+++ b/spec/lib/whitehall_importer/embed_body_references_spec.rb
@@ -12,31 +12,87 @@ RSpec.describe WhitehallImporter::EmbedBodyReferences do
       expect(govspeak_body).to eq("[Contact:#{content_id}]")
     end
 
-    it "converts Whitehall image syntax to Content Publisher syntax" do
-      govspeak_body = described_class.call(
-        body: "!!1 test !!2",
-        images: ["foo.png", "bar.jpg"],
-      )
+    it "converts Whitehall image bang embeds to govspeak Image embeds" do
+      body = described_class.call(body: "!!1", images: ["file.jpg"])
 
-      expect(govspeak_body).to eq("[Image:foo.png] test [Image:bar.jpg]")
+      expect(body).to eq("[Image:file.jpg]")
     end
 
-    it "removes any image markdown that doesn't resolve to an image" do
-      govspeak_body = described_class.call(
-        body: "Bar !!2 Baz",
-        images: ["foo.png"],
-      )
+    it "converts Whitehall attachment bang embeds to govspeak Attachment embeds" do
+      body = described_class.call(body: "!@1", attachments: ["file.pdf"])
 
-      expect(govspeak_body).to eq("Bar  Baz")
+      expect(body).to eq("[Attachment:file.pdf]")
     end
 
-    it "converts Whitehall attachment syntax to Content Publisher syntax" do
-      govspeak_body = described_class.call(
-        body: "!@1 test !@2",
-        attachments: ["file.pdf", "download.csv"],
-      )
+    it "ignores Whitehall image bang embeds that are neither start of the string or preceeded by new lines" do
+      body = described_class.call(body: "!!1 test !!2",
+                                  images: ["file.png", "file.jpg"])
 
-      expect(govspeak_body).to eq("[Attachment:file.pdf] test [Attachment:download.csv]")
+      expect(body).to eq("[Image:file.png] test !!2")
+    end
+
+    it "ignores Whitehall attachment bang embeds that are neither start of the string or preceeded by new lines" do
+      body = described_class.call(body: "!@1 test !@2",
+                                  attachments: ["file.pdf", "file.csv"])
+
+      expect(body).to eq("[Attachment:file.pdf] test !@2")
+    end
+
+    it "ignores Whitehall image bang embeds that do not resolve to an Image" do
+      body = described_class.call(body: "!!2 test", images: ["file.png"])
+
+      expect(body).to eq(" test")
+    end
+
+    it "ignores Whitehall attachment bang embeds that do not resolve to an Attachment" do
+      body = described_class.call(body: "!@2 test", attachments: ["file.pdf"])
+
+      expect(body).to eq(" test")
+    end
+
+    it "converts image and attachment embeds prefixed by single new lines to be prefixed by two" do
+      prefix_conversions = [
+        { prefix: "\n", conversion: "\n\n" },
+        { prefix: "\r\n", conversion: "\r\n\r\n" },
+      ]
+
+      prefix_conversions.each do |prefix_conversion|
+        prefixed = [
+          "#{prefix_conversion[:prefix]}!!1",
+          "#{prefix_conversion[:prefix]}!@1",
+        ]
+
+        converted = []
+        converted << "#{prefix_conversion[:conversion]}[Image:file.jpg]"
+        converted << "#{prefix_conversion[:conversion]}[Attachment:file.pdf]"
+
+        body = described_class.call(
+          body: prefixed.join,
+          images: ["file.jpg"],
+          attachments: ["file.pdf"],
+        )
+
+        expect(body).to eq(converted.join)
+      end
+    end
+
+    it "doesn't change the prefixes of images and attachments preceeded by two or more new lines" do
+      prefixes = [
+        "\n\n", "\r\n\r\n",
+        "\n\n\n", "\r\n\r\n\r\n",
+        "\n\n\n\n", "\r\n\r\n\r\n\r\n"
+      ]
+
+      prefixes.each do |prefix|
+        body = described_class.call(
+          body: "#{prefix}!!1#{prefix}!@1",
+          images: ["file.jpg"],
+          attachments: ["file.pdf"],
+        )
+
+        expect(body)
+          .to eq("#{prefix}[Image:file.jpg]#{prefix}[Attachment:file.pdf]")
+      end
     end
 
     it "converts Whitehall inline attachment syntax to Content Publisher syntax" do
@@ -45,16 +101,8 @@ RSpec.describe WhitehallImporter::EmbedBodyReferences do
         attachments: ["file.pdf", "download.csv"],
       )
 
-      expect(govspeak_body).to eq("[AttachmentLink:file.pdf] test [AttachmentLink:download.csv]")
-    end
-
-    it "removes any attachment markdown that doesn't resolve to an attachment" do
-      govspeak_body = described_class.call(
-        body: "Bar !@2 Baz [InlineAttachment:3] << removed, but !@1 continues to work",
-        attachments: ["foo.pdf"],
-      )
-
-      expect(govspeak_body).to eq("Bar  Baz  << removed, but [Attachment:foo.pdf] continues to work")
+      expect(govspeak_body)
+        .to eq("[AttachmentLink:file.pdf] test [AttachmentLink:download.csv]")
     end
   end
 end


### PR DESCRIPTION
When migrating two of NDA's news articles from Whitehall to Content Publisher, we encounter integrity check failures on the body.  The cause of this is the presence of image markdown in the proposed payload which we have failed to convert to an actual image, i.e. we're sending '[Image:wood_640_x_960.jpg]' rather than '<img ....'.

The documents are:

- [ID: 431866 Content ID: 809d70b1-3e9b-4833-a28b-41366a925805](https://www.gov.uk/government/news/barrnon-and-wood-move-to-next-stage-of-innovation-competition)

- [ID: 370367 Content ID: 5a88536b-7831-4184-b5fd-c40275ba7558](https://www.gov.uk/government/news/awards-recognise-supply-chain-excellence)

It is expected that a similar situation will occur with attachments due to the similarity of their handling.
    
On inspection of the original document body of these documents and their revisions, it is noticed that in the first case a user had manually removed one new line (e.g. `\r\n!!2\r\n`)...

**431866 Revisions**

1. `\r\n\r\n!!2\r\n\r\n`

1. `\r\n!!2\r\n`

1. `\r\n!!2\r\n`

In the second case two images are present with only one new line between them (e.g. `\n\n!!2\n!!3`)...

**370367 Revisions**

1. `\r\n\r\n!!2\r\n!!3\r\n\r\n`, `\r\n\r\n!!4\r\n!!5\r\n\r\n`, `\r\n\r\n!!6\r\n!!7\r\n\r\n`, `\r\n\r\n!!8\r\n\r\n`, `\r\n\r\n!!9\r\n!!10\r\n\r\n`
             
1. `\r\n\r\n!!2\r\n!!3\r\n\r\n`, `\r\n\r\n!!4\r\n!!5\r\n\r\n`, `\r\n\r\n!!6\r\n!!7\r\n\r\n`, `\r\n\r\n!!8\r\n\r\n`, `\r\n\r\n!!9\r\n!!10\r\n\r\n`

Files are defined in GovSpeak as `!!2` for images and `!@2` for attachments.  Both require two new lines to be entered prior to the file (e.g. `\n\n!!2` or `\n\n!@2`) in order to be correctly converted into HTML correctly.
    
We need to fix the import so these files are correctly parsed, and the proposed payload for Publishing API matches the currently published document.

Trello: https://trello.com/c/x42Ye088/1406-fix-import-of-embedded-images-in-news-articles
