### PR TITLE
Split and rename delete draft service

### DIFF
--- a/app/interactors/editions/destroy_interactor.rb
+++ b/app/interactors/editions/destroy_interactor.rb
@@ -21,7 +21,7 @@ private
   end
 
   def discard_draft
-    DeleteDraftEditionService.call(edition, user)
+    DiscardDraftEditionService.call(edition, user)
   rescue GdsApi::BaseError => e
     GovukError.notify(e)
     context.fail!(api_error: true)

--- a/app/interactors/editions/destroy_interactor.rb
+++ b/app/interactors/editions/destroy_interactor.rb
@@ -10,6 +10,8 @@ class Editions::DestroyInteractor < ApplicationInteractor
       find_and_lock_edition
       discard_draft
       create_timeline_entry
+    rescue Interactor::Failure
+      edition.update!(revision_synced: false)
     end
   end
 

--- a/app/services/delete_draft_assets_service.rb
+++ b/app/services/delete_draft_assets_service.rb
@@ -1,0 +1,22 @@
+class DeleteDraftAssetsService < ApplicationService
+  def initialize(edition)
+    @edition = edition
+  end
+
+  def call
+    edition.assets.each do |asset|
+      next unless asset.draft?
+
+      begin
+        GdsApi.asset_manager.delete_asset(asset.asset_manager_id)
+      rescue GdsApi::HTTPNotFound
+        Rails.logger.warn("No asset to delete for id #{asset.asset_manager_id}")
+      end
+      asset.absent!
+    end
+  end
+
+private
+
+  attr_reader :edition
+end

--- a/app/services/delete_draft_edition_service.rb
+++ b/app/services/delete_draft_edition_service.rb
@@ -9,7 +9,7 @@ class DeleteDraftEditionService < ApplicationService
     raise "Trying to delete a live edition" if edition.live?
 
     begin
-      delete_assets(edition.assets)
+      DeleteDraftAssetsService.call(edition)
       discard_draft(edition)
     rescue GdsApi::BaseError
       edition.update!(revision_synced: false)
@@ -17,7 +17,7 @@ class DeleteDraftEditionService < ApplicationService
     end
 
     reset_live_edition if document.live_edition
-    discard_path_reservations(edition) if edition.first?
+    DiscardPathReservationsService.call(edition) if edition.first?
     document.reload_current_edition
   end
 
@@ -25,17 +25,6 @@ private
 
   attr_reader :edition, :user
   delegate :document, to: :edition
-
-  def discard_path_reservations(edition)
-    paths = edition.revisions.map(&:base_path).uniq.compact
-    publishing_app = PreviewDraftEditionService::Payload::PUBLISHING_APP
-
-    paths.each do |path|
-      GdsApi.publishing_api.unreserve_path(path, publishing_app)
-    rescue GdsApi::HTTPNotFound
-      Rails.logger.warn("Tried to discard unreserved path #{path}")
-    end
-  end
 
   def reset_live_edition
     document.live_edition.update!(current: true)
@@ -59,18 +48,5 @@ private
 
     AssignEditionStatusService.call(edition, user: user, state: :discarded)
     edition.update!(current: false)
-  end
-
-  def delete_assets(assets)
-    assets.each do |asset|
-      next unless asset.draft?
-
-      begin
-        GdsApi.asset_manager.delete_asset(asset.asset_manager_id)
-      rescue GdsApi::HTTPNotFound
-        Rails.logger.warn("No asset to delete for id #{asset.asset_manager_id}")
-      end
-      asset.absent!
-    end
   end
 end

--- a/app/services/delete_draft_edition_service.rb
+++ b/app/services/delete_draft_edition_service.rb
@@ -8,14 +8,8 @@ class DeleteDraftEditionService < ApplicationService
     raise "Only current editions can be deleted" unless edition.current?
     raise "Trying to delete a live edition" if edition.live?
 
-    begin
-      DeleteDraftAssetsService.call(edition)
-      discard_draft(edition)
-    rescue GdsApi::BaseError
-      edition.update!(revision_synced: false)
-      raise
-    end
-
+    DeleteDraftAssetsService.call(edition)
+    discard_draft(edition)
     reset_live_edition if document.live_edition
     DiscardPathReservationsService.call(edition) if edition.first?
     document.reload_current_edition

