### PR TITLE
Return document import from WhitehallImporter::Sync

### DIFF
--- a/lib/whitehall_importer/sync.rb
+++ b/lib/whitehall_importer/sync.rb
@@ -23,6 +23,7 @@ module WhitehallImporter
       MigrateAssets.call(whitehall_import)
 
       whitehall_import.update!(state: "completed")
+      whitehall_import
     end
   end
 end

--- a/spec/lib/whitehall_importer/sync_spec.rb
+++ b/spec/lib/whitehall_importer/sync_spec.rb
@@ -42,8 +42,8 @@ RSpec.describe WhitehallImporter::Sync do
     end
 
     it "returns a completed WhitehallMigration::DocumentImport" do
-      described_class.call(whitehall_migration_document_import)
-      expect(whitehall_migration_document_import).to be_completed
+      document_import = described_class.call(whitehall_migration_document_import)
+      expect(document_import).to be_completed
     end
 
     it "raises if the WhitehallMigration::DocumentImport doesn't have a state of imported" do


### PR DESCRIPTION
We expect this class to return a document import so that in the Whitehall
Document Import Job we can check that if its Whitehall Migration has finished.