### PR TITLE
Update document type selections to match new structure

### DIFF
--- a/config/document_type_selections.yml
+++ b/config/document_type_selections.yml
@@ -95,6 +95,10 @@
       type: managed_elsewhere
       hostname: whitehall-admin
       path: /government/admin/consultations/new
+    - id: policy_paper
+      type: managed_elsewhere
+      hostname: whitehall-admin
+      path: /government/admin/publications/new
 
 - id: specialist_notices
   options:

--- a/config/document_type_selections.yml
+++ b/config/document_type_selections.yml
@@ -3,20 +3,14 @@
   options:
     - id: news
       type: document_type_selection
-    - id: guidance
+    - id: guidance_and_regulation
       type: document_type_selection
-    - id: transparency
+    - id: transparency_statistics_reports
       type: document_type_selection
     - id: policy
       type: document_type_selection
-    - id: document_collection
-      type: managed_elsewhere
-      hostname: whitehall-admin
-      path: /government/admin/collections/new
-    - id: corporate_information
-      type: managed_elsewhere
-      hostname: whitehall-admin
-      path: /government/admin/organisations/government-digital-service/corporate_information_pages
+    - id: specialist_notices
+      type: document_type_selection
     - id: not_sure
       type: managed_elsewhere
       path: /documents/publishing-guidance
@@ -27,64 +21,159 @@
       type: document_type
     - id: press_release
       type: document_type
-    - id: fatality_notice
-      type: managed_elsewhere
-      hostname: whitehall-admin
-      path: /government/admin/fatalities/new
     - id: speech
       type: managed_elsewhere
       hostname: whitehall-admin
       path: /government/admin/speeches/new
-    - id: world_news_story
+    - id: statement_to_parliament
+      type: document_type_selection
+    - id: articles_and_correspondence
+      type: document_type_selection
+    - id: case_study
       type: managed_elsewhere
       hostname: whitehall-admin
-      path: /government/admin/news/new
+      path: /government/admin/case-studies/new
+
+- id: statement_to_parliament
+  options:
+    - id: oral_statement
+      type: managed_elsewhere
+      hostname: whitehall-admin
+      path: /government/admin/speeches/new
+    - id: written_statement
+      type: managed_elsewhere
+      hostname: whitehall-admin
+      path: /government/admin/speeches/new
+
+- id: articles_and_correspondence
+  options:
+    - id: authored_article
+      type: managed_elsewhere
+      hostname: whitehall-admin
+      path: /government/admin/speeches/new
+    - id: correspondence
+      type: managed_elsewhere
+      hostname: whitehall-admin
+      path: /government/admin/publications/new
+
+- id: guidance_and_regulation
+  options:
+    - id: guidance
+      type: document_type_selection
+    - id: regulation
+      type: managed_elsewhere
+      hostname: whitehall-admin
+      path: /government/admin/publications/new
+    - id: form
+      type: managed_elsewhere
+      hostname: whitehall-admin
+      path: /government/admin/publications/new
+    - id: map
+      type: managed_elsewhere
+      hostname: whitehall-admin
+      path: /government/admin/publications/new
 
 - id: guidance
   options:
-    - id: detailed_guide
+    - id: non_statutory_guidance
       type: managed_elsewhere
       hostname: whitehall-admin
-      path: /government/admin/detailed-guides/new
-    - id: any_whitehall_publication
+      path: /government/admin/publications/new
+    - id: statutory_guidance
       type: managed_elsewhere
       hostname: whitehall-admin
       path: /government/admin/publications/new
     - id: manual
       type: managed_elsewhere
-      hostname: manuals-publisher
-      path: /
+      hostname: support
+      path: /content_advice_request/new
+    - id: detailed_guide
+      type: managed_elsewhere
+      hostname: whitehall-admin
+      path: /government/admin/detailed-guides/new
     - id: any_mainstream_publication
       type: managed_elsewhere
       hostname: support
       path: /content_change_request/new
-    - id: travel_advice
-      type: managed_elsewhere
-      hostname: travel-advice-publisher
-      path: /admin
 
-- id: transparency
+- id: transparency_statistics_reports
   options:
