### PR TITLE
Perform integrity check on the change_history during migration

### DIFF
--- a/lib/whitehall_importer/integrity_checker.rb
+++ b/lib/whitehall_importer/integrity_checker.rb
@@ -56,6 +56,12 @@ module WhitehallImporter
         publishing_api_content.dig("details", "body"),
       ).sufficiently_similar?
 
+      problems << "change history doesn't match" unless ChangeHistoryCheck.new(
+        proposed_payload.dig("details", "change_history"),
+        publishing_api_content.dig("details", "change_history"),
+        live_edition: edition.live?,
+      ).match?
+
       problems
     end
 

--- a/lib/whitehall_importer/integrity_checker/change_history_check.rb
+++ b/lib/whitehall_importer/integrity_checker/change_history_check.rb
@@ -1,0 +1,47 @@
+module WhitehallImporter
+  class IntegrityChecker::ChangeHistoryCheck
+    attr_reader :live_edition, :proposed_change_history, :publishing_api_change_history
+
+    def initialize(proposed_change_history, publishing_api_change_history, live_edition:)
+      @proposed_change_history = proposed_change_history
+      @publishing_api_change_history = publishing_api_change_history
+      @live_edition = live_edition
+    end
+
+    def match?
+      return false unless history_length_matches?
+
+      if live_edition
+        history_matches?(proposed_change_history, publishing_api_change_history)
+      else
+        history_excluding_first_timestamp_matches?
+      end
+    end
+
+  private
+
+    def history_length_matches?
+      proposed_change_history.length == publishing_api_change_history.length
+    end
+
+    def history_matches?(proposed, publishing_api)
+      proposed.zip(publishing_api).all? do |proposed_history, publishing_api_history|
+        proposed_time = proposed_history["public_timestamp"]
+        publishing_api_time = publishing_api_history["public_timestamp"]
+
+        proposed_history["note"] == publishing_api_history["note"] &&
+          IntegrityChecker.time_matches?(proposed_time, publishing_api_time)
+      end
+    end
+
+    def history_excluding_first_timestamp_matches?
+      proposed_head, *proposed_tail = proposed_change_history
+      publishing_api_head, *publishing_api_tail = publishing_api_change_history
+
+      first_note_matches = proposed_head["note"] == publishing_api_head["note"]
+      remaining_history_matches = history_matches?(proposed_tail, publishing_api_tail)
+
+      first_note_matches && remaining_history_matches
+    end
+  end
+end

--- a/spec/lib/whitehall_importer/integrity_checker/change_history_check_spec.rb
+++ b/spec/lib/whitehall_importer/integrity_checker/change_history_check_spec.rb
@@ -1,0 +1,75 @@
+RSpec.describe WhitehallImporter::IntegrityChecker::ChangeHistoryCheck do
+  describe "#match?" do
+    it "returns true if the proposed change history matches the Publishing API history for a non-draft edition" do
+      proposed_change_history = change_note("First published.", Date.yesterday.noon)
+      publishing_api_change_history = change_note("First published.", Date.yesterday.noon)
+
+
+      integrity_check = described_class.new(
+        proposed_change_history,
+        publishing_api_change_history,
+        live_edition: true,
+      )
+      expect(integrity_check.match?).to be true
+    end
+
+    it "returns true if the proposed change history matches for a draft edition with mismatched time stamps for first item" do
+      proposed_change_history = change_note("First published.", Date.yesterday.noon) +
+        change_note("Updated", Time.zone.now)
+
+      publishing_api_change_history = change_note("First published.", Time.zone.now) +
+        change_note("Updated", Time.zone.now)
+
+      integrity_check = described_class.new(
+        proposed_change_history,
+        publishing_api_change_history,
+        live_edition: false,
+      )
+      expect(integrity_check.match?).to be true
+    end
+
+    it "returns false if length of change history does not match" do
+      proposed_change_history = change_note("First published.", Date.yesterday.noon)
+
+      publishing_api_change_history = change_note("First published.", Date.yesterday.noon) +
+        change_note("Updated", Time.zone.now)
+
+      integrity_check = described_class.new(
+        proposed_change_history,
+        publishing_api_change_history,
+        live_edition: true,
+      )
+      expect(integrity_check.match?).to be false
+    end
+
+    it "returns false if notes do not match" do
+      proposed_change_history = change_note("First published.", Date.yesterday.noon)
+
+      publishing_api_change_history = change_note("Updated", Date.yesterday.noon)
+
+      integrity_check = described_class.new(
+        proposed_change_history,
+        publishing_api_change_history,
+        live_edition: true,
+      )
+      expect(integrity_check.match?).to be false
+    end
+
+    it "returns false if public_timestamp does not match" do
+      proposed_change_history = change_note("First published.", Date.yesterday.noon)
+
+      publishing_api_change_history = change_note("First published.", Time.zone.now)
+
+      integrity_check = described_class.new(
+        proposed_change_history,
+        publishing_api_change_history,
+        live_edition: true,
+      )
+      expect(integrity_check.match?).to be false
+    end
+  end
+
+  def change_note(note, timestamp)
+    [{ "note" => note, "public_timestamp" => timestamp.rfc3339 }]
+  end
+end

