### PR TITLE
Add validation for change notes stored in MetadataRevision

### DIFF
--- a/app/models/metadata_revision.rb
+++ b/app/models/metadata_revision.rb
@@ -4,6 +4,24 @@
 #
 # This model is immutable.
 class MetadataRevision < ApplicationRecord
+  validates_each :change_history do |record, attribute, change_notes|
+    uuid_regex = /\A[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}\Z/
+
+    change_notes.each do |change_note|
+      unless change_note.keys.sort == %w(id note public_timestamp)
+        record.errors.add(attribute, "has an entry with invalid keys", strict: true)
+      end
+      unless change_note["id"].match?(uuid_regex)
+        record.errors.add(attribute, "has an entry with a non UUID id", strict: true)
+      end
+      begin
+        Time.zone.rfc3339(change_note["public_timestamp"])
+      rescue ArgumentError
+        record.errors.add(attribute, "has an entry with an invalid timestamp", strict: true)
+      end
+    end
+  end
+
   belongs_to :created_by, class_name: "User", optional: true
 
   enum update_type: { major: "major", minor: "minor" }

--- a/spec/models/metadata_revision_spec.rb
+++ b/spec/models/metadata_revision_spec.rb
@@ -1,0 +1,80 @@
+RSpec.describe MetadataRevision do
+  describe "change_history" do
+    failure_prefix = "Change history"
+
+    it "successfully creates an entry when change_history is valid" do
+      change_history = [
+        {
+          "id" => SecureRandom.uuid,
+          "note" => "Testing",
+          "public_timestamp" => Time.zone.today.rfc3339,
+        },
+      ]
+
+      expect { create(:metadata_revision, change_history: change_history) }
+        .to change(described_class, :count).by(1)
+    end
+
+    it "fails validation if 'id' is missing" do
+      change_history = [
+        { "note" => "Testing", "public_timestamp" => Time.zone.today.rfc3339 },
+      ]
+
+      expect { create(:metadata_revision, change_history: change_history) }
+        .to raise_error(ActiveModel::StrictValidationFailed,
+                        "#{failure_prefix} has an entry with invalid keys")
+    end
+
+    it "fails validation if 'note' is missing" do
+      id = SecureRandom.uuid
+      change_history = [
+        { "id" => id, "public_timestamp" => Time.zone.today.rfc3339 },
+      ]
+
+      expect { create(:metadata_revision, change_history: change_history) }
+        .to raise_error(ActiveModel::StrictValidationFailed,
+                        "#{failure_prefix} has an entry with invalid keys")
+    end
+
+    it "fails validation if 'public_timestamp' is missing" do
+      id = SecureRandom.uuid
+      change_history = [
+        { "id" => id, "note" => "Testing" },
+      ]
+
+      expect { create(:metadata_revision, change_history: change_history) }
+        .to raise_error(ActiveModel::StrictValidationFailed,
+                        "#{failure_prefix} has an entry with invalid keys")
+    end
+
+    it "fails validation if the 'id' is not a valid UUID" do
+      id = "1234567-123-123-123-01234567890"
+      change_history = [
+        {
+          "id" => id,
+          "note" => "Testing",
+          "public_timestamp" => Time.zone.today.rfc3339,
+        },
+      ]
+
+      expect { create(:metadata_revision, change_history: change_history) }
+        .to raise_error(ActiveModel::StrictValidationFailed,
+                        "#{failure_prefix} has an entry with a non UUID id")
+    end
+
+    it "fails validation if 'public_timestamp' is not a valid date" do
+      id = SecureRandom.uuid
+      change_history = [
+        {
+          "id" => id,
+          "note" => "Testing",
+          "public_timestamp" => "20201-13-32 29:61:61",
+        },
+      ]
+
+      expect { create(:metadata_revision, change_history: change_history) }
+        .to raise_error(ActiveModel::StrictValidationFailed,
+                        "#{failure_prefix} has an entry with an invalid timestamp")
+    end
+  end
+end


### PR DESCRIPTION
`change_history` is a JSON column that has been added to `MetadataRevision` and defaults to an empty array.

Change notes will be added to this column.

Each change note should be a JSON object with 3 attributes:
- `id` - A uuid that we generate
- `note` - the change note content or text
- `public_timestamp` - a string representing the RFC3339 representation of the `edition.published_at` timestamp.

To have confidence in this JSON structure, we should add a validator on`MetadataRevision` that tests both the structure and that the fields are what we expect them to be (e.g. `id` is a valid UUID and `public_timestamp` is a valid RFC3339 representation).

The validator is defined as `strict`.  This ensures a particular exception is raised and that the application will crash with suitable debug information. `strict` validators differentiate from the type of validation that is used to give user feedback.

Trello: https://trello.com/c/xMRotBoK/1460-create-a-changehistory-json-column-on-metadatarevisions-and-populate-it-when-new-editions-are-added