### PR TITLE
Include change history in Publishing API payload

### DIFF
--- a/app/services/discard_path_reservations_service.rb
+++ b/app/services/discard_path_reservations_service.rb
@@ -5,7 +5,7 @@ class DiscardPathReservationsService < ApplicationService
 
   def call
     paths = edition.revisions.map(&:base_path).uniq.compact
-    publishing_app = PreviewDraftEditionService::Payload::PUBLISHING_APP
+    publishing_app = PublishingApiPayload::PUBLISHING_APP
 
     paths.each do |path|
       GdsApi.publishing_api.unreserve_path(path, publishing_app)

--- a/app/services/preview_draft_edition_service.rb
+++ b/app/services/preview_draft_edition_service.rb
@@ -17,7 +17,7 @@ private
   attr_reader :edition, :republish
 
   def put_draft_content
-    payload = Payload.new(edition, republish: republish).payload
+    payload = PublishingApiPayload.new(edition, republish: republish).payload
     GdsApi.publishing_api.put_content(edition.content_id, payload)
     edition.update!(revision_synced: true)
   end

--- a/app/services/schedule_publish_service/payload.rb
+++ b/app/services/schedule_publish_service/payload.rb
@@ -8,7 +8,7 @@ class SchedulePublishService::Payload
   def intent_payload
     {
       publish_time: publish_time,
-      publishing_app: PreviewDraftEditionService::Payload::PUBLISHING_APP,
+      publishing_app: PublishingApiPayload::PUBLISHING_APP,
       rendering_app: rendering_app,
     }
   end

--- a/lib/publishing_api_payload.rb
+++ b/lib/publishing_api_payload.rb
@@ -22,8 +22,9 @@ class PublishingApiPayload
       links: links,
       access_limited: access_limited,
       auth_bypass_ids: auth_bypass_ids,
+      public_updated_at: history.public_updated_at,
     }
-    payload[:change_note] = edition.change_note if edition.major?
+    payload[:first_published_at] = history.first_published_at if history.first_published_at.present?
 
     document_type.contents.each do |field|
       payload.deep_merge!(field.payload(edition))
@@ -43,6 +44,10 @@ class PublishingApiPayload
   end
 
 private
+
+  def history
+    @history ||= History.new(edition)
+  end
 
   def access_limited
     return {} unless edition.access_limit
@@ -79,7 +84,10 @@ private
   end
 
   def details
-    details = { political: edition.political? }
+    details = {
+      political: edition.political?,
+      change_history: history.change_history,
+    }
 
     if document_type.lead_image? && edition.lead_image_revision.present?
       details[:image] = image

--- a/lib/publishing_api_payload.rb
+++ b/lib/publishing_api_payload.rb
@@ -1,4 +1,4 @@
-class PreviewDraftEditionService::Payload
+class PublishingApiPayload
   PUBLISHING_APP = "content-publisher".freeze
 
   attr_reader :edition, :document_type, :publishing_metadata, :republish

--- a/lib/publishing_api_payload/history.rb
+++ b/lib/publishing_api_payload/history.rb
@@ -1,0 +1,39 @@
+class PublishingApiPayload::History
+  FIRST_CHANGE_NOTE = "First published.".freeze
+
+  def initialize(edition)
+    @edition = edition
+  end
+
+  def public_updated_at
+    change_history.first&.fetch(:public_timestamp)
+  end
+
+  def first_published_at
+    return edition.backdated_to if edition.backdated_to
+
+    edition.document.first_published_at
+  end
+
+  def change_history
+    change_history = edition.change_history.map do |item|
+      { note: item.fetch("note"), public_timestamp: item.fetch("public_timestamp").in_time_zone }
+    end
+
+    change_history << { note: FIRST_CHANGE_NOTE,
+                        public_timestamp: first_published_at || Time.zone.now }
+
+    if edition.change_note && edition.major? && !edition.first?
+      change_history << { note: edition.change_note,
+                          public_timestamp: Time.zone.now }
+    end
+
+    change_history.reject { |note| first_published_at && note[:public_timestamp] < first_published_at }
+                  .sort_by { |note| note[:public_timestamp] }
+                  .reverse
+  end
+
+private
+
+  attr_reader :edition
+end

