### PR TITLE
Add rake task to make edits to change note history on documents

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,6 +72,7 @@ listen to the sidekiq processes.
 ### Further documentation
 
 - [Approach to analytics](docs/approach-to-analytics.md)
+- [Editing change note history](docs/editing-change-note-history.md)
 - [History mode](docs/history-mode.md)
 - [Importing documents from Whitehall](docs/import-from-whitehall.md)
 - [Removing documents](docs/removing-documents.md)

--- a/docs/edit-change-note-history.md
+++ b/docs/edit-change-note-history.md
@@ -1,0 +1,79 @@
+# Editing a document's change history
+
+Sometimes publishers will need to edit the historic change notes for a document.  Currently, a user cannot do this using the UI so a developer needs to run a rake task to achieve this.
+
+To alter a document's change history **the current edition must be in an editable state**.  For a published edition, a new edition must be created through the UI.  Once the change history has been edited, the document can then be republished (e.g. as a minor change, to prevent any further change notes being added to the history).
+
+When calling these tasks the USER_EMAIL variable should be passed in with your email address, for example:
+
+```
+rake change_history:delete['a-content-id','a-change-note-id'] USER_EMAIL='me@example.com'
+```
+
+This is so the change can be associated with you, the developer that performed the task, and attributed correctly in the document history.
+
+In addition, an optional LOCALE variable can be supplied, for example:
+
+```
+rake change_history:delete['a-content-id','a-change-note-id'] USER_EMAIL='me@example.com' LOCALE='cy'
+```
+
+If omitted, LOCALE defaults to "en".
+
+## Viewing all change notes for a document
+Required parameters:
+- content_id
+
+Optional parameters:
+- LOCALE
+
+```
+rake change_history:show['a-content-id']
+```
+
+## Deleting a change note
+The document must have an editable current edition.
+
+Required parameters:
+- content_id
+- change_history_id (can be retrieved using the 'show' task)
+
+Optional parameters:
+- LOCALE
+- USER_EMAIL
+
+```
+rake change_history:delete['a-content-id','a-change-history-id']
+```
+
+## Editing a change note
+The document must have an editable current edition.
+
+Required parameters:
+- content_id
+- change_history_id (can be retrieved using the 'show' task)
+- NOTE
+
+Optional parameters:
+- LOCALE
+- USER_EMAIL
+
+```
+rake change_history:edit['a-content-id','a-change-history-id'] NOTE='Made some change to this document.'
+```
+
+## Adding a change note
+The document must have an editable current edition.
+
+Required parameters:
+- content_id
+- TIMESTAMP
+- NOTE
+
+Optional parameters:
+- LOCALE
+- USER_EMAIL
+
+```
+rake change_history:add['a-content-id'] TIMESTAMP='2020-01-02 09:30' NOTE='Added new statistics.'
+```

--- a/lib/tasks/change_history.rake
+++ b/lib/tasks/change_history.rake
@@ -8,4 +8,16 @@ namespace :change_history do
       puts [entry["id"], entry["public_timestamp"], entry["note"]].join(" | ")
     end
   end
+
+  desc "Delete a single change note for a document, e.g. change_history:delete[content_id change-note-id]"
+  task :delete, %i[content_id change_history_id] => :environment do |_, args|
+    Tasks::EditionUpdater.call(args.content_id,
+                               locale: ENV.fetch("LOCALE", "en"),
+                               user_email: ENV["USER_EMAIL"]) do |edition, updater|
+      entry = edition.change_history.find { |item| item["id"] == args.change_history_id }
+      raise "No change history entry with id #{args.change_history_id}" unless entry
+
+      updater.assign(change_history: edition.change_history - [entry])
+    end
+  end
 end

--- a/lib/tasks/change_history.rake
+++ b/lib/tasks/change_history.rake
@@ -20,4 +20,20 @@ namespace :change_history do
       updater.assign(change_history: edition.change_history - [entry])
     end
   end
+
+  desc "Edit a single change note for a document, e.g. change_history:edit[content-id, change-note-id] NOTE='some note'"
+  task :edit, %i[content_id change_history_id] => :environment do |_, args|
+    Tasks::EditionUpdater.call(args.content_id,
+                               locale: ENV.fetch("LOCALE", "en"),
+                               user_email: ENV["USER_EMAIL"]) do |edition, updater|
+      raise "Expected a note" if ENV["NOTE"].blank?
+
+      change_history = edition.change_history.deep_dup
+      entry = change_history.find { |item| item["id"] == args.change_history_id }
+      raise "No change history entry with id #{args.change_history_id}" unless entry
+
+      entry["note"] = ENV["NOTE"]
+      updater.assign(change_history: change_history)
+    end
+  end
 end

