### PR TITLE
Add new assertion for edition features

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -17,7 +17,7 @@ class ApplicationController < ActionController::Base
     Rails.logger.warn(e.message)
 
     if rendering_context == "modal"
-      render nothing: true, status: :bad_request
+      raise ActionController::BadRequest
     elsif e.edition.first? && e.edition.discarded?
       redirect_to documents_path
     else

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -25,6 +25,10 @@ class ApplicationController < ActionController::Base
     end
   end
 
+  rescue_from EditionAssertions::FeatureError do |e|
+    raise ActionController::RoutingError, e.message
+  end
+
   rescue_from BulkData::LocalDataUnavailableError do |error|
     GovukError.notify(error)
 

--- a/app/interactors/images/update_interactor.rb
+++ b/app/interactors/images/update_interactor.rb
@@ -48,7 +48,7 @@ private
 
   def update_edition
     is_lead_image = params[:lead_image] == "on"
-    raise ActionController::BadRequest if !edition.document_type.lead_image && is_lead_image
+    raise ActionController::BadRequest if !edition.document_type.lead_image? && is_lead_image
 
     updater = Versioning::RevisionUpdater.new(edition.revision, user)
     updater.update_image(image_revision)

--- a/app/interactors/images/update_interactor.rb
+++ b/app/interactors/images/update_interactor.rb
@@ -48,8 +48,9 @@ private
 
   def update_edition
     is_lead_image = params[:lead_image] == "on"
-    updater = Versioning::RevisionUpdater.new(edition.revision, user)
+    raise ActionController::BadRequest if !edition.document_type.lead_image && is_lead_image
 
+    updater = Versioning::RevisionUpdater.new(edition.revision, user)
     updater.update_image(image_revision)
     updater.assign_lead_image(image_revision, is_lead_image)
 

--- a/app/interactors/lead_image/choose_interactor.rb
+++ b/app/interactors/lead_image/choose_interactor.rb
@@ -22,6 +22,7 @@ private
   def find_and_lock_edition
     context.edition = Edition.lock.find_current(document: params[:document])
     assert_edition_state(edition, &:editable?)
+    assert_edition_feature(edition, &:lead_image)
   end
 
   def find_image_revision

--- a/app/interactors/lead_image/choose_interactor.rb
+++ b/app/interactors/lead_image/choose_interactor.rb
@@ -22,7 +22,7 @@ private
   def find_and_lock_edition
     context.edition = Edition.lock.find_current(document: params[:document])
     assert_edition_state(edition, &:editable?)
-    assert_edition_feature(edition, &:lead_image)
+    assert_edition_feature(edition, &:lead_image?)
   end
 
   def find_image_revision

--- a/app/interactors/lead_image/remove_interactor.rb
+++ b/app/interactors/lead_image/remove_interactor.rb
@@ -23,6 +23,7 @@ private
   def find_and_lock_edition
     context.edition = Edition.lock.find_current(document: params[:document])
     assert_edition_state(edition, &:editable?)
+    assert_edition_feature(edition, &:lead_image)
   end
 
   def check_lead_image

--- a/app/interactors/lead_image/remove_interactor.rb
+++ b/app/interactors/lead_image/remove_interactor.rb
@@ -23,7 +23,7 @@ private
   def find_and_lock_edition
     context.edition = Edition.lock.find_current(document: params[:document])
     assert_edition_state(edition, &:editable?)
-    assert_edition_feature(edition, &:lead_image)
+    assert_edition_feature(edition, &:lead_image?)
   end
 
   def check_lead_image

--- a/app/models/document_type.rb
+++ b/app/models/document_type.rb
@@ -4,6 +4,8 @@ class DocumentType
   attr_reader :contents, :id, :managed_elsewhere, :publishing_metadata, :label,
               :path_prefix, :tags, :lead_image, :topics
 
+  alias_method :lead_image?, :lead_image
+
   def self.find(id)
     item = all.find { |document_type| document_type.id == id }
     item || (raise RuntimeError, "Document type #{id} not found")

