### PR TITLE
Add change_history to metadata_revisons

### DIFF
--- a/db/migrate/20200217112039_add_change_history_to_metadata_revisions.rb
+++ b/db/migrate/20200217112039_add_change_history_to_metadata_revisions.rb
@@ -1,0 +1,5 @@
+class AddChangeHistoryToMetadataRevisions < ActiveRecord::Migration[6.0]
+  def change
+    add_column :metadata_revisions, :change_history, :json, default: [], null: false
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2020_02_07_224528) do
+ActiveRecord::Schema.define(version: 2020_02_17_112039) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -221,6 +221,7 @@ ActiveRecord::Schema.define(version: 2020_02_07_224528) do
     t.datetime "backdated_to"
     t.string "document_type_id", null: false
     t.boolean "editor_political"
+    t.json "change_history", default: [], null: false
   end
 
   create_table "removals", force: :cascade do |t|


### PR DESCRIPTION
We want to create a column for a revision that can store the change history for that edition. By change history we mean an array of all the past change notes with their times.

Created a new column on `metadata_revisions` called `change_history`.  Column type is JSON, default is [] (empty array), and is not nullable.

Trello: https://trello.com/c/xMRotBoK/1460-create-a-changehistory-json-column-on-metadatarevisions-and-populate-it-when-new-editions-are-added