### PR TITLE
Fix public_updated_at time for published editions

### DIFF
--- a/lib/publishing_api_payload/history.rb
+++ b/lib/publishing_api_payload/history.rb
@@ -25,7 +25,7 @@ class PublishingApiPayload::History
 
     if edition.change_note && edition.major? && !edition.first?
       change_history << { note: edition.change_note,
-                          public_timestamp: Time.zone.now }
+                          public_timestamp: edition.published_at || Time.zone.now }
     end
 
     change_history.reject { |note| first_published_at && note[:public_timestamp] < first_published_at }

--- a/spec/lib/publishing_api_payload/history_spec.rb
+++ b/spec/lib/publishing_api_payload/history_spec.rb
@@ -1,12 +1,24 @@
 RSpec.describe PublishingApiPayload::History do
   describe "#public_updated_at" do
-    it "returns current time if a major change is published" do
-      freeze_time do
-        first_edition = build(:edition)
-        second_edition = build(:edition, document: first_edition.document, update_type: "major")
+    it "returns current time when a major change has not been published before" do
+      first_edition = build(:edition)
+      second_edition = build(:edition, document: first_edition.document, update_type: "major")
 
+      freeze_time do
         expect(described_class.new(second_edition).public_updated_at).to eq(Time.zone.now)
       end
+    end
+
+    it "returns published_at time when an edition has already been published with a major change" do
+      first_edition = create(:edition, current: false,
+                             first_published_at: "2020-02-22 11:00:00")
+      second_edition = build(:edition, :published,
+                             document: first_edition.document,
+                             update_type: "major",
+                             first_published_at: "2020-02-22 11:00:00",
+                             published_at: "2020-03-01 12:00:00")
+
+      expect(described_class.new(second_edition).public_updated_at).to eq("2020-03-01 12:00:00")
     end
 
     it "returns most recent change history time if a minor change is published" do


### PR DESCRIPTION
Previously if an edition has been previously published with a major
change the public_updated_at time being sent to the publishing-api
would've been set to the current time, this is incorrect behaviour and
as the time should be set to the published_at time of the edition.