-    - id: any_whitehall_publication
+    - id: statistics
+      type: document_type_selection
+    - id: independent_report
       type: managed_elsewhere
       hostname: whitehall-admin
       path: /government/admin/publications/new
-    - id: statistical_data_set
+    - id: foi_release
+      type: managed_elsewhere
+      hostname: whitehall-admin
+      path: /government/admin/publications/new
+    - id: corporate_report
+      type: managed_elsewhere
+      hostname: whitehall-admin
+      path: /government/admin/publications/new
+    - id: transparency
+      type: managed_elsewhere
+      hostname: whitehall-admin
+      path: /government/admin/publications/new
+    - id: research_and_analysis
+      type: managed_elsewhere
+      hostname: whitehall-admin
+      path: /government/admin/publications/new
+    - id: international_treaty
+      type: managed_elsewhere
+      hostname: whitehall-admin
+      path: /government/admin/publications/new
+    - id: promotional_material
+      type: managed_elsewhere
+      hostname: whitehall-admin
+      path: /government/admin/publications/new
+
+- id: statistics
+  options:
+    - id: official_statistics
+      type: managed_elsewhere
+      hostname: whitehall-admin
+      path: /government/admin/publications/new
+    - id: national_statistics
+      type: managed_elsewhere
+      hostname: whitehall-admin
+      path: /government/admin/publications/new
+    - id: statistics_announcement
+      type: managed_elsewhere
+      hostname: whitehall-admin
+      path: /government/admin/statistics_announcements/new
+    - id: statistical_dataset
       type: managed_elsewhere
       hostname: whitehall-admin
       path: /government/admin/statistical-data-sets/new
 
 - id: policy
   options:
-    - id: case_study
+    - id: impact_assessment
       type: managed_elsewhere
       hostname: whitehall-admin
-      path: /government/admin/case-studies/new
+      path: /government/admin/publications/new
     - id: consultation
       type: managed_elsewhere
       hostname: whitehall-admin
       path: /government/admin/consultations/new
-    - id: any_whitehall_publication
+
+- id: specialist_notices
+  options:
+    - id: descision
       type: managed_elsewhere
       hostname: whitehall-admin
       path: /government/admin/publications/new
+    - id: fatality_notice
+      type: managed_elsewhere
+      hostname: whitehall-admin
+      path: /government/admin/fatalities/new
+    - id: notice
+      type: managed_elsewhere
+      hostname: whitehall-admin
+      path: /government/admin/publications/new
+    - id: specialist_notice
+      type: managed_elsewhere
+      hostname: specialist-publisher
+      path: /

--- a/config/document_type_selections.yml
+++ b/config/document_type_selections.yml
@@ -15,36 +15,6 @@
       type: managed_elsewhere
       path: /documents/publishing-guidance
 
-- id: news
-  options:
-    - id: news_story
-      type: document_type
-    - id: press_release
-      type: document_type
-    - id: speech
-      type: managed_elsewhere
-      hostname: whitehall-admin
-      path: /government/admin/speeches/new
-    - id: statement_to_parliament
-      type: document_type_selection
-    - id: articles_and_correspondence
-      type: document_type_selection
-    - id: case_study
-      type: managed_elsewhere
-      hostname: whitehall-admin
-      path: /government/admin/case-studies/new
-
-- id: statement_to_parliament
-  options:
-    - id: oral_statement
-      type: managed_elsewhere
-      hostname: whitehall-admin
-      path: /government/admin/speeches/new
-    - id: written_statement
-      type: managed_elsewhere
-      hostname: whitehall-admin
-      path: /government/admin/speeches/new
-
 - id: articles_and_correspondence
   options:
     - id: authored_article
@@ -52,23 +22,6 @@
       hostname: whitehall-admin
       path: /government/admin/speeches/new
     - id: correspondence