--- a/lib/whitehall_importer/integrity_checker.rb
+++ b/lib/whitehall_importer/integrity_checker.rb
@@ -15,7 +15,7 @@ module WhitehallImporter
     end
 
     def proposed_payload
-      @proposed_payload ||= PreviewDraftEditionService::Payload.new(edition, republish: edition.live?).payload
+      @proposed_payload ||= PublishingApiPayload.new(edition, republish: edition.live?).payload
     end
 
   private

--- a/spec/factories/edition_factory.rb
+++ b/spec/factories/edition_factory.rb
@@ -21,6 +21,7 @@ FactoryBot.define do
       file_attachment_revisions { [] }
       first_published_at { nil }
       government { nil }
+      change_history { [] }
     end
 
     after(:build) do |edition, evaluator|
@@ -61,6 +62,7 @@ FactoryBot.define do
           lead_image_revision: evaluator.lead_image_revision,
           image_revisions: image_revisions,
           file_attachment_revisions: evaluator.file_attachment_revisions,
+          change_history: evaluator.change_history,
         )
       end
 

--- a/spec/factories/revision_factory.rb
+++ b/spec/factories/revision_factory.rb
@@ -18,6 +18,7 @@ FactoryBot.define do
       proposed_publish_time { nil }
       backdated_to { nil }
       editor_political { nil }
+      change_history { [] }
     end
   end
 
@@ -53,6 +54,7 @@ FactoryBot.define do
           backdated_to: evaluator.backdated_to,
           document_type_id: evaluator.document_type_id,
           editor_political: evaluator.editor_political,
+          change_history: evaluator.change_history,
         )
       end
 

--- a/spec/lib/publishing_api_payload/history_spec.rb
+++ b/spec/lib/publishing_api_payload/history_spec.rb
@@ -1,0 +1,119 @@
+RSpec.describe PublishingApiPayload::History do
+  describe "#public_updated_at" do
+    it "returns current time if a major change is published" do
+      freeze_time do
+        first_edition = build(:edition)
+        second_edition = build(:edition, document: first_edition.document, update_type: "major")
+
+        expect(described_class.new(second_edition).public_updated_at).to eq(Time.zone.now)
+      end
+    end
+
+    it "returns most recent change history time if a minor change is published" do
+      first_edition = build(:edition, first_published_at: "2020-02-22 11:00:00")
+      second_edition = build(:edition, document: first_edition.document, update_type: "minor")
+
+      expect(described_class.new(second_edition).public_updated_at).to eq("2020-02-22 11:00:00")
+    end
+  end
+
+  describe "#first_published_at" do
+    it "returns backdated date if edition is backdated" do
+      edition = build(:edition, first_published_at: "2020-02-22 11:00:00", backdated_to: "2020-02-20 09:00:00")
+
+      expect(described_class.new(edition).first_published_at).to eq("2020-02-20 09:00:00")
+    end
+
+    it "returns first published date if edition is not backdated" do
+      edition = build(:edition, first_published_at: "2020-02-22 11:00:00")
+
+      expect(described_class.new(edition).first_published_at).to eq("2020-02-22 11:00:00")
+    end
+  end
+
+  describe "#change_history" do
+    let(:first_edition) { build(:edition, first_published_at: "2020-02-22 11:00:00") }
+    let(:first_change_note) do
+      {
+        note: "First published.",
+        public_timestamp: "2020-02-22 11:00:00",
+      }
+    end
+
+    it "appends first change note to end of history array" do
+      expect(described_class.new(first_edition).change_history).to eq([first_change_note])
+    end
+
+    it "adds change note to start of array for major changes" do
+      freeze_time do
+        second_edition = build(:edition, document: first_edition.document, number: 2, update_type: "major", change_note: "Some changes")
+
+        expected_change_note = {
+          note: "Some changes",
+          public_timestamp: Time.zone.now,
+        }
+
+        expect(described_class.new(second_edition).change_history).to eq([expected_change_note, first_change_note])
+      end
+    end
+
+    it "does not add change note to start of array for minor changes" do
+      second_edition = build(:edition, document: first_edition.document, number: 2, update_type: "minor", change_note: "A minor change")
+
+      expect(described_class.new(second_edition).change_history).to eq([first_change_note])
+    end
+
+    it "returns change notes in reverse chronological order" do
+      change_history = [
+        {
+          note: "First update",
+          public_timestamp: "2020-02-23 09:00:00",
+        },
+        {
+          note: "Third update",
+          public_timestamp: "2020-02-25 21:00:00",
+        },
+        {
+          note: "Second update",
+          public_timestamp: "2020-02-24 12:00:00",
+        },
+      ]
+
+      second_edition = build(:edition, document: first_edition.document, change_history: change_history)
+
+      expected_change_notes = [
+        {
+          note: "Third update",
+          public_timestamp: "2020-02-25 21:00:00",
+        },
+        {
+          note: "Second update",
+          public_timestamp: "2020-02-24 12:00:00",
+        },
+        {
+          note: "First update",
+          public_timestamp: "2020-02-23 09:00:00",
+        },
+        {
+          note: "First published.",
+          public_timestamp: "2020-02-22 11:00:00",
+        },
+      ]
+
+      expect(described_class.new(second_edition).change_history).to eq(expected_change_notes)
+    end
+
+    it "does not include change notes set before backdating" do
+      change_history = [
+        {
+          note: "Update before backdating",
+          public_timestamp: "2020-02-18 08:00:00",
+        },
+      ]
+
+      edition = build(:edition, :published, change_history: change_history, backdated_to: "2020-02-22 11:00:00")
+
+      expect(described_class.new(edition).change_history).to eq([first_change_note])
+    end
+  end
+end

