### PR TITLE
Add published at data

### DIFF
--- a/app/services/publish_draft_edition_service.rb
+++ b/app/services/publish_draft_edition_service.rb
@@ -11,10 +11,10 @@ class PublishDraftEditionService < ApplicationService
 
     publish_assets
     associate_with_government
+    set_published_at
     publish_current_edition
     supersede_live_edition
     set_new_live_edition
-    set_first_published_at
   rescue GdsApi::BaseError => e
     GovukError.notify(e)
     raise
@@ -73,9 +73,12 @@ private
     document.reload_live_edition
   end
 
-  def set_first_published_at
+  def set_published_at
+    current_time = Time.current
+    edition.published_at = current_time
+
     return if document.first_published_at
 
-    document.update!(first_published_at: Time.current)
+    document.update!(first_published_at: current_time)
   end
 end

--- a/db/migrate/20200218153946_add_published_at_to_editions.rb
+++ b/db/migrate/20200218153946_add_published_at_to_editions.rb
@@ -1,0 +1,5 @@
+class AddPublishedAtToEditions < ActiveRecord::Migration[6.0]
+  def change
+    add_column :editions, :published_at, :datetime
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2020_02_17_112039) do
+ActiveRecord::Schema.define(version: 2020_02_18_153946) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -90,6 +90,7 @@ ActiveRecord::Schema.define(version: 2020_02_17_112039) do
     t.bigint "access_limit_id"
     t.boolean "system_political", default: false, null: false
     t.uuid "government_id"
+    t.datetime "published_at"
     t.index ["access_limit_id"], name: "index_editions_on_access_limit_id"
     t.index ["created_by_id"], name: "index_editions_on_created_by_id"
     t.index ["document_id", "current"], name: "index_editions_on_document_id_and_current", unique: true, where: "(current = true)"


### PR DESCRIPTION
First PR to populate `published_at` column for editions when publishing an edition, we also move when publishing times are set to be before the syncing with publishing-api.

Trello:
https://trello.com/c/ShhyTqqU/1459-create-store-and-backfill-publishedat-on-editions