### PR TITLE
Integrity check for withdrawn and removed content

### DIFF
--- a/lib/whitehall_importer/integrity_checker.rb
+++ b/lib/whitehall_importer/integrity_checker.rb
@@ -141,6 +141,14 @@ module WhitehallImporter
         )
       end
 
+      unless check.expected_unpublishing_time?
+        problems << problem_description(
+          "unpublishing time doesn't match",
+          publishing_api_content.dig("unpublishing", "unpublished_at"),
+          check.expected_unpublishing_time,
+        )
+      end
+
       problems
     end
 

--- a/lib/whitehall_importer/integrity_checker.rb
+++ b/lib/whitehall_importer/integrity_checker.rb
@@ -141,6 +141,14 @@ module WhitehallImporter
         )
       end
 
+      unless check.expected_alternative_path?
+        problems << problem_description(
+          "unpublishing alternative path doesn't match",
+          publishing_api_content.dig("unpublishing", "alternative_path"),
+          check.expected_alternative_path,
+        )
+      end
+
       unless check.expected_unpublishing_time?
         problems << problem_description(
           "unpublishing time doesn't match",

--- a/lib/whitehall_importer/integrity_checker.rb
+++ b/lib/whitehall_importer/integrity_checker.rb
@@ -149,6 +149,10 @@ module WhitehallImporter
         )
       end
 
+      unless check.expected_explanation?
+        problems << "unpublishing explanation doesn't match"
+      end
+
       problems
     end
 

--- a/lib/whitehall_importer/integrity_checker.rb
+++ b/lib/whitehall_importer/integrity_checker.rb
@@ -130,6 +130,15 @@ module WhitehallImporter
       problems = []
       return problems unless edition.withdrawn? || edition.removed?
 
+      unless expected_state?
+        problems << problem_description(
+          "edition state isn't as expected",
+          "unpublished",
+          publishing_api_content.dig("publication_state"),
+        )
+        return problems
+      end
+
       check = UnpublishingCheck.new(edition,
                                     publishing_api_content["unpublishing"])
 
@@ -211,6 +220,11 @@ module WhitehallImporter
       attribute == "alt_text" &&
         proposed_image_payload.empty? &&
         publishing_api_image[attribute] == "placeholder"
+    end
+
+    def expected_state?
+      %w[withdrawn removed].include?(edition.state) &&
+        publishing_api_content.dig("publication_state") == "unpublished"
     end
   end
 end

--- a/lib/whitehall_importer/integrity_checker.rb
+++ b/lib/whitehall_importer/integrity_checker.rb
@@ -139,21 +139,20 @@ module WhitehallImporter
         return problems
       end
 
-      check = UnpublishingCheck.new(edition,
-                                    publishing_api_content["unpublishing"])
+      check = UnpublishingCheck.new(edition, publishing_api_unpublishing)
 
       unless check.expected_type?
         problems << problem_description(
           "unpublishing type not expected",
           check.expected_type,
-          publishing_api_content.dig("unpublishing", "type"),
+          publishing_api_unpublishing["type"],
         )
       end
 
       unless check.expected_alternative_path?
         problems << problem_description(
           "unpublishing alternative path doesn't match",
-          publishing_api_content.dig("unpublishing", "alternative_path"),
+          publishing_api_unpublishing["alternative_path"],
           check.expected_alternative_path,
         )
       end
@@ -161,7 +160,7 @@ module WhitehallImporter
       unless check.expected_unpublishing_time?
         problems << problem_description(
           "unpublishing time doesn't match",
-          publishing_api_content.dig("unpublishing", "unpublished_at"),
+          publishing_api_unpublishing["unpublished_at"],
           check.expected_unpublishing_time,
         )
       end
@@ -225,6 +224,10 @@ module WhitehallImporter
     def expected_state?
       %w[withdrawn removed].include?(edition.state) &&
         publishing_api_content.dig("publication_state") == "unpublished"
+    end
+
+    def publishing_api_unpublishing
+      publishing_api_content["unpublishing"]
     end
   end
 end

--- a/lib/whitehall_importer/integrity_checker.rb
+++ b/lib/whitehall_importer/integrity_checker.rb
@@ -22,7 +22,8 @@ module WhitehallImporter
     end
 
     def problems