-      type: managed_elsewhere
-      hostname: whitehall-admin
-      path: /government/admin/publications/new
-
-- id: guidance_and_regulation
-  options:
-    - id: guidance
-      type: document_type_selection
-    - id: regulation
-      type: managed_elsewhere
-      hostname: whitehall-admin
-      path: /government/admin/publications/new
-    - id: form
-      type: managed_elsewhere
-      hostname: whitehall-admin
-      path: /government/admin/publications/new
-    - id: map
       type: managed_elsewhere
       hostname: whitehall-admin
       path: /government/admin/publications/new
@@ -95,6 +48,102 @@
       type: managed_elsewhere
       hostname: support
       path: /content_change_request/new
+
+- id: guidance_and_regulation
+  options:
+    - id: guidance
+      type: document_type_selection
+    - id: regulation
+      type: managed_elsewhere
+      hostname: whitehall-admin
+      path: /government/admin/publications/new
+    - id: form
+      type: managed_elsewhere
+      hostname: whitehall-admin
+      path: /government/admin/publications/new
+    - id: map
+      type: managed_elsewhere
+      hostname: whitehall-admin
+      path: /government/admin/publications/new
+
+- id: news
+  options:
+    - id: news_story
+      type: document_type
+    - id: press_release
+      type: document_type
+    - id: speech
+      type: managed_elsewhere
+      hostname: whitehall-admin
+      path: /government/admin/speeches/new
+    - id: statement_to_parliament
+      type: document_type_selection
+    - id: articles_and_correspondence
+      type: document_type_selection
+    - id: case_study
+      type: managed_elsewhere
+      hostname: whitehall-admin
+      path: /government/admin/case-studies/new
+
+- id: policy
+  options:
+    - id: impact_assessment
+      type: managed_elsewhere
+      hostname: whitehall-admin
+      path: /government/admin/publications/new
+    - id: consultation
+      type: managed_elsewhere
+      hostname: whitehall-admin
+      path: /government/admin/consultations/new
+
+- id: specialist_notices
+  options:
+    - id: decision
+      type: managed_elsewhere
+      hostname: whitehall-admin
+      path: /government/admin/publications/new
+    - id: fatality_notice
+      type: managed_elsewhere
+      hostname: whitehall-admin
+      path: /government/admin/fatalities/new
+    - id: notice
+      type: managed_elsewhere
+      hostname: whitehall-admin
+      path: /government/admin/publications/new
+    - id: specialist_notice
+      type: managed_elsewhere
+      hostname: specialist-publisher
+      path: /
+
+- id: statement_to_parliament
+  options:
+    - id: oral_statement
+      type: managed_elsewhere
+      hostname: whitehall-admin
+      path: /government/admin/speeches/new
+    - id: written_statement
+      type: managed_elsewhere
+      hostname: whitehall-admin
+      path: /government/admin/speeches/new
+
+- id: statistics
+  options:
+    - id: official_statistics
+      type: managed_elsewhere
+      hostname: whitehall-admin
+      path: /government/admin/publications/new
+    - id: national_statistics
+      type: managed_elsewhere
+      hostname: whitehall-admin
+      path: /government/admin/publications/new
+    - id: statistics_announcement
+      type: managed_elsewhere
+      hostname: whitehall-admin
+      path: /government/admin/statistics_announcements/new
+    - id: statistical_dataset
+      type: managed_elsewhere
+      hostname: whitehall-admin
+      path: /government/admin/statistical-data-sets/new
 
 - id: transparency_statistics_reports
   options:
@@ -128,52 +177,3 @@
       type: managed_elsewhere
       hostname: whitehall-admin
       path: /government/admin/publications/new
