### PR TITLE
Display data UI migration

### DIFF
--- a/app/controllers/whitehall_migration_controller.rb
+++ b/app/controllers/whitehall_migration_controller.rb
@@ -9,7 +9,7 @@ class WhitehallMigrationController < ApplicationController
     @whitehall_migration = WhitehallMigration.find(params[:migration_id])
     scope = @whitehall_migration.document_imports
     scope = scope.where(state: params[:state]) if params[:state]
-    @document_imports = scope.order(:id).page(params.fetch(:page, 1)).per(25)
+    @document_imports = scope.order(:id).page(params.fetch(:page, 1)).per(50)
   end
 
   def document_import

--- a/app/controllers/whitehall_migration_controller.rb
+++ b/app/controllers/whitehall_migration_controller.rb
@@ -7,8 +7,9 @@ class WhitehallMigrationController < ApplicationController
 
   def document_imports
     @whitehall_migration = WhitehallMigration.find(params[:migration_id])
+    @state = params[:state] if WhitehallMigration::DocumentImport.states.keys.include?(params[:state])
     scope = @whitehall_migration.document_imports
-    scope = scope.where(state: params[:state]) if params[:state]
+    scope = scope.where(state: @state) if @state
     @document_imports = scope.order(:id).page(params.fetch(:page, 1)).per(50)
   end
 

--- a/app/controllers/whitehall_migration_controller.rb
+++ b/app/controllers/whitehall_migration_controller.rb
@@ -5,14 +5,14 @@ class WhitehallMigrationController < ApplicationController
     @whitehall_migration = WhitehallMigration.find(params[:migration_id])
   end
 
-  def documents
+  def document_imports
     @whitehall_migration = WhitehallMigration.find(params[:migration_id])
     scope = @whitehall_migration.document_imports
     scope = scope.where(state: params[:state]) if params[:state]
     @document_imports = scope.order(:id).page(params.fetch(:page, 1)).per(25)
   end
 
-  def document
+  def document_import
     @document_import = WhitehallMigration::DocumentImport.find_by!(
       id: params[:document_import_id],
       whitehall_migration_id: params[:migration_id],

--- a/app/controllers/whitehall_migration_controller.rb
+++ b/app/controllers/whitehall_migration_controller.rb
@@ -13,7 +13,7 @@ class WhitehallMigrationController < ApplicationController
   end
 
   def document
-    @document = WhitehallMigration::DocumentImport.find_by!(
+    @document_import = WhitehallMigration::DocumentImport.find_by!(
       id: params[:document_import_id],
       whitehall_migration_id: params[:migration_id],
     )

--- a/app/controllers/whitehall_migration_controller.rb
+++ b/app/controllers/whitehall_migration_controller.rb
@@ -9,7 +9,7 @@ class WhitehallMigrationController < ApplicationController
     @whitehall_migration = WhitehallMigration.find(params[:migration_id])
     scope = @whitehall_migration.document_imports
     scope = scope.where(state: params[:state]) if params[:state]
-    @documents = scope.order(:id).page(params.fetch(:page, 1)).per(25)
+    @document_imports = scope.order(:id).page(params.fetch(:page, 1)).per(25)
   end
 
   def document

--- a/app/controllers/whitehall_migration_controller.rb
+++ b/app/controllers/whitehall_migration_controller.rb
@@ -6,8 +6,10 @@ class WhitehallMigrationController < ApplicationController
   end
 
   def documents
-    whitehall_migration = WhitehallMigration.find(params[:migration_id])
-    @documents = whitehall_migration.document_imports
+    @whitehall_migration = WhitehallMigration.find(params[:migration_id])
+    scope = @whitehall_migration.document_imports
+    scope = scope.where(state: params[:state]) if params[:state]
+    @documents = scope.order(:id).page(params.fetch(:page, 1)).per(25)
   end
 
   def document

--- a/app/models/whitehall_migration/document_import.rb
+++ b/app/models/whitehall_migration/document_import.rb
@@ -19,4 +19,10 @@ class WhitehallMigration::DocumentImport < ApplicationRecord
   def migratable_assets
     assets.select { |a| a.pending? || a.migration_failed? }
   end
+
+  def current_title
+    return nil unless document
+
+    document.current_edition.title
+  end
 end

--- a/app/views/whitehall_migration/_document_imports_list.html.erb
+++ b/app/views/whitehall_migration/_document_imports_list.html.erb
@@ -1,0 +1,40 @@
+<% items = document_imports.map do |document_import|
+  view_links = []
+
+  if document_import.content_id
+    url = "#{Plek.find('whitehall-admin')}/government/admin/by-content-id/#{document_import.content_id}"
+    view_links << link_to("Whitehall", url, target: "_blank")
+  end
+
+  if document_import.document
+    view_links << link_to("Content Publisher",
+                          document_path(document_import.document),
+                          target: "_blank")
+  end
+
+  if document_import.completed?
+    view_links << link_to("Draft GOV.UK",
+                          edition_preview_url(document_import.document.current_edition),
+                          target: "_blank")
+  end
+
+  if document_import.completed? && document_import.document.live_edition
+    view_links << link_to("Live GOV.UK",
+                          edition_public_url(document_import.document.live_edition),
+                          target: "_blank")
+  end
+
+  {
+    link: {
+      text: document_import.current_title ? document_import.current_title : document_import.id.to_s,
+      path: whitehall_migration_document_path(document_import.whitehall_migration_id, document_import),
+    },
+    metadata: {
+      state: document_import.state.to_s.titleize,
+      error_message: document_import.error_log ? "Error log: #{document_import.error_log}" : ""
+    },
+    subtext: view_links.any? ? "View: #{view_links.join(" ")}".html_safe : nil,
+  }
+  end
+%>
+<%= render "govuk_publishing_components/components/document_list", items: items %>

--- a/app/views/whitehall_migration/_document_imports_list.html.erb
+++ b/app/views/whitehall_migration/_document_imports_list.html.erb
@@ -35,6 +35,5 @@
     },
     subtext: view_links.any? ? "View: #{view_links.join(" ")}".html_safe : nil,
   }
