### PR TITLE
Enable Group 1 Publication formats for pre-release users

### DIFF
--- a/app/models/document_type.rb
+++ b/app/models/document_type.rb
@@ -13,7 +13,7 @@ class DocumentType
 
   def self.all
     @all ||= begin
-      hashes = YAML.load_file(Rails.root.join("config/document_types.yml"))
+      hashes = YAML.load_file(Rails.root.join("config/document_types.yml"))["document_types"]
 
       hashes.map do |hash|
         hash["contents"] = hash["contents"].to_a.map do |field_id|

--- a/app/models/document_type.rb
+++ b/app/models/document_type.rb
@@ -2,7 +2,7 @@ class DocumentType
   include InitializeWithHash
 
   attr_reader :contents, :id, :managed_elsewhere, :publishing_metadata, :label,
-              :path_prefix, :tags, :lead_image, :topics
+              :path_prefix, :tags, :lead_image, :topics, :pre_release
 
   alias_method :lead_image?, :lead_image
 
@@ -31,6 +31,8 @@ class DocumentType
   def self.clear
     @all = nil
   end
+
+  alias_method :pre_release?, :pre_release
 
   class TagField
     include InitializeWithHash

--- a/app/models/document_type_selection/option.rb
+++ b/app/models/document_type_selection/option.rb
@@ -1,7 +1,7 @@
 class DocumentTypeSelection::Option
   include InitializeWithHash
 
-  attr_reader :id, :type, :hostname, :path
+  attr_reader :id, :type, :hostname, :path, :pre_release
 
   def document_type_selection?
     type == "document_type_selection"
@@ -18,4 +18,6 @@ class DocumentTypeSelection::Option
   def managed_elsewhere_url
     hostname ? Plek.new.external_url_for(hostname) + path : path
   end
+
+  alias_method :pre_release?, :pre_release
 end

--- a/app/models/document_type_selection/option.rb
+++ b/app/models/document_type_selection/option.rb
@@ -1,7 +1,7 @@
 class DocumentTypeSelection::Option
   include InitializeWithHash
 
-  attr_reader :id, :type, :hostname, :path, :pre_release
+  attr_reader :id, :type, :hostname, :path
 
   def document_type_selection?
     type == "document_type_selection"
@@ -19,5 +19,9 @@ class DocumentTypeSelection::Option
     hostname ? Plek.new.external_url_for(hostname) + path : path
   end
 
-  alias_method :pre_release?, :pre_release
+  def pre_release?
+    return false unless document_type?
+
+    DocumentType.find(id).pre_release?
+  end
 end

--- a/app/services/preview_draft_edition_service/payload.rb
+++ b/app/services/preview_draft_edition_service/payload.rb
@@ -85,6 +85,8 @@ private
       details[:image] = image
     end
 
+    details[:documents] = [] if publication?
+
     details
   end
 
@@ -101,5 +103,9 @@ private
         memo[:roles] = (memo[:roles] + roles).uniq
         memo[:people] = (memo[:people] + people).uniq
       end
+  end
+
+  def publication?
+    publishing_metadata.schema_name == "publication"
   end
 end

--- a/app/views/documents/index/_filters.html.erb
+++ b/app/views/documents/index/_filters.html.erb
@@ -77,7 +77,7 @@
 
   <div class="govuk-form-group">
     <% document_type_select = DocumentType.all
-      .reject(&:managed_elsewhere)
+      .reject { |d| d.pre_release? && !current_user.has_permission?(User::PRE_RELEASE_FEATURES_PERMISSION) }
       .map { |d| [d.label, d.id] }
     %>
 

--- a/app/views/new_document/show.html.erb
+++ b/app/views/new_document/show.html.erb
@@ -10,8 +10,10 @@
         is_page_heading: true,
         name: "selected_option_id",
         error_items: @issues&.items_for(:document_type_selection),
