### PR TITLE
Fix autocomplete.yml

### DIFF
--- a/app/views/components/docs/autocomplete.yml
+++ b/app/views/components/docs/autocomplete.yml
@@ -159,6 +159,7 @@ examples:
           - France
           - Germany
           - United Kingdom
+
   autocomplete_js_only:
     description: |
       Shows an autocomplete component only if JavaScript is enabled.


### PR DESCRIPTION
A missing empty line in the autocomplete is causing the component guide (`/component-guide`) to crash with a 500 error.