### PR TITLE
Don't reload the whole document, only the changed edition

### DIFF
--- a/spec/db/scrub_access_limited_spec.rb
+++ b/spec/db/scrub_access_limited_spec.rb
@@ -13,11 +13,11 @@ RSpec.describe "Scrub Access Limited SQL Script" do
                           current: false,
                           document: current_edition.document)
 
-    expect(document.reload.current_edition).to eq(current_edition)
+    expect(document.reload_current_edition).to eq(current_edition)
 
     execute_sql
 
-    expect(document.reload.current_edition).to eq(live_edition)
+    expect(document.reload_current_edition).to eq(live_edition)
     expect { current_edition.reload }.to raise_error(ActiveRecord::RecordNotFound)
   end
 


### PR DESCRIPTION
Follows on from: https://github.com/alphagov/content-publisher/pull/1781#discussion_r379402007

`reload_` only reloads the one association of the document that's changed (one query on an edition) whereas `document.reload.current_edition` reloads the document model and then `current_edition` is called, another query is made for that association and any other cached associations are lost