### PR TITLE
Add removed_at to removals

### DIFF
--- a/db/migrate/20200303115207_add_removed_at_to_removals.rb
+++ b/db/migrate/20200303115207_add_removed_at_to_removals.rb
@@ -1,0 +1,5 @@
+class AddRemovedAtToRemovals < ActiveRecord::Migration[6.0]
+  def change
+    add_column :removals, :removed_at, :datetime
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2020_02_20_111317) do
+ActiveRecord::Schema.define(version: 2020_03_03_115207) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -230,6 +230,7 @@ ActiveRecord::Schema.define(version: 2020_02_20_111317) do
     t.string "alternative_url"
     t.boolean "redirect", default: false
     t.datetime "created_at", null: false
+    t.datetime "removed_at"
   end
 
   create_table "revisions", force: :cascade do |t|

--- a/lib/tasks/remove.rake
+++ b/lib/tasks/remove.rake
@@ -12,7 +12,8 @@ namespace :remove do
     raise "Document must have a published version before it can be removed" unless document.live_edition
 
     removal = Removal.new(explanatory_note: explanatory_note,
-                          alternative_url: alternative_url)
+                          alternative_url: alternative_url,
+                          removed_at: Time.zone.now)
 
     RemoveDocumentService.call(document.live_edition, removal, user: user)
   end
@@ -32,7 +33,8 @@ namespace :remove do
 
     removal = Removal.new(redirect: true,
                           explanatory_note: explanatory_note,
-                          alternative_url: redirect_url)
+                          alternative_url: redirect_url,
+                          removed_at: Time.zone.now)
 
     RemoveDocumentService.call(document.live_edition, removal, user: user)
   end

--- a/spec/lib/tasks/remove_spec.rb
+++ b/spec/lib/tasks/remove_spec.rb
@@ -12,13 +12,16 @@ RSpec.describe "Remove tasks" do
     it "delegates to RemoveDocumentService" do
       note = "The reason the edition is being removed"
 
-      ClimateControl.modify NOTE: note do
-        Rake::Task["remove:gone"].invoke(edition.content_id)
-      end
+      freeze_time do
+        ClimateControl.modify NOTE: note do
+          Rake::Task["remove:gone"].invoke(edition.content_id)
+        end
 
-      expect(RemoveDocumentService).to have_received(:call) do |removed_edition, removal|
-        expect(removed_edition).to eq(edition)
-        expect(removal.explanatory_note).to eq(note)
+        expect(RemoveDocumentService).to have_received(:call) do |removed_edition, removal|
+          expect(removed_edition).to eq(edition)
+          expect(removal.explanatory_note).to eq(note)
+          expect(removal.removed_at).to eq(Time.zone.now)
+        end
       end
     end
 
@@ -66,20 +69,23 @@ RSpec.describe "Remove tasks" do
       note = "The reason the edition is being removed"
       url = "/redirect-url"
 
-      ClimateControl.modify NOTE: note, URL: url do
-        Rake::Task["remove:redirect"].invoke(edition.content_id)
-      end
+      freeze_time do
+        ClimateControl.modify NOTE: note, URL: url do
+          Rake::Task["remove:redirect"].invoke(edition.content_id)
+        end
 
-      expect(RemoveDocumentService).to have_received(:call) do |removed_edition, removal|
-        expect(removed_edition).to eq(edition)
-        expect(removal.attributes)
-          .to match(
-            a_hash_including(
-              "explanatory_note" => note,
-              "alternative_url" => url,
-              "redirect" => true,
-            ),
-          )
+        expect(RemoveDocumentService).to have_received(:call) do |removed_edition, removal|
+          expect(removed_edition).to eq(edition)
+          expect(removal.attributes)
+            .to match(
+              a_hash_including(
+                "explanatory_note" => note,
+                "alternative_url" => url,
+                "redirect" => true,
+                "removed_at" => Time.zone.now,
+              ),
+            )
+        end
       end
     end
 


### PR DESCRIPTION
For https://trello.com/c/O0Nndw14/1474-store-and-import-removedat-time

This adds a `removed_at` column to Removal and sets this value when creating a Removal in the remove content rake tasks.  At this stage we are not making this a required value for a Removal; we will need to backfill existing Removals before doing so.