-
-- id: statistics
-  options:
-    - id: official_statistics
-      type: managed_elsewhere
-      hostname: whitehall-admin
-      path: /government/admin/publications/new
-    - id: national_statistics
-      type: managed_elsewhere
-      hostname: whitehall-admin
-      path: /government/admin/publications/new
-    - id: statistics_announcement
-      type: managed_elsewhere
-      hostname: whitehall-admin
-      path: /government/admin/statistics_announcements/new
-    - id: statistical_dataset
-      type: managed_elsewhere
-      hostname: whitehall-admin
-      path: /government/admin/statistical-data-sets/new
-
-- id: policy
-  options:
-    - id: impact_assessment
-      type: managed_elsewhere
-      hostname: whitehall-admin
-      path: /government/admin/publications/new
-    - id: consultation
-      type: managed_elsewhere
-      hostname: whitehall-admin
-      path: /government/admin/consultations/new
-
-- id: specialist_notices
-  options:
-    - id: descision
-      type: managed_elsewhere
-      hostname: whitehall-admin
-      path: /government/admin/publications/new
-    - id: fatality_notice
-      type: managed_elsewhere
-      hostname: whitehall-admin
-      path: /government/admin/fatalities/new
-    - id: notice
-      type: managed_elsewhere
-      hostname: whitehall-admin
-      path: /government/admin/publications/new
-    - id: specialist_notice
-      type: managed_elsewhere
-      hostname: specialist-publisher
-      path: /

--- a/config/locales/en/document_type_selections.yml
+++ b/config/locales/en/document_type_selections.yml
@@ -98,6 +98,9 @@ en:
       guidance:
         body_govspeak: |
           For example, policy papers or impact assessments
+    policy_paper:
+      label: Policy paper
+      description: An explanation of the government's position on something. It doesn’t include instructions on how to carry out a task, only the policy itself and how it’ll be implemented.
     press_release:
       label: Press release
       description: "Unedited press releases as sent to the media, and official statements from the organisation."

--- a/config/locales/en/document_type_selections.yml
+++ b/config/locales/en/document_type_selections.yml
@@ -2,147 +2,147 @@ en:
   document_type_selections:
     root:
       label: "What is the content for?"
-    news:
-      label: News and communications
-      description: To tell users about something government has done or will do
-      guidance:
-        body_govspeak: |
-          For example, news stories, press releases, speeches, or statements
-    guidance_and_regulation:
-      label: Guidance and regulation
-      description: To help the user do something or understand what they need to do
-      guidance:
-        body_govspeak: |
-          For example, manuals, or statutory guidance
-    transparency_statistics_reports:
-      label: Transparency, statistics and reports
-      description: To provide information that helps users hold government to account
-      guidance:
-        body_govspeak: |
-          For example, statistics, FOI data, or reports
-    statistics:
-      label: Statistics
-      description: Official and national statistics, announcements and raw datasets.
-    official_statistics:
-      label: Official statistics
-      description: Statistics governed by the UK Statistics Authority and produced by members of the Government Statistical Service.
-    national_statistics:
-      label: National statistics
-      description: Official Statistics that have been produced in accordance with the Code of Practice for Official Statistics, which is indicated using the National Statistics quality mark.
-    statistics_announcement:
-      label: Statistics announcement
-      description: An announcement of national and official statistics releases to comply with the Code of Practice for Official Statistics.
-    policy:
-      label: Policy or consultation
-      description: To explain the government’s position or request views or evidence on an issue
-      guidance:
-        body_govspeak: |
-          For example, policy papers or impact assessments
-    impact_assessment:
-      label: Impact assessment
-      description: Cost-benefit analyses and other assessments of the impact of proposed initiatives, or changes to regulations or legislation.
-    not_sure:
-      label: I’m not sure if this should be on GOV.UK
-      description: View this guide to see what should go on GOV.UK and where else you can publish content
-    news_story:
-      label: News story
-      description: "News written for GOV.UK which users need, can act on, and cannot get from other sources."
-    press_release:
-      label: Press release
-      description: "Unedited press releases as sent to the media, and official statements from the organisation."
-    statement_to_parliament:
-      label: Statement to Parliament
-      description: A written or oral statement made to Parliament
-    oral_statement:
-      label: Oral statement to Parliament
-      description: Oral statements made to Parliament by a minister, where there is significant public interest in the entire statement.
-    written_statement:
-      label: Written statement to Parliament
-      description: Written statements given to Parliament by a minister, where there is significant public interest in the entire statement.
+    any_mainstream_publication:
+      label: Mainstream guide
+      description: Guidance for the general public, written for people not expected to have any previous experience or specialist knowledge.
+    any_whitehall_publication:
+      label: Publication
+      description: Standalone government documents that are issued and not usually updated
     articles_and_correspondence:
       label: Articles and correspondence
       description: Articles written by a minister or official, responses from the organisation or a minister, and circulars or newsletters.
     authored_article:
       label: Authored article
       description: Bylined articles written in the name of a minister or official, usually republished from elsewhere.
