### PR TITLE
Set alternative url to imported alternative path

### DIFF
--- a/lib/whitehall_importer/create_edition.rb
+++ b/lib/whitehall_importer/create_edition.rb
@@ -140,8 +140,8 @@ module WhitehallImporter
 
       Removal.new(
         explanatory_note: unpublishing["explanation"],
-        alternative_url: unpublishing["alternative_url"],
-        redirect: unpublishing["alternative_url"].present?,
+        alternative_url: unpublishing["alternative_path"],
+        redirect: unpublishing["alternative_path"].present?,
         removed_at: unpublishing["created_at"],
       )
     end

--- a/spec/factories/whitehall_export/unpublishing_factory.rb
+++ b/spec/factories/whitehall_export/unpublishing_factory.rb
@@ -6,7 +6,7 @@ FactoryBot.define do
     created_at { Time.zone.now.rfc3339 }
     updated_at { Time.zone.now.rfc3339 }
     explanation { "User facing explanation" }
-    alternative_url { "" }
+    alternative_path { "" }
     redirect { false }
     unpublishing_reason { "No longer current government policy/activity" }
 

--- a/spec/lib/whitehall_importer/create_edition_spec.rb
+++ b/spec/lib/whitehall_importer/create_edition_spec.rb
@@ -299,7 +299,7 @@ RSpec.describe WhitehallImporter::CreateEdition do
                       event: "update", state: "draft", created_at: updated_at),
               ],
               unpublishing: build(:whitehall_export_unpublishing,
-                                  alternative_url: "https://www.gov.uk/gators",
+                                  alternative_path: "/gators",
                                   unpublishing_reason: "Consolidated into another GOV.UK page",
                                   explanation: "Gator"))
       end
@@ -318,7 +318,7 @@ RSpec.describe WhitehallImporter::CreateEdition do
 
         removal = edition.status.details
         expect(removal.explanatory_note).to eq(whitehall_edition["unpublishing"]["explanation"])
-        expect(removal.alternative_url).to eq(whitehall_edition["unpublishing"]["alternative_url"])
+        expect(removal.alternative_url).to eq(whitehall_edition["unpublishing"]["alternative_path"])
         expect(removal.removed_at).to eq(whitehall_edition["unpublishing"]["created_at"])
         expect(removal).to be_redirect
       end
@@ -352,7 +352,7 @@ RSpec.describe WhitehallImporter::CreateEdition do
                       event: "update", state: "draft", created_at: created_at),
               ],
               unpublishing: build(:whitehall_export_unpublishing,
-                                  alternative_url: "https://www.gov.uk/flextension",
+                                  alternative_path: "/flextension",
                                   unpublishing_reason: "Consolidated into another GOV.UK page",
                                   explanation: "Brexit is being delayed again"))
       end
@@ -378,7 +378,7 @@ RSpec.describe WhitehallImporter::CreateEdition do
 
         removal = document.editions.first.status.details
         expect(removal.explanatory_note).to eq(whitehall_edition["unpublishing"]["explanation"])
-        expect(removal.alternative_url).to eq(whitehall_edition["unpublishing"]["alternative_url"])
+        expect(removal.alternative_url).to eq(whitehall_edition["unpublishing"]["alternative_path"])
         expect(removal.removed_at).to eq(whitehall_edition["unpublishing"]["created_at"])
 
         expect(removal).to be_redirect


### PR DESCRIPTION
Dependent on https://github.com/alphagov/whitehall/pull/5455

We have changed Whitehall to export an unpublishing alternative path instead of
an alternative URL.  This is because Whitehall sends the alternative path to
Publishing API when unpublishing content, and this discrepancy was causing the
integrity checker to detect a mismatch between the URL exported from Whitehall
and the path in Publishing API. This updates WhitehallImporter::CreateEdition
to set the removal `alternative_url` to the `alternative_path` that is now
exported from Whitehall.