-      content_problems + image_problems + organisation_problems + time_problems
+      content_problems + image_problems + organisation_problems +
+        time_problems + unpublishing_problems
     end
 
     def proposed_payload
@@ -119,6 +120,24 @@ module WhitehallImporter
           "organisations don't match",
           publishing_api_link("organisations"),
           proposed_payload.dig("links", "organisations"),
+        )
+      end
+
+      problems
+    end
+
+    def unpublishing_problems
+      problems = []
+      return problems unless edition.withdrawn? || edition.removed?
+
+      check = UnpublishingCheck.new(edition,
+                                    publishing_api_content["unpublishing"])
+
+      unless check.expected_type?
+        problems << problem_description(
+          "unpublishing type not expected",
+          check.expected_type,
+          publishing_api_content.dig("unpublishing", "type"),
         )
       end
 

--- a/lib/whitehall_importer/integrity_checker/unpublishing_check.rb
+++ b/lib/whitehall_importer/integrity_checker/unpublishing_check.rb
@@ -23,6 +23,10 @@ module WhitehallImporter
       unpublishing_time_matches?
     end
 
+    def expected_unpublishing_time
+      edition.status.details&.withdrawn_at
+    end
+
     def expected_alternative_path?
       return true unless edition.removed?
 
@@ -37,10 +41,8 @@ module WhitehallImporter
   private
 
     def unpublishing_time_matches?
-      IntegrityChecker.time_matches?(
-        unpublishing["unpublished_at"],
-        edition.status.details.withdrawn_at&.rfc3339,
-      )
+      IntegrityChecker.time_matches?(unpublishing["unpublished_at"],
+                                     expected_unpublishing_time&.rfc3339)
     end
 
     def edition_explanation_html

--- a/lib/whitehall_importer/integrity_checker/unpublishing_check.rb
+++ b/lib/whitehall_importer/integrity_checker/unpublishing_check.rb
@@ -1,0 +1,23 @@
+module WhitehallImporter
+  class IntegrityChecker::UnpublishingCheck
+    attr_reader :edition, :unpublishing
+
+    def initialize(edition, unpublishing)
+      @edition = edition
+      @unpublishing = unpublishing
+    end
+
+    def expected_type?
+      case unpublishing["type"]
+      when "gone"
+        edition.removed? && !edition.status.details.redirect?
+      when "redirect"
+        edition.removed? && edition.status.details.redirect?
+      when "withdrawal"
+        edition.withdrawn?
+      else
+        false
+      end
+    end
+  end
+end

--- a/lib/whitehall_importer/integrity_checker/unpublishing_check.rb
+++ b/lib/whitehall_importer/integrity_checker/unpublishing_check.rb
@@ -32,6 +32,11 @@ module WhitehallImporter
       unpublishing["alternative_path"] == edition.status.details.alternative_url
     end
 
+    def expected_explanation?
+      Sanitize.clean(unpublishing["explanation"]).squish ==
+        Sanitize.clean(edition_explanation_html).squish
+    end
+
   private
 
     def unpublishing_time_matches?
@@ -39,6 +44,13 @@ module WhitehallImporter
         unpublishing["unpublished_at"],
         edition.status.details.withdrawn_at&.rfc3339,
       )
+    end
+
+    def edition_explanation_html
+      explanation = edition.status.details.try(:public_explanation) ||
+        edition.status.details.try(:explanatory_note)
+
+      Govspeak::Document.new(explanation).to_html
     end
   end
 end

--- a/lib/whitehall_importer/integrity_checker/unpublishing_check.rb
+++ b/lib/whitehall_importer/integrity_checker/unpublishing_check.rb
@@ -19,5 +19,20 @@ module WhitehallImporter
         false
       end
     end
+
+    def expected_unpublishing_time?
+      return true unless edition.withdrawn?
+
+      unpublishing_time_matches?
+    end
+
+  private
+
+    def unpublishing_time_matches?
+      IntegrityChecker.time_matches?(
+        unpublishing["unpublished_at"],
+        edition.status.details.withdrawn_at&.rfc3339,
+      )
+    end
   end
 end

--- a/lib/whitehall_importer/integrity_checker/unpublishing_check.rb
+++ b/lib/whitehall_importer/integrity_checker/unpublishing_check.rb
@@ -26,6 +26,12 @@ module WhitehallImporter
       unpublishing_time_matches?
     end
 
