### PR TITLE
Only allow unique options in a document type selection

### DIFF
--- a/spec/models/document_type_selection_spec.rb
+++ b/spec/models/document_type_selection_spec.rb
@@ -36,6 +36,13 @@ RSpec.describe DocumentTypeSelection do
       ids = document_type_selections.pluck("id")
       expect(ids.size).to eq(ids.uniq.size)
     end
+
+    it "only allows unique options in each document_type_selection" do
+      document_type_selections.each do |document_type_selection|
+        ids = document_type_selection["options"].pluck("id")
+        expect(ids).to eq(ids.uniq), "duplicate option ids in #{document_type_selection['id']}: #{ids}"
+      end
+    end
   end
 
   describe ".all" do

--- a/spec/models/document_type_selection_spec.rb
+++ b/spec/models/document_type_selection_spec.rb
@@ -34,7 +34,7 @@ RSpec.describe DocumentTypeSelection do
 
     it "only allows unique document type selections" do
       ids = document_type_selections.pluck("id")
-      expect(ids.size).to eq(ids.uniq.size)
+      expect(ids).to eq(ids.uniq), "duplicate document type selection ids in: #{ids}"
     end
 
     it "only allows unique options in each document_type_selection" do


### PR DESCRIPTION
Trello: https://trello.com/c/tbxRLYMP

This is to prevent the same radio button appearing multiple times on a document type selection page.