### PR TITLE
Create featured file attachments

### DIFF
--- a/app/controllers/featured_attachments_controller.rb
+++ b/app/controllers/featured_attachments_controller.rb
@@ -1,0 +1,6 @@
+class FeaturedAttachmentsController < ApplicationController
+  def index
+    @edition = Edition.find_current(document: params[:document])
+    assert_edition_state(@edition, &:editable?)
+  end
+end

--- a/app/controllers/file_attachments_controller.rb
+++ b/app/controllers/file_attachments_controller.rb
@@ -6,6 +6,11 @@ class FileAttachmentsController < ApplicationController
     assert_edition_state(@edition, &:editable?)
   end
 
+  def new
+    @edition = Edition.find_current(document: params[:document])
+    assert_edition_state(@edition, &:editable?)
+  end
+
   def show
     @edition = Edition.find_current(document: params[:document])
     assert_edition_state(@edition, &:editable?)

--- a/app/controllers/file_attachments_controller.rb
+++ b/app/controllers/file_attachments_controller.rb
@@ -48,7 +48,7 @@ class FileAttachmentsController < ApplicationController
         ),
       }
 
-      render :index,
+      render params[:wizard] == "new" ? :new : :index,
              assigns: { edition: edition,
                         issues: issues },
              status: :unprocessable_entity

--- a/app/controllers/file_attachments_controller.rb
+++ b/app/controllers/file_attachments_controller.rb
@@ -52,6 +52,8 @@ class FileAttachmentsController < ApplicationController
              assigns: { edition: edition,
                         issues: issues },
              status: :unprocessable_entity
+    elsif params[:wizard] == "new"
+      redirect_to featured_attachments_path(edition.document, attachment_revision.file_attachment)
     else
       redirect_to file_attachment_path(edition.document, attachment_revision.file_attachment)
     end

--- a/app/views/documents/show.html.erb
+++ b/app/views/documents/show.html.erb
@@ -51,6 +51,10 @@
   <div class="govuk-grid-column-two-thirds">
     <%= render "documents/show/contents" %>
 
+    <% if @edition.document_type.attachments.featured? && current_user.has_permission?(User::PRE_RELEASE_FEATURES_PERMISSION) %>
+      <%= render "documents/show/featured_attachments" %>
+    <% end %>
+
     <% if @edition.document_type.lead_image? %>
       <%= render "documents/show/lead_image" %>
     <% end %>

--- a/app/views/documents/show/_featured_attachments.html.erb
+++ b/app/views/documents/show/_featured_attachments.html.erb
@@ -1,0 +1,11 @@
+<%= render "govuk_publishing_components/components/summary_list", {
+  id: "attachments",
+  title: t("documents.show.featured_attachments.title"),
+  borderless: true,
+  edit: (
+    if @edition.editable?
+      { href: featured_attachments_path(@edition.document),
+        data_attributes: { gtm: "edit-tags" } }
+    end
+  )
+} %>

--- a/app/views/featured_attachments/_featured_attachment.html.erb
+++ b/app/views/featured_attachments/_featured_attachment.html.erb
@@ -1,0 +1,4 @@
+<%= render "components/attachment_meta", {
+  attachment: file_attachment_attributes(attachment, document),
+  actions: [],
+} %>

--- a/app/views/featured_attachments/index.html.erb
+++ b/app/views/featured_attachments/index.html.erb
@@ -1,0 +1,36 @@
+<% content_for :back_link, render_back_link(href: document_path(@edition.document)) %>
+<% content_for :title, t("featured_attachments.index.title", title: @edition.title_or_fallback) %>
+
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-two-thirds">
+    <p class="govuk-body">
+      <%= t("featured_attachments.index.upload.description_govspeak") %>
+    </p>
+
+    <%= render "govuk_publishing_components/components/button", {
+      text: t("featured_attachments.index.upload.title"),
+      href: new_file_attachment_path(@edition.document, wizard: "new"),
+      margin_bottom: true,
+    } %>
+
+    <% attachments = @edition.file_attachment_revisions %>
+
+    <h2 class="govuk-heading-m">
+      <%= t("featured_attachments.index.featured_attachments.title") %>
+    </h2>
+
+    <% if attachments.any? %>
+      <p class="govuk-body">
+        <%= t("featured_attachments.index.featured_attachments.description_govspeak") %>
+      </p>
+
+      <% attachments.each do |attachment| %>
+        <%= render "featured_attachment", document: @edition.document, attachment: attachment %>
+      <% end %>
+    <% else %>
+      <p class="govuk-body">
+        <%= t("featured_attachments.index.no_attachments") %>
+      </p>
+    <% end %>
+  </div>
+</div>