+    def expected_alternative_path?
+      return true unless edition.removed?
+
+      unpublishing["alternative_path"] == edition.status.details.alternative_url
+    end
+
   private
 
     def unpublishing_time_matches?

--- a/lib/whitehall_importer/integrity_checker/unpublishing_check.rb
+++ b/lib/whitehall_importer/integrity_checker/unpublishing_check.rb
@@ -8,16 +8,13 @@ module WhitehallImporter
     end
 
     def expected_type?
-      case unpublishing["type"]
-      when "gone"
-        edition.removed? && !edition.status.details.redirect?
-      when "redirect"
-        edition.removed? && edition.status.details.redirect?
-      when "withdrawal"
-        edition.withdrawn?
-      else
-        false
-      end
+      unpublishing["type"] == expected_type
+    end
+
+    def expected_type
+      return "withdrawal" if edition.withdrawn?
+
+      edition.status.details.redirect? ? "redirect" : "gone"
     end
 
     def expected_unpublishing_time?

--- a/lib/whitehall_importer/integrity_checker/unpublishing_check.rb
+++ b/lib/whitehall_importer/integrity_checker/unpublishing_check.rb
@@ -33,6 +33,10 @@ module WhitehallImporter
       unpublishing["alternative_path"] == edition.status.details.alternative_url
     end
 
+    def expected_alternative_path
+      edition.status.details&.alternative_url
+    end
+
     def expected_explanation?
       Sanitize.clean(unpublishing["explanation"]).squish ==
         Sanitize.clean(edition_explanation_html).squish

--- a/spec/lib/whitehall_importer/integrity_checker/unpublishing_check_spec.rb
+++ b/spec/lib/whitehall_importer/integrity_checker/unpublishing_check_spec.rb
@@ -151,6 +151,15 @@ RSpec.describe WhitehallImporter::IntegrityChecker::UnpublishingCheck do
     end
   end
 
+  describe "#expected_alternative_path" do
+    it "returns the edition's alternative_url" do
+      unpublishing_check = described_class.new(removed_edition_with_redirect,
+                                               publishing_api_redirect)
+      expect(unpublishing_check.expected_alternative_path)
+        .to eq(removal_with_redirect.alternative_url)
+    end
+  end
+
   describe "#expected_explanation?" do
     context "when imported edition is withdrawn" do
       it "returns true if public_explanation matches explanation in Publishing API" do

--- a/spec/lib/whitehall_importer/integrity_checker/unpublishing_check_spec.rb
+++ b/spec/lib/whitehall_importer/integrity_checker/unpublishing_check_spec.rb
@@ -66,6 +66,26 @@ RSpec.describe WhitehallImporter::IntegrityChecker::UnpublishingCheck do
     end
   end
 
+  describe "#expected_type" do
+    it "returns 'withdrawal' when edition is withdrawn" do
+      unpublishing_check = described_class.new(withdrawn_edition,
+                                               publishing_api_withdrawal)
+      expect(unpublishing_check.expected_type).to eq "withdrawal"
+    end
+
+    it "returns 'gone' when edition is removed" do
+      unpublishing_check = described_class.new(removed_edition,
+                                               publishing_api_gone)
+      expect(unpublishing_check.expected_type).to eq "gone"
+    end
+
+    it "returns 'redirect' when edition is removed and redirected" do
+      unpublishing_check = described_class.new(removed_edition_with_redirect,
+                                               publishing_api_redirect)
+      expect(unpublishing_check.expected_type).to eq "redirect"
+    end
+  end
+
   describe "#expected_unpublishing_time?" do
     context "when imported edition is withdrawn" do
       it "returns true if withdrawn_at matches unpublished_at in Publishing API" do

--- a/spec/lib/whitehall_importer/integrity_checker/unpublishing_check_spec.rb
+++ b/spec/lib/whitehall_importer/integrity_checker/unpublishing_check_spec.rb
@@ -115,6 +115,16 @@ RSpec.describe WhitehallImporter::IntegrityChecker::UnpublishingCheck do
     end
   end
 
+  describe "#expected_unpublishing_time" do
+    it "returns withdrawn_at for withdrawn editions" do
+      unpublishing_check = described_class.new(withdrawn_edition,
+                                               publishing_api_withdrawal)
+
+      expect(unpublishing_check.expected_unpublishing_time)
+        .to eq(withdrawal.withdrawn_at)
+    end
+  end
+
   describe "#expected_alternative_path?" do
     context "when imported edition is withdrawn" do
       it "returns true and does not check for an alternative path" do

