### PR TITLE
Re-order db/schema.rb

### DIFF
--- a/db/schema.rb
+++ b/db/schema.rb
@@ -374,10 +374,10 @@ ActiveRecord::Schema.define(version: 2020_03_03_143426) do
   create_table "whitehall_migrations", force: :cascade do |t|
     t.text "organisation_content_id"
     t.text "document_type"
-    t.text "document_subtypes", array: true
     t.datetime "finished_at"
     t.datetime "created_at", precision: 6, null: false
     t.datetime "updated_at", precision: 6, null: false
+    t.text "document_subtypes", array: true
   end
 
   create_table "withdrawals", force: :cascade do |t|


### PR DESCRIPTION
This document_subtypes column is added through a migration, so ends up at the end of the column list.  However, due to a merge conflict that went unnoticed, it ended up in the wrong place in the schema that was committed in aa31f36e2.  This causes issues each time a developer runs a migration, since Git detects a change in the db/schema.rb file.