### PR TITLE
Support "Delete file" action for featured file attachments

### DIFF
--- a/app/controllers/file_attachments_controller.rb
+++ b/app/controllers/file_attachments_controller.rb
@@ -75,9 +75,13 @@ class FileAttachmentsController < ApplicationController
     result = FileAttachments::DestroyInteractor.call(params: params, user: current_user)
     attachment_revision = result.attachment_revision
 
-    redirect_to file_attachments_path(params[:document]),
-                notice: t("file_attachments.index.flashes.deleted",
-                          file: attachment_revision.filename)
+    if params[:wizard] == "featured"
+      redirect_to featured_attachments_path(params[:document])
+    else
+      redirect_to file_attachments_path(params[:document]),
+                  notice: t("file_attachments.index.flashes.deleted",
+                            file: attachment_revision.filename)
+    end
   end
 
   def edit

--- a/app/controllers/file_attachments_controller.rb
+++ b/app/controllers/file_attachments_controller.rb
@@ -31,6 +31,14 @@ class FileAttachmentsController < ApplicationController
       .find_by!(file_attachment_id: params[:file_attachment_id])
   end
 
+  def confirm_delete
+    @edition = Edition.find_current(document: params[:document])
+    assert_edition_state(@edition, &:editable?)
+
+    @attachment = @edition.file_attachment_revisions
+      .find_by!(file_attachment_id: params[:file_attachment_id])
+  end
+
   def preview
     result = FileAttachments::PreviewInteractor.call(params: params, user: current_user)
     can_preview, api_error = result.to_h.values_at(:can_preview, :api_error)