-    correspondence:
-      label: Correspondence
-      description: Minister or organisation responses (for example to campaign letters), correspondence to individuals, organisations and professionals, circulars, bulletins and newsletters.
-    guidance:
-      label: Guidance
-      description: Guidance to help the user do something or understand what they need to do.
-    non_statutory_guidance:
-      label: Non-statutory guidance
-      description: Publications like manuals, handbooks, and other documents that offer advice. Use for content produced as a standalone hard-copy publicaton. For web-original content use 'detailed guide'.
-    statutory_guidance:
-      label: Statutory guidance
-      description: Guidance which relevant users are legally obliged to follow.
-    regulation:
-      label: Regulation
-      description: Regulations imposed by an independent regulatory authority.
-    form:
-      label: Form
-      description: Form documents that need to be completed by the users.
-    map:
-      label: Map
-      description: Drawn maps and geographical data.
-    fatality_notice:
-      label: Fatality notice
-      description: Initial fatality notices and subsequent obituaries of forces and Ministry of Defence personnel.
-    speech:
-      label: Speech
-      description: A significant speech by a minister or official.
-    detailed_guide:
-      label: Detailed guide
-      description: Guidance for specialist or professional users detailing the steps they need to take to complete a clearly defined task.
-    any_whitehall_publication:
-      label: Publication
-      description: Standalone government documents that are issued and not usually updated
-    manual:
-      label: Manual
-      description: Long, complex guidance or legal documents for specialist users who are familiar with a topic, usually with named or numbered chapters or clauses.
-    any_mainstream_publication:
-      label: Mainstream guide
-      description: Guidance for the general public, written for people not expected to have any previous experience or specialist knowledge.
-    statistical_dataset:
-      label: Statistical dataset
-      description: Data you publish monthly or more often without analysis (ie raw data).
-    independent_report:
-      label: Independent report
-      description: Reports commissioned by government but written by non-government organisations, including independent enquiries, investigations and reviews.
-    foi_release:
-      label: FOI release
-      description: Responses to Freedom of Information (FOI) requests.
-    corporate_report:
-      label: Corporate report
-      description: Publications about the organisation as a public entity, for example, annual reports, business plans and accounts.
-    transparency:
-      label: Transparency
-      description: Information about how an organisation operates, for example departmental spending, salaries and staff survey results.
-    research_and_analysis:
-      label: Research and analysis
-      description: Research reports, surveys, analyses and evaluations.
-    international_treaty:
-      label: International treaty
-      description: Treaties and memorandums of understanding between the UK and other nations.
-    promotional_material:
-      label: Promotional material
-      description: Leaflets, posters, factsheets and marketing materials.
     case_study:
       label: Case study
       description: Real examples that help users understand a process or an important aspect of government policy.
     consultation:
       label: Consultation
       description: Consultations (officially ‘documents requiring collective agreement across government’), calls for evidence and requests for people's views on a question.
-    specialist_notices:
-      label: Specialist notices
-      description: To give notice of permit and licence applications, fatalities and formal decisions by tribunals, regulators or adjudicators.
-    descision:
-      label: Descision
+    corporate_report:
+      label: Corporate report
+      description: Publications about the organisation as a public entity, for example, annual reports, business plans and accounts.
+    correspondence:
+      label: Correspondence
+      description: Minister or organisation responses (for example to campaign letters), correspondence to individuals, organisations and professionals, circulars, bulletins and newsletters.
+    decision:
+      label: Decision
       description: Formal decisions by tribunals, regulators or adjudicators (including courts and Secretaries of State).