--- a/app/models/document_type.rb
+++ b/app/models/document_type.rb
@@ -2,7 +2,7 @@ class DocumentType
   include InitializeWithHash
 
   attr_reader :contents, :id, :managed_elsewhere, :publishing_metadata, :label,
-              :path_prefix, :tags, :images, :topics
+              :path_prefix, :tags, :lead_image, :topics
 
   def self.find(id)
     item = all.find { |document_type| document_type.id == id }

--- a/app/services/preview_draft_edition_service/payload.rb
+++ b/app/services/preview_draft_edition_service/payload.rb
@@ -81,7 +81,7 @@ private
   def details
     details = { political: edition.political? }
 
-    if document_type.lead_image && edition.lead_image_revision.present?
+    if document_type.lead_image? && edition.lead_image_revision.present?
       details[:image] = image
     end
 

--- a/app/services/preview_draft_edition_service/payload.rb
+++ b/app/services/preview_draft_edition_service/payload.rb
@@ -81,7 +81,7 @@ private
   def details
     details = { political: edition.political? }
 
-    if document_type.images && edition.lead_image_revision.present?
+    if document_type.lead_image && edition.lead_image_revision.present?
       details[:image] = image
     end
 

--- a/app/views/documents/show.html.erb
+++ b/app/views/documents/show.html.erb
@@ -51,7 +51,7 @@
   <div class="govuk-grid-column-two-thirds">
     <%= render "documents/show/contents" %>
 
-    <% if @edition.document_type.lead_image %>
+    <% if @edition.document_type.lead_image? %>
       <%= render "documents/show/lead_image" %>
     <% end %>
 

--- a/app/views/documents/show.html.erb
+++ b/app/views/documents/show.html.erb
@@ -51,7 +51,7 @@
   <div class="govuk-grid-column-two-thirds">
     <%= render "documents/show/contents" %>
 
-    <% if @edition.document_type.images %>
+    <% if @edition.document_type.lead_image %>
       <%= render "documents/show/lead_image" %>
     <% end %>
 

--- a/app/views/images/_image.html.erb
+++ b/app/views/images/_image.html.erb
@@ -1,10 +1,10 @@
 <% actions = [] %>
 
-<% actions << link_to("Edit details", edit_image_path(document, image.image_id),
+<% actions << link_to("Edit details", edit_image_path(edition.document, image.image_id),
                       class: "govuk-link",
                       data: { "modal-action": "edit", gtm: "edit-image" }) %>
 
-<% actions << link_to("Crop image", crop_image_path(document, image.image_id),
+<% actions << link_to("Crop image", crop_image_path(edition.document, image.image_id),
                       class: "govuk-link",
                       data: { "modal-action": "edit", gtm: "crop-image" }) %>
 
@@ -16,9 +16,9 @@
                           gtm: "insert-image-markdown"
                         },
                         class: "govuk-link govuk-link--no-visited-state") %>
-<% else %>
+<% elsif edition.document_type.lead_image  %>
   <% actions << capture do %>
-    <%= form_tag choose_lead_image_path(document, image.image_id),
+    <%= form_tag choose_lead_image_path(edition.document, image.image_id),
                  class: "app-inline-block",
                  data: { gtm: "select-lead-image" } do %>
       <button class="govuk-link app-link--button">Select as lead image</button>
@@ -29,7 +29,7 @@
 
 <% actions << capture do %>
   <%= form_tag(
-    destroy_image_path(document, image.image_id),
+    destroy_image_path(edition.document, image.image_id),
     method: :delete,
     data: {
       "modal-action": "delete",

--- a/app/views/images/_image.html.erb
+++ b/app/views/images/_image.html.erb
@@ -16,7 +16,7 @@
                           gtm: "insert-image-markdown"
                         },
                         class: "govuk-link govuk-link--no-visited-state") %>
