### PR TITLE
Introduce cop for TimeZone

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -36,6 +36,10 @@ Rails/DynamicFindBy:
 Rails/SaveBang:
   Enabled: true
 
+Rails/TimeZone:
+  Enabled: true
+  EnforcedStyle: "strict"
+
 Style/DateTime:
   Enabled: true
 

--- a/app/jobs/scheduled_publishing_job.rb
+++ b/app/jobs/scheduled_publishing_job.rb
@@ -43,7 +43,7 @@ private
 
     scheduling = edition.status.details
 
-    if scheduling.publish_time > Time.current
+    if scheduling.publish_time > Time.zone.now
       Rails.logger.warn("Cannot publish an edition (\##{edition.id}) scheduled in the future")
       return false
     end

--- a/app/models/edition.rb
+++ b/app/models/edition.rb
@@ -6,7 +6,7 @@
 class Edition < ApplicationRecord
   before_create do
     # set a default value for last_edited_at works better than using DB default
-    self.last_edited_at = Time.current unless last_edited_at
+    self.last_edited_at = Time.zone.now unless last_edited_at
   end
 
   after_save do

--- a/app/models/whitehall_migration.rb
+++ b/app/models/whitehall_migration.rb
@@ -2,6 +2,6 @@ class WhitehallMigration < ApplicationRecord
   has_many :document_imports
 
   def check_migration_finished
-    update!(finished_at: Time.current) if document_imports.in_progress.empty?
+    update!(finished_at: Time.zone.now) if document_imports.in_progress.empty?
   end
 end

--- a/app/services/assign_edition_status_service.rb
+++ b/app/services/assign_edition_status_service.rb
@@ -19,7 +19,7 @@ class AssignEditionStatusService < ApplicationService
 
     if record_edit
       edition.last_edited_by = user
-      edition.last_edited_at = Time.current
+      edition.last_edited_at = Time.zone.now
       edition.add_edition_editor(user)
     end
   end

--- a/app/services/edit_draft_edition_service.rb
+++ b/app/services/edit_draft_edition_service.rb
@@ -9,7 +9,7 @@ class EditDraftEditionService < ApplicationService
     raise "cannot edit a live edition" if edition.live?
 
     edition.assign_attributes(
-      attributes.merge(last_edited_by: user, last_edited_at: Time.current),
+      attributes.merge(last_edited_by: user, last_edited_at: Time.zone.now),
     )
 
     determine_political

--- a/app/services/publish_draft_edition_service.rb
+++ b/app/services/publish_draft_edition_service.rb
@@ -74,7 +74,7 @@ private
   end
 
   def set_published_at
-    current_time = Time.current
+    current_time = Time.zone.now
     edition.published_at = current_time
 
     return if document.first_published_at

--- a/app/services/withdraw_document_service.rb
+++ b/app/services/withdraw_document_service.rb
@@ -55,7 +55,7 @@ private
     else
       Withdrawal.new(public_explanation: public_explanation,
                      published_status: edition.status,
-                     withdrawn_at: Time.current)
+                     withdrawn_at: Time.zone.now)
     end
   end
 

--- a/app/views/schedule/_datetime.html.erb
+++ b/app/views/schedule/_datetime.html.erb
@@ -1,5 +1,5 @@
 <%
-  publish_time ||= Time.current.tomorrow.change(hour: 9)
+  publish_time ||= Time.zone.now.tomorrow.change(hour: 9)
 %>
 
 <% legend = capture do %>

--- a/lib/bulk_data/cache.rb
+++ b/lib/bulk_data/cache.rb
@@ -13,7 +13,7 @@ module BulkData
 
     def self.write(key, value)
       cache.write(key, value, expires_in: 24.hours)
-      cache.write("#{key}:created", Time.current, expires_in: 24.hours)
+      cache.write("#{key}:created", Time.zone.now, expires_in: 24.hours)
     end
 
     def self.read(key)

--- a/lib/datetime_parser.rb
+++ b/lib/datetime_parser.rb
@@ -15,7 +15,7 @@ class DatetimeParser
     check_time_is_valid
     return if issues.any?
 
