### PR TITLE
Format times for PublishingApiPayload to rfc3339

### DIFF
--- a/lib/publishing_api_payload.rb
+++ b/lib/publishing_api_payload.rb
@@ -22,16 +22,16 @@ class PublishingApiPayload
       links: links,
       access_limited: access_limited,
       auth_bypass_ids: auth_bypass_ids,
-      public_updated_at: history.public_updated_at,
+      public_updated_at: history.public_updated_at.rfc3339,
     }
-    payload[:first_published_at] = history.first_published_at if history.first_published_at.present?
+    payload[:first_published_at] = history.first_published_at.rfc3339 if history.first_published_at.present?
 
     fields = document_type.contents + document_type.tags
     fields.each { |f| payload.deep_merge!(f.payload(edition)) }
 
     if edition.backdated_to.present?
-      payload[:first_published_at] = edition.backdated_to
-      payload[:public_updated_at] = edition.backdated_to if edition.first?
+      payload[:first_published_at] = edition.backdated_to.rfc3339
+      payload[:public_updated_at] = edition.backdated_to.rfc3339 if edition.first?
     end
 
     if republish

--- a/lib/publishing_api_payload.rb
+++ b/lib/publishing_api_payload.rb
@@ -30,7 +30,6 @@ class PublishingApiPayload
     fields.each { |f| payload.deep_merge!(f.payload(edition)) }
 
     if edition.backdated_to.present?
-      payload[:first_published_at] = edition.backdated_to.rfc3339
       payload[:public_updated_at] = edition.backdated_to.rfc3339 if edition.first?
     end
 

--- a/spec/lib/publishing_api_payload_spec.rb
+++ b/spec/lib/publishing_api_payload_spec.rb
@@ -157,7 +157,7 @@ RSpec.describe PublishingApiPayload do
     end
 
     it "includes first_published_at if the edition has a backdated_to value" do
-      date = Time.zone.now.yesterday
+      date = Time.zone.now.yesterday.rfc3339
       revision = build(:revision, backdated_to: date)
       edition = build(:edition, revision: revision)
       payload = described_class.new(edition).payload
@@ -166,7 +166,7 @@ RSpec.describe PublishingApiPayload do
     end
 
     it "include public_updated_at if the edition has backdated_to and is a first edition" do
-      date = Time.zone.now.yesterday
+      date = Time.zone.now.yesterday.rfc3339
       revision = build(:revision, backdated_to: date)
       edition = build(:edition, revision: revision, number: 1)
       payload = described_class.new(edition).payload

--- a/spec/lib/publishing_api_payload_spec.rb
+++ b/spec/lib/publishing_api_payload_spec.rb
@@ -156,15 +156,6 @@ RSpec.describe PublishingApiPayload do
       expect(payload[:links][:government]).to eq [government.content_id]
     end
 
-    it "includes first_published_at if the edition has a backdated_to value" do
-      date = Time.zone.now.yesterday.rfc3339
-      revision = build(:revision, backdated_to: date)
-      edition = build(:edition, revision: revision)
-      payload = described_class.new(edition).payload
-
-      expect(payload).to match a_hash_including(first_published_at: date)
-    end
-
     it "include public_updated_at if the edition has backdated_to and is a first edition" do
       date = Time.zone.now.yesterday.rfc3339
       revision = build(:revision, backdated_to: date)


### PR DESCRIPTION
Converts time objects to rfc3339 strings for the generated payload's
timestamps. The reason we've decided to do this is that when we come to
compare times it helps if we're dealing with the same objects, e.g all
strings. An example of where we are comparing times is the
IntegrityChecker where we fetch the edition from the publishing-api and the
timestamps that are returned are strings where as the payload generates
Time objects.

Doing this will make comparing these two times in the IntegrityChecker
simpler for future pieces of work.