### PR TITLE
Add not null constraint to removed_at

### DIFF
--- a/db/migrate/20200304083621_add_not_null_constraint_to_removed_at.rb
+++ b/db/migrate/20200304083621_add_not_null_constraint_to_removed_at.rb
@@ -1,0 +1,5 @@
+class AddNotNullConstraintToRemovedAt < ActiveRecord::Migration[6.0]
+  def change
+    change_column_null :removals, :removed_at, false
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2020_03_03_143426) do
+ActiveRecord::Schema.define(version: 2020_03_04_083621) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -230,7 +230,7 @@ ActiveRecord::Schema.define(version: 2020_03_03_143426) do
     t.string "alternative_url"
     t.boolean "redirect", default: false
     t.datetime "created_at", null: false
-    t.datetime "removed_at"
+    t.datetime "removed_at", null: false
   end
 
   create_table "revisions", force: :cascade do |t|


### PR DESCRIPTION
For https://trello.com/c/O0Nndw14/1474-store-and-import-removedat-time

A removal should always have a `removed_at` timestamp so that we can accurately
update the Publishing API. Now that existing removals have this value
backfilled, we can add a not null constraint to it.