-    Time.current.change(
+    Time.zone.now.change(
       day: raw_date[:day].to_i,
       month: raw_date[:month].to_i,
       year: raw_date[:year].to_i,

--- a/lib/requirements/publish_time_checker.rb
+++ b/lib/requirements/publish_time_checker.rb
@@ -14,13 +14,13 @@ module Requirements
                       time_period: MAX_PUBLISH_DELAY.inspect)
       end
 
-      if publish_time > Time.current && publish_time < MIN_PUBLISH_DELAY.from_now
+      if publish_time > Time.zone.now && publish_time < MIN_PUBLISH_DELAY.from_now
         issues.create(:schedule_time,
                       :too_close_to_now,
                       time_period: MIN_PUBLISH_DELAY.inspect)
       end
 
-      if publish_time < Time.current
+      if publish_time < Time.zone.now
         field = publish_time.today? ? :schedule_time : :schedule_date
         issues.create(field, :in_the_past)
       end

--- a/lib/topic_index.rb
+++ b/lib/topic_index.rb
@@ -30,13 +30,13 @@ private
 
   def raw_level_one_topics
     @raw_level_one_topics ||= begin
-      start_time = Time.current
+      start_time = Time.zone.now
 
       topics = publishing_api.get_expanded_links(GOVUK_HOMEPAGE_CONTENT_ID)
         .dig("expanded_links", "level_one_taxons")
 
       topics.each do |raw_topic|
-        raise GdsApi::TimedOutException.new if Time.current - start_time > TOPIC_INDEX_TIMEOUT
+        raise GdsApi::TimedOutException.new if Time.zone.now - start_time > TOPIC_INDEX_TIMEOUT
 
         topic_content_id = raw_topic["content_id"]
         raw_topic["links"] = publishing_api.get_expanded_links(topic_content_id)["expanded_links"]

--- a/spec/factories/document_factory.rb
+++ b/spec/factories/document_factory.rb
@@ -5,7 +5,7 @@ FactoryBot.define do
     association :created_by, factory: :user
 
     trait :live do
-      first_published_at { Time.current }
+      first_published_at { Time.zone.now }
     end
 
     trait :with_live_edition do

--- a/spec/factories/edition_factory.rb
+++ b/spec/factories/edition_factory.rb
@@ -1,6 +1,6 @@
 FactoryBot.define do
   factory :edition do
-    last_edited_at { Time.current }
+    last_edited_at { Time.zone.now }
     current { true }
     live { false }
     government_id { government&.content_id }
@@ -85,11 +85,11 @@ FactoryBot.define do
     trait :published do
       summary { SecureRandom.alphanumeric(10) }
       live { true }
-      first_published_at { Time.current }
+      first_published_at { Time.zone.now }
 
       transient do
         state { "published" }
-        published_at { Time.current }
+        published_at { Time.zone.now }
       end
 
       after(:build) do |edition, evaluator|
@@ -106,7 +106,7 @@ FactoryBot.define do
     trait :withdrawn do
       summary { SecureRandom.alphanumeric(10) }
       live { true }
-      first_published_at { Time.current }
+      first_published_at { Time.zone.now }
 
       transient do
         withdrawal { nil }

--- a/spec/factories/whitehall_export/document_factory.rb
+++ b/spec/factories/whitehall_export/document_factory.rb
@@ -3,8 +3,8 @@ FactoryBot.define do
     skip_create
 
     sequence(:id)
-    created_at { Time.current.rfc3339 }
-    updated_at { Time.current.rfc3339 }
+    created_at { Time.zone.now.rfc3339 }
+    updated_at { Time.zone.now.rfc3339 }
     slug { SecureRandom.alphanumeric(10).parameterize }
     content_id { SecureRandom.uuid }
     editions { [build(:whitehall_export_edition)] }

--- a/spec/factories/whitehall_export/edition_factory.rb
+++ b/spec/factories/whitehall_export/edition_factory.rb
@@ -3,8 +3,8 @@ FactoryBot.define do
     skip_create
 
     sequence(:id)
-    created_at { Time.current.rfc3339 }
-    updated_at { Time.current.rfc3339 }
+    created_at { Time.zone.now.rfc3339 }
+    updated_at { Time.zone.now.rfc3339 }
     access_limited { false }
     change_note { "First published" }
     state { "draft" }
@@ -37,7 +37,7 @@ FactoryBot.define do
       end
 
       created_at { 3.days.ago.rfc3339 }
-      scheduled_publication { Time.current.tomorrow.rfc3339 }
+      scheduled_publication { Time.zone.now.tomorrow.rfc3339 }
       state { "scheduled" }
       editorial_remarks { [] }
       fact_check_requests { [] }
@@ -52,7 +52,7 @@ FactoryBot.define do
           build(:whitehall_export_revision_history_event,
                 event: "update",
                 state: "scheduled",
-                created_at: Time.current.tomorrow.rfc3339),
+                created_at: Time.zone.now.tomorrow.rfc3339),
         ]
       end
     end

