### PR TITLE
Fix time linting error

### DIFF
--- a/lib/bulk_data/government_repository.rb
+++ b/lib/bulk_data/government_repository.rb
@@ -46,7 +46,7 @@ module BulkData
     end
 
     def cache_age
-      Time.current - Cache.written_at(CACHE_KEY)
+      Time.zone.now - Cache.written_at(CACHE_KEY)
     end
 
     def cache_populated?


### PR DESCRIPTION
The cop to enforce Time.zone.now (instead of Time.current) was merged recently, but it appears this file was merged afterwards.