### PR TITLE
Change Resync Document Service to use removed_at

### DIFF
--- a/app/services/resync_document_service.rb
+++ b/app/services/resync_document_service.rb
@@ -92,7 +92,7 @@ private
       explanation: removal.explanatory_note,
       alternative_path: removal.alternative_url,
       locale: live_edition.locale,
-      unpublished_at: removal.created_at,
+      unpublished_at: removal.removed_at,
       allow_draft: true,
     )
   end

--- a/spec/factories/removal_factory.rb
+++ b/spec/factories/removal_factory.rb
@@ -1,6 +1,6 @@
 FactoryBot.define do
   factory :removal do
     redirect { false }
-    created_at { Date.yesterday.noon }
+    removed_at { Date.yesterday.noon }
   end
 end

--- a/spec/services/resync_document_service_spec.rb
+++ b/spec/services/resync_document_service_spec.rb
@@ -131,7 +131,7 @@ RSpec.describe ResyncDocumentService do
         stub_any_publishing_api_unpublish
       end
 
-      context "when the live edition is removed with a redirect" do
+      context "with a redirect" do
         let(:removal) do
           build(
             :removal,
@@ -149,7 +149,7 @@ RSpec.describe ResyncDocumentService do
             explanation: explanation,
             alternative_path: removal.alternative_url,
             locale: edition.locale,
-            unpublished_at: removal.created_at,
+            unpublished_at: removal.removed_at,
             allow_draft: true,
           }
 
@@ -160,14 +160,14 @@ RSpec.describe ResyncDocumentService do
         end
       end
 
-      context "when the live edition is removed without a redirect" do
+      context "without a redirect" do
         let(:edition) { create(:edition, :removed) }
 
         it "removes the edition" do
           remove_params = {
             type: "gone",
             locale: edition.locale,
-            unpublished_at: edition.status.details.created_at,
+            unpublished_at: edition.status.details.removed_at,
             allow_draft: true,
           }
 


### PR DESCRIPTION
For https://trello.com/c/O0Nndw14/1474-store-and-import-removedat-time

When syncing an edition that has been removed, the Resync Document Service
should now send the removal's `removed_at` value instead of `created_at`.