### PR TITLE
Make "path" required if "type" is "managed_elsewhere"

### DIFF
--- a/spec/support/schemas/document_type_selection.json
+++ b/spec/support/schemas/document_type_selection.json
@@ -11,7 +11,21 @@
       "$ref": "#/definitions/id"
     },
     "options": {
-      "$ref": "#/definitions/options"
+      "type": "array",
+      "items": {
+        "type": "object",
+        "oneOf": [
+          {
+            "$ref": "#/definitions/document_type"
+          },
+          {
+            "$ref": "#/definitions/document_type_selection"
+          },
+          {
+            "$ref": "#/definitions/managed_elsewhere"
+          }
+        ]
+      }
     }
   },
   "definitions": {
@@ -19,38 +33,66 @@
       "type": "string",
       "pattern": "^[a-z_]+$"
     },
-    "options": {
-      "type": "array",
-      "items": {
-        "type": "object",
-        "required": [
-          "id",
-          "type"
-        ],
-        "additionalProperties": false,
-        "properties": {
-          "id": {
-            "$ref": "#/definitions/id"
-          },
-          "type": {
-            "$ref": "#/definitions/type"
-          },
-          "hostname": {
-            "type": "string"
-          },
-          "path": {
-            "type": "string"
-          }
+    "document_type": {
+      "required": [
+        "id",
+        "type"
+      ],
+      "additionalProperties": false,
+      "properties": {
+        "id": {
+          "$ref": "#/definitions/id"
+        },
+        "type": {
+          "type": "string",
+          "enum": [
+            "document_type"
+          ]
         }
       }
     },
-    "type": {
-      "type": "string",
-      "enum": [
-        "document_type",
-        "managed_elsewhere",
-        "document_type_selection"
-      ]
+    "document_type_selection": {
+      "required": [
+        "id",
+        "type"
+      ],
+      "additionalProperties": false,
+      "properties": {
+        "id": {
+          "$ref": "#/definitions/id"
+        },
+        "type": {
+          "type": "string",
+          "enum": [
+            "document_type_selection"
+          ]
+        }
+      }
+    },
+    "managed_elsewhere": {
+      "required": [
+        "id",
+        "type",
+        "path"
+      ],
+      "additionalProperties": false,
+      "properties": {
+        "id": {
+          "$ref": "#/definitions/id"
+        },
+        "type": {
+          "type": "string",
+          "enum": [
+            "managed_elsewhere"
+          ]
+        },
+        "hostname": {
+          "type": "string"
+        },
+        "path": {
+          "type": "string"
+        }
+      }
     }
   }
 }


### PR DESCRIPTION
Trello: https://trello.com/c/tbxRLYMP

If the format is not one that can be created in Content Publisher, we need to route users to
the correct publishing app or piece of guidance. To be able to do that we need to make
"path" a required field, but only if the type is "managed elsewhere".

There is is no elegant way to do this.
I investigated using the new [if-then-else][1] logic, or trying to set [dependencies][2],
but neither of these approaches failed schema validation when a "path" was removed from
`config/document_type_selections.yml`, so I went with the only approach that did work:
[creating two schemas][3]

[1]https://json-schema.org/understanding-json-schema/reference/conditionals.html
[2]https://json-schema.org/understanding-json-schema/reference/object.html#dependencies
[3]https://tonyyan.wordpress.com/2015/03/12/json-schema-based-on-property-values-use-of-oneof/