--- a/app/services/discard_draft_edition_service.rb
+++ b/app/services/discard_draft_edition_service.rb
@@ -1,4 +1,4 @@
-class DeleteDraftEditionService < ApplicationService
+class DiscardDraftEditionService < ApplicationService
   def initialize(edition, user)
     @edition = edition
     @user = user

--- a/app/services/discard_path_reservations_service.rb
+++ b/app/services/discard_path_reservations_service.rb
@@ -1,0 +1,20 @@
+class DiscardPathReservationsService < ApplicationService
+  def initialize(edition)
+    @edition = edition
+  end
+
+  def call
+    paths = edition.revisions.map(&:base_path).uniq.compact
+    publishing_app = PreviewDraftEditionService::Payload::PUBLISHING_APP
+
+    paths.each do |path|
+      GdsApi.publishing_api.unreserve_path(path, publishing_app)
+    rescue GdsApi::HTTPNotFound
+      Rails.logger.warn("Tried to discard unreserved path #{path}")
+    end
+  end
+
+private
+
+  attr_reader :edition
+end

--- a/spec/interactors/editions/destroy_interactor_spec.rb
+++ b/spec/interactors/editions/destroy_interactor_spec.rb
@@ -18,8 +18,8 @@ RSpec.describe Editions::DestroyInteractor do
       expect(result.edition).to be_discarded
     end
 
-    it "delegates to the DeleteDraftEditionService" do
-      expect(DeleteDraftEditionService)
+    it "delegates to the DiscardDraftEditionService" do
+      expect(DiscardDraftEditionService)
         .to receive(:call)
         .with(edition, user)
       described_class.call(params: params, user: user)

--- a/spec/interactors/editions/destroy_interactor_spec.rb
+++ b/spec/interactors/editions/destroy_interactor_spec.rb
@@ -39,6 +39,11 @@ RSpec.describe Editions::DestroyInteractor do
         expect(result).to be_failure
         expect(result.api_error).to be(true)
       end
+
+      it "marks the edition as revision not synced" do
+        result = described_class.call(params: params, user: user)
+        expect(result.edition).not_to be_revision_synced
+      end
     end
 
     context "when the edition isn't editable" do

--- a/spec/services/delete_draft_assets_service_spec.rb
+++ b/spec/services/delete_draft_assets_service_spec.rb
@@ -1,0 +1,41 @@
+RSpec.describe DeleteDraftAssetsService do
+  describe ".call" do
+    it "attempts to delete an edition's assets from asset manager" do
+      file_attachment_revision = create(:file_attachment_revision, :on_asset_manager)
+      image_revision = create(:image_revision, :on_asset_manager)
+      edition = create(:edition,
+                       lead_image_revision: image_revision,
+                       file_attachment_revisions: [file_attachment_revision])
+
+      delete_request = stub_asset_manager_deletes_any_asset
+
+      described_class.call(edition)
+
+      expect(delete_request).to have_been_requested.at_least_once
+      expect(image_revision.reload.assets.map(&:state).uniq).to eq(%w[absent])
+      expect(file_attachment_revision.reload.asset).to be_absent
+    end
+
+    it "copes if an asset is not in Asset Manager" do
+      file_attachment_revision = create(:file_attachment_revision, :on_asset_manager)
+      edition = create(:edition,
+                       file_attachment_revisions: [file_attachment_revision])
+      stub_any_asset_manager_call.to_return(status: 404)
+
+      described_class.call(edition)
+
+      expect(file_attachment_revision.reload.asset).to be_absent
+    end
+
+    it "skips any live assets from asset manager" do
+      image_revision = create(:image_revision, :on_asset_manager, state: :live)
+      edition = create(:edition, lead_image_revision: image_revision)
+      delete_request = stub_asset_manager_deletes_any_asset
+
+      described_class.call(edition)
+
+      expect(delete_request).not_to have_been_requested
+      expect(image_revision.reload.assets.map(&:state).uniq).to eq(%w[live])
+    end
+  end
+end

--- a/spec/services/delete_draft_edition_service_spec.rb
+++ b/spec/services/delete_draft_edition_service_spec.rb
@@ -7,202 +7,102 @@ RSpec.describe DeleteDraftEditionService do
       stub_any_publishing_api_unreserve_path
     end
 
