### PR TITLE
Backfill removed_at value for Removals

### DIFF
--- a/db/migrate/20200303143426_backfill_removals_removed_at.rb
+++ b/db/migrate/20200303143426_backfill_removals_removed_at.rb
@@ -1,0 +1,9 @@
+class BackfillRemovalsRemovedAt < ActiveRecord::Migration[6.0]
+  disable_ddl_transaction!
+
+  class Removal < ApplicationRecord; end
+
+  def up
+    Removal.find_each { |removal| removal.update!(removed_at: removal.created_at) }
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2020_03_03_115207) do
+ActiveRecord::Schema.define(version: 2020_03_03_143426) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"


### PR DESCRIPTION
For https://trello.com/c/O0Nndw14/1474-store-and-import-removedat-time

In anticipation of making `removed_at` a required attribute for a Removal
record, we backfill the value for existing Removals. Since we set the
`removed_at` value to the current time when a Removal is created, it makes
sense to set `removed_at` for existing Removals to their `created_at` value.