### PR TITLE
Fix import of documents with PDF attachments from Whitehall to Content Publisher

### DIFF
--- a/app/models/file_attachment/blob_revision.rb
+++ b/app/models/file_attachment/blob_revision.rb
@@ -16,7 +16,7 @@ class FileAttachment::BlobRevision < ApplicationRecord
   end
 
   def asset_url
-    asset.file_url
+    asset.file_url.to_s
   end
 
   def bytes_for_asset

--- a/lib/whitehall_importer/create_file_attachment_revision.rb
+++ b/lib/whitehall_importer/create_file_attachment_revision.rb
@@ -100,5 +100,9 @@ module WhitehallImporter
     def content_type
       nil
     end
+
+    def tempfile
+      self
+    end
   end
 end

--- a/lib/whitehall_importer/import.rb
+++ b/lib/whitehall_importer/import.rb
@@ -1,3 +1,5 @@
+require "gds_api/whitehall_export"
+
 module WhitehallImporter
   class Import
     attr_reader :document_import

--- a/lib/whitehall_importer/integrity_checker.rb
+++ b/lib/whitehall_importer/integrity_checker.rb
@@ -90,11 +90,13 @@ module WhitehallImporter
     end
 
     def primary_publishing_organisation_matches?
-      proposed_payload.dig(:links, :primary_publishing_organisation) == publishing_api_link(:primary_publishing_organisation)
+      proposed_payload.dig(:links, :primary_publishing_organisation).presence ==
+        publishing_api_link(:primary_publishing_organisation).presence
     end
 
     def organisations_match?
-      proposed_payload.dig(:links, :organisations)&.sort == publishing_api_link(:organisations)&.sort
+      proposed_payload.dig(:links, :organisations).to_a.sort ==
+        publishing_api_link(:organisations).to_a.sort
     end
 
     def publishing_api_content

--- a/lib/whitehall_importer/integrity_checker.rb
+++ b/lib/whitehall_importer/integrity_checker.rb
@@ -37,16 +37,12 @@ module WhitehallImporter
         end
       end
 
-      problems << "body text doesn't match" unless body_text_matches?
+      problems << "body text doesn't match" unless BodyTextCheck.new(
+        proposed_payload.dig(:details, :body),
+        publishing_api_content.dig(:details, :body),
+      ).sufficiently_similar?
 
       problems
-    end
-
-    def body_text_matches?
-      proposed_body_text = proposed_payload.dig(:details, :body)
-      publishing_api_body_text = publishing_api_content.dig(:details, :body)
-
-      Sanitize.clean(publishing_api_body_text).squish == Sanitize.clean(proposed_body_text).squish
     end
 
     def image_problems

--- a/lib/whitehall_importer/integrity_checker/body_text_check.rb
+++ b/lib/whitehall_importer/integrity_checker/body_text_check.rb
@@ -1,0 +1,14 @@
+module WhitehallImporter
+  class IntegrityChecker::BodyTextCheck
+    attr_reader :proposed_body_text, :publishing_api_body_text
+
+    def initialize(proposed_body_text, publishing_api_body_text)
+      @proposed_body_text = proposed_body_text
+      @publishing_api_body_text = publishing_api_body_text
+    end
+
+    def sufficiently_similar?
+      Sanitize.clean(publishing_api_body_text).squish == Sanitize.clean(proposed_body_text).squish
+    end
+  end
+end

--- a/lib/whitehall_importer/integrity_checker/body_text_check.rb
+++ b/lib/whitehall_importer/integrity_checker/body_text_check.rb
@@ -8,7 +8,24 @@ module WhitehallImporter
     end
 
     def sufficiently_similar?
-      Sanitize.clean(publishing_api_body_text).squish == Sanitize.clean(proposed_body_text).squish
+      proposed_body = remove_attachment_file_size(proposed_body_text)
+      publishing_api_body = remove_attachment_file_size(publishing_api_body_text)
+      Sanitize.clean(publishing_api_body).squish == Sanitize.clean(proposed_body).squish
+    end
+
+  private
+
+    def remove_attachment_file_size(body)
+      file_size_selector = ".attachment-inline .file-size, .gem-c-attachment-link .gem-c-attachment-link__attribute:nth-of-type(2)"
+      remove_html_elements(body, file_size_selector)
+    end
+
+    def remove_html_elements(body, selector)
+      doc = Nokogiri.HTML(body)
+      doc.search(selector).each do |el|
+        el.replace("")
+      end
+      doc.to_html
     end
   end
 end