--- a/app/views/file_attachments/new.html.erb
+++ b/app/views/file_attachments/new.html.erb
@@ -7,6 +7,7 @@
       file_attachments_path(@edition.document),
       multipart: true,
     ) do %>
+      <%= hidden_field_tag(:wizard, params[:wizard]) %>
 
       <%= render_govspeak(t("file_attachments.new.description_govspeak")) %>
 

--- a/app/views/file_attachments/new.html.erb
+++ b/app/views/file_attachments/new.html.erb
@@ -1,0 +1,40 @@
+<% content_for :back_link, render_back_link(href: featured_attachments_path(@edition.document)) %>
+<% content_for :title, t("file_attachments.new.title", title: @edition.title_or_fallback) %>
+
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-two-thirds">
+    <%= form_tag(
+      file_attachments_path(@edition.document),
+      multipart: true,
+    ) do %>
+
+      <%= render_govspeak(t("file_attachments.new.description_govspeak")) %>
+
+      <%= render "govuk_publishing_components/components/inset_text", {
+        text: render_govspeak(
+          t("file_attachments.new.callout_govspeak")
+        ),
+      } %>
+
+      <%= render "govuk_publishing_components/components/file_upload", {
+        label: {
+          text: t("file_attachments.new.attachment_file.heading"),
+        },
+        name: "file"
+      } %>
+
+      <%= render "govuk_publishing_components/components/input", {
+        label: {
+          text: t("file_attachments.new.attachment_title.heading"),
+          bold: true
+        },
+        name: "title",
+        value: params[:title],
+        hint: t("file_attachments.new.attachment_title.hint_text"),
+        error_items: @issues&.items_for(:file_attachment_title),
+      } %>
+
+      <%= render "govuk_publishing_components/components/button", { text: "Save and continue" } %>
+    <% end %>
+  </div>
+</div>

--- a/config/locales/en/documents/show.yml
+++ b/config/locales/en/documents/show.yml
@@ -31,6 +31,8 @@ en:
           It was scheduled to publish at %{time} on %{date}
 
           You can publish it now, schedule it to publish later, or edit it.
+      featured_attachments:
+        title: Attachments
       flashes:
         pre_preview_issues:
           warning: To preview this document you need to

--- a/config/locales/en/documents/show.yml
+++ b/config/locales/en/documents/show.yml
@@ -1,20 +1,6 @@
 en:
   documents:
     show:
-      heading: "Document summary"
-      withdrawn:
-        title: "This %{document_type} was withdrawn on %{withdrawn_date}"
-      historical:
-        title: "This %{document_type} is in history mode"
-        description: "It was created under the %{government_name}"
-      topics:
-        title: Topics
-        no_topics: No topics.
-        api_down: This content isn’t available right now. We’re having trouble getting the data we need to show you this content.
-      tags:
-        title: Tags
-        api_down: This content isn’t available right now. We’re having trouble getting the data we need to show you this content.
-        none: None
       contents:
         title: Content
         items:
@@ -23,12 +9,6 @@ en:
         update_type:
           minor: There’s no change to the published information. For example, spelling corrections.
           major: There’s a change to the published information.
-      lead_image:
-        title: Lead image
-        no_lead_image: No image selected. The default image for your department will be used.
-        alt_text: Alt text
-        caption: Caption
-        credit: Credit
       content_settings:
         title: Content settings
         backdate:
@@ -44,17 +24,6 @@ en:
           title: Gets history mode
           true_label: "Yes"
           false_label: "No"
-      metadata:
-        status: Status
-        updated_at: Last updated
-        created_at: Created
-        created_by: Document created by
-        last_edited_by: Last edited by
-        withdrawn_by: Withdrawn by
-      scheduled_notice:
-        title: Scheduled to publish at %{time} on %{date}
-      proposed_scheduling_notice:
-        title: Proposed to publish at %{time} on %{date}
       failed_to_publish:
         title: There is a problem
         description_govspeak: |
@@ -62,9 +31,6 @@ en:
           It was scheduled to publish at %{time} on %{date}
 
           You can publish it now, schedule it to publish later, or edit it.
