### PR TITLE
Use consistent naming for button to crop image

### DIFF
--- a/app/views/images/crop.html.erb
+++ b/app/views/images/crop.html.erb
@@ -34,7 +34,13 @@ content_for :title,t(title_key, title: @edition.title_or_fallback)
 
   <div class="app-js-only">
     <%= render "govuk_publishing_components/components/button", {
-      text: (@image_revision.at_exact_dimensions?) || params[:wizard] == 'upload' ? "Continue" : "Crop image",
+      text: if @image_revision.at_exact_dimensions?
+              "Continue"
+            elsif params[:wizard] == 'upload'
+              "Save and continue"
+            else
+              "Save"
+            end,
       margin_bottom: true
     } %>
   </div>

--- a/spec/features/editing_images/edit_image_spec.rb
+++ b/spec/features/editing_images/edit_image_spec.rb
@@ -83,7 +83,7 @@ RSpec.feature "Edit image", js: true do
     stub_asset_manager_receives_an_asset
     stub_asset_manager_updates_any_asset
 
-    click_on "Crop image"
+    click_on "Save"
   end
 
   def when_i_edit_the_image_metadata

--- a/spec/features/editing_images/upload_image_spec.rb
+++ b/spec/features/editing_images/upload_image_spec.rb
@@ -45,7 +45,7 @@ RSpec.feature "Upload an image", js: true do
 
   def and_i_crop_the_image
     stub_publishing_api_put_content(@edition.content_id, {})
-    click_on "Continue"
+    click_on "Save and continue"
   end
 
   def and_i_fill_in_the_metadata


### PR DESCRIPTION
https://trello.com/c/QZmkUoTr/1516-support-metadata-just-unique-reference-for-file-attachments

Previously we used custom 'Crop image' text when passing through the
'crop image' page. This updates the text to make it consistent with
the upcoming work on file attachments (as we add an extra edit page).

When no crop is occurring, we still say 'Continue'. The 'Crop image'
text may have been intended to reassure the user of the outcome of the
crop, but we think that 'Save' should accomplish this just fine.