### PR TITLE
Exclude pre-release publications from edition filter results

### DIFF
--- a/lib/edition_filter.rb
+++ b/lib/edition_filter.rb
@@ -22,6 +22,7 @@ class EditionFilter
                    .preload(revision_joins, :status, :document, :last_edited_by)
     scope = access_limited_scope(scope)
     scope = filtered_scope(scope)
+    scope = non_pre_release_type_scope(scope)
     scope = ordered_scope(scope)
     scope.page(page).per(per_page)
   end
@@ -89,5 +90,12 @@ private
     else
       scope
     end
+  end
+
+  def non_pre_release_type_scope(scope)
+    return scope if user.has_permission?(User::PRE_RELEASE_FEATURES_PERMISSION)
+
+    types = DocumentType.all.reject(&:pre_release?).map(&:id)
+    scope.where("metadata_revisions.document_type_id": types)
   end
 end

--- a/spec/factories/document_type_factory.rb
+++ b/spec/factories/document_type_factory.rb
@@ -37,5 +37,9 @@ FactoryBot.define do
     trait :with_lead_image do
       lead_image { true }
     end
+
+    trait :pre_release do
+      pre_release { true }
+    end
   end
 end

--- a/spec/lib/edition_filter_spec.rb
+++ b/spec/lib/edition_filter_spec.rb
@@ -203,6 +203,23 @@ RSpec.describe EditionFilter do
         expect(editions).to eq([edition])
       end
     end
+
+    context "when the edition's document type is tagged as pre release" do
+      let!(:edition1) { create(:edition) }
+      let!(:edition2) { create(:edition, document_type: build(:document_type, :pre_release)) }
+
+      it "includes the edition for users with pre_release_features permission" do
+        pre_release_user = build(:user)
+        editions = described_class.new(pre_release_user).editions
+        expect(editions).to match_array([edition1, edition2])
+      end
+
+      it "excludes the edition for users without pre_release_features permission" do
+        user = build(:user, permissions: [])
+        editions = described_class.new(user).editions
+        expect(editions).to match_array([edition1])
+      end
+    end
   end
 
   describe "#filter_params" do

--- a/spec/models/document_type_selection/option_spec.rb
+++ b/spec/models/document_type_selection/option_spec.rb
@@ -59,7 +59,7 @@ RSpec.describe DocumentTypeSelection::Option do
 
   describe "#pre_release?" do
     it "returns true when the option is an existing document type and a pre-release feature" do
-      pre_release_document_type = build(:document_type, pre_release: true)
+      pre_release_document_type = build(:document_type, :pre_release)
 
       allow(DocumentType)
         .to receive(:all)

--- a/spec/views/documents/index/_filters.html.erb_spec.rb
+++ b/spec/views/documents/index/_filters.html.erb_spec.rb
@@ -25,7 +25,7 @@ RSpec.describe "documents/index/_filters.html.erb" do
   end
 
   describe "Document type select" do
-    let(:pre_release_document_type) { build(:document_type, pre_release: true) }
+    let(:pre_release_document_type) { build(:document_type, :pre_release) }
 
     before do
       stub_publishing_api_has_linkables([], document_type: "organisation")

--- a/spec/views/new_document/show.html.erb_spec.rb
+++ b/spec/views/new_document/show.html.erb_spec.rb
@@ -1,5 +1,5 @@
 RSpec.describe "new_document/show.html.erb" do
-  let(:pre_release_document_type) { build(:document_type, id: "news", pre_release: true) }
+  let(:pre_release_document_type) { build(:document_type, :pre_release, id: "news") }
 
   let(:pre_release_option) do
     DocumentTypeSelection::Option.new(


### PR DESCRIPTION
Trello - https://trello.com/c/wzzVIihM/1521-exclude-prerelease-publications-from-edition-filter-results

As it stands, users without the pre_release_features permission are able to see editions with the pre release flag when they visit content-publisher. This will give the false impression that these are things that can be edited. This adds the functionality to remove these editions from the list of things that such users can see.