### PR TITLE
Support "Edit attachment" action for featured file attachments

### DIFF
--- a/app/controllers/featured_attachments_controller.rb
+++ b/app/controllers/featured_attachments_controller.rb
@@ -7,4 +7,12 @@ class FeaturedAttachmentsController < ApplicationController
       @edition.document_type.attachments.featured?
     end
   end
+
+  def edit
+    @edition = Edition.find_current(document: params[:document])
+    assert_edition_state(@edition, &:editable?)
+
+    @attachment = @edition.file_attachment_revisions
+      .find_by!(file_attachment_id: params[:attachment_id])
+  end
 end

--- a/app/controllers/featured_attachments_controller.rb
+++ b/app/controllers/featured_attachments_controller.rb
@@ -14,5 +14,9 @@ class FeaturedAttachmentsController < ApplicationController
 
     @attachment = @edition.file_attachment_revisions
       .find_by!(file_attachment_id: params[:attachment_id])
+
+    assert_edition_feature(@edition, assertion: "supports featured attachments") do
+      @edition.document_type.attachments.featured?
+    end
   end
 end

--- a/app/controllers/file_attachments_controller.rb
+++ b/app/controllers/file_attachments_controller.rb
@@ -129,16 +129,17 @@ class FileAttachmentsController < ApplicationController
         ),
       }
 
-      render :edit,
+      render params[:wizard] == "featured" ? "featured_attachments/edit" : :edit,
              title: params.dig(:file_attachment, :title),
              assigns: { edition: edition,
                         issues: issues,
                         attachment: attachment_revision },
              status: :unprocessable_entity
-    elsif unchanged
-      redirect_to file_attachments_path(edition.document)
+
+    elsif params[:wizard] == "featured"
+      redirect_to featured_attachments_path(edition.document)
     else
-      flash[:notice] = I18n.t!("file_attachments.edit.flashes.update_confirmation")
+      flash[:notice] = I18n.t!("file_attachments.edit.flashes.update_confirmation") unless unchanged
       redirect_to file_attachments_path(edition.document)
     end
   end

--- a/app/controllers/file_attachments_controller.rb
+++ b/app/controllers/file_attachments_controller.rb
@@ -112,6 +112,10 @@ class FileAttachmentsController < ApplicationController
 
     @attachment = @edition.file_attachment_revisions
       .find_by!(file_attachment_id: params[:file_attachment_id])
+
+    assert_edition_feature(@edition, assertion: "supports inline attachments") do
+      @edition.document_type.attachments.inline_file_only?
+    end
   end
 
   def update

