### PR TITLE
Set removed_at for Whitehall imports

### DIFF
--- a/lib/whitehall_importer/create_edition.rb
+++ b/lib/whitehall_importer/create_edition.rb
@@ -128,6 +128,7 @@ module WhitehallImporter
         explanatory_note: unpublishing["explanation"],
         alternative_url: unpublishing["alternative_url"],
         redirect: unpublishing["alternative_url"].present?,
+        removed_at: unpublishing["created_at"],
       )
     end
 

--- a/spec/lib/whitehall_importer/create_edition_spec.rb
+++ b/spec/lib/whitehall_importer/create_edition_spec.rb
@@ -319,6 +319,7 @@ RSpec.describe WhitehallImporter::CreateEdition do
         removal = edition.status.details
         expect(removal.explanatory_note).to eq(whitehall_edition["unpublishing"]["explanation"])
         expect(removal.alternative_url).to eq(whitehall_edition["unpublishing"]["alternative_url"])
+        expect(removal.removed_at).to eq(whitehall_edition["unpublishing"]["created_at"])
         expect(removal).to be_redirect
       end
 
@@ -374,6 +375,8 @@ RSpec.describe WhitehallImporter::CreateEdition do
         removal = document.editions.first.status.details
         expect(removal.explanatory_note).to eq(whitehall_edition["unpublishing"]["explanation"])
         expect(removal.alternative_url).to eq(whitehall_edition["unpublishing"]["alternative_url"])
+        expect(removal.removed_at).to eq(whitehall_edition["unpublishing"]["created_at"])
+
         expect(removal).to be_redirect
       end
 


### PR DESCRIPTION
For https://trello.com/c/O0Nndw14/1474-store-and-import-removedat-time

If a Whitehall document has been removed, then when it is imported into Content
Publisher we set its Removal `removed_at` value to the unpublishing
`created_at` value. This means we can ensure that the Publishing API is
accurately updated when we sync this imported content.