### PR TITLE
Remove organisation redirect on index page

### DIFF
--- a/app/controllers/documents_controller.rb
+++ b/app/controllers/documents_controller.rb
@@ -1,10 +1,5 @@
 class DocumentsController < ApplicationController
   def index
-    if filter_params[:filters].empty? && current_user.organisation_content_id
-      redirect_to documents_path(organisation: current_user.organisation_content_id)
-      return
-    end
-
     filter = EditionFilter.new(current_user, filter_params)
     @editions = filter.editions
     @filter_params = filter.filter_params

--- a/spec/features/finding/index_filtering_spec.rb
+++ b/spec/features/finding/index_filtering_spec.rb
@@ -2,7 +2,6 @@ RSpec.feature "Index filtering" do
   scenario do
     given_there_are_some_editions
     when_i_visit_the_index_page
-    then_i_only_see_my_organisations_editions
 
     when_i_clear_the_filters
     then_i_see_all_editions
@@ -83,10 +82,6 @@ RSpec.feature "Index filtering" do
 
   def when_i_clear_the_filters
     click_on "Clear all filters"
-  end
-
-  def then_i_only_see_my_organisations_editions
-    expect(page).to have_content("2 documents")
   end
 
   def when_i_filter_by_all_organisations

--- a/spec/requests/documents_spec.rb
+++ b/spec/requests/documents_spec.rb
@@ -16,20 +16,6 @@ RSpec.describe "Documents" do
       end
     end
 
-    context "when the user has an organisation" do
-      let(:organisation_content_id) { SecureRandom.uuid }
-      let(:user) { create(:user, organisation_content_id: organisation_content_id) }
-
-      before { login_as(user) }
-
-      it "redirects to filter by the users organisation" do
-        get documents_path
-        expect(response).to redirect_to(
-          documents_path(organisation: organisation_content_id),
-        )
-      end
-    end
-
     context "when the user doesn't have an organisation" do
       let(:user) { create(:user, organisation_content_id: nil) }
 


### PR DESCRIPTION
# What's changed and why?

Remove the automatic redirect that filters the index page by organisation if no filters have been selected.

This is while we fix an underlying issue with how JSON data is stored in Postgres.