### PR TITLE
Basic UI for viewing Whitehall migration status

### DIFF
--- a/app/controllers/whitehall_migration_controller.rb
+++ b/app/controllers/whitehall_migration_controller.rb
@@ -1,0 +1,19 @@
+class WhitehallMigrationController < ApplicationController
+  before_action { authorise_user!(User::DEBUG_PERMISSION) }
+
+  def show
+    @whitehall_migration = WhitehallMigration.find(params[:migration_id])
+  end
+
+  def documents
+    whitehall_migration = WhitehallMigration.find(params[:migration_id])
+    @documents = whitehall_migration.document_imports
+  end
+
+  def document
+    @document = WhitehallMigration::DocumentImport.find_by!(
+      id: params[:document_import_id],
+      whitehall_migration_id: params[:migration_id],
+    )
+  end
+end

--- a/app/views/whitehall_migration/document.html.erb
+++ b/app/views/whitehall_migration/document.html.erb
@@ -1,0 +1,2 @@
+<h1>Document</h1>
+<%= @document.id %>

--- a/app/views/whitehall_migration/documents.html.erb
+++ b/app/views/whitehall_migration/documents.html.erb
@@ -1,0 +1,6 @@
+<h1>Documents</h1>
+
+<% @documents.each do |document| %>
+  <li>ID: <%= document.id %></li>
+  <li>Status: <%= document.state %></li>
+<% end %>

--- a/app/views/whitehall_migration/show.html.erb
+++ b/app/views/whitehall_migration/show.html.erb
@@ -1,0 +1,14 @@
+<h1>Whitehall Migration: <%= @whitehall_migration.id %> </h1>
+<ul>
+    <li>Time started: <%= @whitehall_migration.created_at.strftime("At %T on %d/%m/%Y") %></li>
+    <li>Time finished: <%= @whitehall_migration.finished_at.nil? ? "Unfinished" : @whitehall_migration.finished_at %></li>
+    <li>Number of documents: <%= @whitehall_migration.document_imports.count %></li>
+</ul>
+
+<h3>Document Import Status</h3>
+
+<ul>
+    <% @whitehall_migration.document_imports.states.each_value do |state| %>
+        <li><%= "#{state}:" %> <%= @whitehall_migration.document_imports.where(state: "#{state}").count%></li>
+    <% end %>
+</ul>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,6 +1,12 @@
 Rails.application.routes.draw do
   root to: redirect("/documents")
 
+  scope "/whitehall-migration/:migration_id" do
+    get "" => "whitehall_migration#show", as: :whitehall_migration
+    get "/documents" => "whitehall_migration#documents", as: :whitehall_migration_documents
+    get "/documents/:document_import_id" => "whitehall_migration#document", as: :whitehall_migration_document
+  end
+
   get "/documents/publishing-guidance" => "new_document#guidance", as: :guidance
   get "/documents/new" => "new_document#show", as: :new_document
   post "/documents/new" => "new_document#select"

--- a/lib/tasks/import.rake
+++ b/lib/tasks/import.rake
@@ -1,31 +1,37 @@
-# frozen_string_literal: true
-
 require "gds_api/whitehall_export"
 
 namespace :import do
   desc "Import all documents matching an organisation, document type and optional list of document subtypes from Whitehall Publisher, e.g. import:whitehall_migration[\"cabinet-office\",\"news_article\",\"news_story,press_release\"]"
   task :whitehall_migration, %i[organisation_slug document_type document_subtypes] => :environment do |_, args|
+    include Rails.application.routes.url_helpers
+
     organisation_content_id = GdsApi.publishing_api.lookup_content_id(
       base_path: "/government/organisations/#{args.organisation_slug}",
-    )
+     )
     document_subtypes = args.document_subtypes ? args.document_subtypes.split(",") : []
     whitehall_migration = WhitehallImporter::CreateMigration.call(
       organisation_content_id, args.document_type, document_subtypes
     )
 
-    documents_to_import = WhitehallMigration::DocumentImport.where(whitehall_migration_id: whitehall_migration.id).count
+    documents_to_import = WhitehallMigration::DocumentImport.where(whitehall_migration: whitehall_migration).count
     puts "Identified #{documents_to_import} documents to import"