--- a/spec/factories/whitehall_export/editorial_remark_event.rb
+++ b/spec/factories/whitehall_export/editorial_remark_event.rb
@@ -5,7 +5,7 @@ FactoryBot.define do
     sequence(:id)
     body { "Note about the revision" }
     sequence(:author_id)
-    created_at { Time.current.rfc3339 }
+    created_at { Time.zone.now.rfc3339 }
 
     initialize_with { attributes.stringify_keys }
   end

--- a/spec/factories/whitehall_export/fact_check_event_factory.rb
+++ b/spec/factories/whitehall_export/fact_check_event_factory.rb
@@ -9,8 +9,8 @@ FactoryBot.define do
     instructions { "Do something" }
     comments { "hello" }
     sequence(:requestor_id)
-    created_at { Time.current.rfc3339 }
-    updated_at { Time.current.rfc3339 }
+    created_at { Time.zone.now.rfc3339 }
+    updated_at { Time.zone.now.rfc3339 }
 
     initialize_with { attributes.stringify_keys }
   end

--- a/spec/factories/whitehall_export/file_attachment_factory.rb
+++ b/spec/factories/whitehall_export/file_attachment_factory.rb
@@ -3,8 +3,8 @@ FactoryBot.define do
     skip_create
 
     sequence(:id)
-    created_at { Time.current.rfc3339 }
-    updated_at { Time.current.rfc3339 }
+    created_at { Time.zone.now.rfc3339 }
+    updated_at { Time.zone.now.rfc3339 }
     title { "Some random text file" }
     accessible { false }
     isbn { "" }

--- a/spec/factories/whitehall_export/image_factory.rb
+++ b/spec/factories/whitehall_export/image_factory.rb
@@ -5,8 +5,8 @@ FactoryBot.define do
     sequence(:id)
     alt_text { "Alt text for image" }
     caption { "This is a caption" }
