### PR TITLE
Don't mark assets as absent in an ensure

### DIFF
--- a/app/jobs/asset_cleanup_job.rb
+++ b/app/jobs/asset_cleanup_job.rb
@@ -37,10 +37,12 @@ private
   end
 
   def delete_asset(asset)
-    GdsApi.asset_manager.delete_asset(asset.asset_manager_id)
-  rescue GdsApi::HTTPNotFound
-    logger.warn("No asset to delete for id #{asset.asset_manager_id}")
-  ensure
+    begin
+      GdsApi.asset_manager.delete_asset(asset.asset_manager_id)
+    rescue GdsApi::HTTPNotFound
+      logger.warn("No asset to delete for id #{asset.asset_manager_id}")
+    end
+
     asset.absent!
   end
 end

--- a/spec/jobs/asset_cleanup_job_spec.rb
+++ b/spec/jobs/asset_cleanup_job_spec.rb
@@ -1,11 +1,11 @@
 RSpec.describe AssetCleanupJob do
   describe "#perform" do
-    context "when the assets only exist on an old edition" do
-      let(:draft_image_revision) { create(:image_revision, :on_asset_manager, state: :draft) }
-      let(:live_image_revision) { create(:image_revision, :on_asset_manager, state: :live) }
-      let(:draft_file_attachment_revision) { create(:file_attachment_revision, :on_asset_manager, state: :draft) }
-      let(:live_file_attachment_revision) { create(:file_attachment_revision, :on_asset_manager, state: :live) }
+    let(:draft_image_revision) { create(:image_revision, :on_asset_manager, state: :draft) }
+    let(:live_image_revision) { create(:image_revision, :on_asset_manager, state: :live) }
+    let(:draft_file_attachment_revision) { create(:file_attachment_revision, :on_asset_manager, state: :draft) }
+    let(:live_file_attachment_revision) { create(:file_attachment_revision, :on_asset_manager, state: :live) }
 
+    context "when the assets only exist on an old edition" do
       before do
         create(:edition,
                current: false,
@@ -27,11 +27,6 @@ RSpec.describe AssetCleanupJob do
     end
 
     context "when the assets only exist on an old revision" do
-      let(:draft_image_revision) { create(:image_revision, :on_asset_manager, state: :draft) }
-      let(:live_image_revision) { create(:image_revision, :on_asset_manager, state: :live) }
-      let(:draft_file_attachment_revision) { create(:file_attachment_revision, :on_asset_manager, state: :draft) }
-      let(:live_file_attachment_revision) { create(:file_attachment_revision, :on_asset_manager, state: :live) }
-
       before do
         preceding_revision = create(:revision,
                                     lead_image_revision: nil,
@@ -55,11 +50,6 @@ RSpec.describe AssetCleanupJob do
     end
 
     context "when the assets exist on a current edition" do
-      let(:draft_image_revision) { create(:image_revision, :on_asset_manager, state: :draft) }
-      let(:live_image_revision) { create(:image_revision, :on_asset_manager, state: :live) }
-      let(:draft_file_attachment_revision) { create(:file_attachment_revision, :on_asset_manager, state: :draft) }
-      let(:live_file_attachment_revision) { create(:file_attachment_revision, :on_asset_manager, state: :live) }
-
       before do
         create(:edition,
                lead_image_revision: nil,
@@ -80,11 +70,6 @@ RSpec.describe AssetCleanupJob do
     end
 
     context "when the assets exist on a live edition" do
-      let(:draft_image_revision) { create(:image_revision, :on_asset_manager, state: :draft) }
-      let(:live_image_revision) { create(:image_revision, :on_asset_manager, state: :live) }
-      let(:draft_file_attachment_revision) { create(:file_attachment_revision, :on_asset_manager, state: :draft) }
-      let(:live_file_attachment_revision) { create(:file_attachment_revision, :on_asset_manager, state: :live) }
-
       before do
         create(:edition,
                live: true,
@@ -107,11 +92,6 @@ RSpec.describe AssetCleanupJob do
     end
 
     context "when the assets exist on an old revision" do
-      let(:draft_image_revision) { create(:image_revision, :on_asset_manager, state: :draft) }
-      let(:live_image_revision) { create(:image_revision, :on_asset_manager, state: :live) }
-      let(:draft_file_attachment_revision) { create(:file_attachment_revision, :on_asset_manager, state: :draft) }
-      let(:live_file_attachment_revision) { create(:file_attachment_revision, :on_asset_manager, state: :live) }
-
       before do
         preceding_revision = create(:revision,
                                     lead_image_revision: nil,
@@ -140,11 +120,6 @@ RSpec.describe AssetCleanupJob do
     end
 
     context "when the assets exist on an old edition" do
-      let(:draft_image_revision) { create(:image_revision, :on_asset_manager, state: :draft) }
-      let(:live_image_revision) { create(:image_revision, :on_asset_manager, state: :live) }
-      let(:draft_file_attachment_revision) { create(:file_attachment_revision, :on_asset_manager, state: :draft) }
-      let(:live_file_attachment_revision) { create(:file_attachment_revision, :on_asset_manager, state: :live) }
-
       before do
         create(:edition,
                current: false,

--- a/spec/jobs/asset_cleanup_job_spec.rb
+++ b/spec/jobs/asset_cleanup_job_spec.rb
@@ -5,7 +5,7 @@ RSpec.describe AssetCleanupJob do
     let(:draft_file_attachment_revision) { create(:file_attachment_revision, :on_asset_manager, state: :draft) }
     let(:live_file_attachment_revision) { create(:file_attachment_revision, :on_asset_manager, state: :live) }
 
-    context "when the assets only exist on an old edition" do
+    context "when the assets only exist on a past edition" do
       before do
         create(:edition,
                current: false,
@@ -26,7 +26,7 @@ RSpec.describe AssetCleanupJob do
       end
     end
 
-    context "when the assets only exist on an old revision" do
+    context "when the assets only exist on a previous revision" do
       before do
         preceding_revision = create(:revision,
                                     lead_image_revision: nil,
@@ -91,7 +91,7 @@ RSpec.describe AssetCleanupJob do
       end
     end
 
-    context "when the assets exist on an old revision" do
+    context "when the assets from the current revision also exist on a past revision" do
       before do
         preceding_revision = create(:revision,
                                     lead_image_revision: nil,
@@ -107,7 +107,7 @@ RSpec.describe AssetCleanupJob do
         create(:edition, revision: revision)
       end
 
-      it "preserves draft/live assets in Asset Manager" do
+      it "doesn't delete the assets" do
         request = stub_asset_manager_deletes_any_asset
         described_class.perform_now
 
@@ -119,7 +119,7 @@ RSpec.describe AssetCleanupJob do
       end
     end
 
-    context "when the assets exist on an old edition" do
+    context "when the assets exist on a past edition and the current edition" do
       before do
         create(:edition,
                current: false,
@@ -133,7 +133,7 @@ RSpec.describe AssetCleanupJob do
                file_attachment_revisions: [draft_file_attachment_revision, live_file_attachment_revision])
       end
 
-      it "preserves draft/live assets in Asset Manager" do
+      it "doesn't delete the assets" do
         request = stub_asset_manager_deletes_any_asset
         described_class.perform_now
 


### PR DESCRIPTION
This is a little bit of a cleanup on the `AssetCleanupJob` where we marked assets as absent in an ensure block, however this would get called for all types of exceptions.

It also removes a bunch of duplication in the tests and makes their expectations a bit clearer to read.