### PR TITLE
Fix removed editions not being imported as live

### DIFF
--- a/lib/whitehall_importer/create_edition.rb
+++ b/lib/whitehall_importer/create_edition.rb
@@ -157,7 +157,7 @@ module WhitehallImporter
         revision: revision,
         status: status,
         current: current,
-        live: whitehall_edition["state"].in?(%w(published withdrawn)),
+        live: status.live?,
         created_at: create_event["created_at"],
         updated_at: last_event["created_at"],
         created_by_id: user_ids[create_event["whodunnit"]],

--- a/spec/lib/whitehall_importer/create_edition_spec.rb
+++ b/spec/lib/whitehall_importer/create_edition_spec.rb
@@ -257,28 +257,17 @@ RSpec.describe WhitehallImporter::CreateEdition do
               unpublishing: build(:whitehall_export_unpublishing))
       end
 
-      let(:edition) do
-        described_class.call(document_import: document_import,
-                             whitehall_edition: whitehall_edition)
-      end
-
-      it "creates two statuses" do
-        expect(edition.statuses.count).to eq(2)
-      end
-
-      it "sets the correct withdrawn status" do
+      it "creates a live withdrawn edition" do
+        edition = described_class.call(document_import: document_import,
+                                       whitehall_edition: whitehall_edition)
         expect(edition).to be_withdrawn
-      end
-
-      it "sets the edition as live" do
         expect(edition).to be_live
+        expect(edition.published_at).to eq(published_at)
       end
 
-      it "sets the correct previous status" do
-        expect(edition.statuses.first).to be_published
-      end
-
-      it "sets the correct withdrawal metadata" do
+      it "sets the expected withdrawal metadata" do
+        edition = described_class.call(document_import: document_import,
+                                       whitehall_edition: whitehall_edition)
         expect(edition.status.details.withdrawn_at.rfc3339).to eq(
           whitehall_edition["unpublishing"]["created_at"],
         )
@@ -287,8 +276,12 @@ RSpec.describe WhitehallImporter::CreateEdition do
         )
       end
 
-      it "sets the published_at time" do
-        expect(edition.published_at).to eq(published_at)
+      it "sets a previous status of the edition of the publishing status " do
+        edition = described_class.call(document_import: document_import,
+                                       whitehall_edition: whitehall_edition)
+        first_status = edition.statuses.first
+        expect(first_status).to be_published
+        expect(edition.status.details.published_status).to eq(first_status)
       end
     end
 

--- a/spec/lib/whitehall_importer/create_edition_spec.rb
+++ b/spec/lib/whitehall_importer/create_edition_spec.rb
@@ -270,6 +270,10 @@ RSpec.describe WhitehallImporter::CreateEdition do
         expect(edition).to be_withdrawn
       end
 
+      it "sets the edition as live" do
+        expect(edition).to be_live
+      end
+
       it "sets the correct previous status" do
         expect(edition.statuses.first).to be_published
       end
@@ -309,10 +313,11 @@ RSpec.describe WhitehallImporter::CreateEdition do
                                   explanation: "Gator"))
       end
 
-      it "creates an edition with a status of removed" do
+      it "creates a live edition with a status of removed" do
         edition = described_class.call(document_import: document_import, whitehall_edition: whitehall_edition)
 
         expect(edition).to be_removed
+        expect(edition).to be_live
       end
 
       it "sets the correct removal metadata" do
@@ -363,10 +368,11 @@ RSpec.describe WhitehallImporter::CreateEdition do
         } .to change(Edition, :count).by(2)
       end
 
-      it "creates an edition with a status of removed" do
+      it "creates a live edition with a status of removed" do
         described_class.call(document_import: document_import, whitehall_edition: whitehall_edition)
 
         expect(document.editions.first).to be_removed
+        expect(document.editions.first).to be_live
       end
 
       it "sets the correct removal metadata" do
@@ -382,7 +388,7 @@ RSpec.describe WhitehallImporter::CreateEdition do
         edition = described_class.call(document_import: document_import, whitehall_edition: whitehall_edition)
 
         expect(edition).to be_draft
-        expect(edition.current).to be_truthy
+        expect(edition).to be_current
       end
 
       it "sets the correct timestamps" do

--- a/spec/lib/whitehall_importer/create_edition_spec.rb
+++ b/spec/lib/whitehall_importer/create_edition_spec.rb
@@ -319,7 +319,7 @@ RSpec.describe WhitehallImporter::CreateEdition do
         removal = edition.status.details
         expect(removal.explanatory_note).to eq(whitehall_edition["unpublishing"]["explanation"])
         expect(removal.alternative_url).to eq(whitehall_edition["unpublishing"]["alternative_url"])
-        expect(removal.redirect).to be_truthy
+        expect(removal).to be_redirect
       end
 
       it "sets the correct timestamps on the edition" do
@@ -374,7 +374,7 @@ RSpec.describe WhitehallImporter::CreateEdition do
         removal = document.editions.first.status.details
         expect(removal.explanatory_note).to eq(whitehall_edition["unpublishing"]["explanation"])
         expect(removal.alternative_url).to eq(whitehall_edition["unpublishing"]["alternative_url"])
-        expect(removal.redirect).to be_truthy
+        expect(removal).to be_redirect
       end
 
       it "creates a draft edition and assigns as current" do
@@ -461,7 +461,7 @@ RSpec.describe WhitehallImporter::CreateEdition do
                                 force_published: false)
       edition = described_class.call(document_import: document_import,
                                      whitehall_edition: whitehall_edition)
-      expect(edition.status.details.reviewed).to be true
+      expect(edition.status.details).to be_reviewed
     end
 
     it "marks a force published whitehall edition as needing review" do
@@ -470,7 +470,7 @@ RSpec.describe WhitehallImporter::CreateEdition do
                                 force_published: true)
       edition = described_class.call(document_import: document_import,
                                      whitehall_edition: whitehall_edition)
-      expect(edition.status.details.reviewed).to be false
+      expect(edition.status.details).not_to be_reviewed
     end
 
     it "aborts when there is no scheduled publication date" do


### PR DESCRIPTION
It turns out only published and withdrawn documents were being imported
as live editions. This can be resolved by using the status.live? method
that was introduced in 648932f