### PR TITLE
Import change history

### DIFF
--- a/lib/whitehall_importer/change_history.rb
+++ b/lib/whitehall_importer/change_history.rb
@@ -1,0 +1,50 @@
+module WhitehallImporter
+  class ChangeHistory
+    attr_reader :entries
+
+    def initialize(whitehall_export)
+      @entries = build_entries(whitehall_export["editions"])
+    end
+
+    def for(edition_number)
+      entries.each_with_object([]) do |item, change_history|
+        change_history << item["change_history_entry"] if item["edition_number"] < edition_number
+      end
+    end
+
+  private
+
+    def build_entries(editions)
+      change_history_entries = editions.map.with_index do |edition, index|
+        edition_number = index + 1
+
+        next if edition["minor_change"] || edition_number == 1
+        next if edition_hasnt_been_published?(edition)
+
+        history_event(edition, edition_number)
+      end
+
+      change_history_entries.compact.reverse
+    end
+
+    def edition_hasnt_been_published?(edition)
+      %w[submitted rejected draft].include?(edition["state"]) && edition["unpublishing"].blank?
+    end
+
+    def history_event(edition, edition_number)
+      publish_event = EditionHistory.new(edition["revision_history"]).last_state_event("published")
+
+      raise AbortImportError, "Edition has a major change but no change note" if edition["change_note"].blank?
+      raise AbortImportError, "Edition has a major change but no publish event" if publish_event.blank?
+
+      {
+        "edition_number" => edition_number,
+        "change_history_entry" => {
+          "id" => SecureRandom.uuid,
+          "note" => edition["change_note"],
+          "public_timestamp" => publish_event["created_at"],
+        },
+      }
+    end
+  end
+end

--- a/lib/whitehall_importer/create_edition.rb
+++ b/lib/whitehall_importer/create_edition.rb
@@ -1,15 +1,17 @@
 module WhitehallImporter
   class CreateEdition
-    attr_reader :document_import, :current, :whitehall_edition, :edition_number, :user_ids
+    attr_reader :document_import, :whitehall_edition, :change_history, :current, :edition_number, :user_ids
 
     def self.call(*args)
       new(*args).call
     end
 
-    def initialize(document_import:, whitehall_edition:, current: true, edition_number: 1, user_ids: {})
+    def initialize(document_import:, whitehall_edition:, change_history:,
+                   current: true, edition_number: 1, user_ids: {})
       @document_import = document_import
-      @current = current
       @whitehall_edition = whitehall_edition
+      @change_history = change_history
+      @current = current
       @edition_number = edition_number
       @user_ids = user_ids
     end
@@ -27,8 +29,10 @@ module WhitehallImporter
                   create_removed_edition
                 else
                   state = MigrateState.call(whitehall_edition["state"], whitehall_edition["force_published"])
-                  status = build_status(state)
-                  create_edition(status: status, current: current, edition_number: edition_number)
+                  revision = create_revision(edition_number)
+                  status = build_status(revision, state)
+                  create_edition(status: status, current: current,
+                                 edition_number: edition_number, revision: revision)
                 end
 
       create_revision_history(edition)
@@ -40,8 +44,8 @@ module WhitehallImporter
 
   private
 
-    def revision
-      @revision ||= CreateRevision.call(document_import, whitehall_edition)
+    def create_revision(edition_number)
+      CreateRevision.call(document_import, whitehall_edition, change_history.for(edition_number))
     end
 
     def history
@@ -54,24 +58,30 @@ module WhitehallImporter
 
     def split_unpublished_edition
       unpublishing_event = history.last_unpublishing_event!
+      removed_revision = create_revision(edition_number)
       create_edition(
-        status: build_status("removed", build_removal),
+        status: build_status(removed_revision, "removed", build_removal),
         current: false,
         edition_number: edition_number,
         last_event: unpublishing_event,
+        revision: removed_revision,
       )
 
+      current_revision = create_revision(edition_number + 1)
+      migrated_state = MigrateState.call(whitehall_edition["state"], whitehall_edition["force_published"])
       create_edition(
-        status: build_status(MigrateState.call(whitehall_edition["state"], whitehall_edition["force_published"])),
+        status: build_status(current_revision, migrated_state),
         edition_number: edition_number + 1,
         current: true,
         create_event: history.next_event!(unpublishing_event),
+        revision: current_revision,
       )
     end
 
     def create_removed_edition
-      removed_status = build_status("removed", build_removal)
-      create_edition(status: removed_status, current: current, edition_number: edition_number)
+      revision = create_revision(edition_number)
+      removed_status = build_status(revision, "removed", build_removal)
+      create_edition(status: removed_status, current: current, edition_number: edition_number, revision: revision)
     end
 
     def check_only_in_english
@@ -83,9 +93,11 @@ module WhitehallImporter
     end
 
     def create_withdrawn_edition