--- a/lib/tasks/change_history.rake
+++ b/lib/tasks/change_history.rake
@@ -1,0 +1,11 @@
+namespace :change_history do
+  desc "Show all change notes for a document"
+  task :show, %i[content_id] => :environment do |_, args|
+    Edition
+      .find_current(document: "#{args.content_id}:#{ENV.fetch('LOCALE', 'en')}")
+      .change_history
+      .each do |entry|
+      puts [entry["id"], entry["public_timestamp"], entry["note"]].join(" | ")
+    end
+  end
+end

--- a/lib/tasks/edition_updater.rb
+++ b/lib/tasks/edition_updater.rb
@@ -1,0 +1,32 @@
+module Tasks
+  class EditionUpdater
+    def self.call(*args, &block)
+      self.new(*args).call(&block)
+    end
+
+    def initialize(content_id, locale: nil, user_email: nil)
+      @content_id = content_id
+      @locale = locale || "en"
+      @user = User.find_by!(email: user_email) if user_email
+    end
+
+    def call
+      Edition.transaction do
+        edition = Edition.lock.find_current(document: "#{@content_id}:#{@locale}")
+        raise "Edition must be editable" unless edition.editable?
+
+        updater = Versioning::RevisionUpdater.new(edition.revision, @user)
+        yield edition, updater
+
+        raise "Expected an updated revision" unless updater.changed?
+
+        EditDraftEditionService.call(edition,
+                                     @user,
+                                     revision: updater.next_revision)
+
+        edition.save!
+        FailsafeDraftPreviewService.call(edition)
+      end
+    end
+  end
+end

--- a/spec/lib/tasks/change_history_spec.rb
+++ b/spec/lib/tasks/change_history_spec.rb
@@ -4,6 +4,7 @@ RSpec.describe "Change History tasks" do
   before do
     populate_default_government_bulk_data
     stub_any_publishing_api_put_content
+    allow(Tasks::EditionUpdater).to receive(:call).and_call_original
   end
 
   describe "change_history:show" do
@@ -42,6 +43,59 @@ RSpec.describe "Change History tasks" do
       }.to output(
         "#{change_history.first[:id]} | 2020-02-20T16:00:00+00:00 | Test\n",
       ).to_stdout
+    end
+  end
+
+  describe "change_history:delete" do
+    let(:id_to_delete) { SecureRandom.uuid }
+
+    let(:change_history) do
+      [
+        {
+          id: SecureRandom.uuid,
+          public_timestamp: "2020-02-20T18:00:00+00:00",
+          note: "Test 1",
+        }, {
+          id: id_to_delete,
+          public_timestamp: "2020-02-20T17:00:00+00:00",
+          note: "Test 2",
+        }, {
+          id: SecureRandom.uuid,
+          public_timestamp: "2020-02-20T16:00:00+00:00",
+          note: "Test 3",
+        }
+      ]
+    end
+
+    let(:edition) do
+      create(:edition,
+             locale: "en",
+             change_history: change_history)
+    end
+
+    before { Rake::Task["change_history:delete"].reenable }
+
+    it "deletes a change history entry" do
+      expected_change_history = [
+        change_history.first.with_indifferent_access,
+        change_history.last.with_indifferent_access,
+      ]
+
+      Rake::Task["change_history:delete"].invoke(edition.content_id, id_to_delete)
+
+      expect(edition.reload.revision.metadata_revision.change_history)
+        .to eq(expected_change_history)
+    end
+
+    it "calls the edition updater" do
+      Rake::Task["change_history:delete"].invoke(edition.content_id, id_to_delete)
+
+      expect(Tasks::EditionUpdater).to have_received(:call)
+    end
+
+    it "raises an error when the change history ID does not exist" do
+      expect { Rake::Task["change_history:delete"].invoke(edition.content_id, "abc123") }
+        .to raise_error("No change history entry with id abc123")
     end
   end
 end

--- a/spec/lib/tasks/change_history_spec.rb
+++ b/spec/lib/tasks/change_history_spec.rb
@@ -1,6 +1,4 @@
 RSpec.describe "Change History tasks" do
