### PR TITLE
Don't store tag params that aren't submitted

### DIFF
--- a/app/models/document_type/multi_tag_field.rb
+++ b/app/models/document_type/multi_tag_field.rb
@@ -6,7 +6,7 @@ class DocumentType::MultiTagField
   end
 
   def updater_params(_edition, params)
-    { id.to_sym => params[id.to_sym] }
+    { id.to_sym => params[id.to_sym] }.compact
   end
 
   def pre_update_issues(_edition, _params)


### PR DESCRIPTION
This is a rather quick fix to resolve an issue where nil values in tags
are breaking Postgres JSON queries. It's a short term step before a
larger fix is put together.