-      create_edition(status: build_status("published"),
+      revision = create_revision(edition_number)
+      create_edition(status: build_status(revision, "published"),
                      current: current,
-                     edition_number: edition_number).tap { |edition| set_withdrawn_status(edition) }
+                     edition_number: edition_number,
+                     revision: revision).tap { |edition| set_withdrawn_status(edition) }
     end
 
     def set_withdrawn_status(edition)
@@ -99,7 +111,7 @@ module WhitehallImporter
         withdrawn_at: whitehall_edition["unpublishing"]["created_at"],
       )
 
-      edition.update!(status: build_status("withdrawn", withdrawal))
+      edition.update!(status: build_status(edition.revision, "withdrawn", withdrawal))
     end
 
     def create_scheduled_edition
@@ -107,14 +119,16 @@ module WhitehallImporter
         raise AbortImportError, "Cannot create scheduled status without scheduled_publication"
       end
 
+      revision = create_revision(edition_number)
       pre_scheduled_state = history.last_state_event("submitted") ? "submitted_for_review" : "draft"
-      edition = create_edition(status: build_status(pre_scheduled_state),
+      edition = create_edition(status: build_status(revision, pre_scheduled_state),
                                current: current,
-                               edition_number: edition_number)
+                               edition_number: edition_number,
+                               revision: revision)
       scheduling = Scheduling.new(pre_scheduled_status: edition.status,
                                   reviewed: !whitehall_edition["force_published"],
                                   publish_time: whitehall_edition["scheduled_publication"])
-      edition.update!(status: build_status("scheduled", scheduling))
+      edition.update!(status: build_status(revision, "scheduled", scheduling))
       edition
     end
 
@@ -132,7 +146,7 @@ module WhitehallImporter
       )
     end
 
-    def build_status(state, details = nil)
+    def build_status(revision, state, details = nil)
       last_state_event = history.last_state_event!(whitehall_edition["state"])
 
       Status.new(
@@ -144,7 +158,7 @@ module WhitehallImporter
       )
     end
 
-    def create_edition(status:, edition_number:, current:, create_event: nil, last_event: nil)
+    def create_edition(status:, edition_number:, current:, revision:, create_event: nil, last_event: nil)
       create_event ||= history.create_event!
       last_event ||= whitehall_edition["revision_history"].last
 

--- a/lib/whitehall_importer/create_revision.rb
+++ b/lib/whitehall_importer/create_revision.rb
@@ -1,6 +1,6 @@
 module WhitehallImporter
   class CreateRevision
-    attr_reader :document_import, :whitehall_edition
+    attr_reader :document_import, :whitehall_edition, :change_history
 
     delegate :document, to: :document_import
 
@@ -16,9 +16,10 @@ module WhitehallImporter
       new(*args).call
     end
 
-    def initialize(document_import, whitehall_edition)
+    def initialize(document_import, whitehall_edition, change_history = [])
       @document_import = document_import
       @whitehall_edition = whitehall_edition
+      @change_history = change_history
     end
 
     def call
@@ -49,6 +50,7 @@ module WhitehallImporter
           change_note: whitehall_edition["change_note"],
           document_type_id: whitehall_edition[document_type_key],
           backdated_to: backdated? ? whitehall_edition["first_published_at"] : nil,