-    describe "invalid edition" do
-      it "raises an error when the edition isn't current" do
-        edition = create(:edition, current: false)
+    it "raises an error when the edition isn't current" do
+      edition = create(:edition, current: false)
 
-        expect { described_class.call(edition, user) }
-          .to raise_error("Only current editions can be deleted")
-      end
-
-      it "raises an exception if the current edition is live" do
-        edition = create(:edition, live: true)
-
-        expect { described_class.call(edition, user) }
-          .to raise_error("Trying to delete a live edition")
-      end
+      expect { described_class.call(edition, user) }
+        .to raise_error("Only current editions can be deleted")
     end
 
-    describe "changing edition status" do
-      it "changes the editions current flag" do
-        edition = create(:edition)
-        expect { described_class.call(edition, user) }
-          .to change { edition.current? }.to(false)
-      end
+    it "raises an exception if the current edition is live" do
+      edition = create(:edition, live: true)
 
-      it "sets a live edition to be current after a draft is discarded" do
-        document = create(:document, :with_current_and_live_editions)
-        live_edition = document.live_edition
-        expect { described_class.call(document.current_edition, user) }
-          .to change { document.current_edition }.to(live_edition)
-      end
-
-      it "sets the status of the edition to discarded" do
-        edition = create(:edition)
-        expect { described_class.call(edition, user) }
-          .to change { edition.discarded? }.to(true)
-      end
+      expect { described_class.call(edition, user) }
+        .to raise_error("Trying to delete a live edition")
     end
 
-    describe "Publishing API communication" do
-      it "discards the draft from the Publishing API" do
-        edition = create(:edition)
-        request = stub_publishing_api_discard_draft(edition.content_id)
-        described_class.call(edition, user)
-        expect(request).to have_been_requested
-      end
-
-      it "attempts to delete path reservations for a first draft" do
-        edition = create(:edition)
-        previous_revision = create(:revision)
-        edition.revisions << previous_revision
-
-        unreserve_request1 = stub_publishing_api_unreserve_path(
-          edition.base_path,
-          PreviewDraftEditionService::Payload::PUBLISHING_APP,
-        )
-
-        unreserve_request2 = stub_publishing_api_unreserve_path(
-          previous_revision.base_path,
-          PreviewDraftEditionService::Payload::PUBLISHING_APP,
-        )
-
-        described_class.call(edition, user)
-
-        expect(unreserve_request1).to have_been_requested
-        expect(unreserve_request2).to have_been_requested
-      end
-
-      it "does not delete path reservations for published documents" do
-        document = create(:document, :with_current_and_live_editions)
-        unreserve_request = stub_publishing_api_unreserve_path(
-          document.current_edition.base_path,
-          PreviewDraftEditionService::Payload::PUBLISHING_APP,
-        )
-
-        described_class.call(document.current_edition, user)
-        expect(unreserve_request).not_to have_been_requested
-      end
-
-
-      it "copes if the document preview does not exist" do
-        edition = create(:edition)
-        stub_any_publishing_api_discard_draft.to_return(status: 404)
-        described_class.call(edition, user)
-        expect(edition).to be_discarded
-      end
-
-      it "copes if the publishing API has a live but not draft edition" do
-        edition = create(:edition)
-        discard_draft_error = {
-          error: {
-            code: 422,
-            message: "There is not a draft edition of this document to discard",
-          },
-        }
-        stub_any_publishing_api_discard_draft
-          .to_return(status: 422, body: discard_draft_error.to_json)
-
-        described_class.call(edition, user)
-        expect(edition).to be_discarded
-      end
-
-      it "doesn't capture all Publishing API unprocessable entity issues" do
-        edition = create(:edition)
-        discard_draft_error = {
-          error: {
-            code: 422,
-            message: "New Publishing API problem",
-          },
-        }
-        stub_any_publishing_api_discard_draft
-          .to_return(status: 422, body: discard_draft_error.to_json)
-
-        expect { described_class.call(edition, user) }
-          .to raise_error(GdsApi::HTTPUnprocessableEntity)
-      end
-
-      it "copes if the base path is not reserved" do
-        edition = create(:edition)
-
-        stub_publishing_api_unreserve_path_not_found(edition.base_path)
-        described_class.call(edition, user)
-
-        expect(edition).to be_discarded
-      end
-
-      it "copes if the base path is not valid" do
-        edition = create(:edition, base_path: nil)
-        described_class.call(edition, user)
-        expect(edition).to be_discarded
-      end
-
-      it "raises an error and marks an edition as not synced when an API error occurs during discarding" do
-        edition = create(:edition)
-        stub_publishing_api_isnt_available
-
-        expect { described_class.call(edition, user) }
-          .to raise_error(GdsApi::BaseError)
-
-        expect(edition.revision_synced?).to be(false)
-      end
-
-      it "doesn't mark an edition as not synced when an API error occurs whilst unreserving paths" do
-        edition = create(:edition)
-        stub_publishing_api_unreserve_path_invalid(edition.base_path)
-
-        expect { described_class.call(edition, user) }
-          .to raise_error(GdsApi::BaseError)
-
-        expect(edition.revision_synced?).to be(true)
-      end
+    it "changes the edition's current flag" do
+      edition = create(:edition)
+      expect { described_class.call(edition, user) }
+        .to change { edition.current? }.to(false)
     end
 
