### PR TITLE
Remove number of pages from payload if nil

### DIFF
--- a/app/helpers/file_attachment_helper.rb
+++ b/app/helpers/file_attachment_helper.rb
@@ -14,6 +14,6 @@ module FileAttachmentHelper
       file_size: attachment_revision.byte_size,
       number_of_pages: attachment_revision.number_of_pages,
       url: preview_file_attachment_path(document, attachment_revision.file_attachment),
-    }
+    }.compact
   end
 end

--- a/spec/lib/publishing_api_payload/file_attachment_payload_spec.rb
+++ b/spec/lib/publishing_api_payload/file_attachment_payload_spec.rb
@@ -1,7 +1,7 @@
 RSpec.describe PublishingApiPayload::FileAttachmentPayload do
   describe "#payload" do
     it "generates a file attachment payload for the publishing_api" do
-      attachment = build(:file_attachment_revision)
+      attachment = build(:file_attachment_revision, number_of_pages: 1)
       edition = create(:edition, file_attachment_revisions: [attachment])
 
       payload = described_class.new(attachment, edition.document).payload


### PR DESCRIPTION
The schema for `publication_attachment_asset` which is used to populated `details.attachments` in the content item, expects the value for `number_of_pages` to be an integer:

https://github.com/alphagov/govuk-content-schemas/blob/ac8fb929789c3678e420f7e58db7eb2519692ac0/dist/formats/publication/notification/schema.json#L858

However, when an image is added as an inline attachment, the value is being set to `nil`. This means that when we try to update the document in publishing-api it's throwing an error:

https://sentry.io/organizations/govuk/issues/999142960/?project=1242052&referrer=slack

This change excludes `number_of_pages` from the payload if it doesn't have a value.