--- a/lib/whitehall_importer/sync.rb
+++ b/lib/whitehall_importer/sync.rb
@@ -1,3 +1,5 @@
+require "gds_api/whitehall_export"
+
 module WhitehallImporter
   class Sync
     attr_reader :whitehall_import

--- a/spec/lib/whitehall_importer/integrity_checker/body_text_check_spec.rb
+++ b/spec/lib/whitehall_importer/integrity_checker/body_text_check_spec.rb
@@ -15,6 +15,32 @@ RSpec.describe WhitehallImporter::IntegrityChecker::BodyTextCheck do
       expect(integrity_check.sufficiently_similar?).to be true
     end
 
+    it "returns true even if there is a mismatch in inline atttachment URL filesize" do
+      proposed_body = %(
+        <p>
+          <span class="gem-c-attachment-link">
+            <a class="govuk-link" href="filename.pdf" target="_blank">Test File</a>
+            (<span class="gem-c-attachment-link__attribute"><abbr title="Portable Document Format" class="gem-c-attachment-link__abbr">PDF</abbr></span>,
+              <span class="gem-c-attachment-link__attribute">391 KB</span>, <span class="gem-c-attachment-link__attribute">9 pages</span>)
+          </span>
+        </p>
+      )
+
+      publishing_api_body = %(
+        <p>
+          <span class="attachment-inline">
+            <a href="/filename.pdf">Test File</a>
+            (<span class="type">PDF</span>,
+              <span class="file-size">391KB</span>,
+              <span class="page-length">9 pages</span>)
+          </span>
+        </p>
+      )
+
+      integrity_check = described_class.new(proposed_body, publishing_api_body)
+      expect(integrity_check.sufficiently_similar?).to be true
+    end
+
     it "returns false when the body text doesn't match" do
       integrity_check = described_class.new("Some text", "Some different text")
       expect(integrity_check.sufficiently_similar?).to be false

--- a/spec/lib/whitehall_importer/integrity_checker/body_text_check_spec.rb
+++ b/spec/lib/whitehall_importer/integrity_checker/body_text_check_spec.rb
@@ -1,0 +1,13 @@
+RSpec.describe WhitehallImporter::IntegrityChecker::BodyTextCheck do
+  describe "#sufficiently_similar?" do
+    it "retuns true if the proposed payload matches" do
+      integrity_check = described_class.new("Some text", "Some text")
+      expect(integrity_check.sufficiently_similar?).to be true
+    end
+
+    it "returns false when the body text doesn't match" do
+      integrity_check = described_class.new("Some text", "Some different text")
+      expect(integrity_check.sufficiently_similar?).to be false
+    end
+  end
+end

--- a/spec/lib/whitehall_importer/integrity_checker/body_text_check_spec.rb
+++ b/spec/lib/whitehall_importer/integrity_checker/body_text_check_spec.rb
@@ -5,6 +5,16 @@ RSpec.describe WhitehallImporter::IntegrityChecker::BodyTextCheck do
       expect(integrity_check.sufficiently_similar?).to be true
     end
 
+    it "returns true when the body text whitespace does not match" do
+      integrity_check = described_class.new("Some text", "Some     text")
+      expect(integrity_check.sufficiently_similar?).to be true
+    end
+
+    it "returns true when the HTML does not match" do
+      integrity_check = described_class.new("<b>Some text</b>", "Some text")
+      expect(integrity_check.sufficiently_similar?).to be true
+    end
+
     it "returns false when the body text doesn't match" do
       integrity_check = described_class.new("Some text", "Some different text")
       expect(integrity_check.sufficiently_similar?).to be false

--- a/spec/lib/whitehall_importer/integrity_checker_spec.rb
+++ b/spec/lib/whitehall_importer/integrity_checker_spec.rb
@@ -20,21 +20,14 @@ RSpec.describe WhitehallImporter::IntegrityChecker do
     end
 
     let(:publishing_api_item) do
-      {
-        content_id: edition.content_id,
-        base_path: edition.base_path,
-        title: edition.title,
-        description: edition.summary,
-        document_type: edition.document_type.id,
-        schema_name: edition.document_type.publishing_metadata.schema_name,
-        details: {
-          body: GovspeakDocument.new(edition.contents["body"], edition).payload_html,
-        },
-        links: {
-          primary_publishing_organisation: edition.tags["primary_publishing_organisation"].to_a,
-          organisations: edition.tags["organisations"].to_a + edition.tags["primary_publishing_organisation"].to_a,
-        },
-      }
+      default_publishing_api_item(edition,
+                                  details: {
+                                    body: GovspeakDocument.new(edition.contents["body"], edition).payload_html,
+                                  },
+                                  links: {
+                                    primary_publishing_organisation: edition.tags["primary_publishing_organisation"].to_a,
+                                    organisations: edition.tags["organisations"].to_a + edition.tags["primary_publishing_organisation"].to_a,
+                                  })
     end
 
     it "returns true if there aren't any problems for edition without image or attachment" do
