### PR TITLE
Make contacts code more resilient

### DIFF
--- a/lib/whitehall_importer/embed_body_references.rb
+++ b/lib/whitehall_importer/embed_body_references.rb
@@ -32,8 +32,8 @@ module WhitehallImporter
     def embed_contacts(body, contacts)
       body&.gsub(/\[Contact:\s*(\d*)\s*\]/) do
         id = Regexp.last_match[1].to_i
-        embed = contacts.select { |x| x["id"] == id }.first["content_id"]
-        "[Contact:#{embed}]"
+        contact = contacts.find { |c| c["id"] == id }
+        "[Contact:#{contact['content_id']}]" if contact.present?
       end
     end
 

--- a/spec/lib/whitehall_importer/embed_body_references_spec.rb
+++ b/spec/lib/whitehall_importer/embed_body_references_spec.rb
@@ -10,6 +10,22 @@ RSpec.describe WhitehallImporter::EmbedBodyReferences do
       expect(govspeak_body).to eq("[Contact:#{content_id}]")
     end
 
+    it "ignores contact embed when there is no contacts" do
+      govspeak_body = described_class.call(
+        body: "[Contact:123]",
+        contacts: [],
+      )
+      expect(govspeak_body).to be_empty
+    end
+
+    it "ignores contact embed when there is no matching contacts" do
+      govspeak_body = described_class.call(
+        body: "[Contact:123]",
+        contacts: [{ "id" => 321, "content_id" => SecureRandom.uuid }],
+      )
+      expect(govspeak_body).to be_empty
+    end
+
     it "converts Whitehall image bang embeds to govspeak Image embeds" do
       body = described_class.call(body: "!!1", images: ["file.jpg"])
 


### PR DESCRIPTION
Now when there are no contacts for an edition the embed is ignored, the
same is true for when there is no matching contacts for an embed.

Previously the code would throw an error at either of these two
scenarios listed above as it tried to look for a content-id on nil.

Trello:
https://trello.com/c/OzdqkkW2/1455-fix-documents-that-failed-the-import-with-an-array-error