### PR TITLE
Integrity check published times

### DIFF
--- a/lib/whitehall_importer/integrity_checker.rb
+++ b/lib/whitehall_importer/integrity_checker.rb
@@ -2,6 +2,17 @@ module WhitehallImporter
   class IntegrityChecker
     attr_reader :edition
 
+    def self.time_matches?(proposed_time, publishing_api_time)
+      return true if proposed_time == publishing_api_time
+
+      proposed_time = Time.zone.rfc3339(proposed_time)
+      publishing_api_time = Time.zone.rfc3339(publishing_api_time)
+
+      proposed_time.between?(publishing_api_time - 5, publishing_api_time + 5)
+    rescue ArgumentError
+      false
+    end
+
     def initialize(edition)
       @edition = edition
     end

--- a/lib/whitehall_importer/integrity_checker.rb
+++ b/lib/whitehall_importer/integrity_checker.rb
@@ -69,6 +69,14 @@ module WhitehallImporter
                                         first_public_at,
                                         proposed_first_published_at)
       end
+      proposed_public_updated_at = proposed_payload["public_updated_at"]
+      public_updated_at = publishing_api_content["public_updated_at"]
+
+      if edition.live? && !time_matches?(proposed_public_updated_at, public_updated_at)
+        problems << problem_description("public_updated_at doesn't match",
+                                        public_updated_at,
+                                        proposed_public_updated_at)
+      end
 
       problems
     end

--- a/lib/whitehall_importer/integrity_checker.rb
+++ b/lib/whitehall_importer/integrity_checker.rb
@@ -22,7 +22,7 @@ module WhitehallImporter
     end
 
     def problems
-      content_problems + image_problems + organisation_problems
+      content_problems + image_problems + organisation_problems + time_problems
     end
 
     def proposed_payload
@@ -56,6 +56,25 @@ module WhitehallImporter
       ).sufficiently_similar?
 
       problems
+    end
+
+    def time_problems
+      problems = []
+
+      proposed_first_published_at = proposed_payload["first_published_at"]
+      first_public_at = publishing_api_content["details"]["first_public_at"]
+
+      unless time_matches?(proposed_first_published_at, first_public_at)
+        problems << problem_description("our first_published_at doesn't match first_public_at",
+                                        first_public_at,
+                                        proposed_first_published_at)
+      end
+
+      problems
+    end
+
+    def time_matches?(proposed_time, publishing_api_time)
+      self.class.time_matches?(proposed_time, publishing_api_time)
     end
 
     def image_problems

--- a/spec/lib/whitehall_importer/integrity_checker_spec.rb
+++ b/spec/lib/whitehall_importer/integrity_checker_spec.rb
@@ -222,6 +222,26 @@ RSpec.describe WhitehallImporter::IntegrityChecker do
     end
   end
 
+  describe ".time_matches?" do
+    let(:time) { Time.zone.now }
+
+    it "returns true when times match" do
+      expect(described_class.time_matches?(time.rfc3339, time.rfc3339)).to eq true
+    end
+
+    it "returns true when times are sufficiently similar" do
+      expect(described_class.time_matches?((time + 4).rfc3339, time.rfc3339)).to eq true
+    end
+
+    it "returns false when times are not sufficiently similar" do
+      expect(described_class.time_matches?((time + 30).rfc3339, time.rfc3339)).to eq false
+    end
+
+    it "returns false when times are invalid" do
+      expect(described_class.time_matches?("Not a time", nil)).to eq false
+    end
+  end
+
   def default_publishing_api_item(edition, override_hash = {})
     {
       content_id: edition.content_id,

--- a/spec/lib/whitehall_importer/integrity_checker_spec.rb
+++ b/spec/lib/whitehall_importer/integrity_checker_spec.rb
@@ -26,7 +26,6 @@ RSpec.describe WhitehallImporter::IntegrityChecker do
         },
       )
     end
-
     let(:publishing_api_item) do
       default_publishing_api_item(edition,
                                   details: {
@@ -37,11 +36,11 @@ RSpec.describe WhitehallImporter::IntegrityChecker do
                                     organisations: edition.tags["organisations"].to_a + edition.tags["primary_publishing_organisation"].to_a,
                                   })
     end
+    let(:integrity_check) { described_class.new(edition) }
 
     it "returns true if there aren't any problems for edition without image or attachment" do
       stub_publishing_api_has_item(publishing_api_item)
 
-      integrity_check = described_class.new(edition)
       expect(integrity_check.valid?).to be true
     end
 