@@ -69,17 +62,7 @@ RSpec.describe WhitehallImporter::IntegrityChecker do
     end
 
     it "compares against organisations in linkset links if there no edition links" do
-      stub_publishing_api_has_item(
-        content_id: edition.content_id,
-        base_path: edition.base_path,
-        title: edition.title,
-        description: edition.summary,
-        document_type: edition.document_type.id,
-        schema_name: edition.document_type.publishing_metadata.schema_name,
-        details: {
-          body: GovspeakDocument.new(edition.contents["body"], edition).payload_html,
-        },
-      )
+      stub_publishing_api_has_item(default_publishing_api_item(edition))
 
       stub_publishing_api_has_links(
         content_id: edition.content_id,
@@ -113,21 +96,14 @@ RSpec.describe WhitehallImporter::IntegrityChecker do
       end
 
       let(:publishing_api_item) do
-        {
-          content_id: edition.content_id,
-          base_path: edition.base_path,
-          title: edition.title,
-          description: edition.summary,
-          document_type: edition.document_type.id,
-          schema_name: edition.document_type.publishing_metadata.schema_name,
-          details: {
-            body: GovspeakDocument.new(edition.contents["body"], edition).payload_html,
-          },
-          links: {
-            primary_publishing_organisation: edition.tags["primary_publishing_organisation"].to_a,
-            organisations: edition.tags["organisations"].to_a + edition.tags["primary_publishing_organisation"].to_a,
-          },
-        }
+        default_publishing_api_item(edition,
+                                    details: {
+                                      body: GovspeakDocument.new(edition.contents["body"], edition).payload_html,
+                                    },
+                                    links: {
+                                      primary_publishing_organisation: edition.tags["primary_publishing_organisation"].to_a,
+                                      organisations: edition.tags["organisations"].to_a + edition.tags["primary_publishing_organisation"].to_a,
+                                    })
       end
 
       before do
@@ -260,5 +236,19 @@ RSpec.describe WhitehallImporter::IntegrityChecker do
 
       expect(integrity_check.problems).to include(message)
     end
+  end
+
+  def default_publishing_api_item(edition, override_hash = {})
+    {
+      content_id: edition.content_id,
+      base_path: edition.base_path,
+      title: edition.title,
+      description: edition.summary,
+      document_type: edition.document_type.id,
+      schema_name: edition.document_type.publishing_metadata.schema_name,
+      details: {
+        body: "",
+      },
+    }.deep_merge!(override_hash)
   end
 end

--- a/spec/lib/whitehall_importer/integrity_checker_spec.rb
+++ b/spec/lib/whitehall_importer/integrity_checker_spec.rb
@@ -139,7 +139,7 @@ RSpec.describe WhitehallImporter::IntegrityChecker do
       it "returns true if there aren't any problems" do
         stub_publishing_api_has_item(publishing_api_item)
 
-        integrity_check = WhitehallImporter::IntegrityChecker.new(edition)
+        integrity_check = described_class.new(edition)
         expect(integrity_check.valid?).to be true
       end
     end


### PR DESCRIPTION
When doing a test migration of NDA's news stories, we found three articles with an embedded PDF attachment did not import with an error:

```
NoMethodError: undefined method `tempfile' for #<Tempfile:/tmp/open-uri20200129-1-g41dgq>
/govuk/content-publisher/app/services/create_file_attachment_blob_service.rb:37:in `number_of_pages'
```

This manual testing revealed there were a number of issues that we had not previously seen through the existing automated tests, which are resolved through this PR:

- Adds require statements for `gds_api/whitehall_export` that were missing
- Adds a `tempfile` method for the imported PDF, solving the issue giving the error above
- Uses a string for a missing asset URL when this would otherwise be nil (i.e. assets not yet synced to asset manager), which otherwise causes a `link_to` to fail
- Ignores inconsistencies in file size presentation (e.g. `131KB` in documents published by Whitehall, but `131 KB` in those published by Content Publisher)

Additionally, the body checking part of the integrity checker has been moved into a subclass, which has made testing this code under specific scenarios much simpler.

Trello card: https://trello.com/c/86Adk1bO