### PR TITLE
Remove frozen string literals

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,5 +1,3 @@
-# frozen_string_literal: true
-
 ruby File.read(".ruby-version").strip
 
 source "https://rubygems.org"

--- a/Rakefile
+++ b/Rakefile
@@ -1,5 +1,3 @@
-# frozen_string_literal: true
-
 # Add your own tasks in files placed in lib/tasks ending in .rake,
 # for example lib/tasks/capistrano.rake, and they will automatically be available to Rake.
 

--- a/lib/tasks/brakeman.rake
+++ b/lib/tasks/brakeman.rake
@@ -1,5 +1,3 @@
-# frozen_string_literal: true
-
 desc "Run Brakeman"
 task brakeman: :environment do
   sh "brakeman -q"

--- a/lib/tasks/development_permissions.rake
+++ b/lib/tasks/development_permissions.rake
@@ -1,5 +1,3 @@
-# frozen_string_literal: true
-
 desc "Set development permissions on the mock User GDS-SSO uses"
 task development_permissions: :environment do
   raise "Setting development permissions outside dev environment" unless Rails.env.development?

--- a/lib/tasks/factorybot.rake
+++ b/lib/tasks/factorybot.rake
@@ -1,5 +1,3 @@
-# frozen_string_literal: true
-
 desc "Run FactoryBot linter"
 namespace :factorybot do
   task lint: :environment do

--- a/lib/tasks/lint.rake
+++ b/lib/tasks/lint.rake
@@ -1,5 +1,3 @@
-# frozen_string_literal: true
-
 desc "lint Ruby, FactoryBot, Sass and Javascript"
 task lint: :environment do
   sh "bundle exec rubocop --format clang"

--- a/lib/tasks/notify.rake
+++ b/lib/tasks/notify.rake
@@ -1,5 +1,3 @@
-# frozen_string_literal: true
-
 namespace :notify do
   desc "Send an email notification"
   task :send_email, [:email_address] => :environment do |_, args|

--- a/lib/tasks/remove.rake
+++ b/lib/tasks/remove.rake
@@ -1,5 +1,3 @@
-# frozen_string_literal: true
-
 namespace :remove do
   desc "Remove a document with a gone on GOV.UK e.g. remove:gone['a-content-id']"
   task :gone, [:content_id] => :environment do |_, args|

--- a/lib/tasks/resync.rake
+++ b/lib/tasks/resync.rake
@@ -1,5 +1,3 @@
-# frozen_string_literal: true
-
 namespace :resync do
   desc "Resync a document with the publishing-api e.g. resync:document['a-content-id:en']"
   task :document, [:content_id_and_locale] => :environment do |_, args|


### PR DESCRIPTION
https://github.com/alphagov/content-publisher/pull/1769 removed the need for the frozen string literal thing. A few of them seem to have snuck back in so this removes them.