### PR TITLE
Set published_at time during import

### DIFF
--- a/app/models/status.rb
+++ b/app/models/status.rb
@@ -23,4 +23,8 @@ class Status < ApplicationRecord
                 superseded: "superseded",
                 scheduled: "scheduled",
                 failed_to_publish: "failed_to_publish" }
+
+  def live?
+    %w[published published_but_needs_2i withdrawn removed].include?(state)
+  end
 end

--- a/lib/whitehall_importer/create_edition.rb
+++ b/lib/whitehall_importer/create_edition.rb
@@ -148,6 +148,7 @@ module WhitehallImporter
       last_event ||= whitehall_edition["revision_history"].last
 
       editor_ids = history.editors.map { |editor| user_ids[editor] }.compact
+      published_at = history.last_state_event!("published")["created_at"] if status.live? || status.superseded?
 
       Edition.create!(
         document: document_import.document,
@@ -162,6 +163,7 @@ module WhitehallImporter
         created_by_id: user_ids[create_event["whodunnit"]],
         last_edited_at: last_event["created_at"],
         last_edited_by_id: user_ids[last_event["whodunnit"]],
+        published_at: published_at,
         editor_ids: editor_ids,
       )
     end


### PR DESCRIPTION
In this commit we populate the published_at column on each imported
edition if the edition has been published in the past. The editions
which will have this field populated will either have a state of
'published', 'published_but_needs_2i', 'superseded', 'removed' or
'withdrawn'.

Trello:
https://trello.com/c/MeyxpGHG/1465-import-publishedat-and-changehistory-for-whitehall-content