-  include ActiveJob::TestHelper
-
   before do
     populate_default_government_bulk_data
     stub_any_publishing_api_put_content
@@ -11,9 +9,9 @@ RSpec.describe "Change History tasks" do
     let(:change_history) do
       [
         {
-          "id": SecureRandom.uuid,
-          "public_timestamp": "2020-02-20T16:00:00+00:00",
-          "note": "Test",
+          "id" => SecureRandom.uuid,
+          "public_timestamp" => "2020-02-20T16:00:00+00:00",
+          "note" => "Change note",
         },
       ]
     end
@@ -29,11 +27,11 @@ RSpec.describe "Change History tasks" do
       expect {
         Rake::Task["change_history:show"].invoke(edition.content_id)
       }.to output(
-        "#{change_history.first[:id]} | 2020-02-20T16:00:00+00:00 | Test\n",
+        "#{change_history.first['id']} | 2020-02-20T16:00:00+00:00 | Change note\n",
       ).to_stdout
     end
 
-    it "prints the change history for a locale" do
+    it "prints the change history for a specific locale" do
       edition = create(:edition, locale: "cy", change_history: change_history)
 
       expect {
@@ -41,7 +39,7 @@ RSpec.describe "Change History tasks" do
           Rake::Task["change_history:show"].invoke(edition.content_id)
         end
       }.to output(
-        "#{change_history.first[:id]} | 2020-02-20T16:00:00+00:00 | Test\n",
+        "#{change_history.first['id']} | 2020-02-20T16:00:00+00:00 | Change note\n",
       ).to_stdout
     end
   end
@@ -52,38 +50,31 @@ RSpec.describe "Change History tasks" do
     let(:change_history) do
       [
         {
-          id: SecureRandom.uuid,
-          public_timestamp: "2020-02-20T18:00:00+00:00",
-          note: "Test 1",
+          "id" => SecureRandom.uuid,
+          "public_timestamp" => "2020-02-20T18:00:00+00:00",
+          "note" => "First change note",
         }, {
-          id: id_to_delete,
-          public_timestamp: "2020-02-20T17:00:00+00:00",
-          note: "Test 2",
+          "id" => id_to_delete,
+          "public_timestamp" => "2020-02-20T17:00:00+00:00",
+          "note" => "Second change note",
         }, {
-          id: SecureRandom.uuid,
-          public_timestamp: "2020-02-20T16:00:00+00:00",
-          note: "Test 3",
+          "id" => SecureRandom.uuid,
+          "public_timestamp" => "2020-02-20T16:00:00+00:00",
+          "note" => "Third change note",
         }
       ]
     end
 
-    let(:edition) do
-      create(:edition,
-             locale: "en",
-             change_history: change_history)
-    end
+    let(:edition) { create(:edition, locale: "en", change_history: change_history) }
 
     before { Rake::Task["change_history:delete"].reenable }
 
     it "deletes a change history entry" do
-      expected_change_history = [
-        change_history.first.with_indifferent_access,
-        change_history.last.with_indifferent_access,
-      ]
+      expected_change_history = [change_history.first, change_history.last]
 
       Rake::Task["change_history:delete"].invoke(edition.content_id, id_to_delete)
 
-      expect(edition.reload.revision.metadata_revision.change_history)
+      expect(edition.reload.change_history)
         .to eq(expected_change_history)
     end
 
@@ -105,54 +96,42 @@ RSpec.describe "Change History tasks" do
     let(:change_history) do
       [
         {
-          id: SecureRandom.uuid,
-          public_timestamp: "2020-03-01T00:00:00+00:00",
-          note: "Test 1",
+          "id" => SecureRandom.uuid,
+          "public_timestamp" => "2020-02-20T18:00:00+00:00",
+          "note" => "First change note",
         }, {
-          id: id_to_edit,
-          public_timestamp: "2020-02-01T00:00:00+00:00",
-          note: "Test 2",
+          "id" => id_to_edit,
+          "public_timestamp" => "2020-02-20T17:00:00+00:00",
+          "note" => "Second change note",
         }, {
-          id: SecureRandom.uuid,
-          public_timestamp: "2020-01-01T00:00:00+00:00",
-          note: "Test 3",
+          "id" => SecureRandom.uuid,
+          "public_timestamp" => "2020-02-20T16:00:00+00:00",
+          "note" => "Third change note",
         }
       ]
     end
 
