### PR TITLE
Check migration finished when handling errors

### DIFF
--- a/app/jobs/whitehall_document_import_job.rb
+++ b/app/jobs/whitehall_document_import_job.rb
@@ -15,7 +15,7 @@ class WhitehallDocumentImportJob < ApplicationJob
   def perform(document_import)
     document_import = WhitehallImporter::Import.call(document_import)
     document_import = WhitehallImporter::Sync.call(document_import)
-    document_import.whitehall_migration&.check_migration_finished
+    document_import.whitehall_migration.check_migration_finished
   end
 
   def self.handle_error(document_import, error)
@@ -41,5 +41,7 @@ class WhitehallDocumentImportJob < ApplicationJob
       state = document_import.imported? ? "sync_failed" : "import_failed"
       document_import.update!(state: state, error_log: error.inspect)
     end
+
+    document_import.whitehall_migration.check_migration_finished
   end
 end

--- a/spec/jobs/whitehall_document_import_job_spec.rb
+++ b/spec/jobs/whitehall_document_import_job_spec.rb
@@ -7,7 +7,8 @@ RSpec.describe WhitehallDocumentImportJob do
   let(:whitehall_host) { Plek.new.external_url_for("whitehall-admin") }
 
   let(:whitehall_migration_document_import) do
-    create(:whitehall_migration_document_import)
+    create(:whitehall_migration_document_import,
+           whitehall_migration_id: whitehall_migration["id"])
   end
 
   let(:imported_document_import) do
@@ -47,6 +48,21 @@ RSpec.describe WhitehallDocumentImportJob do
     expect(completed_document_import.whitehall_migration)
       .to receive(:check_migration_finished)
     WhitehallDocumentImportJob.perform_now(whitehall_migration_document_import)
+  end
+
+  context "when an error is raised" do
+    let(:error_message) { "an error" }
+
+    before do
+      allow(WhitehallImporter::Import).to receive(:call).and_raise(error_message)
+    end
+
+    it "calls on the mark migration completed method" do
+      expect(whitehall_migration_document_import.whitehall_migration)
+        .to receive(:check_migration_finished)
+
+      WhitehallDocumentImportJob.perform_now(whitehall_migration_document_import)
+    end
   end
 
   context "when the import fails" do


### PR DESCRIPTION
If an error occurs when running the Whitehall Document Import Job, we still
need to check if the migration has finished, otherwise we could have a
situation where on the Whitehall Migration record it looks like the migration
has never finished.