### PR TITLE
Add file attachment metadata for publications

### DIFF
--- a/app/models/file_attachment/metadata_revision.rb
+++ b/app/models/file_attachment/metadata_revision.rb
@@ -2,6 +2,10 @@
 class FileAttachment::MetadataRevision < ApplicationRecord
   belongs_to :created_by, class_name: "User", optional: true
 
+  enum official_document: { unofficial: "unofficial",
+                            command_paper: "command_paper",
+                            act_paper: "act_paper" }
+
   def readonly?
     !new_record?
   end

--- a/app/models/file_attachment/revision.rb
+++ b/app/models/file_attachment/revision.rb
@@ -12,7 +12,17 @@ class FileAttachment::Revision < ApplicationRecord
                           foreign_key: "file_attachment_revision_id",
                           join_table: "revisions_file_attachment_revisions"
 
-  delegate :title, to: :metadata_revision
+  delegate :title,
+           :isbn,
+           :unique_reference,
+           :paper_number,
+           :unofficial?,
+           :command_paper?,
+           :act_paper?,
+           :official_document,
+           :parliamentary_session,
+           to: :metadata_revision
+
   delegate :filename,
            :asset,
            :asset_url,

--- a/db/migrate/20200312132425_add_file_attachment_metadata_for_publications.rb
+++ b/db/migrate/20200312132425_add_file_attachment_metadata_for_publications.rb
@@ -1,0 +1,11 @@
+class AddFileAttachmentMetadataForPublications < ActiveRecord::Migration[6.0]
+  def change
+    change_table :file_attachment_metadata_revisions, bulk: true do |t|
+      t.string :isbn
+      t.string :unique_reference
+      t.string :paper_number
+      t.string :parliamentary_session
+      t.string :official_document, default: "unofficial", null: false
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2020_03_04_083621) do
+ActiveRecord::Schema.define(version: 2020_03_12_132425) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -135,6 +135,11 @@ ActiveRecord::Schema.define(version: 2020_03_04_083621) do
     t.datetime "created_at", null: false
     t.string "title", null: false
     t.bigint "created_by_id"
+    t.string "isbn"
+    t.string "unique_reference"
+    t.string "paper_number"
+    t.string "parliamentary_session"
+    t.string "official_document", default: "unofficial", null: false
   end
 
   create_table "file_attachment_revisions", force: :cascade do |t|


### PR DESCRIPTION
https://trello.com/c/HRUXGp3K/1518-support-metadata-for-featured-file-attachments-db-modelling

This adds additional metadata fields for file attachments in order
support the extended workflow for publications. Since these fields
are inherent to the GOV.UK concept of attachments, we think they
should be represented as columns on the model - we also considered
a JSON blob alternative, but it seemed to be mostly disadvantageous.