--- a/spec/lib/publishing_api_payload_spec.rb
+++ b/spec/lib/publishing_api_payload_spec.rb
@@ -1,4 +1,4 @@
-RSpec.describe PreviewDraftEditionService::Payload do
+RSpec.describe PublishingApiPayload do
   describe "#payload" do
     it "generates a payload for the publishing API" do
       document_type = build(:document_type)

--- a/spec/services/discard_path_reservations_service_spec.rb
+++ b/spec/services/discard_path_reservations_service_spec.rb
@@ -7,12 +7,12 @@ RSpec.describe DiscardPathReservationsService do
 
       unreserve_request1 = stub_publishing_api_unreserve_path(
         edition.base_path,
-        PreviewDraftEditionService::Payload::PUBLISHING_APP,
+        PublishingApiPayload::PUBLISHING_APP,
       )
 
       unreserve_request2 = stub_publishing_api_unreserve_path(
         previous_revision.base_path,
-        PreviewDraftEditionService::Payload::PUBLISHING_APP,
+        PublishingApiPayload::PUBLISHING_APP,
       )
 
       described_class.call(edition)

--- a/spec/services/preview_draft_edition_service_spec.rb
+++ b/spec/services/preview_draft_edition_service_spec.rb
@@ -35,7 +35,7 @@ RSpec.describe PreviewDraftEditionService do
     it "sets an update type of republish" do
       edition = create(:edition)
 
-      expect(PreviewDraftEditionService::Payload)
+      expect(PublishingApiPayload)
         .to receive(:new)
         .with(edition, republish: true)
         .and_call_original

--- a/spec/services/schedule_publish_service/payload_spec.rb
+++ b/spec/services/schedule_publish_service/payload_spec.rb
@@ -13,7 +13,7 @@ RSpec.describe SchedulePublishService::Payload do
 
       payload_hash = {
         publish_time: publish_time,
-        publishing_app: PreviewDraftEditionService::Payload::PUBLISHING_APP,
+        publishing_app: PublishingApiPayload::PUBLISHING_APP,
         rendering_app: "government-frontend",
       }
 


### PR DESCRIPTION
Now that we store a full `change_history` for an edition, we need to send this full history (along with the `first_published_date` and `public_updated_at`) to Publishing API.

For the first edition, we always sent a fixed change note.  For subsequent major editions, the user entered change note is used.

This change also moves `Payload` out of the `PreviewDraftEditionService` namespace, into `PublishingApiPayload` since this class is used in multiple contexts, not just when dealing with the preview of draft editions.

Not to be merged until #1806 is merged and deployed.

Trello card: https://trello.com/c/KBFWEkKG