-    let(:edition) do
-      create(:edition,
-             locale: "en",
-             change_history: change_history)
-    end
+    let(:edition) { create(:edition, locale: "en", change_history: change_history) }
 
     before { Rake::Task["change_history:edit"].reenable }
 
     it "updates a change history entry note" do
-      ClimateControl.modify NOTE: "Test 99" do
+      ClimateControl.modify NOTE: "Updated second change note" do
         Rake::Task["change_history:edit"].invoke(edition.content_id, id_to_edit)
+
+        expect(edition.reload.change_history.second["note"]).to eq("Updated second change note")
       end
-
-      change_history[1][:note] = "Test 99"
-
-      expect(edition.reload.revision.metadata_revision.change_history)
-        .to eq(change_history.map(&:with_indifferent_access))
     end
 
     it "calls the edition updater" do
-      ClimateControl.modify NOTE: "Test 99" do
+      ClimateControl.modify NOTE: "Updated second change note" do
         Rake::Task["change_history:edit"].invoke(edition.content_id, id_to_edit)
+
+        expect(Tasks::EditionUpdater).to have_received(:call)
       end
-
-      change_history[1][:note] = "Test 99"
-
-      expect(Tasks::EditionUpdater).to have_received(:call)
     end
 
     it "raises an error when no note is supplied" do
-      expect { Rake::Task["change_history:edit"].invoke(edition.content_id, "abc123") }
-        .to raise_error("Expected a note")
-
       ClimateControl.modify NOTE: "" do
         expect { Rake::Task["change_history:edit"].invoke(edition.content_id, "abc123") }
           .to raise_error("Expected a note")
@@ -160,9 +139,67 @@ RSpec.describe "Change History tasks" do
     end
 
     it "raises an error when the change history ID does not exist" do
-      ClimateControl.modify NOTE: "Test 99" do
+      ClimateControl.modify NOTE: "Updated change note" do
         expect { Rake::Task["change_history:edit"].invoke(edition.content_id, "abc123") }
           .to raise_error("No change history entry with id abc123")
+      end
+    end
+  end
+
+  describe "change_history:add" do
+    let(:change_history) do
+      [
+        {
+          "id" => SecureRandom.uuid,
+          "public_timestamp" => "2020-02-20T16:00:00+00:00",
+          "note" => "First change note",
+        },
+      ]
+    end
+
+    let(:edition) { create(:edition, locale: "en", change_history: change_history) }
+
+    before { Rake::Task["change_history:add"].reenable }
+
+    it "adds a change history entry note" do
+      ClimateControl.modify NOTE: "New change note", TIMESTAMP: "2020-10-22 09:30" do
+        Rake::Task["change_history:add"].invoke(edition.content_id)
+
+        expect(edition.reload.change_history)
+          .to include(a_hash_including("note" => "New change note",
+                                       "public_timestamp" => "2020-10-22T09:30:00+01:00"))
+      end
+    end
+
+    it "calls the edition updater" do
+      ClimateControl.modify NOTE: "New change note", TIMESTAMP: "2020-10-22 09:30" do
+        Rake::Task["change_history:add"].invoke(edition.content_id)
+
+        expect(Tasks::EditionUpdater).to have_received(:call)
+      end
+    end
+
+    it "adds a change history entry note in the correct order" do
+      ClimateControl.modify NOTE: "New change note", TIMESTAMP: "2019-01-01 00:00" do
+        Rake::Task["change_history:add"].invoke(edition.content_id)
+
+        change_notes = edition.reload.change_history.map { |c| c["note"] }
+
+        expect(change_notes).to eq(["First change note", "New change note"])
+      end
+    end
+
+    it "raises an error when no note is supplied" do
+      ClimateControl.modify NOTE: "" do
+        expect { Rake::Task["change_history:add"].invoke(edition.content_id, "abc123") }
+          .to raise_error("Expected a note")
+      end
+    end
+
+    it "raises an error when no timestamp is supplied" do
+      ClimateControl.modify NOTE: "New change note", TIMESTAMP: "" do
+        expect { Rake::Task["change_history:add"].invoke(edition.content_id, "abc123") }
+          .to raise_error("Expected a timestamp")
       end
     end
   end