-<% elsif edition.document_type.lead_image  %>
+<% elsif edition.document_type.lead_image? %>
   <% actions << capture do %>
     <%= form_tag choose_lead_image_path(edition.document, image.image_id),
                  class: "app-inline-block",

--- a/app/views/images/edit.html.erb
+++ b/app/views/images/edit.html.erb
@@ -92,7 +92,7 @@ content_for :title, t(title_key, title: @edition.title_or_fallback)
     } %>
   <% end %>
 
-  <% if rendering_context != "modal" && @edition.document_type.lead_image %>
+  <% if rendering_context != "modal" && @edition.document_type.lead_image? %>
     <% is_lead = params[:image_revision] ? params[:lead_image] :
       (@edition.lead_image_revision == @image_revision) %>
 

--- a/app/views/images/edit.html.erb
+++ b/app/views/images/edit.html.erb
@@ -92,7 +92,7 @@ content_for :title, t(title_key, title: @edition.title_or_fallback)
     } %>
   <% end %>
 
-  <% unless rendering_context == "modal" %>
+  <% if rendering_context != "modal" && @edition.document_type.lead_image %>
     <% is_lead = params[:image_revision] ? params[:lead_image] :
       (@edition.lead_image_revision == @image_revision) %>
 

--- a/app/views/images/index.html.erb
+++ b/app/views/images/index.html.erb
@@ -50,7 +50,7 @@ content_for :title, t(title_key, title: @edition.title_or_fallback)
       </h2>
 
       <% images.each do |image| %>
-        <%= render "image", image: image, document: @edition.document %>
+        <%= render "image", image: image, edition: @edition %>
       <% end %>
     <% end %>
   </div>

--- a/config/document_types.yml
+++ b/config/document_types.yml
@@ -2,7 +2,7 @@
 - id: news_story
   label: News story
   path_prefix: /government/news
-  images: true
+  lead_image: true
   publishing_metadata:
     schema_name: news_article
     rendering_app: government-frontend
@@ -30,7 +30,7 @@
 - id: press_release
   label: Press release
   path_prefix: /government/news
-  images: true
+  lead_image: true
   publishing_metadata:
     schema_name: news_article
     rendering_app: government-frontend

--- a/lib/edition_assertions.rb
+++ b/lib/edition_assertions.rb
@@ -14,11 +14,25 @@ module EditionAssertions
     end
   end
 
+  class FeatureError < Error
+    def initialize(edition, assertion)
+      super(edition, assertion || "edition supports feature")
+    end
+  end
+
   def assert_edition_state(edition, options = {}, &block)
     return if block.call(edition)
 
     assertion = options[:assertion]
     assertion ||= block.to_s if block.to_s =~ /&:/ # &:editable?
     raise StateError.new(edition, assertion)
+  end
+
+  def assert_edition_feature(edition, options = {}, &block)
+    return if block.call(edition.document_type)
+
+    assertion = options[:assertion]
+    assertion ||= block.to_s if block.to_s =~ /&:/ # &:lead_image?
+    raise FeatureError.new(edition, assertion)
   end
 end

--- a/spec/factories/document_type_factory.rb
+++ b/spec/factories/document_type_factory.rb
@@ -31,9 +31,11 @@ FactoryBot.define do
     end
 
     trait :with_body do
-      contents do
-        [DocumentType::BodyField.new]
-      end
+      contents { [DocumentType::BodyField.new] }
+    end
+
+    trait :with_lead_image do
+      lead_image { true }
     end
   end
 end

--- a/spec/features/editing_images/choose_lead_image_spec.rb
+++ b/spec/features/editing_images/choose_lead_image_spec.rb
@@ -17,7 +17,7 @@ RSpec.feature "Choose a lead image" do
   end
 
   def given_there_is_an_edition_with_images