+
+    puts whitehall_migration_url(whitehall_migration, host: Plek.new.external_url_for("content-publisher"))
   end
 
   desc "Import a single document from Whitehall Publisher using Whitehall's internal document ID e.g. import:whitehall_document[123]"
   task :whitehall_document, [:document_id] => :environment do |_, args|
+    include Rails.application.routes.url_helpers
+
     whitehall_import = WhitehallMigration::DocumentImport.create!(
       whitehall_document_id: args.document_id,
       whitehall_migration: WhitehallMigration.create!,
       state: "pending",
-    )
+     )
 
     WhitehallDocumentImportJob.perform_later(whitehall_import)
     puts "Added whitehall document with ID:#{args.document_id} to the import queue"
+
+    puts whitehall_migration_url(whitehall_import.whitehall_migration_id, host: Plek.new.external_url_for("content-publisher"))
   end
 end

--- a/spec/lib/tasks/import_spec.rb
+++ b/spec/lib/tasks/import_spec.rb
@@ -2,7 +2,7 @@ RSpec.describe "Import tasks" do
   include ActiveJob::TestHelper
 
   describe "import:whitehall_migration" do
-    let(:whitehall_migration_document_import) { build(:whitehall_migration_document_import) }
+    let(:whitehall_migration) { create(:whitehall_migration) }
 
     before do
       allow($stdout).to receive(:puts)
@@ -11,7 +11,7 @@ RSpec.describe "Import tasks" do
         "/government/organisations/cabinet-office" => "96ae61d6-c2a1-48cb-8e67-da9d105ae381",
       )
       allow(WhitehallImporter::CreateMigration).to receive(:call)
-                                               .and_return(whitehall_migration_document_import)
+                                               .and_return(whitehall_migration)
     end
 
     it "calls WhitehallImporter::create_migration with correct arguments when subtype is specified" do

--- a/spec/requests/whitehall_migration_spec.rb
+++ b/spec/requests/whitehall_migration_spec.rb
@@ -1,0 +1,53 @@
+RSpec.describe "Whitehall Migration" do
+  let(:whitehall_migration) { create(:whitehall_migration) }
+  let(:document_import) { create(:whitehall_migration_document_import, whitehall_migration: whitehall_migration) }
+  let(:debug_permission_user) { create(:user, permissions: [User::DEBUG_PERMISSION]) }
+
+  it_behaves_like "requests that return status",
+                  "when a user without debug permissions looks at a whitehall migration",
+                  status: :forbidden,
+                  routes: { whitehall_migration_path: %i[get],
+                          whitehall_migration_documents_path: %i[get] } do
+    before { login_as(create(:user)) }
+
+    let(:route_params) { [whitehall_migration] }
+  end
+
+  it_behaves_like "requests that return status",
+                  "when a user without debug permissions looks at a whitehall migration document",
+                  status: :forbidden,
+                  routes: { whitehall_migration_document_path: %i[get] } do
+    before { login_as(create(:user)) }
+
+    let(:route_params) do
+      [whitehall_migration, document_import]
+    end
+  end
+
+  describe "GET /whitehall-migration/:migration_id" do
+    it "returns success" do
+      login_as(debug_permission_user)
+      get whitehall_migration_path(whitehall_migration)
+
+      expect(response).to have_http_status(:ok)
+    end
+  end
+
+  describe "GET /whitehall-migration/:migration_id/documents" do
+    it "returns success" do
+      login_as(debug_permission_user)
+      get whitehall_migration_documents_path(whitehall_migration)
+
+      expect(response).to have_http_status(:ok)
+    end
+  end
+
+  describe "GET /whitehall-migration/:migration_id/documents/:document_import_id" do
+    it "returns success" do
+      login_as(debug_permission_user)
+      get whitehall_migration_document_path(whitehall_migration, document_import)
+
+      expect(response).to have_http_status(:ok)
+    end
+  end
+end


### PR DESCRIPTION
Have set up the following for the migration UI:

- routes
- controller
- request specs
- placeholder views which display some migration data

This PR is for the initial setup, the next PR will contain the full data that we wish to display.

Example:
<img width="1007" alt="Screenshot 2020-02-21 at 11 54 27" src="https://user-images.githubusercontent.com/6329861/75032649-f202ed00-54a0-11ea-95a4-5f19a48d8ff6.png">

Trello card: https://trello.com/c/yFGFseiN