### PR TITLE
Send asset ID to Asset Manager

### DIFF
--- a/app/models/whitehall_migration/asset_import.rb
+++ b/app/models/whitehall_migration/asset_import.rb
@@ -24,10 +24,8 @@ class WhitehallMigration::AssetImport < ApplicationRecord
     end
   end
 
-  def whitehall_asset_id
-    url_array = original_asset_url.to_s.split("/")
-    # https://github.com/alphagov/asset-manager#create-an-asset
-    url_array[url_array.length - 2]
+  def legacy_url_path
+    URI(original_asset_url).path
   end
 
 private

--- a/lib/whitehall_importer/migrate_assets.rb
+++ b/lib/whitehall_importer/migrate_assets.rb
@@ -33,15 +33,22 @@ module WhitehallImporter
 
     def redirect_asset(whitehall_asset)
       GdsApi.asset_manager.update_asset(
-        whitehall_asset.whitehall_asset_id,
+        asset_id(whitehall_asset),
         redirect_url: whitehall_asset.content_publisher_asset.file_url,
       )
       whitehall_asset.update!(state: "redirected")
     end
 
     def remove_asset(whitehall_asset)
-      GdsApi.asset_manager.delete_asset(whitehall_asset.whitehall_asset_id)
+      GdsApi.asset_manager.delete_asset(asset_id(whitehall_asset))
       whitehall_asset.update!(state: "removed")
+    end
+
+    def asset_id(whitehall_asset)
+      attributes = GdsApi.asset_manager
+                         .whitehall_asset(whitehall_asset.legacy_url_path)
+                         .to_h
+      attributes["id"].split("/").last
     end
   end
 end

--- a/spec/factories/whitehall_migration_asset_import_factory.rb
+++ b/spec/factories/whitehall_migration_asset_import_factory.rb
@@ -8,13 +8,13 @@ FactoryBot.define do
     trait :for_image do
       file_attachment_revision { nil }
       image_revision { build(:image_revision, :on_asset_manager, state: :live) }
-      original_asset_url { "https://asset-manager.gov.uk/blah/847150/foo.jpg" }
+      original_asset_url { "https://static.gov.uk/government/uploads/system/uploads/image_data/file/847150/foo.jpg" }
     end
 
     trait :for_file_attachment do
       image_revision { nil }
       file_attachment_revision { build(:file_attachment_revision, :on_asset_manager, state: :live) }
-      original_asset_url { "https://asset-manager.gov.uk/blah/847150/foo.pdf" }
+      original_asset_url { "https://static.gov.uk/government/uploads/system/uploads/attachment_data/file/847150/foo.pdf" }
     end
   end
 end

--- a/spec/models/whitehall_migration/asset_import_spec.rb
+++ b/spec/models/whitehall_migration/asset_import_spec.rb
@@ -31,14 +31,14 @@ RSpec.describe WhitehallMigration::AssetImport do
     end
   end
 
-  describe ".whitehall_asset_id" do
-    it "returns the asset manager ID of the original asset" do
-      whitehall_asset_id = "847150"
+  describe ".legacy_url_path" do
+    it "returns the path of the original asset URL" do
+      asset_path = "/government/uploads/system/uploads/attachment_data/file/1/foo.jpg"
       asset = build(
         :whitehall_migration_asset_import,
-        original_asset_url: "https://asset-manager.gov.uk/blah/#{whitehall_asset_id}/foo.jpg",
+        original_asset_url: "https://static.gov.uk#{asset_path}",
       )
-      expect(asset.whitehall_asset_id).to eq(whitehall_asset_id)
+      expect(asset.legacy_url_path).to eq(asset_path)
     end
   end
 


### PR DESCRIPTION
For https://trello.com/c/piW0fhqa/1454-fix-documents-that-failed-the-sync

Previously we were getting an ID from the `original_asset_url` exported with an
image from Whitehall and sending this to Asset Manager in order to make changes
to the asset. This isn't the right ID however, and resulted in Asset Manager
being unable to find the asset. What we actually need is to find out the Asset
Manager ID and send that to Asset Manager. We can do this by getting the legacy
URL path from the `original_asset_url` and looking this up in Asset Manager to
get the correct Asset Manager ID.