### PR TITLE
Persist content_ids for document_imports on import

### DIFF
--- a/lib/whitehall_importer/create_migration.rb
+++ b/lib/whitehall_importer/create_migration.rb
@@ -45,6 +45,7 @@ module WhitehallImporter
         record.document_imports.create!(
           whitehall_document_id: document["document_id"],
           state: "pending",
+          content_id: document["content_id"],
         )
       end
     end

--- a/spec/factories/whitehall_export/index_document_factory.rb
+++ b/spec/factories/whitehall_export/index_document_factory.rb
@@ -4,13 +4,7 @@ FactoryBot.define do
 
     sequence(:document_id)
 
-    document_information {
-      {
-        locales: %w(en),
-        sub_types: %w(news_story),
-        lead_organisations: %w(96ae61d6-c2a1-48cb-8e67-da9d105ae381),
-      }.stringify_keys
-    }
+    content_id { SecureRandom.uuid }
 
     initialize_with { attributes.stringify_keys }
   end

--- a/spec/lib/whitehall_importer/create_migration_spec.rb
+++ b/spec/lib/whitehall_importer/create_migration_spec.rb
@@ -36,6 +36,11 @@ RSpec.describe WhitehallImporter::CreateMigration do
           .to change { WhitehallMigration::DocumentImport.pending.count }.by(110)
       end
 
+      it "sets the content_id on the WhitehallMigration::DocumentImport" do
+        described_class.call("123", "news_article")
+        expect(WhitehallMigration::DocumentImport.last.content_id).to eq(whitehall_export_page_2["documents"].last["content_id"])
+      end
+
       it "queues a job for each listed document" do
         described_class.call("123", "news_article")
         expect(WhitehallDocumentImportJob).to have_been_enqueued.exactly(110).times


### PR DESCRIPTION
[Trello](https://trello.com/c/ACUVDeXD/1523-export-contentid-from-whitehall-into-content-publisher)

- Will enable the 'View on Whitehall' links in the migration UI to work (as they rely on having the content ID to form the URL path).
- It will also make it easier to find a relationship between the document_import and the whitehall document.

Merge after: https://github.com/alphagov/whitehall/pull/5417 