-  end
-%>
+end %>
 <%= render "govuk_publishing_components/components/document_list", items: items %>

--- a/app/views/whitehall_migration/_document_imports_list.html.erb
+++ b/app/views/whitehall_migration/_document_imports_list.html.erb
@@ -27,7 +27,7 @@
   {
     link: {
       text: document_import.current_title ? document_import.current_title : document_import.id.to_s,
-      path: whitehall_migration_document_path(document_import.whitehall_migration_id, document_import),
+      path: whitehall_migration_document_import_path(document_import.whitehall_migration_id, document_import),
     },
     metadata: {
       state: document_import.state.to_s.titleize,

--- a/app/views/whitehall_migration/document.html.erb
+++ b/app/views/whitehall_migration/document.html.erb
@@ -1,2 +1,27 @@
-<h1>Document</h1>
-<%= @document.id %>
+<% content_for :back_link, render_back_link(href: whitehall_migration_documents_path(migration_id: @document_import.whitehall_migration, state: @document_import.state)) %>
+<% content_for :title, "Document Import: #{@document_import.id}" %>
+<%= render "govuk_publishing_components/components/summary_list", {
+  items: [
+    {
+      field: "ID",
+      value: @document_import.id
+    },
+    {
+      field: "Created at",
+      value: format_time_on_date(@document_import.created_at)
+    },
+    {
+      field: "Updated at",
+      value: format_time_on_date(@document_import.updated_at)
+    },
+    {
+      field: "State",
+      value: @document_import.state.titleize
+    },
+    {
+      field: "Error log",
+      value: @document_import.error_log
+    }
+  ],
+  borderless: true
+} %>

--- a/app/views/whitehall_migration/document_import.html.erb
+++ b/app/views/whitehall_migration/document_import.html.erb
@@ -1,4 +1,4 @@
-<% content_for :back_link, render_back_link(href: whitehall_migration_documents_path(migration_id: @document_import.whitehall_migration, state: @document_import.state)) %>
+<% content_for :back_link, render_back_link(href: whitehall_migration_document_imports_path(migration_id: @document_import.whitehall_migration, state: @document_import.state)) %>
 <% content_for :title, "Document Import: #{@document_import.id}" %>
 <%= render "govuk_publishing_components/components/summary_list", {
   items: [

--- a/app/views/whitehall_migration/document_imports.html.erb
+++ b/app/views/whitehall_migration/document_imports.html.erb
@@ -16,13 +16,13 @@
 <%
   pages = {}
   pages[:previous_page] = {
-    url: whitehall_migration_documents_path(migration_id: @whitehall_migration, page: @document_imports.prev_page, state: params['state']),
+    url: whitehall_migration_document_imports_path(migration_id: @whitehall_migration, page: @document_imports.prev_page, state: params['state']),
     title: "Previous page",
     label: "#{@document_imports.prev_page} of #{@document_imports.total_pages}"
   } if @document_imports.prev_page
 
   pages[:next_page] = {
-    url: whitehall_migration_documents_path(migration_id: @whitehall_migration, page: @document_imports.next_page, state: params['state']),
+    url: whitehall_migration_document_imports_path(migration_id: @whitehall_migration, page: @document_imports.next_page, state: params['state']),
     title: "Next page",
     label: "#{@document_imports.next_page} of #{@document_imports.total_pages}"
   } if @document_imports.next_page

--- a/app/views/whitehall_migration/document_imports.html.erb
+++ b/app/views/whitehall_migration/document_imports.html.erb
@@ -1,5 +1,5 @@
 <% content_for :back_link, render_back_link(href: whitehall_migration_path(@whitehall_migration)) %>
-<% title = params[:state] ? "Document Imports: #{params[:state].titleize}" : "Document Imports" %>
+<% title = @state ? "Document Imports: #{@state.titleize}" : "Document Imports" %>
 <% content_for :title, title %>
 
 <% if @document_imports.any? %>
@@ -7,8 +7,8 @@
 <% else %>
   <p class="govuk-body">
     There are no document imports
-    <% if params[:state] %>
-      with state: <%= params[:state].titleize %>
+    <% if @state %>
+      with state: <%= @state.titleize %>
     <% end %>
   </p>
 <% end %>
@@ -16,13 +16,13 @@
 <%
   pages = {}
   pages[:previous_page] = {
-    url: whitehall_migration_document_imports_path(migration_id: @whitehall_migration, page: @document_imports.prev_page, state: params['state']),
+    url: whitehall_migration_document_imports_path(migration_id: @whitehall_migration, page: @document_imports.prev_page, state: @state),
     title: "Previous page",
     label: "#{@document_imports.prev_page} of #{@document_imports.total_pages}"
   } if @document_imports.prev_page
 
   pages[:next_page] = {
-    url: whitehall_migration_document_imports_path(migration_id: @whitehall_migration, page: @document_imports.next_page, state: params['state']),
+    url: whitehall_migration_document_imports_path(migration_id: @whitehall_migration, page: @document_imports.next_page, state: @state),
     title: "Next page",
     label: "#{@document_imports.next_page} of #{@document_imports.total_pages}"
   } if @document_imports.next_page

--- a/app/views/whitehall_migration/documents.html.erb
+++ b/app/views/whitehall_migration/documents.html.erb
@@ -2,46 +2,16 @@
 <% title = params[:state] ? "Document Imports: #{params[:state].titleize}" : "Document Imports" %>
 <% content_for :title, title %>
 
-<% items = @document_imports.map do |document_import|
-  view_links = []
-
-  if document_import.content_id
-    url = "#{Plek.find('whitehall-admin')}/government/admin/by-content-id/#{document_import.content_id}"
-    view_links << link_to("Whitehall", url, target: "_blank")
-  end
-
-  if document_import.document
-    view_links << link_to("Content Publisher",
-                          document_path(document_import.document),
-                          target: "_blank")
-  end
-
-  if document_import.completed?
-    view_links << link_to("Draft GOV.UK",
-                          edition_preview_url(document_import.document.current_edition),
-                          target: "_blank")
-  end
-
-  if document_import.completed? && document_import.document.live_edition
-    view_links << link_to("Live GOV.UK",
-                          edition_public_url(document_import.document.live_edition),
-                          target: "_blank")
-  end
-
-  {
-    link: {
-      text: document_import.current_title ? document_import.current_title : document_import.id.to_s,
-      path: whitehall_migration_document_path(document_import.whitehall_migration_id, document_import),
-    },
-    metadata: {
-      state: document_import.state.to_s.titleize,
-      error_message: document_import.error_log ? "Error log: #{document_import.error_log}" : ""
-    },
-    subtext: view_links.any? ? "View: #{view_links.join(" ")}".html_safe : nil,
-  }
-end %>
-
-<%= render "govuk_publishing_components/components/document_list", items: items ||= [] %>
+<% if @document_imports.any? %>
+<%= render "document_imports_list", document_imports: @document_imports %>
+<% else %>
+  <p class="govuk-body">
+    There are no document imports
+    <% if params[:state] %>
+      with state: <%= params[:state].titleize %>
+    <% end %>
+  </p>
+<% end %>
 
 <%
   pages = {}

--- a/app/views/whitehall_migration/documents.html.erb
+++ b/app/views/whitehall_migration/documents.html.erb
@@ -1,6 +1,61 @@
-<h1>Documents</h1>
+<% content_for :back_link, render_back_link(href: whitehall_migration_path(@whitehall_migration)) %>
+<% title = params[:state] ? "Document Imports: #{params[:state].titleize}" : "Document Imports" %>
+<% content_for :title, title %>
 
-<% @documents.each do |document| %>
-  <li>ID: <%= document.id %></li>
-  <li>Status: <%= document.state %></li>
-<% end %>
+<% items = @document_imports.map do |document_import|
+  view_links = []
+
+  if document_import.content_id
+    url = "#{Plek.find('whitehall-admin')}/government/admin/by-content-id/#{document_import.content_id}"
+    view_links << link_to("Whitehall", url, target: "_blank")
+  end
+
+  if document_import.document
+    view_links << link_to("Content Publisher",
+                          document_path(document_import.document),
+                          target: "_blank")
+  end
+
+  if document_import.completed?
+    view_links << link_to("Draft GOV.UK",
+                          edition_preview_url(document_import.document.current_edition),
+                          target: "_blank")
+  end
+
+  if document_import.completed? && document_import.document.live_edition
+    view_links << link_to("Live GOV.UK",
+                          edition_public_url(document_import.document.live_edition),
+                          target: "_blank")
+  end
+
+  {
+    link: {
+      text: document_import.current_title ? document_import.current_title : document_import.id.to_s,
+      path: whitehall_migration_document_path(document_import.whitehall_migration_id, document_import),
+    },
+    metadata: {
+      state: document_import.state.to_s.titleize,
+      error_message: document_import.error_log ? "Error log: #{document_import.error_log}" : ""
+    },
+    subtext: view_links.any? ? "View: #{view_links.join(" ")}".html_safe : nil,
+  }
+end %>
+
+<%= render "govuk_publishing_components/components/document_list", items: items ||= [] %>
+
+<%
+  pages = {}
+  pages[:previous_page] = {
+    url: whitehall_migration_documents_path(migration_id: @whitehall_migration, page: @document_imports.prev_page, state: params['state']),
+    title: "Previous page",
+    label: "#{@document_imports.prev_page} of #{@document_imports.total_pages}"
+  } if @document_imports.prev_page
+
+  pages[:next_page] = {
+    url: whitehall_migration_documents_path(migration_id: @whitehall_migration, page: @document_imports.next_page, state: params['state']),
+    title: "Next page",
+    label: "#{@document_imports.next_page} of #{@document_imports.total_pages}"
+  } if @document_imports.next_page
+%>
+
+<%= render "govuk_publishing_components/components/previous_and_next_navigation", pages %>

--- a/app/views/whitehall_migration/show.html.erb
+++ b/app/views/whitehall_migration/show.html.erb
@@ -25,7 +25,7 @@
     {
       link: {
         text: "#{state.titleize}: #{@whitehall_migration.document_imports.where(state: state).count}",
-        path: whitehall_migration_documents_path(migration_id: @whitehall_migration, state: state),
+        path: whitehall_migration_document_imports_path(migration_id: @whitehall_migration, state: state),
       },
     }
   end

--- a/app/views/whitehall_migration/show.html.erb
+++ b/app/views/whitehall_migration/show.html.erb
@@ -35,14 +35,6 @@
 
 <% if @whitehall_migration.document_imports.completed.exists? %>
   <h2 class="govuk-heading-m">Selection of imported documents to view</h2>
-  <% random_items = @whitehall_migration.document_imports.completed.order(Arel.sql("RANDOM()")).first(10).map do |document_import|
-      {
-        link: {
-          text: document_import.document.current_edition.title
-        },
-        subtext: "View: <a href=\"#{Plek.find('whitehall-admin')}/government/admin/by-content-id/#{document_import.content_id}\">Whitehall</a> View: <a href=\"#{Plek.find('content-publisher')}/documents/#{document_import.content_id}:en\">Content Publisher</a>".html_safe
-      }
-    end
-  %>
-  <%= render "govuk_publishing_components/components/document_list", items: random_items %>
+  <% random_items = @whitehall_migration.document_imports.completed.order(Arel.sql("RANDOM()")).first(10) %>
+  <%= render "document_imports_list", document_imports: random_items %>
 <% end %>

--- a/app/views/whitehall_migration/show.html.erb
+++ b/app/views/whitehall_migration/show.html.erb
@@ -1,6 +1,6 @@
 <h1>Whitehall Migration: <%= @whitehall_migration.id %> </h1>
 <ul>
-    <li>Time started: <%= @whitehall_migration.created_at.strftime("At %T on %d/%m/%Y") %></li>
+    <li>Time started: <%= @whitehall_migration.created_at.strftime("At %T on %m/%d/%Y") %></li>
     <li>Time finished: <%= @whitehall_migration.finished_at.nil? ? "Unfinished" : @whitehall_migration.finished_at %></li>
     <li>Number of documents: <%= @whitehall_migration.document_imports.count %></li>
 </ul>

--- a/app/views/whitehall_migration/show.html.erb
+++ b/app/views/whitehall_migration/show.html.erb
@@ -1,4 +1,3 @@
-
 <% content_for :title, "Whitehall Migration: #{@whitehall_migration.id}" %>
 
 <%= render "govuk_publishing_components/components/summary_list", {

--- a/app/views/whitehall_migration/show.html.erb
+++ b/app/views/whitehall_migration/show.html.erb
@@ -1,14 +1,48 @@
-<h1>Whitehall Migration: <%= @whitehall_migration.id %> </h1>
-<ul>
-    <li>Time started: <%= @whitehall_migration.created_at.strftime("At %T on %m/%d/%Y") %></li>
-    <li>Time finished: <%= @whitehall_migration.finished_at.nil? ? "Unfinished" : @whitehall_migration.finished_at %></li>
-    <li>Number of documents: <%= @whitehall_migration.document_imports.count %></li>
-</ul>
 
-<h3>Document Import Status</h3>
+<% content_for :title, "Whitehall Migration: #{@whitehall_migration.id}" %>
 
-<ul>
-    <% @whitehall_migration.document_imports.states.each_value do |state| %>
-        <li><%= "#{state}:" %> <%= @whitehall_migration.document_imports.where(state: "#{state}").count%></li>
-    <% end %>
-</ul>
+<%= render "govuk_publishing_components/components/summary_list", {
+  items: [
+    {
+      field: "Time started",
+      value: format_time_on_date(@whitehall_migration.created_at)
+    },
+    {
+      field: "Time finished",
+      value: @whitehall_migration.finished_at.nil? ? "unfinished" : format_time_on_date(@whitehall_migration.finished_at)
+    },
+    {
+      field: "Number of document imports",
+      value: @whitehall_migration.document_imports.count
+    }
+  ],
+  borderless: true
+} %>
+
+<h2 class="govuk-heading-m">Document import states</h2>
+<%
+  items = @whitehall_migration.document_imports.states.map do |state, _|
+    {
+      link: {
+        text: "#{state.titleize}: #{@whitehall_migration.document_imports.where(state: state).count}",
+        path: whitehall_migration_documents_path(migration_id: @whitehall_migration, state: state),
+      },
+    }
+  end
+%>
+
+<%= render "govuk_publishing_components/components/document_list", items: items %>
+
+<% if @whitehall_migration.document_imports.completed.exists? %>
+  <h2 class="govuk-heading-m">Selection of imported documents to view</h2>
+  <% random_items = @whitehall_migration.document_imports.completed.order(Arel.sql("RANDOM()")).first(10).map do |document_import|
+      {
+        link: {
+          text: document_import.document.current_edition.title
+        },
+        subtext: "View: <a href=\"#{Plek.find('whitehall-admin')}/government/admin/by-content-id/#{document_import.content_id}\">Whitehall</a> View: <a href=\"#{Plek.find('content-publisher')}/documents/#{document_import.content_id}:en\">Content Publisher</a>".html_safe
+      }
+    end
+  %>
+  <%= render "govuk_publishing_components/components/document_list", items: random_items %>
+<% end %>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -3,8 +3,8 @@ Rails.application.routes.draw do
 
   scope "/whitehall-migration/:migration_id" do
     get "" => "whitehall_migration#show", as: :whitehall_migration
-    get "/documents" => "whitehall_migration#documents", as: :whitehall_migration_documents
-    get "/documents/:document_import_id" => "whitehall_migration#document", as: :whitehall_migration_document
+    get "/documents-imports" => "whitehall_migration#document_imports", as: :whitehall_migration_document_imports
+    get "/document-imports/:document_import_id" => "whitehall_migration#document_import", as: :whitehall_migration_document_import
   end
 
   get "/documents/publishing-guidance" => "new_document#guidance", as: :guidance

--- a/lib/tasks/import.rake
+++ b/lib/tasks/import.rake
@@ -4,7 +4,6 @@ namespace :import do
   desc "Import all documents matching an organisation, document type and optional list of document subtypes from Whitehall Publisher, e.g. import:whitehall_migration[\"cabinet-office\",\"news_article\",\"news_story,press_release\"]"
   task :whitehall_migration, %i[organisation_slug document_type document_subtypes] => :environment do |_, args|
     include Rails.application.routes.url_helpers
-
     organisation_content_id = GdsApi.publishing_api.lookup_content_id(
       base_path: "/government/organisations/#{args.organisation_slug}",
      )
@@ -16,13 +15,12 @@ namespace :import do
     documents_to_import = WhitehallMigration::DocumentImport.where(whitehall_migration: whitehall_migration).count
     puts "Identified #{documents_to_import} documents to import"
 
-    puts whitehall_migration_url(whitehall_migration, host: Plek.new.external_url_for("content-publisher"))
+    puts whitehall_migration_url(whitehall_migration, host: Plek.new.external_url_for("content-publisher")).to_s
   end
 
   desc "Import a single document from Whitehall Publisher using Whitehall's internal document ID e.g. import:whitehall_document[123]"
   task :whitehall_document, [:document_id] => :environment do |_, args|
     include Rails.application.routes.url_helpers
-
     whitehall_import = WhitehallMigration::DocumentImport.create!(
       whitehall_document_id: args.document_id,
       whitehall_migration: WhitehallMigration.create!,
@@ -32,6 +30,6 @@ namespace :import do
     WhitehallDocumentImportJob.perform_later(whitehall_import)
     puts "Added whitehall document with ID:#{args.document_id} to the import queue"
 
-    puts whitehall_migration_url(whitehall_import.whitehall_migration_id, host: Plek.new.external_url_for("content-publisher"))
+    puts whitehall_migration_url(whitehall_import.whitehall_migration_id, host: Plek.new.external_url_for("content-publisher")).to_s
   end
 end

--- a/lib/tasks/import.rake
+++ b/lib/tasks/import.rake
@@ -15,7 +15,7 @@ namespace :import do
     documents_to_import = WhitehallMigration::DocumentImport.where(whitehall_migration: whitehall_migration).count
     puts "Identified #{documents_to_import} documents to import"
 
-    puts whitehall_migration_url(whitehall_migration, host: Plek.new.external_url_for("content-publisher")).to_s
+    puts whitehall_migration_url(whitehall_migration, host: Plek.new.external_url_for("content-publisher"))
   end
 
   desc "Import a single document from Whitehall Publisher using Whitehall's internal document ID e.g. import:whitehall_document[123]"
@@ -30,6 +30,6 @@ namespace :import do
     WhitehallDocumentImportJob.perform_later(whitehall_import)
     puts "Added whitehall document with ID:#{args.document_id} to the import queue"
 
-    puts whitehall_migration_url(whitehall_import.whitehall_migration_id, host: Plek.new.external_url_for("content-publisher")).to_s
+    puts whitehall_migration_url(whitehall_import.whitehall_migration_id, host: Plek.new.external_url_for("content-publisher"))
   end
 end

--- a/spec/requests/whitehall_migration_spec.rb
+++ b/spec/requests/whitehall_migration_spec.rb
@@ -36,7 +36,8 @@ RSpec.describe "Whitehall Migration" do
   describe "GET /whitehall-migration/:migration_id/documents" do
     it "returns success" do
       login_as(debug_permission_user)
-      get whitehall_migration_documents_path(whitehall_migration)
+      create(:whitehall_migration_document_import, whitehall_migration_id: whitehall_migration.id)
+      get whitehall_migration_documents_path(whitehall_migration.id)
 
       expect(response).to have_http_status(:ok)
     end
@@ -45,7 +46,8 @@ RSpec.describe "Whitehall Migration" do
   describe "GET /whitehall-migration/:migration_id/documents/:document_import_id" do
     it "returns success" do
       login_as(debug_permission_user)
-      get whitehall_migration_document_path(whitehall_migration, document_import)
+      document_import = create(:whitehall_migration_document_import, whitehall_migration_id: whitehall_migration.id)
+      get whitehall_migration_document_path(whitehall_migration.id, document_import.id)
 
       expect(response).to have_http_status(:ok)
     end

--- a/spec/requests/whitehall_migration_spec.rb
+++ b/spec/requests/whitehall_migration_spec.rb
@@ -36,8 +36,7 @@ RSpec.describe "Whitehall Migration" do
   describe "GET /whitehall-migration/:migration_id/documents" do
     it "returns success" do
       login_as(debug_permission_user)
-      create(:whitehall_migration_document_import, whitehall_migration_id: whitehall_migration.id)
-      get whitehall_migration_documents_path(whitehall_migration.id)
+      get whitehall_migration_documents_path(whitehall_migration)
 
       expect(response).to have_http_status(:ok)
     end
@@ -46,8 +45,7 @@ RSpec.describe "Whitehall Migration" do
   describe "GET /whitehall-migration/:migration_id/documents/:document_import_id" do
     it "returns success" do
       login_as(debug_permission_user)
-      document_import = create(:whitehall_migration_document_import, whitehall_migration_id: whitehall_migration.id)
-      get whitehall_migration_document_path(whitehall_migration.id, document_import.id)
+      get whitehall_migration_document_path(whitehall_migration, document_import)
 
       expect(response).to have_http_status(:ok)
     end

--- a/spec/requests/whitehall_migration_spec.rb
+++ b/spec/requests/whitehall_migration_spec.rb
@@ -7,7 +7,7 @@ RSpec.describe "Whitehall Migration" do
                   "when a user without debug permissions looks at a whitehall migration",
                   status: :forbidden,
                   routes: { whitehall_migration_path: %i[get],
-                          whitehall_migration_documents_path: %i[get] } do
+                          whitehall_migration_document_imports_path: %i[get] } do
     before { login_as(create(:user)) }
 
     let(:route_params) { [whitehall_migration] }
@@ -16,7 +16,7 @@ RSpec.describe "Whitehall Migration" do
   it_behaves_like "requests that return status",
                   "when a user without debug permissions looks at a whitehall migration document",
                   status: :forbidden,
-                  routes: { whitehall_migration_document_path: %i[get] } do
+                  routes: { whitehall_migration_document_import_path: %i[get] } do
     before { login_as(create(:user)) }
 
     let(:route_params) do
@@ -36,7 +36,7 @@ RSpec.describe "Whitehall Migration" do
   describe "GET /whitehall-migration/:migration_id/documents" do
     it "returns success" do
       login_as(debug_permission_user)
-      get whitehall_migration_documents_path(whitehall_migration)
+      get whitehall_migration_document_imports_path(whitehall_migration)
 
       expect(response).to have_http_status(:ok)
     end
@@ -45,7 +45,7 @@ RSpec.describe "Whitehall Migration" do
   describe "GET /whitehall-migration/:migration_id/documents/:document_import_id" do
     it "returns success" do
       login_as(debug_permission_user)
-      get whitehall_migration_document_path(whitehall_migration, document_import)
+      get whitehall_migration_document_import_path(whitehall_migration, document_import)
 
       expect(response).to have_http_status(:ok)
     end


### PR DESCRIPTION
UI to display information resulting from a Whitehall migration.

- On the `whitehall_migration#documents` page, for unsuccessfully imported documents, the link to view an individual document import currently displays the `id` of the `document_import`. We want it to display the `content_id` but at the moment the import script is not importing `content_ids`. This will be addressed in a following PR.

- To anyone reviewing... Please review the code as per usual and also let us know of any additional information that you think would be useful to display.

Show page:
![whitehall-migration-show](https://user-images.githubusercontent.com/5963488/75872175-a12ab700-5e05-11ea-9d7c-d95acd52ca80.png)

Document imports page for successfully imported documents:
![document-imports-completed](https://user-images.githubusercontent.com/5963488/75872205-a8ea5b80-5e05-11ea-8c9d-12335fa0509b.png)


Document imports page for unsuccessfully imported documents:
![document-imports-import-failed](https://user-images.githubusercontent.com/5963488/75872225-b30c5a00-5e05-11ea-93b2-910612c900b6.png)


Document page:
![document-import](https://user-images.githubusercontent.com/5963488/75872246-b99ad180-5e05-11ea-99fc-2df1c2d95316.png)