-    describe "Asset Manager communication" do
-      it "attempts to delete the assets from asset manager" do
-        image_revision = create(:image_revision, :on_asset_manager)
-        file_attachment_revision = create(:file_attachment_revision, :on_asset_manager)
-        edition = create(:edition,
-                         lead_image_revision: image_revision,
-                         file_attachment_revisions: [file_attachment_revision])
+    it "sets a live edition to be current after a draft is discarded" do
+      document = create(:document, :with_current_and_live_editions)
+      live_edition = document.live_edition
+      expect { described_class.call(document.current_edition, user) }
+        .to change { document.current_edition }.to(live_edition)
+    end
 
-        delete_request = stub_asset_manager_deletes_any_asset
+    it "sets the status of the edition to discarded" do
+      edition = create(:edition)
+      expect { described_class.call(edition, user) }
+        .to change { edition.discarded? }.to(true)
+    end
 
-        described_class.call(edition, user)
+    it "delegates to the DeleteDraftAssetsService" do
+      edition = create(:edition)
+      expect(DeleteDraftAssetsService).to receive(:call).with(edition)
+      described_class.call(edition, user)
+    end
 
-        expect(delete_request).to have_been_requested.at_least_once
-        expect(image_revision.reload.assets.map(&:state).uniq).to eq(%w[absent])
-        expect(file_attachment_revision.reload.asset).to be_absent
-      end
+    it "discards the draft from the Publishing API" do
+      edition = create(:edition)
+      request = stub_publishing_api_discard_draft(edition.content_id)
+      described_class.call(edition, user)
+      expect(request).to have_been_requested
+    end
 
-      it "copes if an asset is not in Asset Manager" do
-        image_revision = create(:image_revision, :on_asset_manager)
-        file_attachment_revision = create(:file_attachment_revision, :on_asset_manager)
-        edition = create(:edition,
-                         lead_image_revision: image_revision,
-                         file_attachment_revisions: [file_attachment_revision])
-        stub_any_asset_manager_call.to_return(status: 404)
+    it "copes if the publishing API has a live but not draft edition" do
+      edition = create(:edition)
+      discard_draft_error = {
+        error: {
+          code: 422,
+          message: "There is not a draft edition of this document to discard",
+        },
+      }
+      stub_any_publishing_api_discard_draft
+        .to_return(status: 422, body: discard_draft_error.to_json)
 
-        described_class.call(edition, user)
+      described_class.call(edition, user)
+      expect(edition).to be_discarded
+    end
 
-        expect(image_revision.reload.assets.map(&:state).uniq).to eq(%w[absent])
-        expect(file_attachment_revision.reload.asset).to be_absent
-      end
+    it "doesn't capture all Publishing API unprocessable entity issues" do
+      edition = create(:edition)
+      discard_draft_error = {
+        error: {
+          code: 422,
+          message: "New Publishing API problem",
+        },
+      }
+      stub_any_publishing_api_discard_draft
+        .to_return(status: 422, body: discard_draft_error.to_json)
 
