### PR TITLE
Validate that change history is in the expected order

### DIFF
--- a/spec/models/metadata_revision_spec.rb
+++ b/spec/models/metadata_revision_spec.rb
@@ -1,8 +1,6 @@
 RSpec.describe MetadataRevision do
-  describe "change_history" do
-    failure_prefix = "Change history"
-
-    it "successfully creates an entry when change_history is valid" do
+  describe "validating change_history" do
+    it "validates when the change history is valid" do
       change_history = [
         {
           "id" => SecureRandom.uuid,
@@ -11,8 +9,7 @@ RSpec.describe MetadataRevision do
         },
       ]
 
-      expect { create(:metadata_revision, change_history: change_history) }
-        .to change(described_class, :count).by(1)
+      expect(build(:metadata_revision, change_history: change_history)).to be_valid
     end
 
     it "fails validation if 'id' is missing" do
@@ -20,9 +17,9 @@ RSpec.describe MetadataRevision do
         { "note" => "Testing", "public_timestamp" => Time.zone.today.rfc3339 },
       ]
 
-      expect { create(:metadata_revision, change_history: change_history) }
+      expect { build(:metadata_revision, change_history: change_history).valid? }
         .to raise_error(ActiveModel::StrictValidationFailed,
-                        "#{failure_prefix} has an entry with invalid keys")
+                        "Change history has an entry with invalid keys")
     end
 
     it "fails validation if 'note' is missing" do
@@ -31,9 +28,9 @@ RSpec.describe MetadataRevision do
         { "id" => id, "public_timestamp" => Time.zone.today.rfc3339 },
       ]
 
-      expect { create(:metadata_revision, change_history: change_history) }
+      expect { build(:metadata_revision, change_history: change_history).valid? }
         .to raise_error(ActiveModel::StrictValidationFailed,
-                        "#{failure_prefix} has an entry with invalid keys")
+                        "Change history has an entry with invalid keys")
     end
 
     it "fails validation if 'public_timestamp' is missing" do
@@ -42,9 +39,9 @@ RSpec.describe MetadataRevision do
         { "id" => id, "note" => "Testing" },
       ]
 
-      expect { create(:metadata_revision, change_history: change_history) }
+      expect { build(:metadata_revision, change_history: change_history).valid? }
         .to raise_error(ActiveModel::StrictValidationFailed,
-                        "#{failure_prefix} has an entry with invalid keys")
+                        "Change history has an entry with invalid keys")
     end
 
     it "fails validation if the 'id' is not a valid UUID" do
@@ -57,9 +54,9 @@ RSpec.describe MetadataRevision do
         },
       ]
 
-      expect { create(:metadata_revision, change_history: change_history) }
+      expect { build(:metadata_revision, change_history: change_history).valid? }
         .to raise_error(ActiveModel::StrictValidationFailed,
-                        "#{failure_prefix} has an entry with a non UUID id")
+                        "Change history has an entry with a non UUID id")
     end
 
     it "fails validation if 'public_timestamp' is not a valid date" do
@@ -72,9 +69,9 @@ RSpec.describe MetadataRevision do
         },
       ]
 
-      expect { create(:metadata_revision, change_history: change_history) }
+      expect { build(:metadata_revision, change_history: change_history).valid? }
         .to raise_error(ActiveModel::StrictValidationFailed,
-                        "#{failure_prefix} has an entry with an invalid timestamp")
+                        "Change history has an entry with an invalid timestamp")
     end
   end
 end

--- a/spec/models/metadata_revision_spec.rb
+++ b/spec/models/metadata_revision_spec.rb
@@ -4,7 +4,29 @@ RSpec.describe MetadataRevision do
       change_history = [
         {
           "id" => SecureRandom.uuid,
-          "note" => "Testing",
+          "note" => "Newest",
+          "public_timestamp" => Time.zone.today.rfc3339,
+        },
+        {
+          "id" => SecureRandom.uuid,
+          "note" => "Oldest",
+          "public_timestamp" => Time.zone.yesterday.rfc3339,
+        },
+      ]
+
+      expect(build(:metadata_revision, change_history: change_history)).to be_valid
+    end
+
+    it "copes when two items have the same public_timestamp" do
+      change_history = [
+        {
+          "id" => SecureRandom.uuid,
+          "note" => "Note",
+          "public_timestamp" => Time.zone.today.rfc3339,
+        },
+        {
+          "id" => SecureRandom.uuid,
+          "note" => "Note",
           "public_timestamp" => Time.zone.today.rfc3339,
         },
       ]
@@ -72,6 +94,25 @@ RSpec.describe MetadataRevision do
       expect { build(:metadata_revision, change_history: change_history).valid? }
         .to raise_error(ActiveModel::StrictValidationFailed,
                         "Change history has an entry with an invalid timestamp")
+    end
+
+    it "fails validation when notes are not in reverse chronological order" do
+      change_history = [
+        {
+          "id" => SecureRandom.uuid,
+          "note" => "Oldest",
+          "public_timestamp" => Time.zone.yesterday.rfc3339,
+        },
+        {
+          "id" => SecureRandom.uuid,
+          "note" => "Newest",
+          "public_timestamp" => Time.zone.today.rfc3339,
+        },
+      ]
+
+      expect { build(:metadata_revision, change_history: change_history).valid? }
+        .to raise_error(ActiveModel::StrictValidationFailed,
+                        "Change history is not in a reverse chronological ordering")
     end
   end
 end


### PR DESCRIPTION
We've learnt in the last few days that is quite easy to get this wrong
and then have inconsistent ordering. This is applied so that anything
being saved has the ordering we expect.