### PR TITLE
Add new 'attachments' attribute to document types

### DIFF
--- a/app/models/document_type.rb
+++ b/app/models/document_type.rb
@@ -34,6 +34,10 @@ class DocumentType
 
   alias_method :pre_release?, :pre_release
 
+  def attachments
+    ActiveSupport::StringInquirer.new(@attachments)
+  end
+
   class TagField
     include InitializeWithHash
     attr_reader :id, :type, :document_type, :hint

--- a/app/models/document_type.rb
+++ b/app/models/document_type.rb
@@ -1,7 +1,7 @@
 class DocumentType
   include InitializeWithHash
 
-  attr_reader :contents, :id, :managed_elsewhere, :publishing_metadata, :label,
+  attr_reader :contents, :id, :publishing_metadata, :label,
               :path_prefix, :tags, :topics
 
   def self.find(id)

--- a/app/models/document_type.rb
+++ b/app/models/document_type.rb
@@ -2,9 +2,7 @@ class DocumentType
   include InitializeWithHash
 
   attr_reader :contents, :id, :managed_elsewhere, :publishing_metadata, :label,
-              :path_prefix, :tags, :lead_image, :topics, :pre_release
-
-  alias_method :lead_image?, :lead_image
+              :path_prefix, :tags, :topics
 
   def self.find(id)
     item = all.find { |document_type| document_type.id == id }
@@ -32,7 +30,9 @@ class DocumentType
     @all = nil
   end
 
-  alias_method :pre_release?, :pre_release
+  def lead_image?; @lead_image; end
+
+  def pre_release?; @pre_release; end
 
   def attachments
     ActiveSupport::StringInquirer.new(@attachments)

--- a/config/document_types.yml
+++ b/config/document_types.yml
@@ -2,6 +2,7 @@
 news_article: &news_article
   path_prefix: /government/news
   lead_image: true
+  attachments: inline_file_only
   publishing_metadata:
     schema_name: news_article
     rendering_app: government-frontend
@@ -30,6 +31,7 @@ publication: &publication
   pre_release: true
   path_prefix: /government/publications
   lead_image: false
+  attachments: featured
   publishing_metadata:
     schema_name: publication
     rendering_app: government-frontend

--- a/lib/publishing_api_payload.rb
+++ b/lib/publishing_api_payload.rb
@@ -93,7 +93,7 @@ private
       details[:image] = image
     end
 
-    details[:documents] = [] if publication?
+    details[:documents] = [] if document_type.attachments.featured?
 
     details
   end
@@ -111,9 +111,5 @@ private
         memo[:roles] = (memo[:roles] + roles).uniq
         memo[:people] = (memo[:people] + people).uniq
       end
-  end
-
-  def publication?
-    publishing_metadata.schema_name == "publication"
   end
 end

--- a/spec/factories/document_type_factory.rb
+++ b/spec/factories/document_type_factory.rb
@@ -12,6 +12,7 @@ FactoryBot.define do
     tags { [] }
     guidance { [] }
     topics { false }
+    attachments { "inline_file_only" }
 
     contents do
       [DocumentType::SummaryField.new]

--- a/spec/support/schemas/document_type.json
+++ b/spec/support/schemas/document_type.json
@@ -5,6 +5,7 @@
     "id",
     "label",
     "path_prefix",
+    "attachments",
     "lead_image",
     "publishing_metadata",
     "contents",
@@ -23,6 +24,13 @@
     },
     "lead_image": {
       "type": "boolean"
+    },
+    "attachments": {
+      "type": "string",
+      "enum": [
+        "inline_file_only",
+        "featured"
+      ]
     },
     "publishing_metadata": {
       "type": "object",


### PR DESCRIPTION
https://trello.com/c/dzFScHVI/1498-disable-inline-file-attachments-when-featured-attachments-are-available

This does some of the initial work on the card to unblock the next ones.

Previously we only supported (inline) file attachments for news, but we
will have a different workflow for publications, which have (inline)
featured attachments. This adds a new attribute to clearly indicate in what
form attachments are available for a document type.

Please see the commits for more details.