### PR TITLE
Maintain removed_at in Remove Document Service

### DIFF
--- a/app/services/remove_document_service.rb
+++ b/app/services/remove_document_service.rb
@@ -9,6 +9,7 @@ class RemoveDocumentService < ApplicationService
     Document.transaction do
       edition.document.lock!
       check_removeable
+      set_removed_at
       unpublish_edition
       update_edition_status
       create_timeline_entry
@@ -45,6 +46,14 @@ private
       status: edition.status,
       details: removal,
     )
+  end
+
+  def set_removed_at
+    removal.removed_at = if edition.removed?
+                           edition.status.details.removed_at
+                         else
+                           Time.zone.now
+                         end
   end
 
   def check_removeable

--- a/app/services/remove_document_service.rb
+++ b/app/services/remove_document_service.rb
@@ -29,6 +29,7 @@ private
       explanation: removal.explanatory_note,
       alternative_path: removal.alternative_url,
       locale: edition.locale,
+      unpublished_at: removal.removed_at,
     )
   end
 

--- a/lib/tasks/remove.rake
+++ b/lib/tasks/remove.rake
@@ -12,8 +12,7 @@ namespace :remove do
     raise "Document must have a published version before it can be removed" unless document.live_edition
 
     removal = Removal.new(explanatory_note: explanatory_note,
-                          alternative_url: alternative_url,
-                          removed_at: Time.zone.now)
+                          alternative_url: alternative_url)
 
     RemoveDocumentService.call(document.live_edition, removal, user: user)
   end
@@ -33,8 +32,7 @@ namespace :remove do
 
     removal = Removal.new(redirect: true,
                           explanatory_note: explanatory_note,
-                          alternative_url: redirect_url,
-                          removed_at: Time.zone.now)
+                          alternative_url: redirect_url)
 
     RemoveDocumentService.call(document.live_edition, removal, user: user)
   end

--- a/spec/services/remove_document_service_spec.rb
+++ b/spec/services/remove_document_service_spec.rb
@@ -45,43 +45,49 @@ RSpec.describe RemoveDocumentService do
 
     context "when the removal is a redirect" do
       it "unpublishes in the Publishing API with a type of redirect" do
-        removal = build(:removal,
-                        redirect: true,
-                        alternative_url: "/path",
-                        explanatory_note: "explanation")
+        freeze_time do
+          removal = build(:removal,
+                          redirect: true,
+                          alternative_url: "/path",
+                          explanatory_note: "explanation")
 
-        request = stub_publishing_api_unpublish(
-          edition.content_id,
-          body: {
-            alternative_path: "/path",
-            explanation: "explanation",
-            locale: edition.locale,
-            type: "redirect",
-          },
-        )
-        described_class.call(edition, removal)
-        expect(request).to have_been_requested
+          request = stub_publishing_api_unpublish(
+            edition.content_id,
+            body: {
+              alternative_path: "/path",
+              explanation: "explanation",
+              locale: edition.locale,
+              type: "redirect",
+              unpublished_at: Time.zone.now,
+            },
+          )
+          described_class.call(edition, removal)
+          expect(request).to have_been_requested
+        end
       end
     end
 
     context "when the removal is not a redirect" do
       it "unpublishes in the Publishing API with a type of gone" do
-        removal = build(:removal,
-                        redirect: false,
-                        alternative_url: "/path",
-                        explanatory_note: "explanation")
+        freeze_time do
+          removal = build(:removal,
+                          redirect: false,
+                          alternative_url: "/path",
+                          explanatory_note: "explanation")
 
-        request = stub_publishing_api_unpublish(
-          edition.content_id,
-          body: {
-            alternative_path: "/path",
-            explanation: "explanation",
-            locale: edition.locale,
-            type: "gone",
-          },
-        )
-        described_class.call(edition, removal)
-        expect(request).to have_been_requested
+          request = stub_publishing_api_unpublish(
+            edition.content_id,
+            body: {
+              alternative_path: "/path",
+              explanation: "explanation",
+              locale: edition.locale,
+              type: "gone",
+              unpublished_at: Time.zone.now,
+            },
+          )
+          described_class.call(edition, removal)
+          expect(request).to have_been_requested
+        end
       end
     end
 

--- a/spec/services/remove_document_service_spec.rb
+++ b/spec/services/remove_document_service_spec.rb
@@ -85,6 +85,32 @@ RSpec.describe RemoveDocumentService do
       end
     end
 
+    context "when the edition does not have a removal" do
+      it "sets the removed_at time" do
+        freeze_time do
+          removal = build(:removal)
+
+          described_class.call(edition, removal)
+          expect(edition.status.details.removed_at).to eq(Time.zone.now)
+        end
+      end
+    end
+
+    context "when the edition already has a removal" do
+      it "maintains the existing removed_at time" do
+        existing_removed_at = 2.days.ago.noon
+        existing_removal = build(:removal, removed_at: existing_removed_at)
+        edition = create(:edition, :removed, removal: existing_removal)
+        new_removal = build(:removal,
+                            alternative_url: "/path",
+                            explanatory_note: "explanation",
+                            redirect: true)
+
+        described_class.call(edition, new_removal)
+        expect(edition.status.details.removed_at).to eq(existing_removed_at)
+      end
+    end
+
     context "when Publishing API is down" do
       before { stub_publishing_api_isnt_available }
 


### PR DESCRIPTION
For https://trello.com/c/O0Nndw14/1474-store-and-import-removedat-time

In cases where we attempt to remove an edition that has already been removed
(for example, if the explanation needs to be updated) then we need to ensure
that the existing `removed_at` date is kept the same. This modifies the Remove
Document Service to do this.  We also update the Remove Document Service to
send the `removed_at` date to the Publishing API as the `unpublished_at` value.