### PR TITLE
Update destructive link colour

### DIFF
--- a/app/assets/stylesheets/core/_link.scss
+++ b/app/assets/stylesheets/core/_link.scss
@@ -18,7 +18,7 @@
   &:visited,
   &:hover,
   &:active {
-    color: $govuk-error-colour;
+    color: darken($govuk-error-colour, 5%);
   }
 
   &:focus {


### PR DESCRIPTION
When we originally used `$govuk-error-colour` for destructive links it met the
contrast requirements on the `light-grey` colour (which is used for panels or
to highlight sections on a page). After the colour palette update, destructive links
on panels became non-compliant with AA level of WCAG2.1. We decided to darken
the `$govuk-error-colour` by 5% to make sure it meets the required contrast ratio
regardless of it being presented on a default (white) background or on a light
grey background.

[Trello card](https://trello.com/c/f9JwfwIW)