### PR TITLE
Restrict access to pre release

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -2,6 +2,8 @@ class ApplicationController < ActionController::Base
   include GDS::SSO::ControllerMethods
   include EditionAssertions
 
+  class Forbidden < RuntimeError; end
+
   helper_method :rendering_context
   layout -> { rendering_context }
 

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -50,7 +50,7 @@ class ApplicationController < ActionController::Base
       .find_current(document: document_param)
 
     unless current_user.can_access?(edition)
-      render "documents/forbidden", status: :forbidden,
+      render "documents/access_limited", status: :forbidden,
         assigns: { edition: edition }
     end
   end

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -51,6 +51,12 @@ class ApplicationController < ActionController::Base
       .includes(:access_limit, revision: [:tags_revision])
       .find_current(document: document_param)
 
+    if edition.document_type.pre_release? &&
+        !current_user.has_permission?(User::PRE_RELEASE_FEATURES_PERMISSION)
+
+      raise Forbidden
+    end
+
     unless current_user.can_access?(edition)
       render "documents/access_limited", status: :forbidden,
         assigns: { edition: edition }

--- a/app/controllers/errors_controller.rb
+++ b/app/controllers/errors_controller.rb
@@ -6,6 +6,10 @@ class ErrorsController < ApplicationController
     render status: :bad_request, formats: :html
   end
 
+  def forbidden
+    render status: :forbidden, formats: :html
+  end
+
   def not_found
     render status: :not_found, formats: :html
   end

--- a/app/views/documents/access_limited.html.erb
+++ b/app/views/documents/access_limited.html.erb
@@ -1,0 +1,17 @@
+<% content_for :title, t("documents.access_limited.title") %>
+
+<div class="govuk-body" data-gtm="access-limit-forbidden" data-gtm-visibility-tracking="true">
+  <%= t("documents.access_limited.description") %>
+</div>
+
+<div class="govuk-body">
+  <% begin %>
+    <% primary_org = Linkables.new("organisation")
+      .by_content_id(@edition.primary_publishing_organisation_id) %>
+
+    <% if primary_org %>
+      <%= t("documents.access_limited.owner",
+            primary_org: primary_org.fetch("internal_name")) %>
+    <% end %>
+  <% rescue GdsApi::BaseError; end %>
+</div>

--- a/app/views/errors/forbidden.html.erb
+++ b/app/views/errors/forbidden.html.erb
@@ -1,0 +1,1 @@
+<%= render partial: "error", locals: t("errors.forbidden") %>

--- a/config/application.rb
+++ b/config/application.rb
@@ -35,6 +35,9 @@ module ContentPublisher
     config.eager_load_paths << Rails.root.join("lib")
     config.autoload_paths << Rails.root.join("lib")
     config.exceptions_app = self.routes
+    config.action_dispatch.rescue_responses.merge!(
+      "ApplicationController::Forbidden" => :forbidden,
+    )
 
     unless Rails.application.secrets.jwt_auth_secret
       raise "JWT auth secret is not configured. See config/secrets.yml"

--- a/config/locales/en/documents/access_limited.yml
+++ b/config/locales/en/documents/access_limited.yml
@@ -1,6 +1,6 @@
 en:
   documents:
-    forbidden:
+    access_limited:
       title: Forbidden
       description: You do not have permission to access this page.
       owner: This page is owned by %{primary_org}.

--- a/config/locales/en/errors/forbidden.yml
+++ b/config/locales/en/errors/forbidden.yml
@@ -1,0 +1,6 @@
+en:
+  errors:
+    forbidden:
+      title: Forbidden
+      body_govspeak: |
+        You do not have permission to access this page.

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -113,6 +113,7 @@ Rails.application.routes.draw do
 
   scope via: :all do
     match "/400" => "errors#bad_request"
+    match "/403" => "errors#forbidden"
     match "/404" => "errors#not_found"
     match "/422" => "errors#unprocessable_entity"
     match "/500" => "errors#internal_server_error"

--- a/spec/features/editing_content_settings/enforce_access_limit_spec.rb
+++ b/spec/features/editing_content_settings/enforce_access_limit_spec.rb
@@ -102,11 +102,11 @@ RSpec.feature "Enforce access limit" do
 
   def i_cannot_edit_the_edition
     visit document_path(@edition.document)
-    expect(page).to have_content(I18n.t!("documents.forbidden.description"))
-    expect(page).to have_content(I18n.t!("documents.forbidden.owner", primary_org: "Primary org"))
+    expect(page).to have_content(I18n.t!("documents.access_limited.description"))
+    expect(page).to have_content(I18n.t!("documents.access_limited.owner", primary_org: "Primary org"))
     visit content_path(@edition.document)
-    expect(page).to have_content(I18n.t!("documents.forbidden.description"))
-    expect(page).to have_content(I18n.t!("documents.forbidden.owner", primary_org: "Primary org"))
+    expect(page).to have_content(I18n.t!("documents.access_limited.description"))
+    expect(page).to have_content(I18n.t!("documents.access_limited.owner", primary_org: "Primary org"))
   end
 
   def and_i_see_the_timeline_entry

--- a/spec/requests/errors_spec.rb
+++ b/spec/requests/errors_spec.rb
@@ -7,6 +7,14 @@ RSpec.describe "Errors" do
     end
   end
 
+  describe "/403" do
+    it "returns a forbidden response" do
+      get "/403"
+      expect(response).to have_http_status(:forbidden)
+      expect(response.body).to include(I18n.t!("errors.forbidden.title"))
+    end
+  end
+
   describe "/404" do
     it "returns a not found response" do
       get "/404"

--- a/spec/requests/errors_spec.rb
+++ b/spec/requests/errors_spec.rb
@@ -60,4 +60,16 @@ RSpec.describe "Errors" do
       expect(response.body).to include(I18n.t!("errors.local_data_unavailable.title"))
     end
   end
+
+  it "forbids users without pre-release permission from accessing pre-release documents" do
+    pre_release_document_type = build(:document_type, pre_release: true)
+    edition = create(:edition, document_type: pre_release_document_type)
+    user = build(:user, permissions: %w(signin))
+
+    login_as(user)
+    get document_path(edition.document)
+
+    expect(response).to have_http_status(:forbidden)
+    expect(response.body).to include(I18n.t!("errors.forbidden.title"))
+  end
 end


### PR DESCRIPTION
Trello: https://trello.com/c/HILuWHOt
Builds on: #1825 

## What's changed and why?
Publications were added in: #1810, but the ability to create new publications, or filter by publications on the index page was restricted to users who have the "pre_release_features" permission.

This restriction has been expanded to viewing and editing any publications documents as well. This includes everything from viewing the document summary page, to being able to tag the document etc. Users without the correct permission are shown a generic 403 Forbidden page.

This is so that we don't end up with users being in the position of being able to do some parts of pre-release format work based off a link but not being able to create one or find it in the index.

Co-authored with @kevindew 