### PR TITLE
Generic forbidden response handling

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -2,6 +2,8 @@ class ApplicationController < ActionController::Base
   include GDS::SSO::ControllerMethods
   include EditionAssertions
 
+  class Forbidden < RuntimeError; end
+
   helper_method :rendering_context
   layout -> { rendering_context }
 

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -50,7 +50,7 @@ class ApplicationController < ActionController::Base
       .find_current(document: document_param)
 
     unless current_user.can_access?(edition)
-      render "documents/forbidden", status: :forbidden,
+      render "documents/access_limited", status: :forbidden,
         assigns: { edition: edition }
     end
   end

--- a/app/controllers/errors_controller.rb
+++ b/app/controllers/errors_controller.rb
@@ -6,6 +6,10 @@ class ErrorsController < ApplicationController
     render status: :bad_request, formats: :html
   end
 
+  def forbidden
+    render status: :forbidden, formats: :html
+  end
+
   def not_found
     render status: :not_found, formats: :html
   end

--- a/app/views/documents/access_limited.html.erb
+++ b/app/views/documents/access_limited.html.erb
@@ -1,0 +1,17 @@
+<% content_for :title, t("documents.access_limited.title") %>
+
+<div class="govuk-body" data-gtm="access-limit-forbidden" data-gtm-visibility-tracking="true">
+  <%= t("documents.access_limited.description") %>
+</div>
+
+<div class="govuk-body">
+  <% begin %>
+    <% primary_org = Linkables.new("organisation")
+      .by_content_id(@edition.primary_publishing_organisation_id) %>
+
+    <% if primary_org %>
+      <%= t("documents.access_limited.owner",
+            primary_org: primary_org.fetch("internal_name")) %>
+    <% end %>
+  <% rescue GdsApi::BaseError; end %>
+</div>

--- a/app/views/errors/forbidden.html.erb
+++ b/app/views/errors/forbidden.html.erb
@@ -1,0 +1,1 @@
+<%= render partial: "error", locals: t("errors.forbidden") %>

--- a/config/application.rb
+++ b/config/application.rb
@@ -35,6 +35,9 @@ module ContentPublisher
     config.eager_load_paths << Rails.root.join("lib")
     config.autoload_paths << Rails.root.join("lib")
     config.exceptions_app = self.routes
+    config.action_dispatch.rescue_responses.merge!(
+      "ApplicationController::Forbidden" => :forbidden,
+    )
 
     unless Rails.application.secrets.jwt_auth_secret
       raise "JWT auth secret is not configured. See config/secrets.yml"

--- a/config/locales/en/documents/access_limited.yml
+++ b/config/locales/en/documents/access_limited.yml
@@ -1,6 +1,6 @@
 en:
   documents:
-    forbidden:
+    access_limited:
       title: Forbidden
       description: You do not have permission to access this page.
       owner: This page is owned by %{primary_org}.

--- a/config/locales/en/errors/forbidden.yml
+++ b/config/locales/en/errors/forbidden.yml
@@ -1,0 +1,6 @@
+en:
+  errors:
+    forbidden:
+      title: Forbidden
+      body_govspeak: |
+        You do not have permission to access this page.

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -113,6 +113,7 @@ Rails.application.routes.draw do
 
   scope via: :all do
     match "/400" => "errors#bad_request"
+    match "/403" => "errors#forbidden"
     match "/404" => "errors#not_found"
     match "/422" => "errors#unprocessable_entity"
     match "/500" => "errors#internal_server_error"

--- a/spec/features/editing_content_settings/enforce_access_limit_spec.rb
+++ b/spec/features/editing_content_settings/enforce_access_limit_spec.rb
@@ -102,11 +102,11 @@ RSpec.feature "Enforce access limit" do
 
   def i_cannot_edit_the_edition
     visit document_path(@edition.document)
-    expect(page).to have_content(I18n.t!("documents.forbidden.description"))
-    expect(page).to have_content(I18n.t!("documents.forbidden.owner", primary_org: "Primary org"))
+    expect(page).to have_content(I18n.t!("documents.access_limited.description"))
+    expect(page).to have_content(I18n.t!("documents.access_limited.owner", primary_org: "Primary org"))
     visit content_path(@edition.document)
-    expect(page).to have_content(I18n.t!("documents.forbidden.description"))
-    expect(page).to have_content(I18n.t!("documents.forbidden.owner", primary_org: "Primary org"))
+    expect(page).to have_content(I18n.t!("documents.access_limited.description"))
+    expect(page).to have_content(I18n.t!("documents.access_limited.owner", primary_org: "Primary org"))
   end
 
   def and_i_see_the_timeline_entry

--- a/spec/requests/errors_spec.rb
+++ b/spec/requests/errors_spec.rb
@@ -7,6 +7,14 @@ RSpec.describe "Errors" do
     end
   end
 
+  describe "/403" do
+    it "returns a forbidden response" do
+      get "/403"
+      expect(response).to have_http_status(:forbidden)
+      expect(response.body).to include(I18n.t!("errors.forbidden.title"))
+    end
+  end
+
   describe "/404" do
     it "returns a not found response" do
       get "/404"


### PR DESCRIPTION
Trello: https://trello.com/c/HILuWHOt/1483-users-without-pre-release-permissions-cant-interact-with-publications-documents

This renames the documents/forbidden view to reflect that this is used for access_limited. It then creates a generic forbidden response for the errors controller. 

As there are no built in exceptions in Rails that generate a forbidden response this creates a AppliciationController::Forbidden error that is registered in the rescue responses config.

This work has been done so that we have something generic to use for when a pre_release format is accessed.