--- a/spec/lib/tasks/change_history_spec.rb
+++ b/spec/lib/tasks/change_history_spec.rb
@@ -1,0 +1,47 @@
+RSpec.describe "Change History tasks" do
+  include ActiveJob::TestHelper
+
+  before do
+    populate_default_government_bulk_data
+    stub_any_publishing_api_put_content
+  end
+
+  describe "change_history:show" do
+    let(:change_history) do
+      [
+        {
+          "id": SecureRandom.uuid,
+          "public_timestamp": "2020-02-20T16:00:00+00:00",
+          "note": "Test",
+        },
+      ]
+    end
+
+    before do
+      allow($stdout).to receive(:puts)
+      Rake::Task["change_history:show"].reenable
+    end
+
+    it "prints the change history" do
+      edition = create(:edition, locale: "en", change_history: change_history)
+
+      expect {
+        Rake::Task["change_history:show"].invoke(edition.content_id)
+      }.to output(
+        "#{change_history.first[:id]} | 2020-02-20T16:00:00+00:00 | Test\n",
+      ).to_stdout
+    end
+
+    it "prints the change history for a locale" do
+      edition = create(:edition, locale: "cy", change_history: change_history)
+
+      expect {
+        ClimateControl.modify LOCALE: "cy" do
+          Rake::Task["change_history:show"].invoke(edition.content_id)
+        end
+      }.to output(
+        "#{change_history.first[:id]} | 2020-02-20T16:00:00+00:00 | Test\n",
+      ).to_stdout
+    end
+  end
+end

--- a/spec/lib/tasks/edition_updater_spec.rb
+++ b/spec/lib/tasks/edition_updater_spec.rb
@@ -1,0 +1,71 @@
+RSpec.describe Tasks::EditionUpdater do
+  before do
+    stub_any_publishing_api_put_content
+    allow(EditDraftEditionService).to receive(:call).and_call_original
+    allow(FailsafeDraftPreviewService).to receive(:call).and_call_original
+  end
+
+  describe ".call" do
+    let(:edition) { create(:edition, locale: "en") }
+    let(:title) { "The quick brown fox jumps over a lazy dog" }
+
+    it "delegates to the EditDraftEditionService to record the edit" do
+      user = create(:user)
+      described_class.call(edition.content_id,
+                           user_email: user.email) do |_, updater|
+        updater.assign(title: title)
+      end
+
+      expect(EditDraftEditionService)
+        .to have_received(:call)
+        .with(edition, user, a_hash_including(:revision))
+    end
+
+    it "delegates to the FailsafeDraftPreviewService to create a preview" do
+      described_class.call(edition.content_id) do |_, updater|
+        updater.assign(title: title)
+      end
+
+      expect(FailsafeDraftPreviewService).to have_received(:call).with(edition)
+    end
+
+    it "updates an edition" do
+      described_class.call(edition.content_id) do |_, updater|
+        updater.assign(title: title)
+      end
+
+      expect(edition.reload.title).to eq(title)
+    end
+
+    it "updates an internationalized edition" do
+      chinese_locale = "cn"
+      chinese_edition = create(:edition, locale: chinese_locale)
+      chinese_title = "敏捷的棕色狐狸跳过了一只懒狗"
+
+      described_class.call(chinese_edition.content_id,
+                           locale: chinese_locale) do |_, updater|
+        updater.assign(title: chinese_title)
+      end
+
+      expect(chinese_edition.reload.title).to eq(chinese_title)
+    end
+
+    it "raises an error if the edition is not editable" do
+      published_edition = create(:edition, :published, locale: "en")
+
+      expect {
+        described_class.call(published_edition.content_id) do |_, updater|
+          updater.assign(title: title)
+        end
+      }.to raise_error("Edition must be editable")
+    end
+
+    it "raises an error if the edition has not been updated" do
+      expect {
+        described_class.call(edition.content_id) do |_, updater|
+          updater.assign(title: edition.title)
+        end
+      }.to raise_error("Expected an updated revision")
+    end
+  end
+end


### PR DESCRIPTION
Sometimes publishers have the need to modify the change notes on a published document.  They cannot currently do this through the UI, and developers cannot do this without performing many manual steps using a Rails console.

This adds rake tasks that allow change note history to be viewed, deleted, edited and added to by a developer.

It also adds documentation explaining how the tasks should be run.

Trello card: https://trello.com/c/I8oRBPjH