### PR TITLE
Small cleanup on PublishDraftEditionService

### DIFF
--- a/app/services/publish_draft_edition_service.rb
+++ b/app/services/publish_draft_edition_service.rb
@@ -6,6 +6,9 @@ class PublishDraftEditionService < ApplicationService
   end
 
   def call
+    raise "Only a current edition can be published" unless edition.current?
+    raise "Live editions cannot be published" if edition.live?
+
     publish_assets
     associate_with_government
     publish_current_edition

--- a/app/services/publish_draft_edition_service.rb
+++ b/app/services/publish_draft_edition_service.rb
@@ -12,7 +12,6 @@ class PublishDraftEditionService < ApplicationService
     supersede_live_edition
     set_new_live_edition
     set_first_published_at
-    document.reload
   rescue GdsApi::BaseError => e
     GovukError.notify(e)
     raise
@@ -68,6 +67,7 @@ private
     edition.access_limit = nil
     edition.live = true
     edition.save!
+    document.reload_live_edition
   end
 
   def set_first_published_at

--- a/app/services/publish_draft_edition_service.rb
+++ b/app/services/publish_draft_edition_service.rb
@@ -6,11 +6,10 @@ class PublishDraftEditionService < ApplicationService
   end
 
   def call
-    live_edition = document.live_edition
-    publish_assets(live_edition)
+    publish_assets
     associate_with_government
     publish_current_edition
-    supersede_live_edition(live_edition)
+    supersede_live_edition
     set_new_live_edition
     set_first_published_at
     document.reload
@@ -24,8 +23,8 @@ private
   attr_reader :edition, :user, :with_review
   delegate :document, to: :edition
 
-  def publish_assets(live_edition)
-    PublishAssetsService.call(edition, superseded_edition: live_edition)
+  def publish_assets
+    PublishAssetsService.call(edition, superseded_edition: document.live_edition)
   end
 
   def associate_with_government
@@ -51,7 +50,8 @@ private
     )
   end
 
-  def supersede_live_edition(live_edition)
+  def supersede_live_edition
+    live_edition = document.live_edition
     return unless live_edition
 
     AssignEditionStatusService.call(live_edition,

--- a/spec/services/publish_draft_edition_service_spec.rb
+++ b/spec/services/publish_draft_edition_service_spec.rb
@@ -52,6 +52,18 @@ RSpec.describe PublishDraftEditionService do
       described_class.call(current_edition, user, with_review: true)
     end
 
+    it "raises an error when the edition is not current" do
+      edition = build(:edition, current: false)
+      expect { described_class.call(edition, user, with_review: true) }
+        .to raise_error("Only a current edition can be published")
+    end
+
+    it "raises an error when the edition is already live" do
+      edition = build(:edition, live: true)
+      expect { described_class.call(edition, user, with_review: true) }
+        .to raise_error("Live editions cannot be published")
+    end
+
     context "when the edition is not associated with a government" do
       let(:past_government) do
         build(:government, ended_on: Time.zone.today)

--- a/spec/services/publish_draft_edition_service_spec.rb
+++ b/spec/services/publish_draft_edition_service_spec.rb
@@ -33,11 +33,8 @@ RSpec.describe PublishDraftEditionService do
     context "when there is a live edition" do
       it "supersedes the live edition" do
         document = create(:document, :with_current_and_live_editions)
-        current_edition = document.current_edition
         live_edition = document.live_edition
-
-        described_class.call(current_edition, user, with_review: true)
-        expect(document.live_edition).to eq(current_edition)
+        described_class.call(document.current_edition, user, with_review: true)
         expect(live_edition).to be_superseded
       end
     end

--- a/spec/services/publish_draft_edition_service_spec.rb
+++ b/spec/services/publish_draft_edition_service_spec.rb
@@ -39,6 +39,12 @@ RSpec.describe PublishDraftEditionService do
       end
     end
 
+    it "updates the document's live edition to be the current edition" do
+      document = create(:document, :with_current_edition)
+      expect { described_class.call(document.current_edition, user, with_review: true) }
+        .to change(document, :live_edition).to(document.current_edition)
+    end
+
     it "calls the PublishAssetsService" do
       document = create(:document, :with_current_and_live_editions)
       current_edition = document.current_edition


### PR DESCRIPTION
As part of tinkering with change notes prototypes I made some tweaks to PublishDraftEditionService that simplified the code and added some guards against bad states.

More info in commits.