-      submitted_for_review:
-        title: Content has been marked as ready for 2i review
-        label: Send the Content Publisher link to another publisher for them to review. When content is ready you or they can publish it.
       flashes:
         pre_preview_issues:
           warning: To preview this document you need to
@@ -100,3 +66,37 @@ en:
         unschedule_error:
           title: Something has gone wrong
           description_govspeak: Something went wrong when stopping the scheduling of this document. Please try again or [raise a support request](https://support.publishing.service.gov.uk/technical_fault_report/new).
+      heading: "Document summary"
+      historical:
+        title: "This %{document_type} is in history mode"
+        description: "It was created under the %{government_name}"
+      lead_image:
+        title: Lead image
+        no_lead_image: No image selected. The default image for your department will be used.
+        alt_text: Alt text
+        caption: Caption
+        credit: Credit
+      metadata:
+        status: Status
+        updated_at: Last updated
+        created_at: Created
+        created_by: Document created by
+        last_edited_by: Last edited by
+        withdrawn_by: Withdrawn by
+      proposed_scheduling_notice:
+        title: Proposed to publish at %{time} on %{date}
+      scheduled_notice:
+        title: Scheduled to publish at %{time} on %{date}
+      submitted_for_review:
+        title: Content has been marked as ready for 2i review
+        label: Send the Content Publisher link to another publisher for them to review. When content is ready you or they can publish it.
+      tags:
+        title: Tags
+        api_down: This content isn’t available right now. We’re having trouble getting the data we need to show you this content.
+        none: None
+      topics:
+        title: Topics
+        no_topics: No topics.
+        api_down: This content isn’t available right now. We’re having trouble getting the data we need to show you this content.
+      withdrawn:
+        title: "This %{document_type} was withdrawn on %{withdrawn_date}"

--- a/config/locales/en/featured_attachments/index.yml
+++ b/config/locales/en/featured_attachments/index.yml
@@ -1,0 +1,13 @@
+en:
+  featured_attachments:
+    index:
+      title: "Attachments for ‘%{title}’"
+      upload:
+        title: Upload file attachment
+        description_govspeak: |
+          Publications have a summary page that must link to a file attachment or a document hosted on an external website.
+      featured_attachments:
+        title: Attachments
+        description_govspeak: |
+          Attachments will be listed on the document in this order.
+      no_attachments: No attachments added to this document.

--- a/config/locales/en/file_attachments/new.yml
+++ b/config/locales/en/file_attachments/new.yml
@@ -1,0 +1,16 @@
+en:
+  file_attachments:
+    new:
+      title: "Add attachment to ‘%{title}’"
+      description_govspeak: |
+        All files must be accessible. Read [full guidance on accessible attachment](https://www.gov.uk/guidance/how-to-publish-on-gov-uk/accessible-pdfs){:target="_blank"}.
+
+        Files must be uploaded in an [open standards file format](https://www.gov.uk/guidance/content-design/planning-content#open-formats){:target="_blank"}.
+        For example, .odt not .docx.
+      callout_govspeak: |
+        Attachments must be in English
+      attachment_file:
+        heading: Choose a file
+      attachment_title:
+        heading: Attachment title
+        hint_text: Use the full title of the document

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -93,6 +93,7 @@ Rails.application.routes.draw do
     post "/govspeak-preview" => "govspeak_preview#to_html", as: :govspeak_preview
 
     get "/file-attachments" => "file_attachments#index", as: :file_attachments
+    get "/file-attachments/new" => "file_attachments#new", as: :new_file_attachment
     post "/file-attachments" => "file_attachments#create"
     get "/file-attachments/:file_attachment_id" => "file_attachments#show", as: :file_attachment
     get "/file-attachments/:file_attachment_id/preview" => "file_attachments#preview", as: :preview_file_attachment

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -92,6 +92,8 @@ Rails.application.routes.draw do
 
     post "/govspeak-preview" => "govspeak_preview#to_html", as: :govspeak_preview
 
+    get "/attachments" => "featured_attachments#index", as: :featured_attachments
+
     get "/file-attachments" => "file_attachments#index", as: :file_attachments
     get "/file-attachments/new" => "file_attachments#new", as: :new_file_attachment
     post "/file-attachments" => "file_attachments#create"

--- a/spec/features/editing_file_attachments/upload_file_attachment_spec.rb
+++ b/spec/features/editing_file_attachments/upload_file_attachment_spec.rb
@@ -1,10 +1,23 @@
 RSpec.feature "Upload file attachment", js: true do
-  scenario do
+  scenario "inline attachment" do
     given_there_is_an_edition
     when_i_go_to_edit_the_edition
     and_i_go_to_insert_an_attachment
-    and_i_upload_a_file_attachment
-    then_i_can_see_previews_of_the_attachment
+    and_i_select_a_file_to_upload
+    and_i_upload_the_file_attachment
+    then_i_can_see_the_attachment
+    and_i_can_see_an_action_to_preview_the_attachment
+    and_i_see_the_timeline_entry
+  end
+
+  scenario "featured attachment" do
+    given_there_is_an_edition_that_allows_featured_attachments
+    when_i_visit_the_summary_page
+    and_i_go_to_change_an_attachment
+    and_i_go_to_add_an_attachment
+    and_i_select_a_file_to_upload
+    and_i_save_the_file_attachment
+    then_i_can_see_the_attachment
     and_i_see_the_timeline_entry
   end
 
@@ -13,9 +26,18 @@ RSpec.feature "Upload file attachment", js: true do
     @edition = create(:edition, document_type: document_type)
   end
 
+  def given_there_is_an_edition_that_allows_featured_attachments
+    document_type = build(:document_type, :with_body, attachments: "featured")
+    @edition = create(:edition, document_type: document_type)
+  end
+
   def when_i_go_to_edit_the_edition
     visit document_path(@edition.document)
     click_on "Change Content"
+  end
+
+  def when_i_visit_the_summary_page
+    visit document_path(@edition.document)
   end
 
   def and_i_go_to_insert_an_attachment
@@ -23,7 +45,15 @@ RSpec.feature "Upload file attachment", js: true do
     click_on "Attachment"
   end
 
-  def and_i_upload_a_file_attachment
+  def and_i_go_to_change_an_attachment
+    click_on "Change Attachments"
+  end
+
+  def and_i_go_to_add_an_attachment
+    click_on "Upload file attachment"
+  end
+
+  def and_i_select_a_file_to_upload
     @attachment_filename = "13kb-1-page-attachment.pdf"
     @title = "A title"
 
@@ -32,20 +62,29 @@ RSpec.feature "Upload file attachment", js: true do
 
     find('form input[type="file"]').set(Rails.root.join(file_fixture(@attachment_filename)))
     fill_in "title", with: @title
+  end
+
+  def and_i_upload_the_file_attachment
     click_on "Upload"
   end
 
-  def then_i_can_see_previews_of_the_attachment
-    metadata = "PDF, 13 KB, 1 page"
+  def and_i_save_the_file_attachment
+    click_on "Save and continue"
+  end
+
+  def then_i_can_see_the_attachment
+    @metadata = "PDF, 13 KB, 1 page"
 
     within(".gem-c-attachment") do
       expect(page).to have_content(@title)
-      expect(page).to have_content(metadata)
+      expect(page).to have_content(@metadata)
     end
+  end
 
+  def and_i_can_see_an_action_to_preview_the_attachment
     within(".gem-c-attachment-link") do
       expect(page).to have_content(@title)
-      expect(page).to have_content(metadata)
+      expect(page).to have_content(@metadata)
     end
   end
 

--- a/spec/requests/featured_attachments_spec.rb
+++ b/spec/requests/featured_attachments_spec.rb
@@ -1,0 +1,15 @@
+RSpec.describe "Featured Attachments" do
+  it_behaves_like "requests that assert edition state",
+                  "accessing featured attachments for a non editable edition",
+                  routes: { featured_attachments_path: %i[get] } do
+    let(:edition) { create(:edition, :published) }
+  end
+
+  describe "GET /documents/:document/attachments" do
+    it "returns successfully" do
+      edition = create(:edition)
+      get featured_attachments_path(edition.document)
+      expect(response).to have_http_status(:ok)
+    end
+  end
+end

--- a/spec/requests/file_attachments_spec.rb
+++ b/spec/requests/file_attachments_spec.rb
@@ -110,6 +110,18 @@ RSpec.describe "File Attachments" do
         .to redirect_to(file_attachment_path(edition.document, file_attachment))
     end
 
+    it "redirects to attachments index view when featured attachment is created successfully" do
+      stub_asset_manager_receives_an_asset(filename: "text-file-74bytes.txt")
+
+      file = fixture_file_upload("files/text-file-74bytes.txt")
+      post file_attachments_path(edition.document, wizard: "new"),
+           params: { file: file, title: "File" }
+
+      file_attachment = FileAttachment.last
+      expect(response)
+        .to redirect_to(featured_attachments_path(edition.document, file_attachment))
+    end
+
     it "returns issues and an unprocessable response when there are requirement issues" do
       file = fixture_file_upload("files/bad_file.rb")
       post file_attachments_path(edition.document),

--- a/spec/requests/file_attachments_spec.rb
+++ b/spec/requests/file_attachments_spec.rb
@@ -1,7 +1,8 @@
 RSpec.describe "File Attachments" do
   it_behaves_like "requests that assert edition state",
                   "accessing file attachments for a non editable edition",
-                  routes: { file_attachments_path: %i[get post] } do
+                  routes: { file_attachments_path: %i[get post],
+                            new_file_attachment_path: %i[get] } do
     let(:edition) { create(:edition, :published) }
   end
 
@@ -23,6 +24,14 @@ RSpec.describe "File Attachments" do
     let(:edition) { create(:edition) }
     let(:file_attachment_revision) { create(:file_attachment_revision) }
     let(:route_params) { [edition.document, file_attachment_revision] }
+  end
+
+  describe "GET /documents/:document/file-attachments/new" do
+    it "returns successfully" do
+      edition = create(:edition)
+      get new_file_attachment_path(edition.document)
+      expect(response).to have_http_status(:ok)
+    end
   end
 
   describe "GET /documents/:document/file-attachments/:file_attachment_id" do

--- a/spec/views/featured_attachments/index.html.erb_spec.rb
+++ b/spec/views/featured_attachments/index.html.erb_spec.rb
@@ -1,0 +1,18 @@
+RSpec.describe "featured_attachments/index.html.erb" do
+  describe "featured_attachments index" do
+    it "shows file attachments that exist on the edition" do
+      file_attachment_revision = create(:file_attachment_revision)
+      edition = create(:edition,
+                       file_attachment_revisions: [file_attachment_revision])
+      assign(:edition, edition)
+
+      expect(render).to have_content(file_attachment_revision.title)
+    end
+
+    it "shows a message when there aren't any attachments" do
+      assign(:edition, create(:edition))
+
+      expect(render).to have_content(I18n.t("featured_attachments.index.no_attachments"))
+    end
+  end
+end


### PR DESCRIPTION
Trello: https://trello.com/c/RTw12Wxq

# What's changed and why?

Allow the user to upload a feature file attachment.

Publications, don't just allow inline attachments, linked to from within the body text of a document, they also allow a list of "featured" documents to be added to them. Featured documents are usually displayed along with some metadata about them.

This example has both: https://www.gov.uk/government/publications/the-uks-approach-to-trade-negotiations-with-the-us

To be able to support Publishers creating publications documents, we need to be support adding featured attachments to documents.

Until publications are ready to be released, adding a featured attachment is only available to users with "pre_release" permissions.

# Expected changes

## New attachment page
<img width="1532" alt="Screenshot 2020-03-02 at 10 44 41" src="https://user-images.githubusercontent.com/5793815/75671475-b3c2b600-5c76-11ea-82d7-12eb2c15974b.png">
<img width="1532" alt="Screenshot 2020-03-02 at 10 45 15" src="https://user-images.githubusercontent.com/5793815/75671499-be7d4b00-5c76-11ea-82bb-72d84acef48b.png">

## Attachment index page
<img width="1532" alt="Screenshot 2020-03-03 at 12 37 35" src="https://user-images.githubusercontent.com/5793815/75777555-16d34c00-5d4e-11ea-88c8-9f67d17daf02.png">

<img width="1532" alt="Screenshot 2020-03-02 at 10 44 27" src="https://user-images.githubusercontent.com/5793815/75671445-a279a980-5c76-11ea-8bf5-dcc3aebaf6f1.png">

## Document summary page

<img width="1532" alt="Screenshot 2020-03-03 at 12 56 47" src="https://user-images.githubusercontent.com/5793815/75777787-7f222d80-5d4e-11ea-9fa2-8d40bf775b56.png">


# Assumptions
The following features are not covered by this change, they will be added as part of a separate piece of work:

* Featured attachments are not sent as part of the publishing-api payload
* Existing attachments are not listed on the summary page
* The attachment index page does not have any "actions" e.g. delete
* The new attachment page and the upload attachment modal are very similar but have not been consolidated here.