### PR TITLE
Remove unnecessary factory attribute

### DIFF
--- a/spec/factories/whitehall_migration_factory.rb
+++ b/spec/factories/whitehall_migration_factory.rb
@@ -1,6 +1,5 @@
 FactoryBot.define do
   factory :whitehall_migration do
-    sequence(:id)
     organisation_content_id { SecureRandom.uuid }
     document_type { "NewsArticle" }
     created_at { Time.current.rfc3339 }


### PR DESCRIPTION
We don't need to set an id for factories that create db records, these
will be given an id automatically when created. This resolves an issue
where any existing WhitehallMigration records in the DB led to primary
key conflicts.