+          change_history: change_history,
         ),
         tags_revision: TagsRevision.new(
           tags: {

--- a/lib/whitehall_importer/import.rb
+++ b/lib/whitehall_importer/import.rb
@@ -27,8 +27,9 @@ module WhitehallImporter
         whitehall_document["editions"].each_with_index do |edition, edition_number|
           CreateEdition.call(
             document_import: document_import,
-            current: current?(edition),
             whitehall_edition: edition,
+            change_history: change_history,
+            current: current?(edition),
             edition_number: edition_number + 1,
             user_ids: user_ids,
           )
@@ -47,6 +48,10 @@ module WhitehallImporter
     end
 
   private
+
+    def change_history
+      @change_history ||= ChangeHistory.new(document_import.payload)
+    end
 
     def whitehall_document
       @whitehall_document ||= GdsApi.whitehall_export

--- a/spec/factories/whitehall_export/edition_factory.rb
+++ b/spec/factories/whitehall_export/edition_factory.rb
@@ -39,8 +39,6 @@ FactoryBot.define do
       created_at { 3.days.ago.rfc3339 }
       scheduled_publication { Time.zone.now.tomorrow.rfc3339 }
       state { "scheduled" }
-      editorial_remarks { [] }
-      fact_check_requests { [] }
       revision_history do
         [
           build(:whitehall_export_revision_history_event,
@@ -58,10 +56,12 @@ FactoryBot.define do
     end
 
     trait :published do
+      transient do
+        published_at { Time.zone.now.rfc3339 }
+      end
+
       created_at { 3.days.ago.rfc3339 }
       state { "published" }
-      editorial_remarks { [] }
-      fact_check_requests { [] }
       revision_history do
         [
           build(:whitehall_export_revision_history_event,
@@ -69,7 +69,29 @@ FactoryBot.define do
           build(:whitehall_export_revision_history_event,
                 event: "update",
                 state: "published",
-                created_at: 2.days.ago.rfc3339),
+                created_at: published_at),
+        ]
+      end
+    end
+
+    trait :superseded do
+      transient do
+        published_at { Time.zone.now.rfc3339 }
+      end
+
+      created_at { 3.days.ago.rfc3339 }
+      state { "superseded" }
+      revision_history do
+        [
+          build(:whitehall_export_revision_history_event,
+                created_at: created_at),
+          build(:whitehall_export_revision_history_event,
+                event: "update",
+                state: "published",
+                created_at: published_at),
+          build(:whitehall_export_revision_history_event,
+                event: "update",
+                state: "superseded"),
         ]
       end
     end

--- a/spec/lib/whitehall_importer/change_history_spec.rb
+++ b/spec/lib/whitehall_importer/change_history_spec.rb
@@ -1,0 +1,71 @@
+RSpec.describe WhitehallImporter::ChangeHistory do
+  describe "#for" do
+    let(:first_edition) { build(:whitehall_export_edition, :superseded) }
+
+    it "returns the change history for the editions preceding the given edition number" do
+      second_edition = build(:whitehall_export_edition, :superseded,
+                             change_note: "Some change",
+                             published_at: Time.zone.now.beginning_of_week.rfc3339)
+      third_edition = build(:whitehall_export_edition, :published,
+                            change_note: "Other change",
+                            published_at: Time.zone.now.beginning_of_day.rfc3339)
+      whitehall_export = build(:whitehall_export_document,
+                               editions: [first_edition, second_edition, third_edition])
+
+      expect(described_class.new(whitehall_export).for(4)).to match([
+        { "id" => anything, "note" => "Other change", "public_timestamp" => Time.zone.now.beginning_of_day.rfc3339 },
+        { "id" => anything, "note" => "Some change", "public_timestamp" => Time.zone.now.beginning_of_week.rfc3339 },
+      ])
+    end
+
+    it "returns draft edition change history if it has been previously unpublished" do
+      edition = build(:whitehall_export_edition,
+                      change_note: "Some change",
+                      unpublishing: build(:whitehall_export_unpublishing),
+                      revision_history: [build(:whitehall_export_revision_history_event,
+                                               state: "published",
+                                               created_at: Time.zone.now.beginning_of_day.rfc3339)])
+      whitehall_export = build(:whitehall_export_document, editions: [first_edition, edition])
+
+      expect(described_class.new(whitehall_export).for(3)).to match([
+        { "id" => anything, "note" => "Some change", "public_timestamp" => Time.zone.now.beginning_of_day.rfc3339 },
+      ])
+    end
+
+    it "doesn't include the first edition in change history" do
+      whitehall_export = build(:whitehall_export_document, editions: [first_edition])
+      expect(described_class.new(whitehall_export).for(2)).to be_empty
+    end
+
+    it "doesn't include draft editions in change history" do
+      edition = build(:whitehall_export_edition)
+      whitehall_export = build(:whitehall_export_document, editions: [first_edition, edition])
+
+      expect(described_class.new(whitehall_export).for(3)).to be_empty
+    end
+
+    it "doesn't include minor change editions in change history" do
+      edition = build(:whitehall_export_edition, :published, minor_change: true, change_note: "")
+      whitehall_export = build(:whitehall_export_document, editions: [first_edition, edition])
+
+      expect(described_class.new(whitehall_export).for(3)).to be_empty
+    end
+
+    it "raises if an edition has a major change but no change note" do
+      edition = build(:whitehall_export_edition, :published, change_note: "")
+      whitehall_export = build(:whitehall_export_document, editions: [first_edition, edition])
+
+      expect { described_class.new(whitehall_export).for(2) }
+        .to raise_error(WhitehallImporter::AbortImportError, "Edition has a major change but no change note")
+    end
+
+    it "raises if an edition has a major change but no publish event" do
+      edition = build(:whitehall_export_edition, :published,
+                      revision_history: [build(:whitehall_export_revision_history_event)])
+      whitehall_export = build(:whitehall_export_document, editions: [first_edition, edition])
+
+      expect { described_class.new(whitehall_export).for(2) }
+        .to raise_error(WhitehallImporter::AbortImportError, "Edition has a major change but no publish event")
+    end
+  end
+end


### PR DESCRIPTION
We now want to generate change history for editions we import.  

Further info in the commits ->

Trello:
https://trello.com/c/MeyxpGHG/1465-import-publishedat-and-changehistory-for-whitehall-content