### PR TITLE
Add download action for file attachments

### DIFF
--- a/app/controllers/file_attachments_controller.rb
+++ b/app/controllers/file_attachments_controller.rb
@@ -52,6 +52,20 @@ class FileAttachmentsController < ApplicationController
     end
   end
 
+  def download
+    edition = Edition.find_current(document: params[:document])
+    assert_edition_state(edition, &:editable?)
+
+    attachment_revision = edition.file_attachment_revisions
+      .find_by!(file_attachment_id: params[:file_attachment_id])
+
+    send_data(
+      attachment_revision.blob.download,
+      filename: attachment_revision.filename,
+      type: attachment_revision.content_type,
+    )
+  end
+
   def create
     result = FileAttachments::CreateInteractor.call(params: params, user: current_user)
     edition, attachment_revision, issues = result.to_h.values_at(:edition,

--- a/app/models/file_attachment/revision.rb
+++ b/app/models/file_attachment/revision.rb
@@ -18,6 +18,7 @@ class FileAttachment::Revision < ApplicationRecord
            :asset_url,
            :content_type,
            :byte_size,
+           :blob,
            :number_of_pages,
            to: :blob_revision
 

--- a/app/views/featured_attachments/_featured_attachment.html.erb
+++ b/app/views/featured_attachments/_featured_attachment.html.erb
@@ -1,8 +1,18 @@
 <% actions = [] %>
+
 <% actions << link_to(
-    "Delete attachment",
-    confirm_delete_file_attachment_path(document, attachment.file_attachment_id, wizard: "featured"),
-    class: "govuk-link app-link--button app-link--destructive",
+  "Delete attachment",
+  confirm_delete_file_attachment_path(document, attachment.file_attachment_id, wizard: "featured"),
+  class: "govuk-link app-link--button app-link--destructive",
+) %>
+
+<% actions << link_to(
+  "Download",
+  download_file_attachment_path(document, attachment.file_attachment),
+  class: "govuk-link govuk-link--no-visited-state app-link--button",
+  data: {
+    gtm: "download-attachment"
+  }
 ) %>
 
 <%= render "components/attachment_meta", {

--- a/app/views/file_attachments/_file_attachment.html.erb
+++ b/app/views/file_attachments/_file_attachment.html.erb
@@ -11,12 +11,11 @@
 ) %>
 
 <% actions << link_to(
-  "Preview",
-  preview_file_attachment_path(document, attachment.file_attachment),
-  target: :_blank,
+  "Download",
+  download_file_attachment_path(document, attachment.file_attachment),
   class: "govuk-link govuk-link--no-visited-state app-link--button",
   data: {
-    gtm: "preview-attachment"
+    gtm: "download-attachment"
   }
 ) %>
 

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -99,6 +99,7 @@ Rails.application.routes.draw do
     post "/file-attachments" => "file_attachments#create"
     get "/file-attachments/:file_attachment_id" => "file_attachments#show", as: :file_attachment
     get "/file-attachments/:file_attachment_id/preview" => "file_attachments#preview", as: :preview_file_attachment
+    get "/file-attachments/:file_attachment_id/download" => "file_attachments#download", as: :download_file_attachment
     get "/file-attachments/:file_attachment_id/edit" => "file_attachments#edit", as: :edit_file_attachment
     patch "/file-attachments/:file_attachment_id/edit" => "file_attachments#update"
     delete "/file-attachments/:file_attachment_id" => "file_attachments#destroy"

--- a/spec/features/editing_file_attachments/download_file_attachment_spec.rb
+++ b/spec/features/editing_file_attachments/download_file_attachment_spec.rb
@@ -1,0 +1,33 @@
+RSpec.feature "Download a file attachment" do
+  scenario do
+    given_there_is_an_edition_with_featured_attachments
+    when_i_visit_the_attachments_index_page
+    and_i_download_the_attachment
+    then_the_attachment_should_download
+  end
+
+  def given_there_is_an_edition_with_featured_attachments
+    document_type = build(:document_type, attachments: "featured")
+    @attachment_revision = create(:file_attachment_revision)
+
+    @edition = create(:edition,
+                      document_type: document_type,
+                      file_attachment_revisions: [@attachment_revision])
+  end
+
+  def when_i_visit_the_attachments_index_page
+    visit featured_attachments_path(@edition.document)
+  end
+
+  def and_i_download_the_attachment
+    click_on("Download")
+  end
+
+  def then_the_attachment_should_download
+    expected = "attachment; " +
+      "filename=\"#{@attachment_revision.filename}\"; " +
+      "filename*=UTF-8\'\'#{@attachment_revision.filename}"
+
+    expect(page.response_headers["Content-Disposition"]).to eq(expected)
+  end
+end

--- a/spec/features/editing_file_attachments/download_file_attachment_spec.rb
+++ b/spec/features/editing_file_attachments/download_file_attachment_spec.rb
@@ -1,7 +1,14 @@
 RSpec.feature "Download a file attachment" do
-  scenario do
+  scenario "featured" do
     given_there_is_an_edition_with_featured_attachments
     when_i_visit_the_attachments_index_page
+    and_i_download_the_attachment
+    then_the_attachment_should_download
+  end
+
+  scenario "inline" do
+    given_there_is_an_edition_with_attachments
+    when_i_click_to_insert_an_attachment
     and_i_download_the_attachment
     then_the_attachment_should_download
   end
@@ -15,8 +22,23 @@ RSpec.feature "Download a file attachment" do
                       file_attachment_revisions: [@attachment_revision])
   end
 