@@ -55,7 +54,6 @@ RSpec.describe WhitehallImporter::IntegrityChecker do
       }
       stub_publishing_api_has_item(publishing_api_item)
 
-      integrity_check = described_class.new(edition)
       expect(integrity_check.valid?).to be true
     end
 
@@ -65,7 +63,6 @@ RSpec.describe WhitehallImporter::IntegrityChecker do
       }
       stub_publishing_api_has_item(publishing_api_item)
 
-      integrity_check = described_class.new(edition)
       expect(integrity_check.valid?).to be true
     end
 
@@ -80,13 +77,11 @@ RSpec.describe WhitehallImporter::IntegrityChecker do
         },
       )
 
-      integrity_check = described_class.new(edition)
       expect(integrity_check.valid?).to be true
     end
 
     context "with an attachment not yet on asset mananger" do
       let(:file_attachment_revision) { create(:file_attachment_revision) }
-
       let(:edition) do
         build(:edition,
               document_type: document_type,
@@ -107,7 +102,6 @@ RSpec.describe WhitehallImporter::IntegrityChecker do
         stub_publishing_api_has_links(content_id: edition.content_id)
         stub_publishing_api_has_item(publishing_api_item)
 
-        integrity_check = described_class.new(edition)
         expect(integrity_check.valid?).to be true
       end
     end
@@ -120,7 +114,6 @@ RSpec.describe WhitehallImporter::IntegrityChecker do
             image_revisions: [build(:image_revision)],
             tags: { "organisations" => [] })
     end
-
     let(:publishing_api_item) do
       {
         content_id: edition.content_id,
@@ -142,7 +135,6 @@ RSpec.describe WhitehallImporter::IntegrityChecker do
         },
       }
     end
-
     let(:integrity_check) { described_class.new(edition) }
 
     def problem_message(attribute, expected, actual)

--- a/spec/lib/whitehall_importer/integrity_checker_spec.rb
+++ b/spec/lib/whitehall_importer/integrity_checker_spec.rb
@@ -17,19 +17,19 @@ RSpec.describe WhitehallImporter::IntegrityChecker do
 
   describe "#valid?" do
     let(:edition) do