-        items: @document_type_selection.options.map do |option|
-          {
+        items: @document_type_selection.options.each_with_object([]) do |option, memo|
+          next if option.pre_release? && !current_user.has_permission?(User::PRE_RELEASE_FEATURES_PERMISSION)
+
+          memo << {
             value: option.id,
             text: t("document_type_selections.#{option.id}.label"),
             hint_text: I18n.exists?("document_type_selections.#{option.id}.description") ? t("document_type_selections.#{option.id}.description") : nil,

--- a/config/document_type_selections.yml
+++ b/config/document_type_selections.yml
@@ -22,6 +22,9 @@
       hostname: whitehall-admin
       path: /government/admin/speeches/new
     - id: correspondence
+      type: document_type
+      pre_release: true
+    - id: correspondence_managed_elsewhere
       type: managed_elsewhere
       hostname: whitehall-admin
       path: /government/admin/publications/new
@@ -88,6 +91,9 @@
 - id: policy
   options:
     - id: impact_assessment
+      type: document_type
+      pre_release: true
+    - id: impact_assessment_managed_elsewhere
       type: managed_elsewhere
       hostname: whitehall-admin
       path: /government/admin/publications/new
@@ -96,6 +102,9 @@
       hostname: whitehall-admin
       path: /government/admin/consultations/new
     - id: policy_paper
+      type: document_type
+      pre_release: true
+    - id: policy_paper_managed_elsewhere
       type: managed_elsewhere
       hostname: whitehall-admin
       path: /government/admin/publications/new
@@ -154,22 +163,37 @@
     - id: statistics
       type: document_type_selection
     - id: independent_report
+      type: document_type
+      pre_release: true
+    - id: independent_report_managed_elsewhere
       type: managed_elsewhere
       hostname: whitehall-admin
       path: /government/admin/publications/new
     - id: foi_release
+      type: document_type
+      pre_release: true
+    - id: foi_release_managed_elsewhere
       type: managed_elsewhere
       hostname: whitehall-admin
       path: /government/admin/publications/new
     - id: corporate_report
+      type: document_type
+      pre_release: true
+    - id: corporate_report_managed_elsewhere
       type: managed_elsewhere
       hostname: whitehall-admin
       path: /government/admin/publications/new
     - id: transparency
+      type: document_type
+      pre_release: true
+    - id: transparency_managed_elsewhere
       type: managed_elsewhere
       hostname: whitehall-admin
       path: /government/admin/publications/new
-    - id: research_and_analysis
+    - id: research
+      type: document_type
+      pre_release: true
+    - id: research_managed_elsewhere
       type: managed_elsewhere
       hostname: whitehall-admin
       path: /government/admin/publications/new
@@ -177,7 +201,10 @@
       type: managed_elsewhere
       hostname: whitehall-admin
       path: /government/admin/publications/new
-    - id: promotional_material
+    - id: promotional
+      type: document_type
+      pre_release: true
+    - id: promotional_managed_elsewhere
       type: managed_elsewhere
       hostname: whitehall-admin
       path: /government/admin/publications/new

--- a/config/document_type_selections.yml
+++ b/config/document_type_selections.yml
@@ -23,7 +23,6 @@
       path: /government/admin/speeches/new
     - id: correspondence
       type: document_type
-      pre_release: true
     - id: correspondence_managed_elsewhere
       type: managed_elsewhere
       hostname: whitehall-admin
@@ -92,7 +91,6 @@
   options:
     - id: impact_assessment
       type: document_type
-      pre_release: true
     - id: impact_assessment_managed_elsewhere
       type: managed_elsewhere
       hostname: whitehall-admin
@@ -103,7 +101,6 @@
       path: /government/admin/consultations/new
     - id: policy_paper
       type: document_type
-      pre_release: true
     - id: policy_paper_managed_elsewhere
       type: managed_elsewhere
       hostname: whitehall-admin
@@ -164,35 +161,30 @@
       type: document_type_selection
     - id: independent_report
       type: document_type
-      pre_release: true
     - id: independent_report_managed_elsewhere
       type: managed_elsewhere
       hostname: whitehall-admin
       path: /government/admin/publications/new
     - id: foi_release
       type: document_type
-      pre_release: true
     - id: foi_release_managed_elsewhere
       type: managed_elsewhere
       hostname: whitehall-admin
       path: /government/admin/publications/new
     - id: corporate_report
       type: document_type
-      pre_release: true
     - id: corporate_report_managed_elsewhere
       type: managed_elsewhere
       hostname: whitehall-admin
       path: /government/admin/publications/new
     - id: transparency
       type: document_type
-      pre_release: true
     - id: transparency_managed_elsewhere
       type: managed_elsewhere
       hostname: whitehall-admin
       path: /government/admin/publications/new
     - id: research
       type: document_type
-      pre_release: true
     - id: research_managed_elsewhere
       type: managed_elsewhere
       hostname: whitehall-admin
@@ -203,7 +195,6 @@
       path: /government/admin/publications/new
     - id: promotional
       type: document_type
-      pre_release: true
     - id: promotional_managed_elsewhere
       type: managed_elsewhere
       hostname: whitehall-admin

--- a/config/document_types.yml
+++ b/config/document_types.yml
@@ -54,3 +54,263 @@
     - id: world_locations
       type: multi_tag
       document_type: world_location
+
+- id: correspondence
+  label: Correspondence
+  path_prefix: /government/publications
+  images: false
+  publishing_metadata:
+    schema_name: publication
+    rendering_app: government-frontend
+  contents:
+    - title_and_base_path
+    - summary
+    - body
+  tags:
+    - id: primary_publishing_organisation
+      type: single_tag
+      document_type: organisation
+    - id: organisations
+      type: multi_tag
+      document_type: organisation
+    - id: role_appointments
+      type: multi_tag
+      document_type: role_appointment
+    - id: topical_events
+      type: multi_tag
+      document_type: topical_event
+    - id: world_locations
+      type: multi_tag
+      document_type: world_location
+
+- id: corporate_report
+  label: Corporate report
+  path_prefix: /government/publications
+  images: false
+  check_path_conflict: true
+  publishing_metadata:
+    schema_name: publication
+    rendering_app: government-frontend
+  contents:
+    - title_and_base_path
+    - summary
+    - body
+  tags:
+    - id: primary_publishing_organisation
+      type: single_tag
+      document_type: organisation
+    - id: organisations
+      type: multi_tag
+      document_type: organisation
+    - id: role_appointments
+      type: multi_tag
+      document_type: role_appointment
+    - id: topical_events
+      type: multi_tag
+      document_type: topical_event
+    - id: world_locations
+      type: multi_tag
+      document_type: world_location
+
+- id: foi_release
+  label: FOI Release
+  path_prefix: /government/publications
+  images: false
+  check_path_conflict: true
+  publishing_metadata:
+    schema_name: publication
+    rendering_app: government-frontend
+  contents:
+    - title_and_base_path
+    - summary
+    - body
+  tags:
+    - id: primary_publishing_organisation
+      type: single_tag
+      document_type: organisation
+    - id: organisations
+      type: multi_tag
+      document_type: organisation
+    - id: role_appointments
+      type: multi_tag
+      document_type: role_appointment
+    - id: topical_events
+      type: multi_tag
+      document_type: topical_event
+    - id: world_locations
+      type: multi_tag
+      document_type: world_location
+
+- id: impact_assessment
+  label: Impact assessement
+  path_prefix: /government/publications
+  images: false
+  check_path_conflict: true
+  publishing_metadata:
+    schema_name: publication
+    rendering_app: government-frontend
+  contents:
+    - title_and_base_path
+    - summary
+    - body
+  tags:
+    - id: primary_publishing_organisation
+      type: single_tag
+      document_type: organisation
+    - id: organisations
+      type: multi_tag
+      document_type: organisation
+    - id: role_appointments
+      type: multi_tag
+      document_type: role_appointment
+    - id: topical_events
+      type: multi_tag
+      document_type: topical_event
+    - id: world_locations
+      type: multi_tag
+      document_type: world_location
+
+- id: independent_report
+  label: Independent report
+  path_prefix: /government/publications
+  images: false
+  check_path_conflict: true
+  publishing_metadata:
+    schema_name: publication
+    rendering_app: government-frontend
+  contents:
+    - title_and_base_path
+    - summary
+    - body
+  tags:
+    - id: primary_publishing_organisation
+      type: single_tag
+      document_type: organisation
+    - id: organisations
+      type: multi_tag
+      document_type: organisation
+    - id: role_appointments
+      type: multi_tag
+      document_type: role_appointment
+    - id: topical_events
+      type: multi_tag
+      document_type: topical_event
+    - id: world_locations
+      type: multi_tag
+      document_type: world_location
+
+- id: policy_paper
+  label: Policy paper
+  path_prefix: /government/publications
+  images: false
+  check_path_conflict: true
+  publishing_metadata:
+    schema_name: publication
+    rendering_app: government-frontend
+  contents:
+    - title_and_base_path
+    - summary
+    - body
+  tags:
+    - id: primary_publishing_organisation
+      type: single_tag
+      document_type: organisation
+    - id: organisations
+      type: multi_tag
+      document_type: organisation
+    - id: role_appointments
+      type: multi_tag
+      document_type: role_appointment
+    - id: topical_events
+      type: multi_tag
+      document_type: topical_event
+    - id: world_locations
+      type: multi_tag
+      document_type: world_location
+
+- id: promotional
+  label: Promotional material
+  path_prefix: /government/publications
+  images: false
+  check_path_conflict: true
+  publishing_metadata:
+    schema_name: publication
+    rendering_app: government-frontend
+  contents:
+    - title_and_base_path
+    - summary
+    - body
+  tags:
+    - id: primary_publishing_organisation
+      type: single_tag
+      document_type: organisation
+    - id: organisations
+      type: multi_tag
+      document_type: organisation
+    - id: role_appointments
+      type: multi_tag
+      document_type: role_appointment
+    - id: topical_events
+      type: multi_tag
+      document_type: topical_event
+    - id: world_locations
+      type: multi_tag
+      document_type: world_location
+
+- id: research
+  label: Research and analysis
+  path_prefix: /government/publications
+  images: false
+  check_path_conflict: true
+  publishing_metadata:
+    schema_name: publication
+    rendering_app: government-frontend
+  contents:
+    - title_and_base_path
+    - summary
+    - body
+  tags:
+    - id: primary_publishing_organisation
+      type: single_tag
+      document_type: organisation
+    - id: organisations
+      type: multi_tag
+      document_type: organisation
+    - id: role_appointments
+      type: multi_tag
+      document_type: role_appointment
+    - id: topical_events
+      type: multi_tag
+      document_type: topical_event
+    - id: world_locations
+      type: multi_tag
+      document_type: world_location
+
+- id: transparency
+  label: Transparency
+  path_prefix: /government/publications
+  images: false
+  check_path_conflict: true
+  publishing_metadata:
+    schema_name: publication
+    rendering_app: government-frontend
+  contents:
+    - title_and_base_path
+    - summary
+    - body
+  tags:
+    - id: primary_publishing_organisation
+      type: single_tag
+      document_type: organisation
+    - id: organisations
+      type: multi_tag
+      document_type: organisation
+    - id: role_appointments
+      type: multi_tag
+      document_type: role_appointment
+    - id: topical_events
+      type: multi_tag
+      document_type: topical_event
+    - id: world_locations
+      type: multi_tag
+      document_type: world_location

--- a/config/document_types.yml
+++ b/config/document_types.yml
@@ -56,14 +56,6 @@ publication: &publication
 
 
 document_types:
-  - id: news_story
-    <<: *news_article
-    label: News story
-
-  - id: press_release
-    <<: *news_article
-    label: Press release
-
   - id: correspondence
     <<: *publication
     label: Correspondence
@@ -84,9 +76,17 @@ document_types:
     <<: *publication
     label: Independent report
 
+  - id: news_story
+    <<: *news_article
+    label: News story
+
   - id: policy_paper
     <<: *publication
     label: Policy paper
+
+  - id: press_release
+    <<: *news_article
+    label: Press release
 
   - id: promotional
     <<: *publication

--- a/config/document_types.yml
+++ b/config/document_types.yml
@@ -1,325 +1,318 @@
 ---
-- id: news_story
-  label: News story
-  path_prefix: /government/news
-  lead_image: true
-  publishing_metadata:
-    schema_name: news_article
-    rendering_app: government-frontend
-  contents:
-    - title_and_base_path
-    - summary
-    - body
-  tags:
-    - id: primary_publishing_organisation
-      type: single_tag
-      document_type: organisation
-    - id: organisations
-      type: multi_tag
-      document_type: organisation
-    - id: role_appointments
-      type: multi_tag
-      document_type: role_appointment
-    - id: topical_events
-      type: multi_tag
-      document_type: topical_event
-    - id: world_locations
-      type: multi_tag
-      document_type: world_location
+document_types:
+  - id: news_story
+    label: News story
+    path_prefix: /government/news
+    lead_image: true
+    publishing_metadata:
+      schema_name: news_article
+      rendering_app: government-frontend
+    contents:
+      - title_and_base_path
+      - summary
+      - body
+    tags:
+      - id: primary_publishing_organisation
+        type: single_tag
+        document_type: organisation
+      - id: organisations
+        type: multi_tag
+        document_type: organisation
+      - id: role_appointments
+        type: multi_tag
+        document_type: role_appointment
+      - id: topical_events
+        type: multi_tag
+        document_type: topical_event
+      - id: world_locations
+        type: multi_tag
+        document_type: world_location
 
-- id: press_release
-  label: Press release
-  path_prefix: /government/news
-  lead_image: true
-  publishing_metadata:
-    schema_name: news_article
-    rendering_app: government-frontend
-  contents:
-    - title_and_base_path
-    - summary
-    - body
-  tags:
-    - id: primary_publishing_organisation
-      type: single_tag
-      document_type: organisation
-    - id: organisations
-      type: multi_tag
-      document_type: organisation
-    - id: role_appointments
-      type: multi_tag
-      document_type: role_appointment
-    - id: topical_events
-      type: multi_tag
-      document_type: topical_event
-    - id: world_locations
-      type: multi_tag
-      document_type: world_location
+  - id: press_release
+    label: Press release
+    path_prefix: /government/news
+    lead_image: true
+    publishing_metadata:
+      schema_name: news_article
+      rendering_app: government-frontend
+    contents:
+      - title_and_base_path
+      - summary
+      - body
+    tags:
+      - id: primary_publishing_organisation
+        type: single_tag
+        document_type: organisation
+      - id: organisations
+        type: multi_tag
+        document_type: organisation
+      - id: role_appointments
+        type: multi_tag
+        document_type: role_appointment
+      - id: topical_events
+        type: multi_tag
+        document_type: topical_event
+      - id: world_locations
+        type: multi_tag
+        document_type: world_location
 
-- id: correspondence
-  label: Correspondence
-  pre_release: true
-  path_prefix: /government/publications
-  images: false
-  publishing_metadata:
-    schema_name: publication
-    rendering_app: government-frontend
-  contents:
-    - title_and_base_path
-    - summary
-    - body
-  tags:
-    - id: primary_publishing_organisation
-      type: single_tag
-      document_type: organisation
-    - id: organisations
-      type: multi_tag
-      document_type: organisation
-    - id: role_appointments
-      type: multi_tag
-      document_type: role_appointment
-    - id: topical_events
-      type: multi_tag
-      document_type: topical_event
-    - id: world_locations
-      type: multi_tag
-      document_type: world_location
+  - id: correspondence
+    label: Correspondence
+    pre_release: true
+    path_prefix: /government/publications
+    lead_image: false
+    publishing_metadata:
+      schema_name: publication
+      rendering_app: government-frontend
+    contents:
+      - title_and_base_path
+      - summary
+      - body
+    tags:
+      - id: primary_publishing_organisation
+        type: single_tag
+        document_type: organisation
+      - id: organisations
+        type: multi_tag
+        document_type: organisation
+      - id: role_appointments
+        type: multi_tag
+        document_type: role_appointment
+      - id: topical_events
+        type: multi_tag
+        document_type: topical_event
+      - id: world_locations
+        type: multi_tag
+        document_type: world_location
 
-- id: corporate_report
-  label: Corporate report
-  pre_release: true
-  path_prefix: /government/publications
-  images: false
-  check_path_conflict: true
-  publishing_metadata:
-    schema_name: publication
-    rendering_app: government-frontend
-  contents:
-    - title_and_base_path
-    - summary
-    - body
-  tags:
-    - id: primary_publishing_organisation
-      type: single_tag
-      document_type: organisation
-    - id: organisations
-      type: multi_tag
-      document_type: organisation
-    - id: role_appointments
-      type: multi_tag
-      document_type: role_appointment
-    - id: topical_events
-      type: multi_tag
-      document_type: topical_event
-    - id: world_locations
-      type: multi_tag
-      document_type: world_location
+  - id: corporate_report
+    label: Corporate report
+    pre_release: true
+    path_prefix: /government/publications
+    lead_image: false
+    publishing_metadata:
+      schema_name: publication
+      rendering_app: government-frontend
+    contents:
+      - title_and_base_path
+      - summary
+      - body
+    tags:
+      - id: primary_publishing_organisation
+        type: single_tag
+        document_type: organisation
+      - id: organisations
+        type: multi_tag
+        document_type: organisation
+      - id: role_appointments
+        type: multi_tag
+        document_type: role_appointment
+      - id: topical_events
+        type: multi_tag
+        document_type: topical_event
+      - id: world_locations
+        type: multi_tag
+        document_type: world_location
 
-- id: foi_release
-  label: FOI Release
-  pre_release: true
-  path_prefix: /government/publications
-  images: false
-  check_path_conflict: true
-  publishing_metadata:
-    schema_name: publication
-    rendering_app: government-frontend
-  contents:
-    - title_and_base_path
-    - summary
-    - body
-  tags:
-    - id: primary_publishing_organisation
-      type: single_tag
-      document_type: organisation
-    - id: organisations
-      type: multi_tag
-      document_type: organisation
-    - id: role_appointments
-      type: multi_tag
-      document_type: role_appointment
-    - id: topical_events
-      type: multi_tag
-      document_type: topical_event
-    - id: world_locations
-      type: multi_tag
-      document_type: world_location
+  - id: foi_release
+    label: FOI Release
+    pre_release: true
+    path_prefix: /government/publications
+    lead_image: false
+    publishing_metadata:
+      schema_name: publication
+      rendering_app: government-frontend
+    contents:
+      - title_and_base_path
+      - summary
+      - body
+    tags:
+      - id: primary_publishing_organisation
+        type: single_tag
+        document_type: organisation
+      - id: organisations
+        type: multi_tag
+        document_type: organisation
+      - id: role_appointments
+        type: multi_tag
+        document_type: role_appointment
+      - id: topical_events
+        type: multi_tag
+        document_type: topical_event
+      - id: world_locations
+        type: multi_tag
+        document_type: world_location
 
-- id: impact_assessment
-  label: Impact assessement
-  pre_release: true
-  path_prefix: /government/publications
-  images: false
-  check_path_conflict: true
-  publishing_metadata:
-    schema_name: publication
-    rendering_app: government-frontend
-  contents:
-    - title_and_base_path
-    - summary
-    - body
-  tags:
-    - id: primary_publishing_organisation
-      type: single_tag
-      document_type: organisation
-    - id: organisations
-      type: multi_tag
-      document_type: organisation
-    - id: role_appointments
-      type: multi_tag
-      document_type: role_appointment
-    - id: topical_events
-      type: multi_tag
-      document_type: topical_event
-    - id: world_locations
-      type: multi_tag
-      document_type: world_location
+  - id: impact_assessment
+    label: Impact assessement
+    pre_release: true
+    path_prefix: /government/publications
+    lead_image: false
+    publishing_metadata:
+      schema_name: publication
+      rendering_app: government-frontend
+    contents:
+      - title_and_base_path
+      - summary
+      - body
+    tags:
+      - id: primary_publishing_organisation
+        type: single_tag
+        document_type: organisation
+      - id: organisations
+        type: multi_tag
+        document_type: organisation
+      - id: role_appointments
+        type: multi_tag
+        document_type: role_appointment
+      - id: topical_events
+        type: multi_tag
+        document_type: topical_event
+      - id: world_locations
+        type: multi_tag
+        document_type: world_location
 
-- id: independent_report
-  label: Independent report
-  pre_release: true
-  path_prefix: /government/publications
-  images: false
-  check_path_conflict: true
-  publishing_metadata:
-    schema_name: publication
-    rendering_app: government-frontend
-  contents:
-    - title_and_base_path
-    - summary
-    - body
-  tags:
-    - id: primary_publishing_organisation
-      type: single_tag
-      document_type: organisation
-    - id: organisations
-      type: multi_tag
-      document_type: organisation
-    - id: role_appointments
-      type: multi_tag
-      document_type: role_appointment
-    - id: topical_events
-      type: multi_tag
-      document_type: topical_event
-    - id: world_locations
-      type: multi_tag
-      document_type: world_location
+  - id: independent_report
+    label: Independent report
+    pre_release: true
+    path_prefix: /government/publications
+    lead_image: false
+    publishing_metadata:
+      schema_name: publication
+      rendering_app: government-frontend
+    contents:
+      - title_and_base_path
+      - summary
+      - body
+    tags:
+      - id: primary_publishing_organisation
+        type: single_tag
+        document_type: organisation
+      - id: organisations
+        type: multi_tag
+        document_type: organisation
+      - id: role_appointments
+        type: multi_tag
+        document_type: role_appointment
+      - id: topical_events
+        type: multi_tag
+        document_type: topical_event
+      - id: world_locations
+        type: multi_tag
+        document_type: world_location
 
-- id: policy_paper
-  label: Policy paper
-  pre_release: true
-  path_prefix: /government/publications
-  images: false
-  check_path_conflict: true
-  publishing_metadata:
-    schema_name: publication
-    rendering_app: government-frontend
-  contents:
-    - title_and_base_path
-    - summary
-    - body
-  tags:
-    - id: primary_publishing_organisation
-      type: single_tag
-      document_type: organisation
-    - id: organisations
-      type: multi_tag
-      document_type: organisation
-    - id: role_appointments
-      type: multi_tag
-      document_type: role_appointment
-    - id: topical_events
-      type: multi_tag
-      document_type: topical_event
-    - id: world_locations
-      type: multi_tag
-      document_type: world_location
+  - id: policy_paper
+    label: Policy paper
+    pre_release: true
+    path_prefix: /government/publications
+    lead_image: false
+    publishing_metadata:
+      schema_name: publication
+      rendering_app: government-frontend
+    contents:
+      - title_and_base_path
+      - summary
+      - body
+    tags:
+      - id: primary_publishing_organisation
+        type: single_tag
+        document_type: organisation
+      - id: organisations
+        type: multi_tag
+        document_type: organisation
+      - id: role_appointments
+        type: multi_tag
+        document_type: role_appointment
+      - id: topical_events
+        type: multi_tag
+        document_type: topical_event
+      - id: world_locations
+        type: multi_tag
+        document_type: world_location
 
-- id: promotional
-  label: Promotional material
-  pre_release: true
-  path_prefix: /government/publications
-  images: false
-  check_path_conflict: true
-  publishing_metadata:
-    schema_name: publication
-    rendering_app: government-frontend
-  contents:
-    - title_and_base_path
-    - summary
-    - body
-  tags:
-    - id: primary_publishing_organisation
-      type: single_tag
-      document_type: organisation
-    - id: organisations
-      type: multi_tag
-      document_type: organisation
-    - id: role_appointments
-      type: multi_tag
-      document_type: role_appointment
-    - id: topical_events
-      type: multi_tag
-      document_type: topical_event
-    - id: world_locations
-      type: multi_tag
-      document_type: world_location
+  - id: promotional
+    label: Promotional material
+    pre_release: true
+    path_prefix: /government/publications
+    lead_image: false
+    publishing_metadata:
+      schema_name: publication
+      rendering_app: government-frontend
+    contents:
+      - title_and_base_path
+      - summary
+      - body
+    tags:
+      - id: primary_publishing_organisation
+        type: single_tag
+        document_type: organisation
+      - id: organisations
+        type: multi_tag
+        document_type: organisation
+      - id: role_appointments
+        type: multi_tag
+        document_type: role_appointment
+      - id: topical_events
+        type: multi_tag
+        document_type: topical_event
+      - id: world_locations
+        type: multi_tag
+        document_type: world_location
 
-- id: research
-  label: Research and analysis
-  pre_release: true
-  path_prefix: /government/publications
-  images: false
-  check_path_conflict: true
-  publishing_metadata:
-    schema_name: publication
-    rendering_app: government-frontend
-  contents:
-    - title_and_base_path
-    - summary
-    - body
-  tags:
-    - id: primary_publishing_organisation
-      type: single_tag
-      document_type: organisation
-    - id: organisations
-      type: multi_tag
-      document_type: organisation
-    - id: role_appointments
-      type: multi_tag
-      document_type: role_appointment
-    - id: topical_events
-      type: multi_tag
-      document_type: topical_event
-    - id: world_locations
-      type: multi_tag
-      document_type: world_location
+  - id: research
+    label: Research and analysis
+    pre_release: true
+    path_prefix: /government/publications
+    lead_image: false
+    publishing_metadata:
+      schema_name: publication
+      rendering_app: government-frontend
+    contents:
+      - title_and_base_path
+      - summary
+      - body
+    tags:
+      - id: primary_publishing_organisation
+        type: single_tag
+        document_type: organisation
+      - id: organisations
+        type: multi_tag
+        document_type: organisation
+      - id: role_appointments
+        type: multi_tag
+        document_type: role_appointment
+      - id: topical_events
+        type: multi_tag
+        document_type: topical_event
+      - id: world_locations
+        type: multi_tag
+        document_type: world_location
 
-- id: transparency
-  label: Transparency
-  pre_release: true
-  path_prefix: /government/publications
-  images: false
-  check_path_conflict: true
-  publishing_metadata:
-    schema_name: publication
-    rendering_app: government-frontend
-  contents:
-    - title_and_base_path
-    - summary
-    - body
-  tags:
-    - id: primary_publishing_organisation
-      type: single_tag
-      document_type: organisation
-    - id: organisations
-      type: multi_tag
-      document_type: organisation
-    - id: role_appointments
-      type: multi_tag
-      document_type: role_appointment
-    - id: topical_events
-      type: multi_tag
-      document_type: topical_event
-    - id: world_locations
-      type: multi_tag
-      document_type: world_location
+  - id: transparency
+    label: Transparency
+    pre_release: true
+    path_prefix: /government/publications
+    lead_image: false
+    publishing_metadata:
+      schema_name: publication
+      rendering_app: government-frontend
+    contents:
+      - title_and_base_path
+      - summary
+      - body
+    tags:
+      - id: primary_publishing_organisation
+        type: single_tag
+        document_type: organisation
+      - id: organisations
+        type: multi_tag
+        document_type: organisation
+      - id: role_appointments
+        type: multi_tag
+        document_type: role_appointment
+      - id: topical_events
+        type: multi_tag
+        document_type: topical_event
+      - id: world_locations
+        type: multi_tag
+        document_type: world_location

--- a/config/document_types.yml
+++ b/config/document_types.yml
@@ -26,6 +26,35 @@ news_article: &news_article
       type: multi_tag
       document_type: world_location
 
+publication: &publication
+  pre_release: true
+  path_prefix: /government/publications
+  lead_image: false
+  publishing_metadata:
+    schema_name: publication
+    rendering_app: government-frontend
+  contents:
+    - title_and_base_path
+    - summary
+    - body
+  tags:
+    - id: primary_publishing_organisation
+      type: single_tag
+      document_type: organisation
+    - id: organisations
+      type: multi_tag
+      document_type: organisation
+    - id: role_appointments
+      type: multi_tag
+      document_type: role_appointment
+    - id: topical_events
+      type: multi_tag
+      document_type: topical_event
+    - id: world_locations
+      type: multi_tag
+      document_type: world_location
+
+
 document_types:
   - id: news_story
     <<: *news_article
@@ -36,262 +65,37 @@ document_types:
     label: Press release
 
   - id: correspondence
+    <<: *publication
     label: Correspondence
-    pre_release: true
-    path_prefix: /government/publications
-    lead_image: false
-    publishing_metadata:
-      schema_name: publication
-      rendering_app: government-frontend
-    contents:
-      - title_and_base_path
-      - summary
-      - body
-    tags:
-      - id: primary_publishing_organisation
-        type: single_tag
-        document_type: organisation
-      - id: organisations
-        type: multi_tag
-        document_type: organisation
-      - id: role_appointments
-        type: multi_tag
-        document_type: role_appointment
-      - id: topical_events
-        type: multi_tag
-        document_type: topical_event
-      - id: world_locations
-        type: multi_tag
-        document_type: world_location
 
   - id: corporate_report
+    <<: *publication
     label: Corporate report
-    pre_release: true
-    path_prefix: /government/publications
-    lead_image: false
-    publishing_metadata:
-      schema_name: publication
-      rendering_app: government-frontend
-    contents:
-      - title_and_base_path
-      - summary
-      - body
-    tags:
-      - id: primary_publishing_organisation
-        type: single_tag
-        document_type: organisation
-      - id: organisations
-        type: multi_tag
-        document_type: organisation
-      - id: role_appointments
-        type: multi_tag
-        document_type: role_appointment
-      - id: topical_events
-        type: multi_tag
-        document_type: topical_event
-      - id: world_locations
-        type: multi_tag
-        document_type: world_location
 
   - id: foi_release
+    <<: *publication
     label: FOI Release
-    pre_release: true
-    path_prefix: /government/publications
-    lead_image: false
-    publishing_metadata:
-      schema_name: publication
-      rendering_app: government-frontend
-    contents:
-      - title_and_base_path
-      - summary
-      - body
-    tags:
-      - id: primary_publishing_organisation
-        type: single_tag
-        document_type: organisation
-      - id: organisations
-        type: multi_tag
-        document_type: organisation
-      - id: role_appointments
-        type: multi_tag
-        document_type: role_appointment
-      - id: topical_events
-        type: multi_tag
-        document_type: topical_event
-      - id: world_locations
-        type: multi_tag
-        document_type: world_location
 
   - id: impact_assessment
+    <<: *publication
     label: Impact assessement
-    pre_release: true
-    path_prefix: /government/publications
-    lead_image: false
-    publishing_metadata:
-      schema_name: publication
-      rendering_app: government-frontend
-    contents:
-      - title_and_base_path
-      - summary
-      - body
-    tags:
-      - id: primary_publishing_organisation
-        type: single_tag
-        document_type: organisation
-      - id: organisations
-        type: multi_tag
-        document_type: organisation
-      - id: role_appointments
-        type: multi_tag
-        document_type: role_appointment
-      - id: topical_events
-        type: multi_tag
-        document_type: topical_event
-      - id: world_locations
-        type: multi_tag
-        document_type: world_location
 
   - id: independent_report
+    <<: *publication
     label: Independent report
-    pre_release: true
-    path_prefix: /government/publications
-    lead_image: false
-    publishing_metadata:
-      schema_name: publication
-      rendering_app: government-frontend
-    contents:
-      - title_and_base_path
-      - summary
-      - body
-    tags:
-      - id: primary_publishing_organisation
-        type: single_tag
-        document_type: organisation
-      - id: organisations
-        type: multi_tag
-        document_type: organisation
-      - id: role_appointments
-        type: multi_tag
-        document_type: role_appointment
-      - id: topical_events
-        type: multi_tag
-        document_type: topical_event
-      - id: world_locations
-        type: multi_tag
-        document_type: world_location
 
   - id: policy_paper
+    <<: *publication
     label: Policy paper
-    pre_release: true
-    path_prefix: /government/publications
-    lead_image: false
-    publishing_metadata:
-      schema_name: publication
-      rendering_app: government-frontend
-    contents:
-      - title_and_base_path
-      - summary
-      - body
-    tags:
-      - id: primary_publishing_organisation
-        type: single_tag
-        document_type: organisation
-      - id: organisations
-        type: multi_tag
-        document_type: organisation
-      - id: role_appointments
-        type: multi_tag
-        document_type: role_appointment
-      - id: topical_events
-        type: multi_tag
-        document_type: topical_event
-      - id: world_locations
-        type: multi_tag
-        document_type: world_location
 
   - id: promotional
+    <<: *publication
     label: Promotional material
-    pre_release: true
-    path_prefix: /government/publications
-    lead_image: false
-    publishing_metadata:
-      schema_name: publication
-      rendering_app: government-frontend
-    contents:
-      - title_and_base_path
-      - summary
-      - body
-    tags:
-      - id: primary_publishing_organisation
-        type: single_tag
-        document_type: organisation
-      - id: organisations
-        type: multi_tag
-        document_type: organisation
-      - id: role_appointments
-        type: multi_tag
-        document_type: role_appointment
-      - id: topical_events
-        type: multi_tag
-        document_type: topical_event
-      - id: world_locations
-        type: multi_tag
-        document_type: world_location
 
   - id: research
+    <<: *publication
     label: Research and analysis
-    pre_release: true
-    path_prefix: /government/publications
-    lead_image: false
-    publishing_metadata:
-      schema_name: publication
-      rendering_app: government-frontend
-    contents:
-      - title_and_base_path
-      - summary
-      - body
-    tags:
-      - id: primary_publishing_organisation
-        type: single_tag
-        document_type: organisation
-      - id: organisations
-        type: multi_tag
-        document_type: organisation
-      - id: role_appointments
-        type: multi_tag
-        document_type: role_appointment
-      - id: topical_events
-        type: multi_tag
-        document_type: topical_event
-      - id: world_locations
-        type: multi_tag
-        document_type: world_location
 
   - id: transparency
+    <<: *publication
     label: Transparency
-    pre_release: true
-    path_prefix: /government/publications
-    lead_image: false
-    publishing_metadata:
-      schema_name: publication
-      rendering_app: government-frontend
-    contents:
-      - title_and_base_path
-      - summary
-      - body
-    tags:
-      - id: primary_publishing_organisation
-        type: single_tag
-        document_type: organisation
-      - id: organisations
-        type: multi_tag
-        document_type: organisation
-      - id: role_appointments
-        type: multi_tag
-        document_type: role_appointment
-      - id: topical_events
-        type: multi_tag
-        document_type: topical_event
-      - id: world_locations
-        type: multi_tag
-        document_type: world_location

--- a/config/document_types.yml
+++ b/config/document_types.yml
@@ -57,6 +57,7 @@
 
 - id: correspondence
   label: Correspondence
+  pre_release: true
   path_prefix: /government/publications
   images: false
   publishing_metadata:
@@ -85,6 +86,7 @@
 
 - id: corporate_report
   label: Corporate report
+  pre_release: true
   path_prefix: /government/publications
   images: false
   check_path_conflict: true
@@ -114,6 +116,7 @@
 
 - id: foi_release
   label: FOI Release
+  pre_release: true
   path_prefix: /government/publications
   images: false
   check_path_conflict: true
@@ -143,6 +146,7 @@
 
 - id: impact_assessment
   label: Impact assessement
+  pre_release: true
   path_prefix: /government/publications
   images: false
   check_path_conflict: true
@@ -172,6 +176,7 @@
 
 - id: independent_report
   label: Independent report
+  pre_release: true
   path_prefix: /government/publications
   images: false
   check_path_conflict: true
@@ -201,6 +206,7 @@
 
 - id: policy_paper
   label: Policy paper
+  pre_release: true
   path_prefix: /government/publications
   images: false
   check_path_conflict: true
@@ -230,6 +236,7 @@
 
 - id: promotional
   label: Promotional material
+  pre_release: true
   path_prefix: /government/publications
   images: false
   check_path_conflict: true
@@ -259,6 +266,7 @@
 
 - id: research
   label: Research and analysis
+  pre_release: true
   path_prefix: /government/publications
   images: false
   check_path_conflict: true
@@ -288,6 +296,7 @@
 
 - id: transparency
   label: Transparency
+  pre_release: true
   path_prefix: /government/publications
   images: false
   check_path_conflict: true

--- a/config/document_types.yml
+++ b/config/document_types.yml
@@ -1,60 +1,39 @@
 ---
+news_article: &news_article
+  path_prefix: /government/news
+  lead_image: true
+  publishing_metadata:
+    schema_name: news_article
+    rendering_app: government-frontend
+  contents:
+    - title_and_base_path
+    - summary
+    - body
+  tags:
+    - id: primary_publishing_organisation
+      type: single_tag
+      document_type: organisation
+    - id: organisations
+      type: multi_tag
+      document_type: organisation
+    - id: role_appointments
+      type: multi_tag
+      document_type: role_appointment
+    - id: topical_events
+      type: multi_tag
+      document_type: topical_event
+    - id: world_locations
+      type: multi_tag
+      document_type: world_location
+
 document_types:
   - id: news_story
+    <<: *news_article
     label: News story
-    path_prefix: /government/news
-    lead_image: true
-    publishing_metadata:
-      schema_name: news_article
-      rendering_app: government-frontend
-    contents:
-      - title_and_base_path
-      - summary
-      - body
-    tags:
-      - id: primary_publishing_organisation
-        type: single_tag
-        document_type: organisation
-      - id: organisations
-        type: multi_tag
-        document_type: organisation
-      - id: role_appointments
-        type: multi_tag
-        document_type: role_appointment
-      - id: topical_events
-        type: multi_tag
-        document_type: topical_event
-      - id: world_locations
-        type: multi_tag
-        document_type: world_location
 
   - id: press_release
+    <<: *news_article
     label: Press release
-    path_prefix: /government/news
-    lead_image: true
-    publishing_metadata:
-      schema_name: news_article
-      rendering_app: government-frontend
-    contents:
-      - title_and_base_path
-      - summary
-      - body
-    tags:
-      - id: primary_publishing_organisation
-        type: single_tag
-        document_type: organisation
-      - id: organisations
-        type: multi_tag
-        document_type: organisation
-      - id: role_appointments
-        type: multi_tag
-        document_type: role_appointment
-      - id: topical_events
-        type: multi_tag
-        document_type: topical_event
-      - id: world_locations
-        type: multi_tag
-        document_type: world_location
 
   - id: correspondence
     label: Correspondence

--- a/config/locales/en/document_type_selections.yml
+++ b/config/locales/en/document_type_selections.yml
@@ -21,9 +21,15 @@ en:
       label: Consultation
       description: Consultations (officially ‘documents requiring collective agreement across government’), calls for evidence and requests for people's views on a question.
     corporate_report:
+      label: Corporate report (pre-release)
+      description: Publications about the organisation as a public entity, for example, annual reports, business plans and accounts.
+    corporate_report_managed_elsewhere:
       label: Corporate report
       description: Publications about the organisation as a public entity, for example, annual reports, business plans and accounts.
     correspondence:
+      label: Correspondence (pre-release)
+      description: Minister or organisation responses (for example to campaign letters), correspondence to individuals, organisations and professionals, circulars, bulletins and newsletters.
+    correspondence_managed_elsewhere:
       label: Correspondence
       description: Minister or organisation responses (for example to campaign letters), correspondence to individuals, organisations and professionals, circulars, bulletins and newsletters.
     decision:
@@ -36,6 +42,9 @@ en:
       label: Fatality notice
       description: Initial fatality notices and subsequent obituaries of forces and Ministry of Defence personnel.
     foi_release:
+      label: FOI release (pre-release)
+      description: Responses to Freedom of Information (FOI) requests.
+    foi_release_managed_elsewhere:
       label: FOI release
       description: Responses to Freedom of Information (FOI) requests.
     form:
@@ -51,9 +60,15 @@ en:
         body_govspeak: |
           For example, manuals, or statutory guidance
     impact_assessment:
+      label: Impact assessment (pre-release)
+      description: Cost-benefit analyses and other assessments of the impact of proposed initiatives, or changes to regulations or legislation.
+    impact_assessment_managed_elsewhere:
       label: Impact assessment
       description: Cost-benefit analyses and other assessments of the impact of proposed initiatives, or changes to regulations or legislation.
     independent_report:
+      label: Independent report (pre-release)
+      description: Reports commissioned by government but written by non-government organisations, including independent enquiries, investigations and reviews.
+    independent_report_managed_elsewhere:
       label: Independent report
       description: Reports commissioned by government but written by non-government organisations, including independent enquiries, investigations and reviews.
     international_treaty:
@@ -99,18 +114,27 @@ en:
         body_govspeak: |
           For example, policy papers or impact assessments
     policy_paper:
+      label: Policy paper (pre-release)
+      description: An explanation of the government's position on something. It doesn’t include instructions on how to carry out a task, only the policy itself and how it’ll be implemented.
+    policy_paper_managed_elsewhere:
       label: Policy paper
       description: An explanation of the government's position on something. It doesn’t include instructions on how to carry out a task, only the policy itself and how it’ll be implemented.
     press_release:
       label: Press release
       description: "Unedited press releases as sent to the media, and official statements from the organisation."
-    promotional_material:
+    promotional:
+      label: Promotional material (pre-release)
+      description: Leaflets, posters, factsheets and marketing materials.
+    promotional_managed_elsewhere:
       label: Promotional material
       description: Leaflets, posters, factsheets and marketing materials.
     regulation:
       label: Regulation
       description: Regulations imposed by an independent regulatory authority.
-    research_and_analysis:
+    research:
+      label: Research and analysis (pre-release)
+      description: Research reports, surveys, analyses and evaluations.
+    research_managed_elsewhere:
       label: Research and analysis
       description: Research reports, surveys, analyses and evaluations.
     specialist_notice:
@@ -138,6 +162,9 @@ en:
       label: Statutory guidance
       description: Guidance which relevant users are legally obliged to follow.
     transparency:
+      label: Transparency (pre-release)
+      description: Information about how an organisation operates, for example departmental spending, salaries and staff survey results.
+    transparency_managed_elsewhere:
       label: Transparency
       description: Information about how an organisation operates, for example departmental spending, salaries and staff survey results.
     transparency_statistics_reports:

--- a/config/locales/en/document_type_selections.yml
+++ b/config/locales/en/document_type_selections.yml
@@ -80,15 +80,15 @@ en:
     notice:
       label: Notice
       description: Permit and licence applications published temporarily for public awareness.
-    official_statistics:
-      label: Official statistics
-      description: Statistics governed by the UK Statistics Authority and produced by members of the Government Statistical Service.
     national_statistics:
       label: National statistics
       description: Official Statistics that have been produced in accordance with the Code of Practice for Official Statistics, which is indicated using the National Statistics quality mark.
     non_statutory_guidance:
       label: Non-statutory guidance
       description: Publications like manuals, handbooks, and other documents that offer advice. Use for content produced as a standalone hard-copy publicaton. For web-original content use 'detailed guide'.
+    official_statistics:
+      label: Official statistics
+      description: Statistics governed by the UK Statistics Authority and produced by members of the Government Statistical Service.
     oral_statement:
       label: Oral statement to Parliament
       description: Oral statements made to Parliament by a minister, where there is significant public interest in the entire statement.

--- a/config/locales/en/document_types.yml
+++ b/config/locales/en/document_types.yml
@@ -24,6 +24,116 @@ en:
           label: World locations
           hint: Tag locations this content is about. If it only relates to the UK you don’t need to use this tag.
 
+    correspondence:
+      fields:
+        title:
+          guidance:
+            title: Creating a title
+            body_govspeak: This does not have to be the full publication title. The title must be unique and specific, and make clear what the content offers users in their words.
+        summary:
+          guidance:
+            title: Writing a summary
+            body_govspeak: The summary explains the main point of the content and it should end with a full stop. Keep it short, possibly under 160 characters, and avoid repeating the first line of the body.
+        body:
+          guidance:
+            title: Writing the details for correspondence
+            body_govspeak: |
+              Use short words, short sentences, and short paragraphs. Use subheadings in longer content.
+
+              [Guidance on correspondence](https://www.gov.uk/guidance/content-design/content-types#correspondence){:target="_blank"}
+
+              [Writing for GOV.UK](https://www.gov.uk/guidance/content-design/writing-for-gov-uk#writing-to-govuk-style){:target="_blank"}
+
+              [The style guide](https://www.gov.uk/guidance/style-guide){:target="_blank"}
+
+    corporate_report:
+      fields:
+        title:
+          guidance:
+            title: Creating a title
+            body_govspeak: This does not have to be the full publication title. The title must be unique and specific, and make clear what the content offers users in their words.
+        summary:
+          guidance:
+            title: Writing a summary
+            body_govspeak: The summary explains the main point of the content and it should end with a full stop. Keep it short, possibly under 160 characters, and avoid repeating the first line of the body.
+        body:
+          guidance:
+            title: Writing the details for a corporate report
+            body_govspeak: |
+              Use short words, short sentences, and short paragraphs. Use subheadings in longer content.
+
+              [Guidance on corporate reports](https://www.gov.uk/guidance/content-design/content-types#corporate-report){:target="_blank"}
+
+              [Writing for GOV.UK](https://www.gov.uk/guidance/content-design/writing-for-gov-uk#writing-to-govuk-style){:target="_blank"}
+
+              [The style guide](https://www.gov.uk/guidance/style-guide){:target="_blank"}
+
+    foi_release:
+      fields:
+        title:
+          guidance:
+            title: Creating a title
+            body_govspeak: This does not have to be the full publication title. The title must be unique and specific, and make clear what the content offers users in their words.
+        summary:
+          guidance:
+            title: Writing a summary
+            body_govspeak: The summary explains the main point of the content and it should end with a full stop. Keep it short, possibly under 160 characters, and avoid repeating the first line of the body.
+        body:
+          guidance:
+            title: Writing the details for an FOI release
+            body_govspeak: |
+              Use short words, short sentences, and short paragraphs. Use subheadings in longer content.
+
+              [Guidance on FOI releases](https://www.gov.uk/guidance/content-design/content-types#foi){:target="_blank"}
+
+              [Writing for GOV.UK](https://www.gov.uk/guidance/content-design/writing-for-gov-uk#writing-to-govuk-style){:target="_blank"}
+
+              [The style guide](https://www.gov.uk/guidance/style-guide){:target="_blank"}
+
+    impact_assessment:
+      fields:
+        title:
+          guidance:
+            title: Creating a title
+            body_govspeak: This does not have to be the full publication title. The title must be unique and specific, and make clear what the content offers users in their words.
+        summary:
+          guidance:
+            title: Writing a summary
+            body_govspeak: The summary explains the main point of the content and it should end with a full stop. Keep it short, possibly under 160 characters, and avoid repeating the first line of the body.
+        body:
+          guidance:
+            title: Writing the details for an impact assessment
+            body_govspeak: |
+              Use short words, short sentences, and short paragraphs. Use subheadings in longer content.
+
+              [Guidance on impact assessment publications](https://www.gov.uk/guidance/content-design/content-types#impact-assessment){:target="_blank"}
+
+              [Writing for GOV.UK](https://www.gov.uk/guidance/content-design/writing-for-gov-uk#writing-to-govuk-style){:target="_blank"}
+
+              [The style guide](https://www.gov.uk/guidance/style-guide){:target="_blank"}
+
+    independent_report:
+      fields:
+        title:
+          guidance:
+            title: Creating a title
+            body_govspeak: This does not have to be the full publication title. The title must be unique and specific, and make clear what the content offers users in their words.
+        summary:
+          guidance:
+            title: Writing a summary
+            body_govspeak: The summary explains the main point of the content and it should end with a full stop. Keep it short, possibly under 160 characters, and avoid repeating the first line of the body.
+        body:
+          guidance:
+            title: Writing the details for an independent report
+            body_govspeak: |
+              Use short words, short sentences, and short paragraphs. Use subheadings in longer content.
+
+              [Guidance on independent reports](https://www.gov.uk/guidance/content-design/content-types#independent-report){:target="_blank"}
+
+              [Writing for GOV.UK](https://www.gov.uk/guidance/content-design/writing-for-gov-uk#writing-to-govuk-style){:target="_blank"}
+
+              [The style guide](https://www.gov.uk/guidance/style-guide){:target="_blank"}
+
     news_story:
       fields:
         title:
@@ -46,6 +156,28 @@ en:
 
               [The style guide](https://www.gov.uk/guidance/style-guide){:target="_blank"}
 
+    policy_paper:
+      fields:
+        title:
+          guidance:
+            title: Creating a title
+            body_govspeak: This does not have to be the full publication title. The title must be unique and specific, and make clear what the content offers users in their words.
+        summary:
+          guidance:
+            title: Writing a summary
+            body_govspeak: The summary explains the main point of the content and it should end with a full stop. Keep it short, possibly under 160 characters, and avoid repeating the first line of the body.
+        body:
+          guidance:
+            title: Writing the details for a policy paper
+            body_govspeak: |
+              Use short words, short sentences, and short paragraphs. Use subheadings in longer content.
+
+              [Guidance on policy papers](https://www.gov.uk/guidance/content-design/content-types#policy-paper){:target="_blank"}
+
+              [Writing for GOV.UK](https://www.gov.uk/guidance/content-design/writing-for-gov-uk#writing-to-govuk-style){:target="_blank"}
+
+              [The style guide](https://www.gov.uk/guidance/style-guide){:target="_blank"}
+
     press_release:
       fields:
         title:
@@ -63,6 +195,72 @@ en:
               Use short words, short sentences, and short paragraphs. Use subheadings in longer content. Avoid 'notes to editors'.
 
               [Guidance on press releases](https://www.gov.uk/guidance/content-design/content-types#press-release){:target="_blank"}
+
+              [Writing for GOV.UK](https://www.gov.uk/guidance/content-design/writing-for-gov-uk#writing-to-govuk-style){:target="_blank"}
+
+              [The style guide](https://www.gov.uk/guidance/style-guide){:target="_blank"}
+
+    promotional:
+      fields:
+        title:
+          guidance:
+            title: Creating a title
+            body_govspeak: This does not have to be the full publication title. The title must be unique and specific, and make clear what the content offers users in their words.
+        summary:
+          guidance:
+            title: Writing a summary
+            body_govspeak: The summary explains the main point of the content and it should end with a full stop. Keep it short, possibly under 160 characters, and avoid repeating the first line of the body.
+        body:
+          guidance:
+            title: Writing the details for promotional material
+            body_govspeak: |
+              Use short words, short sentences, and short paragraphs. Use subheadings in longer content.
+
+              [Guidance on promotional material](https://www.gov.uk/guidance/content-design/content-types#promotional-material){:target="_blank"}
+
+              [Writing for GOV.UK](https://www.gov.uk/guidance/content-design/writing-for-gov-uk#writing-to-govuk-style){:target="_blank"}
+
+              [The style guide](https://www.gov.uk/guidance/style-guide){:target="_blank"}
+
+    research:
+      fields:
+        title:
+          guidance:
+            title: Creating a title
+            body_govspeak: This does not have to be the full publication title. The title must be unique and specific, and make clear what the content offers users in their words.
+        summary:
+          guidance:
+            title: Writing a summary
+            body_govspeak: The summary explains the main point of the content and it should end with a full stop. Keep it short, possibly under 160 characters, and avoid repeating the first line of the body.
+        body:
+          guidance:
+            title: Writing the details for research and analysis
+            body_govspeak: |
+              Use short words, short sentences, and short paragraphs. Use subheadings in longer content.
+
+              [Guidance on research and analysis](https://www.gov.uk/guidance/content-design/content-types#research-analysis){:target="_blank"}
+
+              [Writing for GOV.UK](https://www.gov.uk/guidance/content-design/writing-for-gov-uk#writing-to-govuk-style){:target="_blank"}
+
+              [The style guide](https://www.gov.uk/guidance/style-guide){:target="_blank"}
+
+    transparency:
+      fields:
+        title:
+          guidance:
+            title: Creating a title
+            body_govspeak: This does not have to be the full publication title. The title must be unique and specific, and make clear what the content offers users in their words.
+        summary:
+          guidance:
+            title: Writing a summary
+            body_govspeak: The summary explains the main point of the content and it should end with a full stop. Keep it short, possibly under 160 characters, and avoid repeating the first line of the body.
+        body:
+          guidance:
+            title: Writing the details for transparency data
+            body_govspeak: |
+              Use short words, short sentences, and short paragraphs. Use subheadings in longer content.
+
+              [Guidance on transparency data](https://www.gov.uk/guidance/content-design/content-types#transparency-data){:target="_blank"}
 
               [Writing for GOV.UK](https://www.gov.uk/guidance/content-design/writing-for-gov-uk#writing-to-govuk-style){:target="_blank"}
 

--- a/spec/features/formats/publication_spec.rb
+++ b/spec/features/formats/publication_spec.rb
@@ -1,0 +1,29 @@
+RSpec.describe "Publication format" do
+  scenario do
+    when_i_choose_this_document_type
+    and_i_fill_in_the_form_fields
+    then_the_document_should_be_previewable
+  end
+
+  def when_i_choose_this_document_type
+    visit root_path
+    click_on "Create new document"
+    choose I18n.t!("document_type_selections.policy.label")
+    click_on "Continue"
+    choose I18n.t!("document_type_selections.policy_paper.label")
+    click_on "Continue"
+  end
+
+  def and_i_fill_in_the_form_fields
+    base_path = Edition.last.document_type.path_prefix + "/a-great-title"
+    stub_publishing_api_has_lookups(base_path => Document.last.content_id)
+    fill_in "title", with: "A great title"
+    click_on "Save"
+  end
+
+  def then_the_document_should_be_previewable
+    expect(a_request(:put, /content/).with { |req|
+             expect(req.body).to be_valid_against_publisher_schema("publication")
+           }).to have_been_requested
+  end
+end

--- a/spec/models/document_type_selection/option_spec.rb
+++ b/spec/models/document_type_selection/option_spec.rb
@@ -56,4 +56,29 @@ RSpec.describe DocumentTypeSelection::Option do
       expect(described_class.new(option).document_type?).to be true
     end
   end
+
+  describe "#pre_release?" do
+    it "returns true when the option is an existing document type and a pre-release feature" do
+      pre_release_document_type = build(:document_type, pre_release: true)
+
+      allow(DocumentType)
+        .to receive(:all)
+        .and_return([pre_release_document_type])
+
+      option = {
+        "id" => pre_release_document_type.id,
+        "type" => "document_type",
+      }
+
+      expect(described_class.new(option).pre_release?).to be true
+    end
+
+    it "returns false when the option is not a document type" do
+      option = {
+        "id" => "foo",
+      }
+
+      expect(described_class.new(option).pre_release?).to be false
+    end
+  end
 end

--- a/spec/models/document_type_spec.rb
+++ b/spec/models/document_type_spec.rb
@@ -1,7 +1,7 @@
 require "json"
 
 RSpec.describe DocumentType do
-  let(:document_types) { YAML.load_file(Rails.root.join("config/document_types.yml")) }
+  let(:document_types) { YAML.load_file(Rails.root.join("config/document_types.yml"))["document_types"] }
 
   describe "all configured document types are valid" do
     it "conforms to the document type schema" do

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -61,7 +61,7 @@ RSpec.configure do |config|
     populate_default_government_bulk_data
   end
 
-  config.after :each, type: ->(spec) { spec.in?(%i[feature request]) } do
+  config.after :each, type: ->(spec) { spec.in?(%i[feature request view]) } do
     reset_authentication
   end
 

--- a/spec/support/schemas/document_type.json
+++ b/spec/support/schemas/document_type.json
@@ -33,10 +33,7 @@
       "additionalProperties": false,
       "properties": {
         "schema_name": {
-          "type": "string",
-          "enum": [
-            "news_article"
-          ]
+          "type": "string"
         },
         "rendering_app": {
           "type": "string"
@@ -61,21 +58,7 @@
   "definitions": {
     "id": {
       "type": "string",
-      "enum": [
-        "news_story",
-        "press_release",
-        "fatality_notice",
-        "speech",
-        "world_news_story",
-        "detailed_guide",
-        "any-whitehall-publication",
-        "manual",
-        "any-mainstream-publication",
-        "travel_advice",
-        "statistical-data-set",
-        "case_study",
-        "consultation"
-      ]
+      "pattern": "^[a-z_]+$"
     },
     "label": {
       "type": "string"

--- a/spec/support/schemas/document_type.json
+++ b/spec/support/schemas/document_type.json
@@ -53,6 +53,9 @@
       "items": {
         "$ref": "#/definitions/tag_field"
       }
+    },
+    "pre_release": {
+      "type": "boolean"
     }
   },
   "definitions": {

--- a/spec/support/schemas/document_type_locale.json
+++ b/spec/support/schemas/document_type_locale.json
@@ -1,9 +1,6 @@
 {
   "$schema": "http://json-schema.org/draft-04/schema#",
   "type": "object",
-  "required": [
-    "fields"
-  ],
   "properties": {
     "fields": {
       "type": "object",

--- a/spec/support/schemas/document_type_selection.json
+++ b/spec/support/schemas/document_type_selection.json
@@ -48,9 +48,6 @@
           "enum": [
             "document_type"
           ]
-        },
-        "pre_release": {
-          "type": "boolean"
         }
       }
     },

--- a/spec/support/schemas/document_type_selection.json
+++ b/spec/support/schemas/document_type_selection.json
@@ -48,6 +48,9 @@
           "enum": [
             "document_type"
           ]
+        },
+        "pre_release": {
+          "type": "boolean"
         }
       }
     },

--- a/spec/views/documents/index/_filters.html.erb_spec.rb
+++ b/spec/views/documents/index/_filters.html.erb_spec.rb
@@ -23,4 +23,30 @@ RSpec.describe "documents/index/_filters.html.erb" do
       end
     end
   end
+
+  describe "Document type select" do
+    let(:pre_release_document_type) { build(:document_type, pre_release: true) }
+
+    before do
+      stub_publishing_api_has_linkables([], document_type: "organisation")
+
+      allow(DocumentType)
+        .to receive(:all)
+        .and_return([pre_release_document_type])
+    end
+
+    it "includes pre-release document types when the user has pre_release_features permissions" do
+      render partial: "documents/index/filters"
+
+      expect(rendered).to include(pre_release_document_type.label)
+    end
+
+    it "excludes pre-release document types when the user does not have pre_release_features permissions" do
+      user = build(:user, permissions: %w(signin))
+      login_as(user)
+
+      render partial: "documents/index/filters"
+      expect(rendered).not_to include(pre_release_document_type.label)
+    end
+  end
 end

--- a/spec/views/new_document/show.html.erb_spec.rb
+++ b/spec/views/new_document/show.html.erb_spec.rb
@@ -1,0 +1,36 @@
+RSpec.describe "new_document/show.html.erb" do
+  let(:pre_release_option) do
+    DocumentTypeSelection::Option.new(
+      id: "news",
+      type: "document_type",
+      pre_release: true,
+    )
+  end
+
+  let(:document_type_selection) do
+    DocumentTypeSelection.new(
+      id: "root",
+      options: [
+        pre_release_option,
+      ],
+    )
+  end
+
+  it "shows pre_release options when the user has pre_release_features permissions" do
+    assign(:document_type_selection, document_type_selection)
+    render
+
+    title = I18n.t!("document_type_selections.#{pre_release_option.id}.label")
+    expect(rendered).to include(title)
+  end
+
+  it "excludes pre_release options when the user does not have pre_release_features permissions" do
+    user = build(:user, permissions: %w(signin))
+    login_as(user)
+    assign(:document_type_selection, document_type_selection)
+    render
+
+    title = I18n.t!("document_type_selections.#{pre_release_option.id}.label")
+    expect(rendered).not_to include(title)
+  end
+end

--- a/spec/views/new_document/show.html.erb_spec.rb
+++ b/spec/views/new_document/show.html.erb_spec.rb
@@ -1,9 +1,10 @@
 RSpec.describe "new_document/show.html.erb" do
+  let(:pre_release_document_type) { build(:document_type, id: "news", pre_release: true) }
+
   let(:pre_release_option) do
     DocumentTypeSelection::Option.new(
-      id: "news",
+      id: pre_release_document_type.id,
       type: "document_type",
-      pre_release: true,
     )
   end
 
@@ -14,6 +15,12 @@ RSpec.describe "new_document/show.html.erb" do
         pre_release_option,
       ],
     )
+  end
+
+  before do
+    allow(DocumentType)
+      .to receive(:all)
+      .and_return([pre_release_document_type])
   end
 
   it "shows pre_release options when the user has pre_release_features permissions" do


### PR DESCRIPTION
Trello: https://trello.com/c/KI9c4Uue

## What's changed?
Allows users with `pre_release_features` to select and create documents in group 1 publications:

- correspondence
- independent report
- foi release
- corporate report
- transparency
- research and analysis
- promotional material
- impact assessment
- policy paper

## Expected changes
### User with "pre_release_features"
![Screenshot 2020-02-24 at 14 52 39](https://user-images.githubusercontent.com/5793815/75162362-59c16e00-5715-11ea-98f8-546a0943320e.png)

![Screenshot 2020-02-24 at 14 53 19](https://user-images.githubusercontent.com/5793815/75162402-6b0a7a80-5715-11ea-8bb7-da880cb9598a.png)

![Screenshot 2020-02-24 at 14 53 51](https://user-images.githubusercontent.com/5793815/75162499-8f665700-5715-11ea-8d0b-d316de5741f0.png)



### Everyone else
![Screenshot 2020-02-24 at 14 49 53](https://user-images.githubusercontent.com/5793815/75162135-f2a3b980-5714-11ea-9bbf-9c5813b50670.png)

![Screenshot 2020-02-24 at 14 50 33](https://user-images.githubusercontent.com/5793815/75162193-09e2a700-5715-11ea-87a6-d9406c02f7be.png)