+    detailed_guide:
+      label: Detailed guide
+      description: Guidance for specialist or professional users detailing the steps they need to take to complete a clearly defined task.
+    fatality_notice:
+      label: Fatality notice
+      description: Initial fatality notices and subsequent obituaries of forces and Ministry of Defence personnel.
+    foi_release:
+      label: FOI release
+      description: Responses to Freedom of Information (FOI) requests.
+    form:
+      label: Form
+      description: Form documents that need to be completed by the users.
+    guidance:
+      label: Guidance
+      description: Guidance to help the user do something or understand what they need to do.
+    guidance_and_regulation:
+      label: Guidance and regulation
+      description: To help the user do something or understand what they need to do
+      guidance:
+        body_govspeak: |
+          For example, manuals, or statutory guidance
+    impact_assessment:
+      label: Impact assessment
+      description: Cost-benefit analyses and other assessments of the impact of proposed initiatives, or changes to regulations or legislation.
+    independent_report:
+      label: Independent report
+      description: Reports commissioned by government but written by non-government organisations, including independent enquiries, investigations and reviews.
+    international_treaty:
+      label: International treaty
+      description: Treaties and memorandums of understanding between the UK and other nations.
+    manual:
+      label: Manual
+      description: Long, complex guidance or legal documents for specialist users who are familiar with a topic, usually with named or numbered chapters or clauses.
+    map:
+      label: Map
+      description: Drawn maps and geographical data.
+    news:
+      label: News and communications
+      description: To tell users about something government has done or will do
+      guidance:
+        body_govspeak: |
+          For example, news stories, press releases, speeches, or statements
+    news_story:
+      label: News story
+      description: "News written for GOV.UK which users need, can act on, and cannot get from other sources."
+    not_sure:
+      label: I’m not sure if this should be on GOV.UK
+      description: View this guide to see what should go on GOV.UK and where else you can publish content
     notice:
       label: Notice
       description: Permit and licence applications published temporarily for public awareness.
+    official_statistics:
+      label: Official statistics
+      description: Statistics governed by the UK Statistics Authority and produced by members of the Government Statistical Service.
+    national_statistics:
+      label: National statistics
+      description: Official Statistics that have been produced in accordance with the Code of Practice for Official Statistics, which is indicated using the National Statistics quality mark.
+    non_statutory_guidance:
+      label: Non-statutory guidance
+      description: Publications like manuals, handbooks, and other documents that offer advice. Use for content produced as a standalone hard-copy publicaton. For web-original content use 'detailed guide'.
+    oral_statement:
+      label: Oral statement to Parliament
+      description: Oral statements made to Parliament by a minister, where there is significant public interest in the entire statement.
+    policy:
+      label: Policy or consultation
+      description: To explain the government’s position or request views or evidence on an issue
+      guidance:
+        body_govspeak: |
+          For example, policy papers or impact assessments
+    press_release:
+      label: Press release
+      description: "Unedited press releases as sent to the media, and official statements from the organisation."
+    promotional_material:
+      label: Promotional material
+      description: Leaflets, posters, factsheets and marketing materials.
+    regulation:
+      label: Regulation
+      description: Regulations imposed by an independent regulatory authority.
+    research_and_analysis:
+      label: Research and analysis
+      description: Research reports, surveys, analyses and evaluations.
     specialist_notice:
       label: Specialist notice
       description: Notices published in Specialist Publisher.
+    specialist_notices:
+      label: Specialist notices
+      description: To give notice of permit and licence applications, fatalities and formal decisions by tribunals, regulators or adjudicators.
+    speech:
+      label: Speech
+      description: A significant speech by a minister or official.
+    statement_to_parliament:
+      label: Statement to Parliament
+      description: A written or oral statement made to Parliament
+    statistical_dataset:
+      label: Statistical dataset
+      description: Data you publish monthly or more often without analysis (ie raw data).
+    statistics:
+      label: Statistics
+      description: Official and national statistics, announcements and raw datasets.
+    statistics_announcement:
+      label: Statistics announcement
+      description: An announcement of national and official statistics releases to comply with the Code of Practice for Official Statistics.
+    statutory_guidance:
+      label: Statutory guidance
+      description: Guidance which relevant users are legally obliged to follow.
+    transparency:
+      label: Transparency
+      description: Information about how an organisation operates, for example departmental spending, salaries and staff survey results.
+    transparency_statistics_reports:
+      label: Transparency, statistics and reports
+      description: To provide information that helps users hold government to account
+      guidance:
+        body_govspeak: |
+          For example, statistics, FOI data, or reports
+    written_statement:
+      label: Written statement to Parliament
+      description: Written statements given to Parliament by a minister, where there is significant public interest in the entire statement.

