### PR TITLE
Backfill change_history for metadata_revisions

### DIFF
--- a/db/migrate/20200220111317_backfill_change_history_for_metadata_revisions.rb
+++ b/db/migrate/20200220111317_backfill_change_history_for_metadata_revisions.rb
@@ -1,0 +1,38 @@
+class BackfillChangeHistoryForMetadataRevisions < ActiveRecord::Migration[6.0]
+  class MetadataRevision < ApplicationRecord
+    has_one :revision
+  end
+  class Revision < ApplicationRecord
+    belongs_to :metadata_revision
+    has_and_belongs_to_many :editions
+  end
+  class Edition < ApplicationRecord
+    belongs_to :revision
+  end
+
+  disable_ddl_transaction!
+
+  def up
+    MetadataRevision.find_each do |metadata_revision|
+      edition = metadata_revision.revision.editions.first
+      Edition.transaction do
+        edition.lock!
+
+        change_history_editions = Edition.joins(revision: :metadata_revision)
+          .where("editions.number > 1 AND editions.number < ?", edition.number)
+          .where("metadata_revisions.update_type": "major")
+          .where(document_id: edition.document_id)
+          .order(:published_at)
+
+        change_history = change_history_editions.map do |e|
+          { id: SecureRandom.uuid,
+            note: e.revision.metadata_revision.change_note,
+            public_timestamp: e.published_at.rfc3339 }
+        end
+
+        metadata_revision.change_history = change_history
+        metadata_revision.save!
+      end
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2020_02_18_161942) do
+ActiveRecord::Schema.define(version: 2020_02_20_111317) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"


### PR DESCRIPTION
This migration backfills the change_history for all metadata_revisions,
the change_history is built up from the individual change notes from
each edition where they have been published with a major change.

The change_history for an edition is built up from the previous editions
change notes and consolidated into the change_history field on the
corresponding metadata_revision. Not all change notes should be included
in this history however, the first published change note and the current
change note should be excluded from this list. E.g for the 4th edition
of a document it would contain the change notes from the 2nd and 3rd
edition but not the 1st (first published) and 4th (current).

Each change note included in the change history will include a UUID,
public_timestamp (publishing time) and the change note itself.

The migration should only be deployed when there has been no whitehall 
migrations as consequently the imported editions currently don't include 
a `published_at` timestamp meaning this migration will fail if any are present. 

Co-authored (Authored) by @kevindew 😄 

Trello:
https://trello.com/c/ymfW8Eeh/1462-backfill-the-changehistory-of-existing-content