### PR TITLE
Fix image integrity bugs

### DIFF
--- a/lib/whitehall_importer/integrity_checker.rb
+++ b/lib/whitehall_importer/integrity_checker.rb
@@ -128,13 +128,13 @@ module WhitehallImporter
     end
 
     def empty_caption?(proposed_image_payload, publishing_api_image, attribute)
-      attribute == "caption" &&
+      attribute == :caption &&
         publishing_api_image[attribute].nil? &&
         proposed_image_payload[attribute].empty?
     end
 
     def default_image?(proposed_image_payload, publishing_api_image, attribute)
-      attribute == "alt_text" &&
+      attribute == :alt_text &&
         proposed_image_payload.empty? &&
         publishing_api_image[attribute] == "placeholder"
     end

--- a/spec/lib/whitehall_importer/integrity_checker_spec.rb
+++ b/spec/lib/whitehall_importer/integrity_checker_spec.rb
@@ -1,10 +1,10 @@
 RSpec.describe WhitehallImporter::IntegrityChecker do
   let(:document_type) do
-    build :document_type, contents: [
+    build(:document_type, images: true, contents: [
       DocumentType::TitleAndBasePathField.new,
       DocumentType::SummaryField.new,
       DocumentType::BodyField.new,
-    ]
+    ])
   end
 
   describe "#valid?" do
@@ -45,9 +45,11 @@ RSpec.describe WhitehallImporter::IntegrityChecker do
     end
 
     it "returns true if the Publishing API image caption is nil but the imported image caption is an empty string" do
-      edition.revision.image_revisions = [build(:image_revision, caption: "")]
+      image_revision = create(:image_revision, caption: "")
+      edition.revision.image_revisions = [image_revision]
+      edition.revision.lead_image_revision = image_revision
 
-      publishing_api_item[:image] = {
+      publishing_api_item[:details][:image] = {
         caption: nil,
       }
       stub_publishing_api_has_item(publishing_api_item)
@@ -57,7 +59,7 @@ RSpec.describe WhitehallImporter::IntegrityChecker do
     end
 
     it "returns true if the Publishing API image is a placeholder and the imported edition has no image" do
-      publishing_api_item[:image] = {
+      publishing_api_item[:details][:image] = {
         alt_text: "placeholder",
       }
       stub_publishing_api_has_item(publishing_api_item)


### PR DESCRIPTION
Strings were previously being used to compare the attribute when the
attribute was always a symbol, the strings have now been converted to
symbols.

There was multiple reasons these issues were not caught by the tests:

For the `default_image?` scenario the reason was because the 'image
problems' logic would never be called due to the if statement -
`publishing_api_image[attribute] != proposed_image_payload[attribute]`
reporting false due to a missed level of nesting in the
publishing_api_content stub, `[:image][:caption]` instead of what it
should be `[:details][:image][:caption]`. This caused a false positive to
be returned.

For the `empty_caption?` scenario the reason was due to the
document_type not being set to accept images and the edition not having
a lead_image_revision set, this caused the
PreviewDraftEditionService::Payload to not acknowledge the edition had
any images, this combined with the incorrect stub caused the 'image
problems' logic to not be called again and record a false positive.

Trello:
https://trello.com/c/duVHl9JD/1457-fix-documents-with-mismatched-caption
https://trello.com/c/MLQrfE8l/1456-fix-documents-with-mismatched-alt-text