### PR TITLE
Present withdrawn_at time to Publishing API when withdrawing a document

### DIFF
--- a/app/services/withdraw_document_service.rb
+++ b/app/services/withdraw_document_service.rb
@@ -23,6 +23,7 @@ private
       type: "withdrawal",
       explanation: format_govspeak(public_explanation, edition),
       locale: edition.locale,
+      unpublished_at: edition.status.details.withdrawn_at,
     )
   end
 

--- a/spec/features/withdrawing/edit_withdrawal_spec.rb
+++ b/spec/features/withdrawing/edit_withdrawal_spec.rb
@@ -33,7 +33,12 @@ RSpec.feature "Edit a withdrawal" do
   def when_i_edit_the_public_explanation
     @new_explanation = "Another explanation"
     converted_explanation = GovspeakDocument.new(@new_explanation, @edition).payload_html
-    body = { type: "withdrawal", explanation: converted_explanation, locale: @edition.locale }
+    body = {
+      type: "withdrawal",
+      explanation: converted_explanation,
+      locale: @edition.locale,
+      unpublished_at: @edition.status.details.withdrawn_at,
+    }
     stub_publishing_api_unpublish(@edition.content_id, body: body)
 
     fill_in "public_explanation", with: @new_explanation

--- a/spec/features/withdrawing/withdraw_spec.rb
+++ b/spec/features/withdrawing/withdraw_spec.rb
@@ -32,10 +32,17 @@ RSpec.feature "Withdraw a document" do
   end
 
   def and_i_confirm_the_withdrawal
-    converted_explanation = GovspeakDocument.new(@explanation, @edition).payload_html
-    body = { type: "withdrawal", explanation: converted_explanation, locale: @edition.locale }
-    stub_publishing_api_unpublish(@edition.content_id, body: body)
-    click_on "Withdraw document"
+    freeze_time do
+      converted_explanation = GovspeakDocument.new(@explanation, @edition).payload_html
+      body = {
+        type: "withdrawal",
+        explanation: converted_explanation,
+        locale: @edition.locale,
+        unpublished_at: Time.zone.now,
+      }
+      stub_publishing_api_unpublish(@edition.content_id, body: body)
+      click_on "Withdraw document"
+    end
   end
 
   def then_i_see_the_document_has_been_withdrawn

--- a/spec/services/withdraw_document_service_spec.rb
+++ b/spec/services/withdraw_document_service_spec.rb
@@ -7,16 +7,19 @@ RSpec.describe WithdrawDocumentService do
     before { stub_any_publishing_api_unpublish }
 
     it "converts the public explanation Govspeak to HTML before sending to Publishing API" do
-      converted_public_explanation = GovspeakDocument.new(public_explanation, edition).payload_html
-      request = stub_publishing_api_unpublish(edition.content_id,
-                                              body: { type: "withdrawal",
-                                                      explanation: converted_public_explanation,
-                                                      locale: edition.locale })
-      described_class.call(edition,
-                           user,
-                           public_explanation: public_explanation)
+      freeze_time do
+        converted_public_explanation = GovspeakDocument.new(public_explanation, edition).payload_html
+        request = stub_publishing_api_unpublish(edition.content_id,
+                                                body: { type: "withdrawal",
+                                                        explanation: converted_public_explanation,
+                                                        locale: edition.locale,
+                                                        unpublished_at: Time.zone.now })
+        described_class.call(edition,
+                             user,
+                             public_explanation: public_explanation)
 
-      expect(request).to have_been_requested
+        expect(request).to have_been_requested
+      end
     end
 
 


### PR DESCRIPTION
This change will present the `withdrawn_at` time to Publishing API when a document is withdrawn.  This will ensure that the time held by Content Publisher to consistent with the time in Publishing API.

Trello card: https://trello.com/c/ntHbfCPB