### PR TITLE
Don't send `Forbidden` errors to sentry

### DIFF
--- a/config/initializers/govuk_error.rb
+++ b/config/initializers/govuk_error.rb
@@ -1,0 +1,3 @@
+GovukError.configure do |config|
+  config.excluded_exceptions << "ApplicationController::Forbidden"
+end


### PR DESCRIPTION
`ApplicationController::Forbidden` errors occur when users try to access something they shouldn't. As this is a user behaviour error and not a problem with the application, we don't need to report it to Sentry. 

[Example in publishing-api](https://github.com/alphagov/publishing-api/blob/76679ce5fc1d300408a80a9bc1a14e30b6f24151/config/initializers/govuk_error.rb)
See: https://sentry.io/organizations/govuk/issues/1537088552/?project=202208