### PR TITLE
Send file attachments details in publishing-api payload

### DIFF
--- a/lib/publishing_api_payload.rb
+++ b/lib/publishing_api_payload.rb
@@ -77,6 +77,7 @@ private
     details = {
       political: edition.political?,
       change_history: history.change_history,
+      attachments: attachments,
     }
 
     if document_type.lead_image? && edition.lead_image_revision.present?
@@ -90,5 +91,13 @@ private
 
   def publication?
     publishing_metadata.schema_name == "publication"
+  end
+
+  def attachments
+    file_attachments = edition.file_attachment_revisions
+
+    file_attachments.map do |attachment|
+      FileAttachmentPayload.new(attachment, edition.document).payload
+    end
   end
 end

--- a/lib/publishing_api_payload/file_attachment_payload.rb
+++ b/lib/publishing_api_payload/file_attachment_payload.rb
@@ -1,0 +1,21 @@
+class PublishingApiPayload::FileAttachmentPayload
+  include Rails.application.routes.url_helpers
+  include FileAttachmentHelper
+
+  attr_reader :attachment, :document
+
+  def initialize(attachment, document)
+    @attachment = attachment
+    @document = document
+  end
+
+  def payload
+    payload = {
+      attachment_type: "file",
+      locale: document.locale,
+      url: attachment.asset_url,
+    }
+
+    file_attachment_attributes(attachment, document).merge!(payload)
+  end
+end

--- a/spec/lib/publishing_api_payload/file_attachment_payload_spec.rb
+++ b/spec/lib/publishing_api_payload/file_attachment_payload_spec.rb
@@ -1,0 +1,24 @@
+RSpec.describe PublishingApiPayload::FileAttachmentPayload do
+  describe "#payload" do
+    it "generates a file attachment payload for the publishing_api" do
+      attachment = build(:file_attachment_revision)
+      edition = create(:edition, file_attachment_revisions: [attachment])
+
+      payload = described_class.new(attachment, edition.document).payload
+
+      expected_payload = {
+        attachment_type: "file",
+        content_type: attachment.content_type,
+        file_size: attachment.byte_size,
+        filename: attachment.filename,
+        id: attachment.filename,
+        locale: edition.locale,
+        number_of_pages: attachment.number_of_pages,
+        title: attachment.title,
+        url: attachment.asset_url,
+      }
+
+      expect(payload).to match a_hash_including(expected_payload)
+    end
+  end
+end

--- a/spec/lib/publishing_api_payload_spec.rb
+++ b/spec/lib/publishing_api_payload_spec.rb
@@ -59,6 +59,19 @@ RSpec.describe PublishingApiPayload do
       expect(payload[:details][:change_history]).to match(history.change_history)
     end
 
+    it "delegates to PublishingApiPayload::FileAttachmentPayload to populate attachments" do
+      file_attachment_revision = create(:file_attachment_revision)
+      edition = build(:edition,
+                      file_attachment_revisions: [file_attachment_revision])
+
+      payload = described_class.new(edition).payload
+      attachment_payload = PublishingApiPayload::FileAttachmentPayload
+                             .new(file_attachment_revision, edition.document)
+                             .payload
+
+      expect(payload[:details][:attachments]).to contain_exactly(attachment_payload)
+    end
+
     it "specifies an auth bypass ID for anonymous previews" do
       edition = build(:edition)
       preview_auth_bypass = instance_double(PreviewAuthBypass, auth_bypass_id: "id")


### PR DESCRIPTION
Trello: https://trello.com/c/lHtCxM6V

# What's changed and why?
Send attachment and featured attachment data to the publishing-api.

As part of the RFC on Attachments we now make data about attachments available in the Content API in a way that's machine readable so that's consumers of the Content API will soon no longer have to manually parse data about attachment from the rendered HTML.

Adding this data into the payload will also featured attachments to be rendered on the frontend as this is done by the publishing-api.

# Expected changes
![attachents_details](https://user-images.githubusercontent.com/5793815/76075803-8f781980-5f95-11ea-8d58-6828928cccc1.png)

