### PR TITLE
Remove backdating conditional for PublishingApiPayload

### DIFF
--- a/lib/publishing_api_payload.rb
+++ b/lib/publishing_api_payload.rb
@@ -29,11 +29,6 @@ class PublishingApiPayload
     fields = document_type.contents + document_type.tags
     fields.each { |f| payload.deep_merge!(f.payload(edition)) }
 
-    if edition.backdated_to.present?
-      payload[:first_published_at] = edition.backdated_to
-      payload[:public_updated_at] = edition.backdated_to if edition.first?
-    end
-
     if republish
       payload[:update_type] = "republish"
       payload[:bulk_publishing] = true

--- a/spec/lib/publishing_api_payload_spec.rb
+++ b/spec/lib/publishing_api_payload_spec.rb
@@ -156,24 +156,6 @@ RSpec.describe PublishingApiPayload do
       expect(payload[:links][:government]).to eq [government.content_id]
     end
 
-    it "includes first_published_at if the edition has a backdated_to value" do
-      date = Time.zone.now.yesterday
-      revision = build(:revision, backdated_to: date)
-      edition = build(:edition, revision: revision)
-      payload = described_class.new(edition).payload
-
-      expect(payload).to match a_hash_including(first_published_at: date)
-    end
-
-    it "include public_updated_at if the edition has backdated_to and is a first edition" do
-      date = Time.zone.now.yesterday
-      revision = build(:revision, backdated_to: date)
-      edition = build(:edition, revision: revision, number: 1)
-      payload = described_class.new(edition).payload
-
-      expect(payload).to match a_hash_including(public_updated_at: date)
-    end
-
     it "includes bulk_publishing and sets the update to republish if the edition is being republished" do
       edition = build(:edition)
       payload = described_class.new(edition, republish: true).payload


### PR DESCRIPTION
This logic is now covered by the PublishingApiPayload::History class.