### PR TITLE
Backfill published_at column for edition

### DIFF
--- a/db/migrate/20200218161942_backfill_published_at_for_editions.rb
+++ b/db/migrate/20200218161942_backfill_published_at_for_editions.rb
@@ -1,0 +1,7 @@
+class BackfillPublishedAtForEditions < ActiveRecord::Migration[6.0]
+  def up
+    Status.where(state: %w[published published_but_needs_2i])
+          .order(:created_at)
+          .find_each { |s| s.edition.update!(published_at: s.created_at) unless s.edition.published_at }
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2020_02_18_153946) do
+ActiveRecord::Schema.define(version: 2020_02_18_161942) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"


### PR DESCRIPTION
This backfills the published_at column for previously published
editions, we use when the published status was created as a means to
work this time out as this should reflect the actual publishing time.

This relies on:
https://github.com/alphagov/content-publisher/pull/1777

Trello:
https://trello.com/c/ShhyTqqU/1459-create-store-and-backfill-publishedat-on-editions