--- a/spec/lib/whitehall_importer/integrity_checker/unpublishing_check_spec.rb
+++ b/spec/lib/whitehall_importer/integrity_checker/unpublishing_check_spec.rb
@@ -1,0 +1,74 @@
+RSpec.describe WhitehallImporter::IntegrityChecker::UnpublishingCheck do
+  let(:withdrawal) { build(:withdrawal) }
+  let(:withdrawn_edition) { build(:edition, :withdrawn, withdrawal: withdrawal) }
+  let(:removal) { build(:removal) }
+  let(:removal_with_redirect) do
+    build(:removal, alternative_url: "/somewhere", redirect: true)
+  end
+
+  let(:removed_edition) { build(:edition, :removed, removal: removal) }
+  let(:removed_edition_with_redirect) do
+    build(:edition, :removed, removal: removal_with_redirect)
+  end
+
+  describe "#expected_type?" do
+    context "when imported edition is withdrawn" do
+      it "returns true if it has a 'withdrawal' unpublishing type in Publishing API" do
+        unpublishing_check = described_class.new(withdrawn_edition,
+                                                 publishing_api_withdrawal)
+        expect(unpublishing_check.expected_type?).to be true
+      end
+
+      it "returns false if it does not have a 'withdrawal' unpublishing type in Publishing API" do
+        unpublishing_check = described_class.new(withdrawn_edition,
+                                                 publishing_api_redirect)
+        expect(unpublishing_check.expected_type?).to be false
+      end
+    end
+
+    context "when imported edition is removed" do
+      it "returns true if it has a 'gone' unpublishing type in the Publishing API" do
+        unpublishing_check = described_class.new(removed_edition, publishing_api_gone)
+        expect(unpublishing_check.expected_type?).to be true
+      end
+
+      it "returns false if it does not have a 'gone' unpublishing type in the Publishing API" do
+        unpublishing_check = described_class.new(removed_edition,
+                                                 publishing_api_redirect)
+        expect(unpublishing_check.expected_type?).to be false
+      end
+    end
+
+    context "when imported edition is removed and redirected" do
+      it "returns true if it has a 'redirect' unpublishing type in the Publishing API" do
+        unpublishing_check = described_class.new(removed_edition_with_redirect,
+                                                 publishing_api_redirect)
+        expect(unpublishing_check.expected_type?).to be true
+      end
+
+      it "returns false if it does not have a 'redirect' unpublishing type in the Publishing API" do
+        unpublishing_check = described_class.new(removed_edition_with_redirect,
+                                                 publishing_api_gone)
+        expect(unpublishing_check.expected_type?).to be false
+      end
+    end
+  end
+
+  def publishing_api_withdrawal(attributes = {})
+    {
+      "type" => "withdrawal",
+    }.merge(attributes).as_json
+  end
+
+  def publishing_api_gone(attributes = {})
+    {
+      "type" => "gone",
+    }.merge(attributes).as_json
+  end
+
+  def publishing_api_redirect(attributes = {})
+    {
+      "type" => "redirect",
+    }.merge(attributes).as_json
+  end
+end

--- a/spec/lib/whitehall_importer/integrity_checker_spec.rb
+++ b/spec/lib/whitehall_importer/integrity_checker_spec.rb
@@ -415,6 +415,19 @@ RSpec.describe WhitehallImporter::IntegrityChecker do
         stub_publishing_api_has_item(publishing_api_item)
       end
 