-    created_at { Time.current.rfc3339 }
-    updated_at { Time.current.rfc3339 }
+    created_at { Time.zone.now.rfc3339 }
+    updated_at { Time.zone.now.rfc3339 }
     variants do
       {
         "s960" => "https://assets.publishing.service.gov.uk/government/uploads/s960_#{filename}",

--- a/spec/factories/whitehall_export/revision_history_event.rb
+++ b/spec/factories/whitehall_export/revision_history_event.rb
@@ -6,7 +6,7 @@ FactoryBot.define do
     event { "create" }
     state { "draft" }
     sequence(:whodunnit)
-    created_at { Time.current.rfc3339 }
+    created_at { Time.zone.now.rfc3339 }
 
     initialize_with { attributes.stringify_keys }
   end

--- a/spec/factories/whitehall_export/unpublishing_factory.rb
+++ b/spec/factories/whitehall_export/unpublishing_factory.rb
@@ -3,8 +3,8 @@ FactoryBot.define do
     skip_create
 
     sequence(:id)
-    created_at { Time.current.rfc3339 }
-    updated_at { Time.current.rfc3339 }
+    created_at { Time.zone.now.rfc3339 }
+    updated_at { Time.zone.now.rfc3339 }
     explanation { "User facing explanation" }
     alternative_url { "" }
     redirect { false }

--- a/spec/factories/whitehall_migration_factory.rb
+++ b/spec/factories/whitehall_migration_factory.rb
@@ -2,7 +2,7 @@ FactoryBot.define do
   factory :whitehall_migration do
     organisation_content_id { SecureRandom.uuid }
     document_type { "NewsArticle" }
-    created_at { Time.current.rfc3339 }
-    updated_at { Time.current.rfc3339 }
+    created_at { Time.zone.now.rfc3339 }
+    updated_at { Time.zone.now.rfc3339 }
   end
 end

--- a/spec/features/workflow/publish_spec.rb
+++ b/spec/features/workflow/publish_spec.rb
@@ -38,7 +38,7 @@ RSpec.feature "Publishing an edition" do
   end
 
   def and_i_publish_the_edition
-    travel_to(@publish_date = Time.current) do
+    travel_to(@publish_date = Time.zone.now) do
       click_on "Publish"
       choose I18n.t!("publish.confirmation.has_been_reviewed")
       stub_any_publishing_api_put_content

--- a/spec/features/workflow/publish_without_review_spec.rb
+++ b/spec/features/workflow/publish_without_review_spec.rb
@@ -36,7 +36,7 @@ RSpec.feature "Publish without review" do
   end
 
   def and_i_publish_without_review
-    travel_to(@publish_date = Time.current) do
+    travel_to(@publish_date = Time.zone.now) do
       click_on "Publish"
       choose I18n.t!("publish.confirmation.should_be_reviewed")
       stub_any_publishing_api_put_content

--- a/spec/interactors/editions/create_interactor_spec.rb
+++ b/spec/interactors/editions/create_interactor_spec.rb
@@ -11,7 +11,7 @@ RSpec.describe Editions::CreateInteractor do
       edition = create(:edition,
                        live: true,
                        change_note: "note",
-                       proposed_publish_time: Time.current,
+                       proposed_publish_time: Time.zone.now,
                        update_type: :minor)
 
       params = { document: edition.document.to_param }

--- a/spec/jobs/scheduled_publishing_job_spec.rb
+++ b/spec/jobs/scheduled_publishing_job_spec.rb
@@ -7,7 +7,7 @@ RSpec.describe ScheduledPublishingJob do
   end
 
   let(:scheduled_edition) do
-    scheduling = create(:scheduling, reviewed: true, publish_time: Time.current.yesterday)
+    scheduling = create(:scheduling, reviewed: true, publish_time: Time.zone.now.yesterday)
     create(:edition, :scheduled, scheduling: scheduling)
   end
 
@@ -44,7 +44,7 @@ RSpec.describe ScheduledPublishingJob do
 
   context "when the publish time is in the future" do
     it "doesn't publish the edition" do
-      scheduling = create(:scheduling, reviewed: true, publish_time: Time.current.tomorrow)
+      scheduling = create(:scheduling, reviewed: true, publish_time: Time.zone.now.tomorrow)
       edition = create(:edition, :scheduled, scheduling: scheduling)
 
       expect { described_class.perform_now(edition.id) }

--- a/spec/lib/bulk_data/cache_spec.rb
+++ b/spec/lib/bulk_data/cache_spec.rb
@@ -12,7 +12,7 @@ RSpec.describe BulkData::Cache do
     it "sets the current time as the age, which also expires" do
       freeze_time do
         described_class.write("key", "value")
-        expect(described_class.cache.read("key:created")).to eq(Time.current)
+        expect(described_class.cache.read("key:created")).to eq(Time.zone.now)
       end
 
       travel_to(25.hours.from_now) do
@@ -45,7 +45,7 @@ RSpec.describe BulkData::Cache do
     end
 
     it "returns nil when only the created value exists but not the actual entry" do
-      described_class.cache.write("key:created", Time.current)
+      described_class.cache.write("key:created", Time.zone.now)
 
       expect(described_class.written_at("key")).to be_nil
     end

--- a/spec/lib/requirements/backdate_checker_spec.rb
+++ b/spec/lib/requirements/backdate_checker_spec.rb
@@ -3,7 +3,7 @@ RSpec.describe Requirements::BackdateChecker do
     let(:checker) { described_class.new }
 
     it "returns no issues if there are none" do
-      date = Time.current.change(day: 1, month: 1, year: 2019)
+      date = Time.zone.now.change(day: 1, month: 1, year: 2019)
       issues = checker.pre_update_issues(date)
       expect(issues).to be_empty
     end

--- a/spec/lib/whitehall_importer/create_edition_spec.rb
+++ b/spec/lib/whitehall_importer/create_edition_spec.rb
@@ -284,8 +284,8 @@ RSpec.describe WhitehallImporter::CreateEdition do
     end
 
     context "when an unpublished edition has not been edited" do
-      let(:created_at) { Time.current.yesterday.rfc3339 }
-      let(:updated_at) { Time.current.rfc3339 }
+      let(:created_at) { Time.zone.now.yesterday.rfc3339 }
+      let(:updated_at) { Time.zone.now.rfc3339 }
       let(:whitehall_edition) do
         build(:whitehall_export_edition,
               revision_history: [
@@ -327,7 +327,7 @@ RSpec.describe WhitehallImporter::CreateEdition do
     end
 
     context "when an unpublished edition has been edited" do
-      let(:created_at) { Time.current.rfc3339 }
+      let(:created_at) { Time.zone.now.rfc3339 }
       let(:whitehall_edition) do
         build(:whitehall_export_edition,
               revision_history: [

--- a/spec/lib/whitehall_importer/create_migration_spec.rb
+++ b/spec/lib/whitehall_importer/create_migration_spec.rb
@@ -27,7 +27,7 @@ RSpec.describe WhitehallImporter::CreateMigration do
           expect(WhitehallMigration.last.organisation_content_id).to eq("123")
           expect(WhitehallMigration.last.document_type).to eq("news_article")
           expect(WhitehallMigration.last.document_subtypes).to eq([])
-          expect(WhitehallMigration.last.created_at).to eq(Time.current)
+          expect(WhitehallMigration.last.created_at).to eq(Time.zone.now)
         end
       end
 
@@ -60,7 +60,7 @@ RSpec.describe WhitehallImporter::CreateMigration do
           expect(WhitehallMigration.last.organisation_content_id).to eq("123")
           expect(WhitehallMigration.last.document_type).to eq("news_article")
           expect(WhitehallMigration.last.document_subtypes).to eq(%w(press_release news_story))
-          expect(WhitehallMigration.last.created_at).to eq(Time.current)
+          expect(WhitehallMigration.last.created_at).to eq(Time.zone.now)
         end
       end
 

--- a/spec/lib/whitehall_importer/create_revision_spec.rb
+++ b/spec/lib/whitehall_importer/create_revision_spec.rb
@@ -31,7 +31,7 @@ RSpec.describe WhitehallImporter::CreateRevision do
     end
 
     it "sets backdated_to when edition has been backdated" do
-      backdated_to = Time.current.yesterday.rfc3339
+      backdated_to = Time.zone.now.yesterday.rfc3339
       whitehall_edition = build(:whitehall_export_edition,
                                 first_published_at: backdated_to)
 

--- a/spec/lib/whitehall_importer/import_spec.rb
+++ b/spec/lib/whitehall_importer/import_spec.rb
@@ -137,7 +137,7 @@ RSpec.describe WhitehallImporter::Import do
     it "sets current boolean on whether edition is current or not" do
       past_edition = build(
         :whitehall_export_edition,
-        created_at: Time.current.yesterday.rfc3339,
+        created_at: Time.zone.now.yesterday.rfc3339,
         revision_history: [build(:whitehall_export_revision_history_event,
                                  whodunnit: whitehall_user["id"])],
       )
@@ -166,7 +166,7 @@ RSpec.describe WhitehallImporter::Import do
     end
 
     it "sets first_published_at date to publish time of first edition" do
-      first_publish_date = Time.current.yesterday.rfc3339
+      first_publish_date = Time.zone.now.yesterday.rfc3339
       first_edition = build(
         :whitehall_export_edition,
         revision_history: [
@@ -184,7 +184,7 @@ RSpec.describe WhitehallImporter::Import do
           build(:whitehall_export_revision_history_event,
                 event: "update",
                 state: "published",
-                created_at: Time.current),
+                created_at: Time.zone.now),
         ],
       )
 

--- a/spec/models/whitehall_migration_spec.rb
+++ b/spec/models/whitehall_migration_spec.rb
@@ -14,7 +14,7 @@ RSpec.describe WhitehallMigration do
       it "updates each of the end times" do
         freeze_time do
           whitehall_migration.check_migration_finished
-          expect(whitehall_migration.finished_at).to eq(Time.current)
+          expect(whitehall_migration.finished_at).to eq(Time.zone.now)
         end
       end
     end

--- a/spec/services/assign_edition_status_service_spec.rb
+++ b/spec/services/assign_edition_status_service_spec.rb
@@ -29,7 +29,7 @@ RSpec.describe AssignEditionStatusService do
                                user: user,
                                state: :submitted_for_review)
         }.to change { edition.last_edited_by }.to(user)
-         .and change { edition.last_edited_at }.to(Time.current)
+         .and change { edition.last_edited_at }.to(Time.zone.now)
       end
     end
 
@@ -41,7 +41,7 @@ RSpec.describe AssignEditionStatusService do
                              state: :submitted_for_review,
                              record_edit: false)
 
-        expect(edition.last_edited_at).not_to eq(Time.current)
+        expect(edition.last_edited_at).not_to eq(Time.zone.now)
         expect(edition.last_edited_at).to eq(3.weeks.ago)
         expect(edition.last_edited_by).not_to eq(user)
       end

--- a/spec/services/edit_draft_edition_service_spec.rb
+++ b/spec/services/edit_draft_edition_service_spec.rb
@@ -22,7 +22,7 @@ RSpec.describe EditDraftEditionService do
 
         expect { described_class.call(edition, user) }
           .to change { edition.last_edited_by }.to(user)
-          .and change { edition.last_edited_at }.to(Time.current)
+          .and change { edition.last_edited_at }.to(Time.zone.now)
       end
     end
 

--- a/spec/services/preview_draft_edition_service/payload_spec.rb
+++ b/spec/services/preview_draft_edition_service/payload_spec.rb
@@ -161,7 +161,7 @@ RSpec.describe PreviewDraftEditionService::Payload do
     end
 
     it "includes first_published_at if the edition has a backdated_to value" do
-      date = Time.current.yesterday
+      date = Time.zone.now.yesterday
       revision = build(:revision, backdated_to: date)
       edition = build(:edition, revision: revision)
       payload = described_class.new(edition).payload
@@ -170,7 +170,7 @@ RSpec.describe PreviewDraftEditionService::Payload do
     end
 
     it "include public_updated_at if the edition has backdated_to and is a first edition" do
-      date = Time.current.yesterday
+      date = Time.zone.now.yesterday
       revision = build(:revision, backdated_to: date)
       edition = build(:edition, revision: revision, number: 1)
       payload = described_class.new(edition).payload

--- a/spec/services/publish_draft_edition_service_spec.rb
+++ b/spec/services/publish_draft_edition_service_spec.rb
@@ -27,7 +27,7 @@ RSpec.describe PublishDraftEditionService do
       it "sets the document first publishing time" do
         freeze_time do
           expect { described_class.call(edition, user, with_review: true) }
-            .to change(edition.document, :first_published_at).to(Time.current)
+            .to change(edition.document, :first_published_at).to(Time.zone.now)
         end
       end
 
@@ -56,7 +56,7 @@ RSpec.describe PublishDraftEditionService do
       document = create(:document, :with_current_edition)
       freeze_time do
         expect { described_class.call(document.current_edition, user, with_review: true) }
-          .to change(document.current_edition, :published_at).to(Time.current)
+          .to change(document.current_edition, :published_at).to(Time.zone.now)
       end
     end
 

--- a/spec/services/schedule_publish_service/payload_spec.rb
+++ b/spec/services/schedule_publish_service/payload_spec.rb
@@ -2,7 +2,7 @@ RSpec.describe SchedulePublishService::Payload do
   describe "#intent_payload" do
     it "generates a payload for the publishing API" do
       document_type = build(:document_type, rendering_app: "government-frontend")
-      publish_time = Time.current.tomorrow.at_noon
+      publish_time = Time.zone.now.tomorrow.at_noon
 
       edition = build(:edition,
                       :scheduled,

--- a/spec/services/schedule_publish_service_spec.rb
+++ b/spec/services/schedule_publish_service_spec.rb
@@ -12,7 +12,7 @@ RSpec.describe SchedulePublishService do
 
   describe "#call" do
     let(:user) { create :user }
-    let(:edition) { create :edition, proposed_publish_time: Time.current.tomorrow }
+    let(:edition) { create :edition, proposed_publish_time: Time.zone.now.tomorrow }
     let(:scheduling) { create :scheduling, publish_time: edition.proposed_publish_time }
 
     it "sets an edition's state to 'scheduled'" do

--- a/spec/services/withdraw_document_service_spec.rb
+++ b/spec/services/withdraw_document_service_spec.rb
@@ -21,7 +21,7 @@ RSpec.describe WithdrawDocumentService do
 
 
     it "updates the edition status to withdrawn" do
-      travel_to(Time.current) do
+      travel_to(Time.zone.now) do
         described_class.call(edition,
                              user,
                              public_explanation: public_explanation)
@@ -30,7 +30,7 @@ RSpec.describe WithdrawDocumentService do
 
         expect(edition.status).to be_withdrawn
         expect(withdrawal.public_explanation).to eq(public_explanation)
-        expect(withdrawal.withdrawn_at).to eq(Time.current)
+        expect(withdrawal.withdrawn_at).to eq(Time.zone.now)
       end
     end
 


### PR DESCRIPTION
It was raised in a previous pr (#1748 (comment)) that we should have a linter to look at TimeZone. In that discussion it was stated that we should prefer `Time.current` over `Time.zone.now` but this is not a thing that rubocop supports. Instead I've implemented the opposite in order to ensure that we have a consistent style.