-      it "raises an error and marks as an edition as not synced when Asset Manager is down" do
-        image_revision = create(:image_revision, :on_asset_manager)
-        file_attachment_revision = create(:file_attachment_revision, :on_asset_manager)
-        edition = create(:edition,
-                         lead_image_revision: image_revision,
-                         file_attachment_revisions: [file_attachment_revision])
+      expect { described_class.call(edition, user) }
+        .to raise_error(GdsApi::HTTPUnprocessableEntity)
+    end
 
-        stub_asset_manager_isnt_available
+    it "delegates to the DiscardPathReservationsService for the first edition" do
+      edition = create(:edition)
+      expect(DiscardPathReservationsService).to receive(:call).with(edition)
+      described_class.call(edition, user)
+    end
 
-        expect { described_class.call(edition, user) }
-          .to raise_error(GdsApi::BaseError)
+    it "doesn't discard paths for later editions" do
+      edition = create(:edition, number: 2)
+      expect(DiscardPathReservationsService).not_to receive(:call).with(edition)
+      described_class.call(edition, user)
+    end
 
-        expect(edition.revision_synced?).to be(false)
-      end
+    it "raises an error and marks an edition as not synced when an API error occurs during discarding" do
+      edition = create(:edition)
+      stub_publishing_api_isnt_available
+
+      expect { described_class.call(edition, user) }
+        .to raise_error(GdsApi::BaseError)
+
+      expect(edition.revision_synced?).to be(false)
     end
   end
 end

--- a/spec/services/delete_draft_edition_service_spec.rb
+++ b/spec/services/delete_draft_edition_service_spec.rb
@@ -94,15 +94,5 @@ RSpec.describe DeleteDraftEditionService do
       expect(DiscardPathReservationsService).not_to receive(:call).with(edition)
       described_class.call(edition, user)
     end
-
-    it "raises an error and marks an edition as not synced when an API error occurs during discarding" do
-      edition = build(:edition)
-      stub_publishing_api_isnt_available
-
-      expect { described_class.call(edition, user) }
-        .to raise_error(GdsApi::BaseError)
-
-      expect(edition.revision_synced?).to be(false)
-    end
   end
 end

--- a/spec/services/discard_draft_edition_service_spec.rb
+++ b/spec/services/discard_draft_edition_service_spec.rb
@@ -1,4 +1,4 @@
-RSpec.describe DeleteDraftEditionService do
+RSpec.describe DiscardDraftEditionService do
   let(:user) { build(:user) }
 
   describe ".call" do

--- a/spec/services/discard_path_reservations_service_spec.rb
+++ b/spec/services/discard_path_reservations_service_spec.rb
@@ -1,0 +1,38 @@
+RSpec.describe DiscardPathReservationsService do
+  describe ".call" do
+    it "unreserves an edition's path reservations" do
+      edition = create(:edition)
+      previous_revision = create(:revision)
+      edition.revisions << previous_revision
+
+      unreserve_request1 = stub_publishing_api_unreserve_path(
+        edition.base_path,
+        PreviewDraftEditionService::Payload::PUBLISHING_APP,
+      )
+
+      unreserve_request2 = stub_publishing_api_unreserve_path(
+        previous_revision.base_path,
+        PreviewDraftEditionService::Payload::PUBLISHING_APP,
+      )
+
+      described_class.call(edition)
+
+      expect(unreserve_request1).to have_been_requested
+      expect(unreserve_request2).to have_been_requested
+    end
+
+    it "copes if the base path is not reserved" do
+      edition = create(:edition)
+      request = stub_publishing_api_unreserve_path_not_found(edition.base_path)
+      described_class.call(edition)
+      expect(request).to have_been_requested
+    end
+
+    it "doesn't discard base paths that are missing" do
+      edition = create(:edition, base_path: nil)
+      request = stub_any_publishing_api_unreserve_path
+      described_class.call(edition)
+      expect(request).not_to have_been_requested
+    end
+  end
+end


### PR DESCRIPTION
Trello: https://trello.com/c/yqXt0RGc/1417-remove-documents-at-dwps-request

Following up from https://github.com/alphagov/content-publisher/pull/1755 this separates out some of the responsibilities of the DeleteDraftEditionService to be handled by separate services for discarding path reservations and deleting assets.

As part of this I re-considered the naming of the service and felt that DiscardDraftEditionService was more fitting with the nomenclature we use within the application.

Finally I found and resolved a bug where we updating the edition in the event of re-raising an exception which had no effect as the transaction would be aborted.

More info in commits.