### PR TITLE
Move check for pending document import before importing

### DIFF
--- a/app/jobs/whitehall_document_import_job.rb
+++ b/app/jobs/whitehall_document_import_job.rb
@@ -11,7 +11,7 @@ class WhitehallDocumentImportJob < ApplicationJob
   end
 
   def perform(document_import)
-    WhitehallImporter::Import.call(document_import)
+    WhitehallImporter::Import.call(document_import) if document_import.pending?
     WhitehallImporter::Sync.call(document_import)
     document_import.whitehall_migration.check_migration_finished
   end

--- a/lib/whitehall_importer/import.rb
+++ b/lib/whitehall_importer/import.rb
@@ -13,10 +13,6 @@ module WhitehallImporter
     end
 
     def call
-      unless document_import.pending?
-        raise "Cannot import with a state of #{document_import.state}"
-      end
-
       lock_document
 
       document_import.update!(

--- a/spec/jobs/whitehall_document_import_job_spec.rb
+++ b/spec/jobs/whitehall_document_import_job_spec.rb
@@ -22,10 +22,15 @@ RSpec.describe WhitehallDocumentImportJob do
     )
   end
 
-  it "calls WhitehallImporter::Import" do
+  it "calls WhitehallImporter::Import if the document import is pending" do
     expect(WhitehallImporter::Import).to receive(:call)
                                      .with(whitehall_migration_document_import)
     described_class.perform_now(whitehall_migration_document_import)
+  end
+
+  it "does not call WhitehallImporter::Import if the document import is not pending" do
+    expect(WhitehallImporter::Import).not_to receive(:call)
+    described_class.perform_now(imported_document_import)
   end
 
   it "calls WhitehallImporter::Sync" do

--- a/spec/lib/whitehall_importer/import_spec.rb
+++ b/spec/lib/whitehall_importer/import_spec.rb
@@ -21,13 +21,6 @@ RSpec.describe WhitehallImporter::Import do
       )
     end
 
-    it "raises if the WhitehallMigration::DocumentImport doesn't have a state of pending" do
-      document_import = create(:whitehall_migration_document_import, state: "imported")
-
-      expect { described_class.call(document_import) }
-        .to raise_error(RuntimeError, "Cannot import with a state of imported")
-    end
-
     it "locks the document in Whitehall" do
       described_class.call(document_import)
       expect(stub_whitehall_lock_document(document_import.whitehall_document_id))


### PR DESCRIPTION
For https://trello.com/c/gao9twxQ/1524-skip-import-if-document-import-is-not-in-pending-state

We originally checked if a document import is in a pending state within the
WhitehallImporter::Import class. However we've found that it's beneficial to do
this check before the class is called, as in situations where a document has
successfully been imported but the job is being retried as a result of an error
in the syncing process, the job errors since the document import is no longer
pending.