### PR TITLE
Make modals less verbose for screen readers

### DIFF
--- a/app/assets/javascripts/modal/modal-workflow.js
+++ b/app/assets/javascripts/modal/modal-workflow.js
@@ -26,6 +26,7 @@ ModalWorkflow.prototype.render = function (response) {
 
 ModalWorkflow.prototype.renderSuccess = function (result) {
   this.$multiSectionViewer.showDynamicSection(result.body)
+  this.setModalAriaLabel(this.getSectionHeadingText())
   this.overrideActions(this.performAction)
   this.initComponents()
 }
@@ -34,6 +35,20 @@ ModalWorkflow.prototype.renderError = function (result) {
   window.Raven.captureException(result)
   console.error(result)
   this.$multiSectionViewer.showStaticSection('error')
+  this.setModalAriaLabel(this.getSectionHeadingText())
+}
+
+ModalWorkflow.prototype.getSectionHeadingText = function () {
+  var sectionHeading = this.$multiSectionViewer.querySelector('h1')
+  if (sectionHeading) {
+    return sectionHeading.innerText
+  }
+}
+
+ModalWorkflow.prototype.setModalAriaLabel = function (ariaLabel) {
+  if (ariaLabel) {
+    this.$modal.querySelector('dialog').setAttribute('aria-label', ariaLabel)
+  }
 }
 
 ModalWorkflow.prototype.initComponents = function () {

--- a/app/views/components/_multi_section_viewer.html.erb
+++ b/app/views/components/_multi_section_viewer.html.erb
@@ -11,9 +11,9 @@
   id: id,
   data: data_attributes,
   aria: aria_attributes do %>
+  <%= tag.section class: "app-c-multi-section-viewer__section js-dynamic-section" %>
+
   <% sections.each do |section| %>
     <%= tag.section section[:content], class: "app-c-multi-section-viewer__section", id: section[:id] %>
   <% end %>
-
-  <%= tag.div class: "app-c-multi-section-viewer__section js-dynamic-section" %>
 <% end %>

--- a/spec/javascripts/helpers/modal-dialogue.js
+++ b/spec/javascripts/helpers/modal-dialogue.js
@@ -9,9 +9,9 @@ window.buildModalDialogue = function buildModalDialogue () {
     '<dialog class="gem-c-modal-dialogue__box" aria-modal="true" role="dialogue" aria-labelledby="my-modal-title">' +
       '<div class="gem-c-modal-dialogue__content">' +
         '<div class="app-c-multi-section-viewer" data-module="multi-section-viewer">' +
+          '<section class="app-c-multi-section-viewer__section js-dynamic-section"></section>' +
           '<section class="app-c-multi-section-viewer__section" id="loading"></section>' +
-          '<section class="app-c-multi-section-viewer__section" id="error"></section>' +
-          '<div class="app-c-multi-section-viewer__section js-dynamic-section"></div>' +
+          '<section class="app-c-multi-section-viewer__section" id="error"><h1>Something has gone wrong</h1></section>' +
         '</div>' +
       '</div>' +
       '<button class="gem-c-modal-dialogue__close-button" aria-label="Close modal dialogue">&times;</button>' +

--- a/spec/javascripts/modal/modal-workflow-spec.js
+++ b/spec/javascripts/modal/modal-workflow-spec.js
@@ -36,10 +36,11 @@ describe('ModalWorkflow', function () {
   })
 
   describe('modalWorkflow.renderSuccess', function () {
-    var dynamicSection
+    var dynamicSection, modalDialogue
 
     beforeEach(function () {
       dynamicSection = modal.querySelector('.js-dynamic-section')
+      modalDialogue = modal.querySelector('dialog')
       spyOn(modalWorkflow, 'performAction')
     })
 
@@ -47,6 +48,11 @@ describe('ModalWorkflow', function () {
       modalWorkflow.renderSuccess({ body: '<h1>Success</h1>' })
       expect(dynamicSection).toBeVisible()
       expect(dynamicSection).toContainHtml('<h1>Success</h1>')
+    })
+
+    it('sets the dynamic section heading as label for the modal', function () {
+      modalWorkflow.renderSuccess({ body: '<h1>Success</h1>' })
+      expect(modalDialogue.getAttribute('aria-label')).toEqual('Success')
     })
 
     it('intercepts submits on forms with modal-action data attributes', function () {
@@ -89,10 +95,11 @@ describe('ModalWorkflow', function () {
   })
 
   describe('modalWorkflow.renderError', function () {
-    var errorSection, error
+    var errorSection, modalDialogue, error
 
     beforeEach(function () {
       errorSection = modal.querySelector('#error')
+      modalDialogue = modal.querySelector('dialog')
       error = new Error('Failed')
       spyOn(window.Raven, 'captureException')
       spyOn(console, 'error')
@@ -101,6 +108,11 @@ describe('ModalWorkflow', function () {
     it('shows the error section', function () {
       modalWorkflow.renderError(error)
       expect(errorSection).toBeVisible()
+    })
+
+    it('sets the dynamic section heading as label for the modal', function () {
+      modalWorkflow.renderError(error)
+      expect(modalDialogue.getAttribute('aria-label')).toEqual('Something has gone wrong')
     })
 
     it('logs the error to the console and to raven', function () {


### PR DESCRIPTION
In [#1300](https://github.com/alphagov/govuk_publishing_components/pull/1300) we enabled `aria-label` on modal dialogue component to make it less verbose. Because in Content Publisher we generate the modal dialogue content dynamically we'll need to set this property via JavaScript as part of the `modalWorkflow` logic.

[Trello card](https://trello.com/c/xZwFwpul)