--- a/config/locales/en/document_type_selections.yml
+++ b/config/locales/en/document_type_selections.yml
@@ -3,82 +3,146 @@ en:
     root:
       label: "What is the content for?"
     news:
-      label: News
+      label: News and communications
       description: To tell users about something government has done or will do
       guidance:
         body_govspeak: |
           For example, news stories, press releases, speeches, or statements
-    guidance:
-      label: Guidance
+    guidance_and_regulation:
+      label: Guidance and regulation
       description: To help the user do something or understand what they need to do
       guidance:
         body_govspeak: |
           For example, manuals, or statutory guidance
-    transparency:
-      label: Transparency and statistics
+    transparency_statistics_reports:
+      label: Transparency, statistics and reports
       description: To provide information that helps users hold government to account
       guidance:
         body_govspeak: |
           For example, statistics, FOI data, or reports
+    statistics:
+      label: Statistics
+      description: Official and national statistics, announcements and raw datasets.
+    official_statistics:
+      label: Official statistics
+      description: Statistics governed by the UK Statistics Authority and produced by members of the Government Statistical Service.
+    national_statistics:
+      label: National statistics
+      description: Official Statistics that have been produced in accordance with the Code of Practice for Official Statistics, which is indicated using the National Statistics quality mark.
+    statistics_announcement:
+      label: Statistics announcement
+      description: An announcement of national and official statistics releases to comply with the Code of Practice for Official Statistics.
     policy:
       label: Policy or consultation
       description: To explain the government’s position or request views or evidence on an issue
       guidance:
         body_govspeak: |
-          For example, policy papers, impact assessments, or case studies
-    document_collection:
-      label: Document collection
-      description: To create a list of related documents on a single page
-    corporate_information:
-      label: Corporate information
-      description: Information about your organisation
+          For example, policy papers or impact assessments
+    impact_assessment:
+      label: Impact assessment
+      description: Cost-benefit analyses and other assessments of the impact of proposed initiatives, or changes to regulations or legislation.
     not_sure:
       label: I’m not sure if this should be on GOV.UK
       description: View this guide to see what should go on GOV.UK and where else you can publish content
     news_story:
       label: News story
       description: "News written for GOV.UK which users need, can act on, and cannot get from other sources."