-    document_type = build(:document_type, images: true)
+    document_type = build(:document_type, :with_lead_image)
     @image_revision = create(:image_revision, :on_asset_manager)
     @edition = create(:edition,
                       document_type: document_type,

--- a/spec/features/editing_images/delete_image_spec.rb
+++ b/spec/features/editing_images/delete_image_spec.rb
@@ -24,7 +24,7 @@ RSpec.feature "Delete an image" do
   end
 
   def given_there_is_an_edition_with_a_lead_image
-    document_type = build(:document_type, images: true)
+    document_type = build(:document_type, :with_lead_image)
     @image_revision = create(:image_revision, :on_asset_manager)
 
     @edition = create(:edition,
@@ -33,7 +33,7 @@ RSpec.feature "Delete an image" do
   end
 
   def given_there_is_an_edition_with_images
-    document_type = build(:document_type, :with_body, images: true)
+    document_type = build(:document_type, :with_body, :with_lead_image)
     @image_revision = create(:image_revision, :on_asset_manager)
 
     @edition = create(:edition,

--- a/spec/features/editing_images/download_image_spec.rb
+++ b/spec/features/editing_images/download_image_spec.rb
@@ -7,7 +7,7 @@ RSpec.feature "Download a image" do
   end
 
   def given_there_is_an_edition_with_images
-    document_type = build(:document_type, images: true)
+    document_type = build(:document_type, :with_lead_image)
     @image_revision = create(:image_revision, :on_asset_manager)
 
     @edition = create(:edition,

--- a/spec/features/editing_images/edit_image_spec.rb
+++ b/spec/features/editing_images/edit_image_spec.rb
@@ -30,6 +30,7 @@ RSpec.feature "Edit image", js: true do
   end
 
   def given_there_is_an_edition_with_a_lead_image
+    document_type = build(:document_type, :with_lead_image)
     @image_revision = create(:image_revision,
                              :on_asset_manager,
                              crop_x: 0,
@@ -38,11 +39,12 @@ RSpec.feature "Edit image", js: true do
                              crop_height: 666,
                              fixture: "1000x1000.jpg")
     @edition = create(:edition,
+                      document_type: document_type,
                       lead_image_revision: @image_revision)
   end
 
   def given_there_is_an_edition_with_images
-    document_type = build(:document_type, :with_body, images: true)
+    document_type = build(:document_type, :with_body)
 
     image_revision = create(:image_revision,
                             :on_asset_manager,

--- a/spec/features/editing_images/remove_lead_image_spec.rb
+++ b/spec/features/editing_images/remove_lead_image_spec.rb
@@ -17,7 +17,7 @@ RSpec.feature "Remove a lead image" do
   end
 
   def given_there_is_an_edition_with_a_lead_image
-    document_type = build(:document_type, images: true)
+    document_type = build(:document_type, :with_lead_image)
     @image_revision = create(:image_revision,
                              :on_asset_manager,
                              alt_text: "image")

--- a/spec/features/editing_images/upload_image_spec.rb
+++ b/spec/features/editing_images/upload_image_spec.rb
@@ -20,7 +20,7 @@ RSpec.feature "Upload an image", js: true do
   end
 
   def given_there_is_an_edition
-    document_type = build(:document_type, :with_body, images: true)
+    document_type = build(:document_type, :with_body, :with_lead_image)
     @edition = create(:edition, document_type: document_type)
   end
 

--- a/spec/lib/edition_assertions_spec.rb
+++ b/spec/lib/edition_assertions_spec.rb
@@ -18,4 +18,27 @@ RSpec.describe EditionAssertions do
         .to raise_error(EditionAssertions::StateError, /custom messaging/)
     end
   end
+
+  describe "#assert_edition_feature" do
+    let(:edition) { build :edition }
+
+    it "does nothing when the assertion block returns true" do
+      allow(edition.document_type).to receive(:feature).and_return(true)
+      expect { assert_edition_feature(edition, &:feature) }.not_to raise_error
+    end
+
+    it "raises an error when the assertion block is false" do
+      allow(edition.document_type).to receive(:feature).and_return(false)
+
+      expect { assert_edition_feature(edition, &:feature) }
+        .to raise_error(EditionAssertions::FeatureError)
+    end
+
+    it "can raise errors with custom messaging" do
+      allow(edition.document_type).to receive(:feature).and_return(false)
+
+      expect { assert_edition_feature(edition, assertion: "custom messaging", &:feature) }
+        .to raise_error(EditionAssertions::FeatureError, /custom messaging/)
+    end
+  end
 end

--- a/spec/lib/whitehall_importer/integrity_checker_spec.rb
+++ b/spec/lib/whitehall_importer/integrity_checker_spec.rb
@@ -1,6 +1,6 @@
 RSpec.describe WhitehallImporter::IntegrityChecker do
   let(:document_type) do
-    build(:document_type, images: true, contents: [
+    build(:document_type, :with_lead_image, contents: [
       DocumentType::TitleAndBasePathField.new,
       DocumentType::SummaryField.new,
       DocumentType::BodyField.new,

--- a/spec/requests/images_spec.rb
+++ b/spec/requests/images_spec.rb
@@ -147,6 +147,14 @@ RSpec.describe "Images" do
       expect(response.body)
         .to include(I18n.t!("requirements.alt_text.blank.form_message"))
     end
+
+    it "returns a bad request when selecting a lead image is not a supported feature" do
+      edition = create(:edition, image_revisions: [image_revision])
+      patch edit_image_path(edition.document, image_revision.image_id),
+            params: { image_revision: { alt_text: "Alt text" }, lead_image: "on" }
+
+      expect(response).to have_http_status(:bad_request)
+    end
   end
 
   describe "DELETE /documents/:document/images/:image_id" do

--- a/spec/requests/images_spec.rb
+++ b/spec/requests/images_spec.rb
@@ -114,7 +114,8 @@ RSpec.describe "Images" do
     end
 
     it "redirects to document summary with an alert when lead image is selected" do
-      edition = create(:edition, image_revisions: [image_revision])
+      document_type = build(:document_type, :with_lead_image)
+      edition = create(:edition, document_type: document_type, image_revisions: [image_revision])
 
       patch edit_image_path(edition.document, image_revision.image_id),
             params: { image_revision: { alt_text: "Alt text" }, lead_image: "on" }

--- a/spec/requests/lead_image_spec.rb
+++ b/spec/requests/lead_image_spec.rb
@@ -18,6 +18,14 @@ RSpec.describe "Lead Image" do
       let(:route_params) { [edition.document, "image_id"] }
     end
 
+    it_behaves_like "requests that return status",
+                    "choosing lead image not associated with edition",
+                    status: :not_found,
+                    routes: { choose_lead_image_path: %i[post] } do
+      let(:edition) { create :edition, document_type: document_type }
+      let(:route_params) { [edition.document, image_revision.image_id] }
+    end
+
     it "redirects to document summary with an alert" do
       edition = create(:edition,
                        document_type: document_type,
@@ -30,13 +38,6 @@ RSpec.describe "Lead Image" do
         I18n.t!("documents.show.flashes.lead_image.selected",
                 file: image_revision.filename),
       )
-    end
-
-    it "returns a 404 if the image revision isn't associated with the edition" do
-      edition = create(:edition, document_type: document_type)
-      post choose_lead_image_path(edition.document, image_revision.image_id)
-
-      expect(response).to have_http_status(:not_found)
     end
   end
 

--- a/spec/requests/lead_image_spec.rb
+++ b/spec/requests/lead_image_spec.rb
@@ -1,6 +1,7 @@
 RSpec.describe "Lead Image" do
   describe "POST /documents/:document/lead-image/:image_id" do
     let(:image_revision) { create(:image_revision) }
+    let(:document_type) { build(:document_type, :with_lead_image) }
 
     it_behaves_like "requests that assert edition state",
                     "choosing lead image for a non editable edition",
@@ -9,8 +10,18 @@ RSpec.describe "Lead Image" do
       let(:route_params) { [edition.document, "image_id"] }
     end
 
+    it_behaves_like "requests that return status",
+                    "choosing lead image when not supported",
+                    status: :not_found,
+                    routes: { choose_lead_image_path: %i[post] } do
+      let(:edition) { create(:edition) }
+      let(:route_params) { [edition.document, "image_id"] }
+    end
+
     it "redirects to document summary with an alert" do
-      edition = create(:edition, image_revisions: [image_revision])
+      edition = create(:edition,
+                       document_type: document_type,
+                       image_revisions: [image_revision])
       post choose_lead_image_path(edition.document, image_revision.image_id)
 
       expect(response).to redirect_to(document_path(edition.document))
@@ -22,7 +33,7 @@ RSpec.describe "Lead Image" do
     end
 
     it "returns a 404 if the image revision isn't associated with the edition" do
-      edition = create(:edition)
+      edition = create(:edition, document_type: document_type)
       post choose_lead_image_path(edition.document, image_revision.image_id)
 
       expect(response).to have_http_status(:not_found)
@@ -30,15 +41,27 @@ RSpec.describe "Lead Image" do
   end
 
   describe "DELETE /documents/:document/lead-image" do
+    let(:document_type) { build(:document_type, :with_lead_image) }
+
     it_behaves_like "requests that assert edition state",
                     "removing lead image for a non editable edition",
                     routes: { remove_lead_image_path: %i[delete] } do
       let(:edition) { create(:edition, :published) }
     end
 
+    it_behaves_like "requests that return status",
+                    "choosing lead image when not supported",
+                    status: :not_found,
+                    routes: { remove_lead_image_path: %i[post] } do
+      let(:edition) { create(:edition) }
+      let(:route_params) { [edition.document, "image_id"] }
+    end
+
     it "redirects with an alert when an edition has a lead image" do
       image_revision = create(:image_revision)
-      edition = create(:edition, lead_image_revision: image_revision)
+      edition = create(:edition,
+                       document_type: document_type,
+                       lead_image_revision: image_revision)
       delete remove_lead_image_path(edition.document)
 
       expect(response).to redirect_to(images_path(edition.document))
@@ -49,7 +72,7 @@ RSpec.describe "Lead Image" do
     end
 
     it "redirects without an alert when an edition doesn't have a lead image" do
-      edition = create(:edition)
+      edition = create(:edition, document_type: document_type)
       delete remove_lead_image_path(edition.document)
 
       expect(response).to redirect_to(images_path(edition.document))

--- a/spec/services/preview_draft_edition_service/payload_spec.rb
+++ b/spec/services/preview_draft_edition_service/payload_spec.rb
@@ -102,7 +102,7 @@ RSpec.describe PreviewDraftEditionService::Payload do
                              caption: "image caption",
                              credit: "image credit")
 
-      document_type = build(:document_type, images: true)
+      document_type = build(:document_type, :with_lead_image)
 
       edition = build(:edition,
                       document_type: document_type,

--- a/spec/support/schemas/document_type.json
+++ b/spec/support/schemas/document_type.json
@@ -5,7 +5,7 @@
     "id",
     "label",
     "path_prefix",
-    "images",
+    "lead_image",
     "publishing_metadata",
     "contents",
     "tags"
@@ -21,7 +21,7 @@
     "path_prefix": {
       "type": "string"
     },
-    "images": {
+    "lead_image": {
       "type": "boolean"
     },
     "publishing_metadata": {


### PR DESCRIPTION
https://trello.com/c/85gkiigT/1397-make-disabled-features-more-robust-lead-images

This introduces a new 'assert_edition_feature' method and applies it to
lead image actions in order to render/return a 404 response when the user
tries to perform a lead image action on an edition that does not support
that feature, as specified in its document type.

![Screenshot 2020-02-24 at 14 40 15](https://user-images.githubusercontent.com/9029009/75161487-cf2c3f00-5713-11ea-8a84-e8023176ff0c.png)

Please see the commits for more details.