### PR TITLE
Restrict attachment actions

### DIFF
--- a/app/controllers/featured_attachments_controller.rb
+++ b/app/controllers/featured_attachments_controller.rb
@@ -2,5 +2,9 @@ class FeaturedAttachmentsController < ApplicationController
   def index
     @edition = Edition.find_current(document: params[:document])
     assert_edition_state(@edition, &:editable?)
+
+    assert_edition_feature(@edition, assertion: "supports featured attachments") do
+      @edition.document_type.attachments.featured?
+    end
   end
 end

--- a/app/controllers/file_attachments_controller.rb
+++ b/app/controllers/file_attachments_controller.rb
@@ -9,6 +9,10 @@ class FileAttachmentsController < ApplicationController
   def new
     @edition = Edition.find_current(document: params[:document])
     assert_edition_state(@edition, &:editable?)
+
+    assert_edition_feature(@edition, assertion: "supports featured attachments") do
+      @edition.document_type.attachments.featured?
+    end
   end
 
   def show

--- a/app/controllers/file_attachments_controller.rb
+++ b/app/controllers/file_attachments_controller.rb
@@ -23,6 +23,10 @@ class FileAttachmentsController < ApplicationController
     @edition = Edition.find_current(document: params[:document])
     assert_edition_state(@edition, &:editable?)
 
+    assert_edition_feature(@edition, assertion: "supports inline attachments") do
+      @edition.document_type.attachments.inline_file_only?
+    end
+
     @attachment = @edition.file_attachment_revisions
       .find_by!(file_attachment_id: params[:file_attachment_id])
   end

--- a/app/controllers/file_attachments_controller.rb
+++ b/app/controllers/file_attachments_controller.rb
@@ -4,6 +4,10 @@ class FileAttachmentsController < ApplicationController
   def index
     @edition = Edition.find_current(document: params[:document])
     assert_edition_state(@edition, &:editable?)
+
+    assert_edition_feature(@edition, assertion: "supports inline attachments") do
+      @edition.document_type.attachments.inline_file_only?
+    end
   end
 
   def new

--- a/app/views/components/_markdown_editor.html.erb
+++ b/app/views/components/_markdown_editor.html.erb
@@ -17,8 +17,8 @@
                             .merge({ "paste-html-to-govspeak": paste_html_to_govspeak })
 
   if edition
-    insert_items = [
-      {
+    if edition.document_type.attachments.inline_file_only?
+      insert_items << {
         text: "Attachment",
         href: file_attachments_path(edition.document),
         target: "_blank",
@@ -27,7 +27,10 @@
           "modal-action": "open",
           gtm: "open-inline-attachment-modal",
         }
-      },
+      }
+    end
+
+    insert_items += [
       {
         text: "Contact",
         href: contact_embed_path,

--- a/spec/requests/featured_attachments_spec.rb
+++ b/spec/requests/featured_attachments_spec.rb
@@ -5,9 +5,19 @@ RSpec.describe "Featured Attachments" do
     let(:edition) { create(:edition, :published) }
   end
 
+  it_behaves_like "requests that return status",
+                  "accessing featured attachments for an edition that doesn't allow them",
+                  status: :not_found,
+                  routes: { featured_attachments_path: %i[get] } do
+    let(:edition) { create(:edition) }
+    let(:route_params) { [edition.document] }
+  end
+
   describe "GET /documents/:document/attachments" do
     it "returns successfully" do
-      edition = create(:edition)
+      document_type = build(:document_type, attachments: "featured")
+      edition = create(:edition, document_type: document_type)
+
       get featured_attachments_path(edition.document)
       expect(response).to have_http_status(:ok)
     end

--- a/spec/requests/file_attachments_spec.rb
+++ b/spec/requests/file_attachments_spec.rb
@@ -34,6 +34,15 @@ RSpec.describe "File Attachments" do
     let(:route_params) { [edition.document] }
   end
 
+  it_behaves_like "requests that return status",
+                  "adding inline attachments for an edition that doesn't allow them",
+                  status: :not_found,
+                  routes: { file_attachments_path: %i[get] } do
+    let(:document_type) { build(:document_type, attachments: "featured") }
+    let(:edition) { create(:edition, document_type: document_type) }
+    let(:route_params) { [edition.document] }
+  end
+
   describe "GET /documents/:document/file-attachments/new" do
     it "returns successfully" do
       document_type = build(:document_type, attachments: "featured")

--- a/spec/requests/file_attachments_spec.rb
+++ b/spec/requests/file_attachments_spec.rb
@@ -43,6 +43,16 @@ RSpec.describe "File Attachments" do
     let(:route_params) { [edition.document] }
   end
 
+  it_behaves_like "requests that return status",
+                  "viewing inline attachments for an edition that doesn't allow them",
+                  status: :not_found,
+                  routes: { file_attachment_path: %i[get] } do
+    let(:document_type) { build(:document_type, attachments: "featured") }
+    let(:edition) { create(:edition, document_type: document_type) }
+    let(:file_attachment_revision) { create(:file_attachment_revision) }
+    let(:route_params) { [edition.document, file_attachment_revision] }
+  end
+
   describe "GET /documents/:document/file-attachments/new" do
     it "returns successfully" do
       document_type = build(:document_type, attachments: "featured")

--- a/spec/requests/file_attachments_spec.rb
+++ b/spec/requests/file_attachments_spec.rb
@@ -26,9 +26,19 @@ RSpec.describe "File Attachments" do
     let(:route_params) { [edition.document, file_attachment_revision] }
   end
 
+  it_behaves_like "requests that return status",
+                  "adding featured attachments for an edition that doesn't allow them",
+                  status: :not_found,
+                  routes: { new_file_attachment_path: %i[get] } do
+    let(:edition) { create(:edition) }
+    let(:route_params) { [edition.document] }
+  end
+
   describe "GET /documents/:document/file-attachments/new" do
     it "returns successfully" do
-      edition = create(:edition)
+      document_type = build(:document_type, attachments: "featured")
+      edition = create(:edition, document_type: document_type)
+
       get new_file_attachment_path(edition.document)
       expect(response).to have_http_status(:ok)
     end


### PR DESCRIPTION
Trello: https://trello.com/c/dzFScHVI
Follows on from: #1842 
Depends on: #1841 

# What's changed?
Only allow inline attachments to be uploaded from the markdown editor if the document type allows inline attachments.
Only allow attachments to be uploaded via the Attachments section in the document summary if the document type allows featured attachments.

# Why?
This allows different types of attachments to be configured ways, and stops users from accidentally stumbling across pages or options that might confuse them. 