-      build(
-        :edition,
-        document_type: document_type,
-        tags: {
-          primary_publishing_organisation: [SecureRandom.uuid],
-          organisations: [SecureRandom.uuid],
-        },
-      )
+      build(:edition,
+            document_type: document_type,
+            document: create(:document, first_published_at: "2020-03-11 12:00 UTC"),
+            tags: {
+              primary_publishing_organisation: [SecureRandom.uuid],
+              organisations: [SecureRandom.uuid],
+            })
     end
     let(:publishing_api_item) do
       default_publishing_api_item(edition,
                                   details: {
                                     body: GovspeakDocument.new(edition.contents["body"], edition).payload_html,
+                                    first_public_at: "2020-03-11T12:00:00.000+00:00",
                                   },
                                   links: {
                                     primary_publishing_organisation: edition.tags["primary_publishing_organisation"].to_a,
@@ -66,8 +66,16 @@ RSpec.describe WhitehallImporter::IntegrityChecker do
       expect(integrity_check.valid?).to be true
     end
 
+    it "returns true if first_published_at times match" do
+      publishing_api_item[:details][:first_public_at] = "2020-03-11T12:00:00.000+00:00"
+      stub_publishing_api_has_item(publishing_api_item)
+
+      expect(integrity_check.valid?).to be true
+    end
+
     it "compares against organisations in linkset links if there no edition links" do
-      stub_publishing_api_has_item(default_publishing_api_item(edition))
+      publishing_api_item[:links] = {}
+      stub_publishing_api_has_item(publishing_api_item)
 
       stub_publishing_api_has_links(
         content_id: edition.content_id,
@@ -84,6 +92,7 @@ RSpec.describe WhitehallImporter::IntegrityChecker do
       let(:file_attachment_revision) { create(:file_attachment_revision) }
       let(:edition) do
         build(:edition,
+              document: create(:document, first_published_at: "2020-03-11 12:00:00 +0000"),
               document_type: document_type,
               file_attachment_revisions: [file_attachment_revision],
               contents: {
@@ -95,6 +104,7 @@ RSpec.describe WhitehallImporter::IntegrityChecker do
         default_publishing_api_item(edition,
                                     details: {
                                       body: GovspeakDocument.new(edition.contents["body"], edition).payload_html,
+                                      first_public_at: "2020-03-11T12:00:00.000+00:00",
                                     })
       end
 
@@ -112,6 +122,7 @@ RSpec.describe WhitehallImporter::IntegrityChecker do
       build(:edition,
             document_type: document_type,
             image_revisions: [build(:image_revision)],
+            document: create(:document, first_published_at: "2020-03-11 18:32:38 UTC"),
             tags: { "organisations" => [] })
     end
     let(:publishing_api_item) do
@@ -137,8 +148,8 @@ RSpec.describe WhitehallImporter::IntegrityChecker do
     end
     let(:integrity_check) { described_class.new(edition) }
 
-    def problem_message(attribute, expected, actual)
-      "#{attribute} doesn't match, expected: #{expected.inspect}, actual: #{actual.inspect}"
+    def problem_message(message, expected, actual)
+      "#{message}, expected: #{expected.inspect}, actual: #{actual.inspect}"
     end
 
     before do
@@ -146,27 +157,38 @@ RSpec.describe WhitehallImporter::IntegrityChecker do
       stub_publishing_api_has_item(publishing_api_item)
     end
 
+    it "returns a problem when first_published_at times don't match" do
+      publishing_api_item[:details][:first_public_at] = "2020-03-11T12:00:00.000+00:00"
+      stub_publishing_api_has_item(publishing_api_item)
+
+      expect(integrity_check.problems).to include(
+        problem_message("our first_published_at doesn't match first_public_at",
+                        publishing_api_item[:details][:first_public_at],
+                        edition.document.first_published_at.as_json),
+      )
+    end
+
     it "returns a problem when the base paths don't match" do
       expect(integrity_check.problems).to include(
-        problem_message("base_path", publishing_api_item[:base_path], edition.base_path),
+        problem_message("base_path doesn't match", publishing_api_item[:base_path], edition.base_path),
       )
     end
 
     it "returns a problem when the titles don't match" do
       expect(integrity_check.problems).to include(
-        problem_message("title", publishing_api_item[:title], edition.title),
+        problem_message("title doesn't match", publishing_api_item[:title], edition.title),
       )
     end
 
     it "returns a problem when the descriptions don't match" do
       expect(integrity_check.problems).to include(
-        problem_message("description", publishing_api_item[:description], edition.summary),
+        problem_message("description doesn't match", publishing_api_item[:description], edition.summary),
       )
     end
 
     it "returns a problem when the document types don't match" do
       expect(integrity_check.problems).to include(
-        problem_message("document_type",
+        problem_message("document_type doesn't match",
                         publishing_api_item[:document_type],
                         edition.document_type.id),
       )
@@ -175,7 +197,7 @@ RSpec.describe WhitehallImporter::IntegrityChecker do
     it "returns a problem when the schema names don't match" do
       edition_schema_name = edition.document_type.publishing_metadata.schema_name
       expect(integrity_check.problems).to include(
-        problem_message("schema_name", publishing_api_item[:schema_name], edition_schema_name),
+        problem_message("schema_name doesn't match", publishing_api_item[:schema_name], edition_schema_name),
       )
     end
 
@@ -188,7 +210,7 @@ RSpec.describe WhitehallImporter::IntegrityChecker do
       publishing_api_image = publishing_api_item[:details][:image]
 
       expect(integrity_check.problems).to include(
-        problem_message("image alt_text",
+        problem_message("image alt_text doesn't match",
                         publishing_api_image[:alt_text],
                         edition_image.alt_text),
       )
@@ -199,7 +221,7 @@ RSpec.describe WhitehallImporter::IntegrityChecker do
       publishing_api_image = publishing_api_item[:details][:image]
 
       expect(integrity_check.problems).to include(
-        problem_message("image caption",
+        problem_message("image caption doesn't match",
                         publishing_api_image[:caption],
                         edition_image.caption),
       )
@@ -207,7 +229,7 @@ RSpec.describe WhitehallImporter::IntegrityChecker do
 
     it "returns a problem when the primary_publishing_organisation doesn't match" do
       expect(integrity_check.problems).to include(
-        problem_message("primary_publishing_organisation",
+        problem_message("primary_publishing_organisation doesn't match",
                         publishing_api_item[:links][:primary_publishing_organisation],
                         edition.tags["primary_publishing_organisation"]),
       )


### PR DESCRIPTION
We want to integrity check publishing times when we import whitehall documents, the times we're concerned about checking are public_updated_at and first_published_at.

More info in the commits ->

Trello:
https://trello.com/c/aCQ4qhB3/1464-check-integrity-of-whitehall-firstpublishedat-and-publicupdatedat