-      guidance:
-        body_govspeak: |
-          Do not include advice in news stories. Do not use to promote other content.
-          Read the full [guidance on news stories](https://www.gov.uk/guidance/content-design/content-types#news-story).
     press_release:
       label: Press release
       description: "Unedited press releases as sent to the media, and official statements from the organisation."
-      guidance:
-        body_govspeak: |
-          Do not use to promote other content. Statements to Parliament should use the Speech document type.
-          Read the full [guidance on press releases](https://www.gov.uk/guidance/content-design/content-types#press-release).
+    statement_to_parliament:
+      label: Statement to Parliament
+      description: A written or oral statement made to Parliament
+    oral_statement:
+      label: Oral statement to Parliament
+      description: Oral statements made to Parliament by a minister, where there is significant public interest in the entire statement.
+    written_statement:
+      label: Written statement to Parliament
+      description: Written statements given to Parliament by a minister, where there is significant public interest in the entire statement.
+    articles_and_correspondence:
+      label: Articles and correspondence
+      description: Articles written by a minister or official, responses from the organisation or a minister, and circulars or newsletters.
+    authored_article:
+      label: Authored article
+      description: Bylined articles written in the name of a minister or official, usually republished from elsewhere.
+    correspondence:
+      label: Correspondence
+      description: Minister or organisation responses (for example to campaign letters), correspondence to individuals, organisations and professionals, circulars, bulletins and newsletters.
+    guidance:
+      label: Guidance
+      description: Guidance to help the user do something or understand what they need to do.
+    non_statutory_guidance:
+      label: Non-statutory guidance
+      description: Publications like manuals, handbooks, and other documents that offer advice. Use for content produced as a standalone hard-copy publicaton. For web-original content use 'detailed guide'.
+    statutory_guidance:
+      label: Statutory guidance
+      description: Guidance which relevant users are legally obliged to follow.
+    regulation:
+      label: Regulation
+      description: Regulations imposed by an independent regulatory authority.
+    form:
+      label: Form
+      description: Form documents that need to be completed by the users.
+    map:
+      label: Map
+      description: Drawn maps and geographical data.
     fatality_notice:
       label: Fatality notice
-      description: Initial fatality notices and subsequent obituaries of forces and MOD personnel
+      description: Initial fatality notices and subsequent obituaries of forces and Ministry of Defence personnel.
     speech:
       label: Speech
-      description: Public speeches, written statements, or authored articles
-    world_news_story:
-      label: World news story
-      description: Announcements specific to one or more world location
+      description: A significant speech by a minister or official.
     detailed_guide:
       label: Detailed guide
-      description: Detailed guidance for specialist users on the steps they need to take to complete a task
+      description: Guidance for specialist or professional users detailing the steps they need to take to complete a clearly defined task.
     any_whitehall_publication:
       label: Publication
       description: Standalone government documents that are issued and not usually updated
     manual:
       label: Manual
-      description: Long and complex guidance broken into chapters and sub-sections for reference
+      description: Long, complex guidance or legal documents for specialist users who are familiar with a topic, usually with named or numbered chapters or clauses.
     any_mainstream_publication:
       label: Mainstream guide
-      description: Guidance for the general public on how to do something. Contact GDS to request changes.
-    travel_advice:
-      label: Travel advice
-      description: Travel advice by country including entry requirements and safety information
-    statistical_data_set:
-      label: Statistical data set
-      description: Frequently updated (“live”) statistical data files.
+      description: Guidance for the general public, written for people not expected to have any previous experience or specialist knowledge.
+    statistical_dataset:
+      label: Statistical dataset
+      description: Data you publish monthly or more often without analysis (ie raw data).
+    independent_report:
+      label: Independent report
+      description: Reports commissioned by government but written by non-government organisations, including independent enquiries, investigations and reviews.
+    foi_release:
+      label: FOI release
+      description: Responses to Freedom of Information (FOI) requests.
+    corporate_report:
+      label: Corporate report
+      description: Publications about the organisation as a public entity, for example, annual reports, business plans and accounts.
+    transparency:
+      label: Transparency
+      description: Information about how an organisation operates, for example departmental spending, salaries and staff survey results.
+    research_and_analysis:
+      label: Research and analysis
+      description: Research reports, surveys, analyses and evaluations.
+    international_treaty:
+      label: International treaty
+      description: Treaties and memorandums of understanding between the UK and other nations.
+    promotional_material:
+      label: Promotional material
+      description: Leaflets, posters, factsheets and marketing materials.
     case_study:
       label: Case study
-      description: Case studies show someone’s experience of a government process or policy problem
+      description: Real examples that help users understand a process or an important aspect of government policy.
     consultation:
       label: Consultation
-      description: A request for views or evidence on an issue
+      description: Consultations (officially ‘documents requiring collective agreement across government’), calls for evidence and requests for people's views on a question.
+    specialist_notices:
+      label: Specialist notices
+      description: To give notice of permit and licence applications, fatalities and formal decisions by tribunals, regulators or adjudicators.
+    descision:
+      label: Descision
+      description: Formal decisions by tribunals, regulators or adjudicators (including courts and Secretaries of State).
+    notice:
+      label: Notice
+      description: Permit and licence applications published temporarily for public awareness.
+    specialist_notice:
+      label: Specialist notice
+      description: Notices published in Specialist Publisher.


### PR DESCRIPTION
Trello: https://trello.com/c/tR0CUleU

# What's changed and why?
Updates the document type selections config to:

- add a new section (specialist notices)
- expand the news, guidance and transparency sections with nested
selections
- update the guidance
- alphabetise the entries to make them easier to update in the future.


