### PR TITLE
Re attempt change history backfill

### DIFF
--- a/db/migrate/20200220111317_backfill_change_history_for_metadata_revisions.rb
+++ b/db/migrate/20200220111317_backfill_change_history_for_metadata_revisions.rb
@@ -1,0 +1,38 @@
+class BackfillChangeHistoryForMetadataRevisions < ActiveRecord::Migration[6.0]
+  class MetadataRevision < ApplicationRecord
+    has_one :revision
+  end
+  class Revision < ApplicationRecord
+    belongs_to :metadata_revision
+    has_and_belongs_to_many :editions
+  end
+  class Edition < ApplicationRecord
+    belongs_to :revision
+  end
+
+  disable_ddl_transaction!
+
+  def up
+    MetadataRevision.find_each do |metadata_revision|
+      edition = metadata_revision.revision.editions.first
+      Edition.transaction do
+        edition.lock!
+
+        change_history_editions = Edition.joins(revision: :metadata_revision)
+          .where("editions.number > 1 AND editions.number < ?", edition.number)
+          .where("metadata_revisions.update_type": "major")
+          .where(document_id: edition.document_id)
+          .order(:published_at)
+
+        change_history = change_history_editions.map do |e|
+          { id: SecureRandom.uuid,
+            note: e.revision.metadata_revision.change_note,
+            public_timestamp: e.published_at.rfc3339 }
+        end
+
+        metadata_revision.change_history = change_history
+        metadata_revision.save!
+      end
+    end
+  end
+end

--- a/db/migrate/20200220111317_backfill_change_history_for_metadata_revisions.rb
+++ b/db/migrate/20200220111317_backfill_change_history_for_metadata_revisions.rb
@@ -13,6 +13,7 @@ class BackfillChangeHistoryForMetadataRevisions < ActiveRecord::Migration[6.0]
   disable_ddl_transaction!
 
   def up
+    change_history_ids = {}
     MetadataRevision.find_each do |metadata_revision|
       edition = metadata_revision.revision.editions.first
       Edition.transaction do
@@ -25,7 +26,7 @@ class BackfillChangeHistoryForMetadataRevisions < ActiveRecord::Migration[6.0]
           .order(:published_at)
 
         change_history = change_history_editions.map do |e|
-          { id: SecureRandom.uuid,
+          { id: change_history_ids[e.id] ||= SecureRandom.uuid,
             note: e.revision.metadata_revision.change_note,
             public_timestamp: e.published_at.rfc3339 }
         end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2020_02_18_161942) do
+ActiveRecord::Schema.define(version: 2020_02_20_111317) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"


### PR DESCRIPTION
Trello: https://trello.com/c/ymfW8Eeh/1462-backfill-the-changehistory-of-existing-content

This re-instates https://github.com/alphagov/content-publisher/pull/1806 which I reverted in https://github.com/alphagov/content-publisher/pull/1836 with a fix for the issue found of changing change history ids.

The difference in this may be best shown through an image:

Before:

<img width="997" alt="Screenshot 2020-02-28 at 18 03 09" src="https://user-images.githubusercontent.com/282717/75573401-ad54f400-5a54-11ea-8765-25d2e3f64dee.png">

After:

<img width="987" alt="Screenshot 2020-02-28 at 17 59 48" src="https://user-images.githubusercontent.com/282717/75573411-b0e87b00-5a54-11ea-8feb-95a2848117b8.png">

 