--- a/app/views/featured_attachments/_featured_attachment.html.erb
+++ b/app/views/featured_attachments/_featured_attachment.html.erb
@@ -1,6 +1,15 @@
 <% actions = [] %>
 
 <% actions << link_to(
+  "Edit attachment",
+  edit_featured_attachment_path(document, attachment.file_attachment_id, wizard: "featured"),
+  class: "govuk-link govuk-link--no-visited-state app-link--button",
+  data: {
+    gtm: "edit-attachment",
+  },
+) %>
+
+<% actions << link_to(
   "Download",
   download_file_attachment_path(document, attachment.file_attachment),
   class: "govuk-link govuk-link--no-visited-state app-link--button",

--- a/app/views/featured_attachments/edit.html.erb
+++ b/app/views/featured_attachments/edit.html.erb
@@ -1,0 +1,57 @@
+<% content_for :back_link, render_back_link(href: featured_attachments_path(@edition.document)) %>
+<% content_for :title, t("featured_attachments.edit.title", title: @attachment.title) %>
+
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-two-thirds">
+    <%= form_tag(
+      edit_file_attachment_path(@edition.document, @attachment.file_attachment_id),
+      method: :patch,
+      multipart: true,
+    ) do %>
+      <%= hidden_field_tag(:wizard, params[:wizard]) %>
+
+      <%= render_govspeak(t("featured_attachments.edit.description_govspeak")) %>
+
+      <%= render "govuk_publishing_components/components/inset_text", {
+        text: render_govspeak(
+          t("featured_attachments.edit.callout_govspeak")
+        ),
+      } %>
+
+      <h2 class="govuk-heading-s govuk-!-margin-bottom-0">
+        <%= t("featured_attachments.edit.attachment_file.current.heading") %>
+      </h2>
+
+      <p class="govuk-body">
+        <%= link_to(
+              @attachment.title,
+              preview_file_attachment_path(@edition.document, @attachment.file_attachment),
+              target: :_blank,
+              class: "govuk-link govuk-link--no-visited-state"
+        )%>
+      <p>
+
+      <%= render "govuk_publishing_components/components/file_upload", {
+        label: {
+          text: t("featured_attachments.edit.attachment_file.heading"),
+          bold: true,
+        },
+        name: "file_attachment[file]",
+        hint: t("featured_attachments.edit.attachment_file.hint_text")
+      } %>
+
+      <%= render "govuk_publishing_components/components/input", {
+        label: {
+          text: t("featured_attachments.edit.attachment_title.heading"),
+          bold: true
+        },
+        name: "file_attachment[title]",
+        value: params.dig(:file_attachment, :title) || @attachment.title,
+        hint: t("featured_attachments.edit.attachment_title.hint_text"),
+        error_items: @issues&.items_for(:file_attachment_title),
+      } %>
+
+      <%= render "govuk_publishing_components/components/button", { text: "Save" } %>
+    <% end %>
+  </div>
+</div>

--- a/config/locales/en/featured_attachments/edit.yml
+++ b/config/locales/en/featured_attachments/edit.yml
@@ -1,0 +1,19 @@
+en:
+  featured_attachments:
+    edit:
+      title: "Update attachment ‘%{title}’"
+      description_govspeak: |
+        All files must be accessible. Read [full guidance on accessible attachment](https://www.gov.uk/guidance/how-to-publish-on-gov-uk/accessible-pdfs){:target="_blank"}.
+
+        Files must be uploaded in an [open standards file format](https://www.gov.uk/guidance/content-design/planning-content#open-formats){:target="_blank"}.
+        For example, .odt not .docx.
+      callout_govspeak: |
+        Attachments must be in English.
+      attachment_file:
+        heading: Choose a file
+        hint_text: Upload a file to replace the current attachment.
+        current:
+          heading: Current attachment
+      attachment_title:
+        heading: Attachment title
+        hint_text: Use the full title of the document

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -93,6 +93,7 @@ Rails.application.routes.draw do
     post "/govspeak-preview" => "govspeak_preview#to_html", as: :govspeak_preview
 
     get "/attachments" => "featured_attachments#index", as: :featured_attachments
+    get "/attachments/:attachment_id/edit" => "featured_attachments#edit", as: :edit_featured_attachment
 
     get "/file-attachments" => "file_attachments#index", as: :file_attachments
     get "/file-attachments/new" => "file_attachments#new", as: :new_file_attachment

--- a/spec/features/editing_file_attachments/replace_file_attachment_file_spec.rb
+++ b/spec/features/editing_file_attachments/replace_file_attachment_file_spec.rb
@@ -1,8 +1,18 @@
 RSpec.feature "Replace a file attachment file", js: true do
-  scenario do
+  scenario "inline" do
     given_there_is_an_edition_with_an_attachment
     when_i_click_to_insert_an_attachment
     and_i_click_on_edit_file
+    and_i_upload_a_replacement_attachment_file
+    and_i_click_save
+    then_i_see_the_replacement_file
+    and_i_see_the_timeline_entry
+  end
+
+  scenario "featured" do
+    given_there_is_an_edition_with_featured_attachments
+    when_i_go_to_change_an_attachment
+    and_i_click_on_edit_attachment
     and_i_upload_a_replacement_attachment_file
     and_i_click_save
     then_i_see_the_replacement_file
@@ -19,6 +29,14 @@ RSpec.feature "Replace a file attachment file", js: true do
                       file_attachment_revisions: [@attachment_revision])
   end
 
+  def given_there_is_an_edition_with_featured_attachments
+    @attachment_revision = create(:file_attachment_revision)
+
+    @edition = create(:edition,
+                      document_type: build(:document_type, attachments: "featured"),
+                      file_attachment_revisions: [@attachment_revision])
+  end
+
   def when_i_click_to_insert_an_attachment
     visit content_path(@edition.document)
     find("markdown-toolbar details").click
@@ -26,8 +44,16 @@ RSpec.feature "Replace a file attachment file", js: true do
     expect(page).to have_content("74 Bytes")
   end
 
+  def when_i_go_to_change_an_attachment
+    visit featured_attachments_path(@edition.document)
+  end
+
   def and_i_click_on_edit_file
     click_on "Edit file"
+  end
+
+  def and_i_click_on_edit_attachment
+    click_on "Edit attachment"
   end
 
   def and_i_upload_a_replacement_attachment_file

--- a/spec/requests/featured_attachments_spec.rb
+++ b/spec/requests/featured_attachments_spec.rb
@@ -5,6 +5,22 @@ RSpec.describe "Featured Attachments" do
     let(:edition) { create(:edition, :published) }
   end
 
+  it_behaves_like "requests that assert edition state",
+                  "accessing a single featured attachment for a non editable edition",
+                  routes: { edit_featured_attachment_path: %i[get] } do
+    let(:edition) { create(:edition, :published) }
+    let(:route_params) { [edition.document, "file_attachment_id"] }
+  end
+
+  it_behaves_like "requests that return status",
+                  "when a file attachment revision belongs to a different edition",
+                  status: :not_found,
+                  routes: { edit_featured_attachment_path: %i[get] } do
+    let(:edition) { create(:edition) }
+    let(:file_attachment_revision) { create(:file_attachment_revision) }
+    let(:route_params) { [edition.document, file_attachment_revision] }
+  end
+
   it_behaves_like "requests that return status",
                   "accessing featured attachments for an edition that doesn't allow them",
                   status: :not_found,

--- a/spec/requests/featured_attachments_spec.rb
+++ b/spec/requests/featured_attachments_spec.rb
@@ -22,4 +22,18 @@ RSpec.describe "Featured Attachments" do
       expect(response).to have_http_status(:ok)
     end
   end
+
+  describe "GET /documents/:document/attachments/:attachment_id/edit" do
+    it "returns successfully" do
+      document_type = build(:document_type, attachments: "featured")
+      file_attachment_revision = create(:file_attachment_revision)
+      edition = create(:edition,
+                       document_type: document_type,
+                       file_attachment_revisions: [file_attachment_revision])
+
+      get edit_featured_attachment_path(edition.document,
+                                        file_attachment_revision.file_attachment_id)
+      expect(response).to have_http_status(:ok)
+    end
+  end
 end

--- a/spec/requests/file_attachments_spec.rb
+++ b/spec/requests/file_attachments_spec.rb
@@ -57,6 +57,16 @@ RSpec.describe "File Attachments" do
     let(:route_params) { [edition.document, file_attachment_revision] }
   end
 
+  it_behaves_like "requests that return status",
+                  "editing inline attachments for an edition that doesn't allow them",
+                  status: :not_found,
+                  routes: { edit_file_attachment_path: %i[get] } do
+    let(:document_type) { build(:document_type, attachments: "featured") }
+    let(:edition) { create(:edition, document_type: document_type) }
+    let(:file_attachment_revision) { create(:file_attachment_revision) }
+    let(:route_params) { [edition.document, file_attachment_revision] }
+  end
+
   describe "GET /documents/:document/file-attachments/new" do
     it "returns successfully" do
       document_type = build(:document_type, attachments: "featured")


### PR DESCRIPTION
Trello: https://trello.com/c/lZKUDZbj

# What's changed?

Adds an "Edit attachment" link to the featured attachment preview block on the attachments index page. Clicking on "Edit attachment" takes the user to a new page where they can edit the title or replace the file.

# Expected changes
![Screenshot 2020-03-12 at 16 27 02](https://user-images.githubusercontent.com/5793815/76546545-9ca87300-6483-11ea-884d-61c4540115d6.png)

![Screenshot 2020-03-12 at 16 27 10](https://user-images.githubusercontent.com/5793815/76546555-a336ea80-6483-11ea-91f5-c5a3b891fbe5.png)