--- a/app/views/featured_attachments/_featured_attachment.html.erb
+++ b/app/views/featured_attachments/_featured_attachment.html.erb
@@ -1,7 +1,7 @@
 <% actions = [] %>
 <% actions << capture do %>
   <%= form_tag(
-    file_attachment_path(document, attachment.file_attachment_id),
+    file_attachment_path(document, attachment.file_attachment_id, wizard: "featured"),
     method: :delete,
     class: "app-inline-block",
     data: {

--- a/app/views/featured_attachments/_featured_attachment.html.erb
+++ b/app/views/featured_attachments/_featured_attachment.html.erb
@@ -1,16 +1,9 @@
 <% actions = [] %>
-<% actions << capture do %>
-  <%= form_tag(
-    file_attachment_path(document, attachment.file_attachment_id, wizard: "featured"),
-    method: :delete,
-    class: "app-inline-block",
-    data: {
-      gtm: "delete-attachment",
-    },
-  ) do %>
-    <button class="govuk-link app-link--button app-link--destructive">Delete attachment</button>
-  <% end %>
-<% end %>
+<% actions << link_to(
+    "Delete attachment",
+    confirm_delete_file_attachment_path(document, attachment.file_attachment_id, wizard: "featured"),
+    class: "govuk-link app-link--button app-link--destructive",
+) %>
 
 <%= render "components/attachment_meta", {
   attachment: file_attachment_attributes(attachment, document),

--- a/app/views/featured_attachments/_featured_attachment.html.erb
+++ b/app/views/featured_attachments/_featured_attachment.html.erb
@@ -1,4 +1,18 @@
+<% actions = [] %>
+<% actions << capture do %>
+  <%= form_tag(
+    file_attachment_path(document, attachment.file_attachment_id),
+    method: :delete,
+    class: "app-inline-block",
+    data: {
+      gtm: "delete-attachment",
+    },
+  ) do %>
+    <button class="govuk-link app-link--button app-link--destructive">Delete attachment</button>
+  <% end %>
+<% end %>
+
 <%= render "components/attachment_meta", {
   attachment: file_attachment_attributes(attachment, document),
-  actions: [],
+  actions: actions,
 } %>

--- a/app/views/file_attachments/confirm_delete.html.erb
+++ b/app/views/file_attachments/confirm_delete.html.erb
@@ -1,0 +1,32 @@
+<% back_link_path = if params[:wizard] == "featured"
+                      featured_attachments_path(@edition.document)
+                    else
+                      file_attachments_path(@edition.document)
+                    end %>
+
+<% content_for :back_link, render_back_link(href: back_link_path) %>
+<% content_for :title, t("file_attachments.confirm_delete.title", title: @attachment.title) %>
+
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-two-thirds">
+    <%= form_tag(
+      file_attachment_path(@edition.document, wizard: params[:wizard]),
+      method: :delete,
+      multipart: true,
+    ) do %>
+      <%= render_govspeak(t("file_attachments.confirm_delete.description_govspeak")) %>
+
+      <%= render "govuk_publishing_components/components/button", {
+        text: "Yes, delete attachment",
+        destructive: true,
+        margin_bottom: true,
+      } %>
+
+      <div class="govuk-body">
+        <%= link_to "Cancel",
+                  back_link_path,
+                  class: "govuk-link govuk-link--no-visited-state" %>
+      <% end %>
+    </div>
+  </div>
+</div>

--- a/config/locales/en/file_attachments/confirm_delete.yml
+++ b/config/locales/en/file_attachments/confirm_delete.yml
@@ -1,0 +1,8 @@
+en:
+  file_attachments:
+    confirm_delete:
+      title: "Delete attachment ‘%{title}’"
+      description_govspeak: |
+        Are you sure you want to delete this attachment?
+
+        This will delete the attachment and its details. This cannot be undone

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -102,6 +102,7 @@ Rails.application.routes.draw do
     get "/file-attachments/:file_attachment_id/edit" => "file_attachments#edit", as: :edit_file_attachment
     patch "/file-attachments/:file_attachment_id/edit" => "file_attachments#update"
     delete "/file-attachments/:file_attachment_id" => "file_attachments#destroy"
+    get "/file-attachments/:file_attachment_id/delete" => "file_attachments#confirm_delete", as: :confirm_delete_file_attachment
   end
 
   get "/healthcheck", to: "healthcheck#index"

--- a/spec/features/editing_file_attachments/delete_file_attachment_spec.rb
+++ b/spec/features/editing_file_attachments/delete_file_attachment_spec.rb
@@ -12,6 +12,7 @@ RSpec.feature "Delete a file attachment", js: true do
     given_there_is_an_edition_with_featured_attachments
     when_i_go_to_change_an_attachment
     and_i_delete_the_attachment
+    and_i_confirm_the_deletion
     then_i_see_the_attachment_is_gone
     and_i_see_the_timeline_entry
   end
@@ -47,6 +48,10 @@ RSpec.feature "Delete a file attachment", js: true do
     stub_publishing_api_put_content(@edition.content_id, {})
     expect(page).to have_selector(".gem-c-attachment__metadata")
     click_on "Delete attachment"
+  end
+
+  def and_i_confirm_the_deletion
+    click_on "Yes, delete attachment"
   end
 
   def then_i_am_told_the_attachment_is_gone

--- a/spec/features/editing_file_attachments/delete_file_attachment_spec.rb
+++ b/spec/features/editing_file_attachments/delete_file_attachment_spec.rb
@@ -1,7 +1,16 @@
 RSpec.feature "Delete a file attachment", js: true do
-  scenario do
+  scenario "inline" do
     given_there_is_an_edition_with_attachments
     when_i_insert_an_attachment
+    and_i_delete_the_attachment
+    then_i_am_told_the_attachment_is_gone
+    and_i_see_the_attachment_is_gone
+    and_i_see_the_timeline_entry
+  end
+
+  scenario "featured" do
+    given_there_is_an_edition_with_featured_attachments
+    when_i_go_to_change_an_attachment
     and_i_delete_the_attachment
     then_i_see_the_attachment_is_gone
     and_i_see_the_timeline_entry
@@ -15,10 +24,23 @@ RSpec.feature "Delete a file attachment", js: true do
                       file_attachment_revisions: [@attachment_revision])
   end
 
+  def given_there_is_an_edition_with_featured_attachments
+    @attachment_revision = create(:file_attachment_revision)
+
+    @edition = create(:edition,
+                      document_type: build(:document_type, attachments: "featured"),
+                      file_attachment_revisions: [@attachment_revision])
+  end
+
   def when_i_insert_an_attachment
     visit content_path(@edition.document)
     find("markdown-toolbar details").click
     click_on "Attachment"
+  end
+
+  def when_i_go_to_change_an_attachment
+    visit document_path(@edition.document)
+    click_on "Change Attachments"
   end
 
   def and_i_delete_the_attachment
@@ -27,10 +49,15 @@ RSpec.feature "Delete a file attachment", js: true do
     click_on "Delete attachment"
   end
 
-  def then_i_see_the_attachment_is_gone
+  def then_i_am_told_the_attachment_is_gone
     expect(page).to have_content(I18n.t!("file_attachments.index.flashes.deleted", file: @attachment_revision.filename))
+  end
+
+  def then_i_see_the_attachment_is_gone
     expect(page).not_to have_selector("#file-attachment-#{@attachment_revision.file_attachment_id}")
   end
+
+  alias_method :and_i_see_the_attachment_is_gone, :then_i_see_the_attachment_is_gone
 
   def and_i_see_the_timeline_entry
     visit document_path(@edition.document)

--- a/spec/requests/file_attachments_spec.rb
+++ b/spec/requests/file_attachments_spec.rb
@@ -10,7 +10,8 @@ RSpec.describe "File Attachments" do
                   "accessing a single file attachments for a non editable edition",
                   routes: { file_attachment_path: %i[get delete],
                             edit_file_attachment_path: %i[get patch],
-                            preview_file_attachment_path: %i[get] } do
+                            preview_file_attachment_path: %i[get],
+                            confirm_delete_file_attachment_path: %i[get] } do
     let(:edition) { create(:edition, :published) }
     let(:route_params) { [edition.document, "file_attachment_id"] }
   end
@@ -20,7 +21,8 @@ RSpec.describe "File Attachments" do
                   status: :not_found,
                   routes: { file_attachment_path: %i[get delete],
                             edit_file_attachment_path: %i[get patch],
-                            preview_file_attachment_path: %i[get] } do
+                            preview_file_attachment_path: %i[get],
+                            confirm_delete_file_attachment_path: %i[get] } do
     let(:edition) { create(:edition) }
     let(:file_attachment_revision) { create(:file_attachment_revision) }
     let(:route_params) { [edition.document, file_attachment_revision] }