+      it "returns a problem if the publication_state isn't 'unpublished' in Publishing API" do
+        publishing_api_item = default_publishing_api_item(edition,
+                                                          publication_state: "published")
+        stub_publishing_api_has_item(publishing_api_item)
+        expected = "unpublished"
+        actual = publishing_api_item[:publication_state]
+        integrity_check = described_class.new(edition)
+
+        expect(integrity_check.problems).to include(
+          "edition state isn't as expected, expected: #{expected.inspect}, actual: #{actual.inspect}",
+        )
+      end
+
       it "returns a problem when the unpublishing type isn't correct" do
         expect(integrity_check.problems).to include(
           unpublishing_problem_message("withdrawal",
@@ -453,6 +466,19 @@ RSpec.describe WhitehallImporter::IntegrityChecker do
 
       before do
         stub_publishing_api_has_item(publishing_api_item)
+      end
+
+      it "returns a problem if the publication_state isn't 'unpublished' in Publishing API" do
+        publishing_api_item = default_publishing_api_item(edition,
+                                                          publication_state: "published")
+        stub_publishing_api_has_item(publishing_api_item)
+        expected = "unpublished"
+        actual = publishing_api_item[:publication_state]
+        integrity_check = described_class.new(edition)
+
+        expect(integrity_check.problems).to include(
+          "edition state isn't as expected, expected: #{expected.inspect}, actual: #{actual.inspect}",
+        )
       end
 
       it "returns a problem when the unpublishing type isn't correct" do

--- a/spec/lib/whitehall_importer/integrity_checker_spec.rb
+++ b/spec/lib/whitehall_importer/integrity_checker_spec.rb
@@ -275,14 +275,8 @@ RSpec.describe WhitehallImporter::IntegrityChecker do
     end
     let(:integrity_check) { described_class.new(edition) }
 
-    def problem_message(message, expected, actual)
+    def problem_description(message, expected, actual)
       "#{message}, expected: #{expected.inspect}, actual: #{actual.inspect}"
-    end
-
-    def unpublishing_problem_message(publishing_api_type, expected)
-      "unpublishing type not expected, " +
-        "expected: #{publishing_api_type.inspect}, " +
-        "actual: #{expected.inspect}"
     end
 
     before do
@@ -295,9 +289,9 @@ RSpec.describe WhitehallImporter::IntegrityChecker do
       stub_publishing_api_has_item(publishing_api_item)
 
       expect(integrity_check.problems).to include(
-        problem_message("our first_published_at doesn't match first_public_at",
-                        publishing_api_item[:details][:first_public_at],
-                        edition.document.first_published_at.as_json),
+        problem_description("our first_published_at doesn't match first_public_at",
+                            publishing_api_item[:details][:first_public_at],
+                            edition.document.first_published_at.as_json),
       )
     end
 
@@ -306,42 +300,50 @@ RSpec.describe WhitehallImporter::IntegrityChecker do
       stub_publishing_api_has_item(publishing_api_item)
 
       expect(integrity_check.problems).to include(
-        problem_message("public_updated_at doesn't match",
-                        publishing_api_item[:public_updated_at],
-                        edition.public_first_published_at.as_json),
+        problem_description("public_updated_at doesn't match",
+                            publishing_api_item[:public_updated_at],
+                            edition.public_first_published_at.as_json),
       )
     end
 
     it "returns a problem when the base paths don't match" do
       expect(integrity_check.problems).to include(
-        problem_message("base_path doesn't match", publishing_api_item[:base_path], edition.base_path),
+        problem_description("base_path doesn't match",
+                            publishing_api_item[:base_path],
+                            edition.base_path),
       )
     end
 
     it "returns a problem when the titles don't match" do
       expect(integrity_check.problems).to include(
-        problem_message("title doesn't match", publishing_api_item[:title], edition.title),
+        problem_description("title doesn't match",
+                            publishing_api_item[:title],
+                            edition.title),
       )
     end
 
     it "returns a problem when the descriptions don't match" do
       expect(integrity_check.problems).to include(
-        problem_message("description doesn't match", publishing_api_item[:description], edition.summary),
+        problem_description("description doesn't match",
+                            publishing_api_item[:description],
+                            edition.summary),
       )
     end
 
     it "returns a problem when the document types don't match" do
       expect(integrity_check.problems).to include(
-        problem_message("document_type doesn't match",
-                        publishing_api_item[:document_type],
-                        edition.document_type.id),
+        problem_description("document_type doesn't match",
+                            publishing_api_item[:document_type],
+                            edition.document_type.id),
       )
     end
 
     it "returns a problem when the schema names don't match" do
       edition_schema_name = edition.document_type.publishing_metadata.schema_name
       expect(integrity_check.problems).to include(
-        problem_message("schema_name doesn't match", publishing_api_item[:schema_name], edition_schema_name),
+        problem_description("schema_name doesn't match",
+                            publishing_api_item[:schema_name],
+                            edition_schema_name),
       )
     end
 
@@ -354,9 +356,9 @@ RSpec.describe WhitehallImporter::IntegrityChecker do
       publishing_api_image = publishing_api_item[:details][:image]
 
       expect(integrity_check.problems).to include(
-        problem_message("image alt_text doesn't match",
-                        publishing_api_image[:alt_text],
-                        edition_image.alt_text),
+        problem_description("image alt_text doesn't match",
+                            publishing_api_image[:alt_text],
+                            edition_image.alt_text),
       )
     end
 
@@ -365,17 +367,17 @@ RSpec.describe WhitehallImporter::IntegrityChecker do
       publishing_api_image = publishing_api_item[:details][:image]
 
       expect(integrity_check.problems).to include(
-        problem_message("image caption doesn't match",
-                        publishing_api_image[:caption],
-                        edition_image.caption),
+        problem_description("image caption doesn't match",
+                            publishing_api_image[:caption],
+                            edition_image.caption),
       )
     end
 
     it "returns a problem when the primary_publishing_organisation doesn't match" do
       expect(integrity_check.problems).to include(
-        problem_message("primary_publishing_organisation doesn't match",
-                        publishing_api_item[:links][:primary_publishing_organisation],
-                        edition.tags["primary_publishing_organisation"]),
+        problem_description("primary_publishing_organisation doesn't match",
+                            publishing_api_item[:links][:primary_publishing_organisation],
+                            edition.tags["primary_publishing_organisation"]),
       )
     end
 
@@ -430,16 +432,17 @@ RSpec.describe WhitehallImporter::IntegrityChecker do
 
       it "returns a problem when the unpublishing type isn't correct" do
         expect(integrity_check.problems).to include(
-          unpublishing_problem_message("withdrawal",
-                                       publishing_api_item[:unpublishing][:type]),
+          problem_description("unpublishing type not expected",
+                              "withdrawal",
+                              publishing_api_item[:unpublishing][:type]),
         )
       end
 
       it "returns a problem when the unpublishing time isn't correct" do
         expect(integrity_check.problems).to include(
-          problem_message("unpublishing time doesn't match",
-                          publishing_api_item[:unpublishing][:unpublished_at],
-                          edition.status.details.withdrawn_at),
+          problem_description("unpublishing time doesn't match",
+                              publishing_api_item[:unpublishing][:unpublished_at],
+                              edition.status.details.withdrawn_at),
         )
       end
 
@@ -483,8 +486,9 @@ RSpec.describe WhitehallImporter::IntegrityChecker do
 
       it "returns a problem when the unpublishing type isn't correct" do
         expect(integrity_check.problems).to include(
-          unpublishing_problem_message("gone",
-                                       publishing_api_item[:unpublishing][:type]),
+          problem_description("unpublishing type not expected",
+                              "gone",
+                              publishing_api_item[:unpublishing][:type]),
         )
       end
 
@@ -515,16 +519,17 @@ RSpec.describe WhitehallImporter::IntegrityChecker do
         integrity_check = described_class.new(edition)
 
         expect(integrity_check.problems).to include(
-          unpublishing_problem_message("redirect",
-                                       publishing_api_item[:unpublishing][:type]),
+          problem_description("unpublishing type not expected",
+                              "redirect",
+                              publishing_api_item[:unpublishing][:type]),
         )
       end
 
       it "returns a problem when the alternative path doesn't match" do
         expect(integrity_check.problems).to include(
-          problem_message("unpublishing alternative path doesn't match",
-                          publishing_api_item[:unpublishing][:alternative_path],
-                          edition.status.details.alternative_url),
+          problem_description("unpublishing alternative path doesn't match",
+                              publishing_api_item[:unpublishing][:alternative_path],
+                              edition.status.details.alternative_url),
         )
       end
     end


### PR DESCRIPTION
For https://trello.com/c/e8zIJIoy/1526-expand-integrity-checks-to-cover-withdrawing-and-removing

This adds the below checks for withdrawn and removed content to the Integrity Checker:

### Withdrawn content
- Unpublishing type in Publishing API is `withdrawal`
- `withdrawn_at` matches `unpublished_at` in Publishing API
- `public_explanation` matches `explanation` in Publishing API

### Removed content
- Unpublishing type in Publishing API is `gone` or `redirect`
- `public_explanation` matches `explanation` in Publishing API
- `alternative_url` matches `alternative_path` in Publishing API
- Unpublishing time is not checked