### PR TITLE
Fix attribute name in attachment component

### DIFF
--- a/app/views/components/_attachment_meta.html.erb
+++ b/app/views/components/_attachment_meta.html.erb
@@ -8,7 +8,7 @@
   <%= render "govuk_publishing_components/components/attachment", {
     attachment: attachment,
     data_attributes: data_attributes,
-    hide_help_text: true,
+    hide_opendocument_metadata: true,
     target: "_blank",
   } %>
   <% if actions.any? %>


### PR DESCRIPTION
The `hide_help_text` attribute was [renamed in govuk_publishing_components](https://github.com/alphagov/govuk_publishing_components/commit/66c1f9f7b43c9cdd26bb2c6acb3e0973cfe3c916) to `hide_opendocument_metadata`.

Thanks @ChrisBAshton for spotting this 🕵 