### PR TITLE
Stop returning document import from Import and Sync

### DIFF
--- a/app/jobs/whitehall_document_import_job.rb
+++ b/app/jobs/whitehall_document_import_job.rb
@@ -11,8 +11,8 @@ class WhitehallDocumentImportJob < ApplicationJob
   end
 
   def perform(document_import)
-    document_import = WhitehallImporter::Import.call(document_import)
-    document_import = WhitehallImporter::Sync.call(document_import)
+    WhitehallImporter::Import.call(document_import)
+    WhitehallImporter::Sync.call(document_import)
     document_import.whitehall_migration.check_migration_finished
   end
 

--- a/lib/whitehall_importer/import.rb
+++ b/lib/whitehall_importer/import.rb
@@ -41,7 +41,6 @@ module WhitehallImporter
         create_timeline_entry(document_import.document.current_edition)
 
         document_import.update!(state: "imported")
-        document_import
       end
     rescue StandardError
       # restore any attributes set during import

--- a/spec/jobs/whitehall_document_import_job_spec.rb
+++ b/spec/jobs/whitehall_document_import_job_spec.rb
@@ -13,17 +13,9 @@ RSpec.describe WhitehallDocumentImportJob do
     create(:whitehall_migration_document_import, state: "imported")
   end
 
-  let(:completed_document_import) do
-    create(:whitehall_migration_document_import,
-           state: "completed",
-           whitehall_migration_id: whitehall_migration["id"])
-  end
-
   before do
     allow(WhitehallImporter::Import).to receive(:call)
-                                    .and_return(imported_document_import)
     allow(WhitehallImporter::Sync).to receive(:call)
-                                  .and_return(completed_document_import)
     allow(whitehall_migration).to receive(:check_migration_finished)
     stub_whitehall_unlock_document(
       whitehall_migration_document_import.whitehall_document_id,
@@ -38,12 +30,12 @@ RSpec.describe WhitehallDocumentImportJob do
 
   it "calls WhitehallImporter::Sync" do
     expect(WhitehallImporter::Sync).to receive(:call)
-                                   .with(imported_document_import)
+                                   .with(whitehall_migration_document_import)
     WhitehallDocumentImportJob.perform_now(whitehall_migration_document_import)
   end
 
   it "calls on the mark migration completed method" do
-    expect(completed_document_import.whitehall_migration)
+    expect(whitehall_migration_document_import.whitehall_migration)
       .to receive(:check_migration_finished)
     WhitehallDocumentImportJob.perform_now(whitehall_migration_document_import)
   end


### PR DESCRIPTION
Both `WhitehallImporter::Import` and `WhitehallImporter::Sync` will update the
document import when called and we don't need to assign the document import to
a variable, so there's no need to return the document import when these classes
are done with it.