### PR TITLE
Fix incorrect ordering of change history migration

### DIFF
--- a/db/migrate/20200220111317_backfill_change_history_for_metadata_revisions.rb
+++ b/db/migrate/20200220111317_backfill_change_history_for_metadata_revisions.rb
@@ -23,7 +23,7 @@ class BackfillChangeHistoryForMetadataRevisions < ActiveRecord::Migration[6.0]
           .where("editions.number > 1 AND editions.number < ?", edition.number)
           .where("metadata_revisions.update_type": "major")
           .where(document_id: edition.document_id)
-          .order(:published_at)
+          .order(published_at: :desc)
 
         change_history = change_history_editions.map do |e|
           { id: change_history_ids[e.id] ||= SecureRandom.uuid,


### PR DESCRIPTION
Trello: https://trello.com/c/ymfW8Eeh/1462-backfill-the-changehistory-of-existing-content

Oh dear - I only noticed this when this migration had been run in
production. It's not too big a concern as we don't validate that the
change history is in a particular order and can likely recover from it
being out of order.

However since this is a backfill it'd be good to set the precedent to be
in the order we expect.

To resolve this I plan to rollback the migration in each environment
(which won't do anything) and then re-run it to reset the change
history. It doesn't seem to be a sufficiently big problem to warrant
creating a new migration.

Before this change change_history was appended:

<img width="977" alt="Screenshot 2020-03-02 at 14 52 20" src="https://user-images.githubusercontent.com/282717/75687319-89ccbc00-5c95-11ea-91d0-088ea70eecfe.png">

After it is prepended:

<img width="969" alt="Screenshot 2020-03-02 at 14 53 00" src="https://user-images.githubusercontent.com/282717/75687339-90f3ca00-5c95-11ea-88b6-8215a4407f10.png">
