### PR TITLE
Only do realistic request errors when we need it

### DIFF
--- a/config/environments/test.rb
+++ b/config/environments/test.rb
@@ -25,7 +25,7 @@ Rails.application.configure do
   config.cache_store = :null_store
 
   # Handle exceptions ourselves and return HTTP status instead of raising exceptions.
-  config.action_dispatch.show_exceptions = true
+  config.action_dispatch.show_exceptions = false
 
   # Disable request forgery protection in test environment.
   config.action_controller.allow_forgery_protection = false

--- a/spec/features/formats/news_article_spec.rb
+++ b/spec/features/formats/news_article_spec.rb
@@ -19,6 +19,8 @@ RSpec.describe "News article format" do
   def and_i_fill_in_the_form_fields
     base_path = Edition.last.document_type.path_prefix + "/a-great-title"
     stub_publishing_api_has_lookups(base_path => Document.last.content_id)
+    stub_any_publishing_api_put_content
+    stub_any_publishing_api_no_links
     fill_in "title", with: "A great title"
     click_on "Save"
   end

--- a/spec/features/formats/publication_spec.rb
+++ b/spec/features/formats/publication_spec.rb
@@ -1,4 +1,6 @@
 RSpec.describe "Publication format" do
+  include TopicsHelper
+
   scenario do
     when_i_choose_this_document_type
     and_i_fill_in_the_form_fields
@@ -17,6 +19,8 @@ RSpec.describe "Publication format" do
   def and_i_fill_in_the_form_fields
     base_path = Edition.last.document_type.path_prefix + "/a-great-title"
     stub_publishing_api_has_lookups(base_path => Document.last.content_id)
+    stub_any_publishing_api_put_content
+    stub_any_publishing_api_no_links
     fill_in "title", with: "A great title"
     click_on "Save"
   end

--- a/spec/requests/errors_spec.rb
+++ b/spec/requests/errors_spec.rb
@@ -40,7 +40,7 @@ RSpec.describe "Errors" do
   end
 
   describe "GET /any-path-for-a-document" do
-    it "returns a not found response when a document doesn't exist" do
+    it "returns a not found response when a document doesn't exist", realistic_error_responses: true do
       get document_path("document-that-does-not-exist")
 
       expect(response).to have_http_status(:not_found)
@@ -62,7 +62,7 @@ RSpec.describe "Errors" do
   end
 
   describe "ANY /pre-release-document-path" do
-    it "returns forbidden when the document type is pre-release" do
+    it "returns forbidden when the document type is pre-release", realistic_error_responses: true do
       pre_release_document_type = build(:document_type, :pre_release)
       edition = create(:edition, document_type: pre_release_document_type)
       user = build(:user, permissions: %w(signin))

--- a/spec/requests/images_spec.rb
+++ b/spec/requests/images_spec.rb
@@ -148,7 +148,7 @@ RSpec.describe "Images" do
         .to include(I18n.t!("requirements.alt_text.blank.form_message"))
     end
 
-    it "returns a bad request when selecting a lead image is not a supported feature" do
+    it "returns a bad request when selecting a lead image is not a supported feature", realistic_error_responses: true do
       edition = create(:edition, image_revisions: [image_revision])
       patch edit_image_path(edition.document, image_revision.image_id),
             params: { image_revision: { alt_text: "Alt text" }, lead_image: "on" }

--- a/spec/requests/new_document_spec.rb
+++ b/spec/requests/new_document_spec.rb
@@ -12,7 +12,7 @@ RSpec.describe "New Document" do
       expect(response.body).to have_content(I18n.t("document_type_selections.news.label"))
     end
 
-    it "returns a 404 when the requested document type selection doesn't exist" do
+    it "returns a 404 when the requested document type selection doesn't exist", realistic_error_responses: true do
       get new_document_path, params: { type: "foo" }
       expect(response.status).to eq(404)
     end
@@ -50,7 +50,7 @@ RSpec.describe "New Document" do
       )
     end
 
-    it "returns a 404 when the requested selected document type doesn't exist" do
+    it "returns a 404 when the requested selected document type doesn't exist", realistic_error_responses: true do
       post new_document_path, params: { type: "foo", selected_option_id: "foo" }
       expect(response.status).to eq(404)
     end

--- a/spec/requests/video_embed_spec.rb
+++ b/spec/requests/video_embed_spec.rb
@@ -8,7 +8,7 @@ RSpec.describe "Video Embed" do
       expect(response).to have_http_status(:ok)
     end
 
-    it "returns a bad request outside of a modal context" do
+    it "returns a bad request outside of a modal context", realistic_error_responses: true do
       get video_embed_path(edition.document)
       expect(response).to have_http_status(:bad_request)
     end
@@ -25,7 +25,7 @@ RSpec.describe "Video Embed" do
       expect(response.body).to eq("[My title](#{video_url})")
     end
 
-    it "returns a bad request outside of a modal context" do
+    it "returns a bad request outside of a modal context", realistic_error_responses: true do
       post video_embed_path(edition.document)
       expect(response).to have_http_status(:bad_request)
     end

--- a/spec/support/error_responses_helper.rb
+++ b/spec/support/error_responses_helper.rb
@@ -1,0 +1,23 @@
+# https://github.com/eliotsykes/rails-testing-toolbox/blob/master/error_responses.rb
+module ErrorResponses
+  # See: https://github.com/rails/rails/pull/11289#issuecomment-118612393
+  def respond_without_detailed_exceptions
+    env_config = Rails.application.env_config
+    original_show_exceptions = env_config["action_dispatch.show_exceptions"]
+    original_show_detailed_exceptions = env_config["action_dispatch.show_detailed_exceptions"]
+    env_config["action_dispatch.show_exceptions"] = true
+    env_config["action_dispatch.show_detailed_exceptions"] = false
+    yield
+  ensure
+    env_config["action_dispatch.show_exceptions"] = original_show_exceptions
+    env_config["action_dispatch.show_detailed_exceptions"] = original_show_detailed_exceptions
+  end
+end
+
+RSpec.configure do |config|
+  config.include ErrorResponses
+
+  config.around(realistic_error_responses: true) do |example|
+    respond_without_detailed_exceptions(&example)
+  end
+end

--- a/spec/support/request_examples.rb
+++ b/spec/support/request_examples.rb
@@ -44,7 +44,7 @@ module RequestExamples
     describe scenario do
       routes.each do |path, methods|
         methods.each do |method|
-          it "returns a #{status} for #{method} #{path}" do
+          it "returns a #{status} for #{method} #{path}", realistic_error_responses: true do
             process(method.to_sym, public_send(path.to_sym, *route_params))
 
             expect(response).to have_http_status(status)


### PR DESCRIPTION
https://trello.com/c/OWZorYWA/1540-allow-attachments-to-be-downloaded

Previously we switched to 'show_exceptions' for all requests in our
tests, which means we return a realistic response instead of raising
an exception. Writing new code with this setting is painful because
it's necessary to debug/inspect the response body and manually look
for an exception/backtrace. This changes 'show_exceptions' back to
false and uses a common 'tag' pattern to enable it where needed.

https://github.com/eliotsykes/rails-testing-toolbox/blob/master/error_responses.rb

This also has the nice side-effect of improving our test performance,
locally and in Docker. I see a consistent improvement in times for
request tests of about 10s.

With: rspec spec/requests  22.40s user 3.16s system 86% cpu 29.413 total

Without: rspec spec/requests  31.52s user 3.26s system 90% cpu 38.490 total