### PR TITLE
Wrap Resync document service in sidekiq job with retries

### DIFF
--- a/app/jobs/resync_document_job.rb
+++ b/app/jobs/resync_document_job.rb
@@ -1,0 +1,5 @@
+class ResyncDocumentJob < ApplicationJob
+  def perform(document)
+    ResyncDocumentService.call(document)
+  end
+end

--- a/app/jobs/resync_document_job.rb
+++ b/app/jobs/resync_document_job.rb
@@ -1,4 +1,10 @@
 class ResyncDocumentJob < ApplicationJob
+  retry_on(
+    GdsApi::BaseError,
+    attempts: 5,
+    wait: :exponentially_longer,
+  ) { |_job, error| GovukError.notify(error) }
+
   def perform(document)
     ResyncDocumentService.call(document)
   end

--- a/lib/tasks/resync.rake
+++ b/lib/tasks/resync.rake
@@ -13,7 +13,7 @@ namespace :resync do
   desc "Resync all documents with the publishing-api e.g. resync:all"
   task all: :environment do
     Document.find_each do |document|
-      ResyncDocumentService.call(document)
+      ResyncDocumentJob.perform_later(document)
     end
   end
 end

--- a/spec/jobs/resync_document_job_spec.rb
+++ b/spec/jobs/resync_document_job_spec.rb
@@ -1,10 +1,21 @@
 RSpec.describe ResyncDocumentJob do
-  it "delegates to the ResyncDocumentService" do
-    document = build(:document)
+  include ActiveJob::TestHelper
 
+  let(:document) { create(:document) }
+
+  before { populate_default_government_bulk_data }
+
+  it "delegates to the ResyncDocumentService" do
     expect(ResyncDocumentService)
       .to receive(:call)
       .with(document)
     described_class.perform_now(document)
+  end
+
+  it "retries the job when an exception is raised" do
+    allow(ResyncDocumentService).to receive(:call).and_raise(GdsApi::BaseError)
+    described_class.perform_now(document)
+
+    expect(described_class).to have_been_enqueued
   end
 end

--- a/spec/jobs/resync_document_job_spec.rb
+++ b/spec/jobs/resync_document_job_spec.rb
@@ -1,0 +1,10 @@
+RSpec.describe ResyncDocumentJob do
+  it "delegates to the ResyncDocumentService" do
+    document = build(:document)
+
+    expect(ResyncDocumentService)
+      .to receive(:call)
+      .with(document)
+    described_class.perform_now(document)
+  end
+end

--- a/spec/lib/tasks/resync_spec.rb
+++ b/spec/lib/tasks/resync_spec.rb
@@ -16,8 +16,8 @@ RSpec.describe "Resync tasks" do
     it "resyncs all documents" do
       create_list(:document, 2)
 
-      expect(ResyncDocumentService)
-        .to receive(:call)
+      expect(ResyncDocumentJob)
+        .to receive(:perform_later)
         .twice
 
       Rake::Task["resync:all"].invoke


### PR DESCRIPTION
Trello: https://trello.com/c/aOl2VwhV

# What's changed and why?
The resync job frequently fails due to network timeout issues. Changing the service to a sidekiq job allows it to be retried.