@@ -73,6 +75,17 @@ RSpec.describe "File Attachments" do
                                file_attachment_revision.file_attachment_id)
       expect(response).to have_http_status(:ok)
       expect(response.body).to have_content(file_attachment_revision.filename)
+    end
+  end
+
+  describe "GET /documents/:document/file-attachments/:file_attachment_id/delete" do
+    it "returns successfully" do
+      file_attachment_revision = create(:file_attachment_revision)
+      edition = create(:edition,
+                       file_attachment_revisions: [file_attachment_revision])
+
+      get confirm_delete_file_attachment_path(edition.document, file_attachment_revision.file_attachment_id)
+      expect(response).to have_http_status(:ok)
     end
   end
 


### PR DESCRIPTION
Trello: https://trello.com/c/qpeNzbYa

# What's changed?

Adds a 'Delete attachment' link to the featured attachment preview block. Clicking delete takes the user to a confirmation page which then redirects them to the current `/attachments` page, where they can see that the attachment is gone.

# Expected changes
![Screenshot 2020-03-11 at 17 15 16](https://user-images.githubusercontent.com/5793815/76445314-22adb680-63bd-11ea-8e39-0088379535cb.png)
![Screenshot 2020-03-11 at 17 17 52](https://user-images.githubusercontent.com/5793815/76445320-23dee380-63bd-11ea-9fbc-8dfd75acba72.png)
![Screenshot 2020-03-11 at 17 18 02](https://user-images.githubusercontent.com/5793815/76445318-23464d00-63bd-11ea-9a1a-2b7ef8774f33.png)