--- a/spec/lib/whitehall_importer/integrity_checker_spec.rb
+++ b/spec/lib/whitehall_importer/integrity_checker_spec.rb
@@ -140,6 +140,12 @@ RSpec.describe WhitehallImporter::IntegrityChecker do
                                     },
                                     details: {
                                       first_public_at: first_published_at,
+                                      change_history: [
+                                        {
+                                          note: "First published.",
+                                          public_timestamp: Date.yesterday.noon,
+                                        },
+],
                                     }),
       )
 
@@ -186,6 +192,12 @@ RSpec.describe WhitehallImporter::IntegrityChecker do
                                       },
                                       details: {
                                         first_public_at: first_published_at,
+                                        change_history: [
+                                          {
+                                            note: "First published.",
+                                            public_timestamp: first_published_at,
+                                          },
+],
                                       }),
         )
 
@@ -206,6 +218,12 @@ RSpec.describe WhitehallImporter::IntegrityChecker do
                                       },
                                       details: {
                                         first_public_at: first_published_at,
+                                        change_history: [
+                                          {
+                                            note: "First published.",
+                                            public_timestamp: first_published_at,
+                                          },
+],
                                       }),
         )
 
@@ -262,6 +280,12 @@ RSpec.describe WhitehallImporter::IntegrityChecker do
         state_history: { "1" => "published" },
         details: {
           body: "body text",
+          change_history: [
+            {
+              note: "",
+              public_timestamp: Time.zone.now,
+            },
+          ],
           image: {
             alt_text: "alt text",
             caption: "caption",
@@ -349,6 +373,10 @@ RSpec.describe WhitehallImporter::IntegrityChecker do
 
     it "returns a problem when the body text doesn't match" do
       expect(integrity_check.problems).to include("body text doesn't match")
+    end
+
+    it "returns a problem when the change history doesn't match" do
+      expect(integrity_check.problems).to include("change history doesn't match")
     end
 
     it "returns a problem when the image alt_text doesn't match" do
@@ -565,6 +593,12 @@ RSpec.describe WhitehallImporter::IntegrityChecker do
       schema_name: edition.document_type.publishing_metadata.schema_name,
       details: {
         body: "",
+        change_history: [
+          {
+            note: "First published.",
+            public_timestamp: Time.zone.rfc3339("2020-03-11T12:00:00.000+00:00"),
+          },
+        ],
       },
     }.deep_merge!(override_hash)
   end


### PR DESCRIPTION
[Trello](https://trello.com/c/EDTO7mb0/1466-perform-integrity-check-on-the-changehistory-during-migration)

- Update the integrity checker to ensure that the change notes we are replacing match the ones in the Publishing API

- Note to reviewer: I still need to run the import locally or on integration. This may effect whether the timestamps need to match exactly or within a range, but I wanted to open for an initial review. 