+  def given_there_is_an_edition_with_attachments
+    @attachment_revision = create(:file_attachment_revision)
+
+    @edition = create(:edition,
+                      document_type: build(:document_type, :with_body),
+                      file_attachment_revisions: [@attachment_revision])
+  end
+
   def when_i_visit_the_attachments_index_page
     visit featured_attachments_path(@edition.document)
+  end
+
+  def when_i_click_to_insert_an_attachment
+    visit content_path(@edition.document)
+    find("markdown-toolbar details").click
+    click_on "Attachment"
+    expect(page).to have_content("74 Bytes")
   end
 
   def and_i_download_the_attachment

--- a/spec/features/editing_file_attachments/preview_file_attachment_spec.rb
+++ b/spec/features/editing_file_attachments/preview_file_attachment_spec.rb
@@ -27,7 +27,7 @@ RSpec.feature "Preview file attachment", js: true do
     end
 
     expect(page).to have_selector(".gem-c-attachment__metadata")
-    @preview_window = window_opened_by { click_on "Preview" }
+    @preview_window = window_opened_by { click_on @attachment_revision.title }
   end
 
   def then_i_should_see_the_attachment

--- a/spec/features/editing_file_attachments/upload_file_attachment_spec.rb
+++ b/spec/features/editing_file_attachments/upload_file_attachment_spec.rb
@@ -27,7 +27,7 @@ RSpec.feature "Upload file attachment", js: true do
   end
 
   def given_there_is_an_edition_that_allows_featured_attachments
-    document_type = build(:document_type, :with_body, attachments: "featured")
+    document_type = build(:document_type, attachments: "featured")
     @edition = create(:edition, document_type: document_type)
   end
 

--- a/spec/features/editing_images/download_image_spec.rb
+++ b/spec/features/editing_images/download_image_spec.rb
@@ -2,8 +2,8 @@ RSpec.feature "Download a image" do
   scenario do
     given_there_is_an_edition_with_images
     when_i_visit_the_image_index_page
-    and_i_click_the_link_to_download_the_image
-    then_the_image_should_have_been_downloaded
+    and_i_download_the_image
+    then_the_image_should_download
   end
 
   def given_there_is_an_edition_with_images
@@ -19,11 +19,15 @@ RSpec.feature "Download a image" do
     visit images_path(@edition.document)
   end
 
-  def and_i_click_the_link_to_download_the_image
+  def and_i_download_the_image
     click_on("Download 960x640 image")
   end
 
-  def then_the_image_should_have_been_downloaded
-    expect(page.response_headers["Content-Disposition"]).to eq("attachment; filename=\"#{@image_revision.filename}\"; filename*=UTF-8\'\'#{@image_revision.filename}")
+  def then_the_image_should_download
+    expected = "attachment; " +
+      "filename=\"#{@image_revision.filename}\"; " +
+      "filename*=UTF-8\'\'#{@image_revision.filename}"
+
+    expect(page.response_headers["Content-Disposition"]).to eq(expected)
   end
 end

--- a/spec/requests/file_attachments_spec.rb
+++ b/spec/requests/file_attachments_spec.rb
@@ -11,7 +11,8 @@ RSpec.describe "File Attachments" do
                   routes: { file_attachment_path: %i[get delete],
                             edit_file_attachment_path: %i[get patch],
                             preview_file_attachment_path: %i[get],
-                            confirm_delete_file_attachment_path: %i[get] } do
+                            confirm_delete_file_attachment_path: %i[get],
+                            download_file_attachment_path: %i[get] } do
     let(:edition) { create(:edition, :published) }
     let(:route_params) { [edition.document, "file_attachment_id"] }
   end
@@ -22,7 +23,8 @@ RSpec.describe "File Attachments" do
                   routes: { file_attachment_path: %i[get delete],
                             edit_file_attachment_path: %i[get patch],
                             preview_file_attachment_path: %i[get],
-                            confirm_delete_file_attachment_path: %i[get] } do
+                            confirm_delete_file_attachment_path: %i[get],
+                            download_file_attachment_path: %i[get] } do
     let(:edition) { create(:edition) }
     let(:file_attachment_revision) { create(:file_attachment_revision) }
     let(:route_params) { [edition.document, file_attachment_revision] }
@@ -248,6 +250,16 @@ RSpec.describe "File Attachments" do
       expect(response.body).to have_content(
         I18n.t!("requirements.file_attachment_title.blank.form_message"),
       )
+    end
+  end
+
+  describe "GET /documents/:document/file_attachments/:file_attachment_id/download" do
+    it "provides a file attachment download" do
+      file_attachment_revision = create(:file_attachment_revision)
+      edition = create(:edition, file_attachment_revisions: [file_attachment_revision])
+      get download_file_attachment_path(edition.document, file_attachment_revision.file_attachment_id)
+      expect(response.headers["Content-Disposition"])
+        .to match(/attachment; filename="#{file_attachment_revision.filename}";/)
     end
   end
 end


### PR DESCRIPTION
https://trello.com/c/OWZorYWA/1540-allow-attachments-to-be-downloaded

Please see the commits for more details.

![Screenshot 2020-03-12 at 11 45 33](https://user-images.githubusercontent.com/9029009/76518440-02323a80-6457-11ea-8e08-bdbe0bbfdd68.png)
![Screenshot 2020-03-12 at 11 45 18](https://user-images.githubusercontent.com/9029009/76518443-02cad100-6457-11ea-8b6b-957ba35a6d26.png)
