### PR TITLE
Store the cumulative change history of all document editions as each new edition is created 

### DIFF
--- a/app/models/edition.rb
+++ b/app/models/edition.rb
@@ -64,6 +64,7 @@ class Edition < ApplicationRecord
            :contents,
            :update_type,
            :change_note,
+           :change_history,
            :major?,
            :minor?,
            :tags,

--- a/app/models/revision.rb
+++ b/app/models/revision.rb
@@ -49,6 +49,7 @@ class Revision < ApplicationRecord
 
   delegate :update_type,
            :change_note,
+           :change_history,
            :major?,
            :minor?,
            :proposed_publish_time,

--- a/app/services/create_next_edition_service.rb
+++ b/app/services/create_next_edition_service.rb
@@ -1,0 +1,51 @@
+class CreateNextEditionService < ApplicationService
+  def initialize(current_edition:, user:, discarded_edition: nil)
+    @current_edition = current_edition
+    @user = user
+    @discarded_edition = discarded_edition
+  end
+
+  def call
+    raise "Can only create a next edition from a live edition" unless current_edition.live
+
+    current_edition.update!(current: false)
+    EditDraftEditionService.call(next_edition, user, current: true, revision: next_revision)
+    AssignEditionStatusService.call(next_edition, user: user, state: :draft)
+    next_edition.save!
+    next_edition
+  end
+
+private
+
+  attr_reader :current_edition, :user, :discarded_edition
+
+  def next_edition
+    @next_edition ||= begin
+      document = current_edition.document
+      discarded_edition || Edition.new(document: document,
+                                       number: document.next_edition_number,
+                                       created_by: user)
+    end
+  end
+
+  def next_revision
+    updater = Versioning::RevisionUpdater.new(current_edition.revision, user)
+    updater.assign(change_note: "",
+                   update_type: "major",
+                   proposed_publish_time: nil,
+                   change_history: change_history)
+    updater.next_revision
+  end
+
+  def change_history
+    if !current_edition.major? || current_edition.change_note.empty? || current_edition.first?
+      return current_edition.change_history
+    end
+
+    current_edition.change_history.prepend(
+      "id" => SecureRandom.uuid,
+      "note" => current_edition.change_note,
+      "public_timestamp" => current_edition.published_at.rfc3339,
+    )
+  end
+end

--- a/spec/factories/edition_factory.rb
+++ b/spec/factories/edition_factory.rb
@@ -86,10 +86,10 @@ FactoryBot.define do
       summary { SecureRandom.alphanumeric(10) }
       live { true }
       first_published_at { Time.zone.now }
+      published_at { Time.zone.now }
 
       transient do
         state { "published" }
-        published_at { Time.zone.now }
       end
 
       after(:build) do |edition, evaluator|

--- a/spec/services/create_next_edition_service_spec.rb
+++ b/spec/services/create_next_edition_service_spec.rb
@@ -1,0 +1,145 @@
+RSpec.describe CreateNextEditionService do
+  describe ".call" do
+    let(:user) { create :user }
+
+    before do
+      populate_default_government_bulk_data
+    end
+
+    it "aborts if the current edition isn't live" do
+      current_edition = create(:edition, live: false)
+
+      expect { described_class.call(current_edition: current_edition, user: user) }
+        .to raise_error("Can only create a next edition from a live edition")
+    end
+
+    it "returns a new current edition" do
+      current_edition = create(:edition, :published, number: 2)
+
+      next_edition = described_class.call(current_edition: current_edition,
+                                          user: user)
+
+      expect(current_edition).not_to be_current
+      expect(next_edition).to be_current
+    end
+
+    it "updates the edition number of the new current edition" do
+      current_edition = create(:edition, :published, number: 2)
+
+      next_edition = described_class.call(current_edition: current_edition,
+                                          user: user)
+
+      expect(next_edition.number).to eq 3
+      expect(next_edition.created_by).to eq user
+    end
+
+    it "returns a draft edition" do
+      current_edition = create(:edition, :published)
+
+      next_edition = described_class.call(current_edition: current_edition,
+                                          user: user)
+
+      expect(next_edition).to be_draft
+    end
+
+    it "resets change_note, update_type and propoposed_publish_time values" do
+      current_edition = create(:edition,
+                               :published,
+                               change_note: "note",
+                               update_type: "minor",
+                               proposed_publish_time: Time.zone.now)
+
+      next_edition = described_class.call(current_edition: current_edition,
+                                          user: user)
+
+      expect(next_edition.change_note).to be_empty
+      expect(next_edition.update_type).to eq("major")
+      expect(next_edition.proposed_publish_time).to be_nil
+    end
+
+    it "appends the change note details when there is a change note and a major change" do
+      current_edition = create(:edition,
+                               :published,
+                               number: 2,
+                               published_at: Date.yesterday.noon,
+                               change_note: "note",
+                               update_type: "major")
+
+      next_edition = described_class.call(current_edition: current_edition,
+                                          user: user)
+
+      expect(next_edition.change_history.first).to match a_hash_including(
+        "note" => "note",
+        "public_timestamp" => Date.yesterday.noon.rfc3339,
+      )
+    end
+
+    it "does not update the change history when the current edition is not a major change" do
+      current_edition = create(:edition,
+                               :published,
+                               number: 2,
+                               published_at: Date.yesterday.noon,
+                               change_note: "note",
+                               update_type: "minor")
+
+      next_edition = described_class.call(current_edition: current_edition,
+                                          user: user)
+
+      expect(next_edition.change_history).to eq(current_edition.change_history)
+    end
+
+    it "does not update the change history when the current edition lacks a change note" do
+      current_edition = create(:edition,
+                               :published,
+                               number: 2,
+                               change_note: "")
+
+      next_edition = described_class.call(current_edition: current_edition,
+                                          user: user)
+
+      expect(next_edition.change_history).to be_empty
+    end
+
+    context "when the current edition is the first edition" do
+      it "doesn't append the change note details" do
+        current_edition = create(:edition,
+                                 :published,
+                                 change_note: "note")
+
+        next_edition = described_class.call(current_edition: current_edition,
+                                            user: user)
+
+        expect(next_edition.change_history).to eq(current_edition.change_history)
+      end
+    end
+
+    context "when given a discarded edition" do
+      let(:live_edition) { create(:edition, :published) }
+      let(:params) { { document: live_edition.document.to_param } }
+
+      let!(:discarded_edition) do
+        create(:edition,
+               state: "discarded",
+               current: false,
+               document: live_edition.document)
+      end
+
+      it "resumes the edition" do
+        next_edition = described_class.call(current_edition: live_edition,
+                                            user: user,
+                                            discarded_edition: discarded_edition)
+
+        expect(next_edition.number).to eq discarded_edition.number
+        expect(next_edition).to eq discarded_edition.reload
+      end
+
+      it "updates the state of the discarded edition" do
+        described_class.call(current_edition: live_edition,
+                             user: user,
+                             discarded_edition: discarded_edition)
+
+        expect(discarded_edition).to be_draft
+      end
+    end
+  end
+end


### PR DESCRIPTION
We have previously created a JSON column in which to store the change history of all editions of a document.  We have also added validation of the fields and structure of the JSON data to be stored.  

We now need to ensure that as each new edition is created - the change history is updated with the superseded edition's change note(s) - if appropriate - and store them with the newly created edition.

This change adds that functionality by introducing a service object (`CreateNextEditionService`) and updating the existing code where required.

Trello: https://trello.com/c/xMRotBoK/1460-create-a-changehistory-json-column-on-metadatarevisions-and-populate-it-when-new-editions-are-added