### PR TITLE
Support "Edit attachment" action for featured file attachments

### DIFF
--- a/app/controllers/file_attachments_controller.rb
+++ b/app/controllers/file_attachments_controller.rb
@@ -135,10 +135,10 @@ class FileAttachmentsController < ApplicationController
                         issues: issues,
                         attachment: attachment_revision },
              status: :unprocessable_entity
-    elsif unchanged
-      redirect_to file_attachments_path(edition.document)
+    elsif params[:wizard] == "featured"
+      redirect_to featured_attachments_path(edition.document)
     else
-      flash[:notice] = I18n.t!("file_attachments.edit.flashes.update_confirmation")
+      flash[:notice] = I18n.t!("file_attachments.edit.flashes.update_confirmation") unless unchanged
       redirect_to file_attachments_path(edition.document)
     end
   end

--- a/app/views/featured_attachments/_featured_attachment.html.erb
+++ b/app/views/featured_attachments/_featured_attachment.html.erb
@@ -1,6 +1,15 @@
 <% actions = [] %>
 
 <% actions << link_to(
+  "Edit attachment",
+  edit_file_attachment_path(document, attachment.file_attachment_id, wizard: "featured"),
+  class: "govuk-link govuk-link--no-visited-state app-link--button",
+  data: {
+    gtm: "edit-attachment",
+  },
+) %>
+
+<% actions << link_to(
   "Download",
   download_file_attachment_path(document, attachment.file_attachment),
   class: "govuk-link govuk-link--no-visited-state app-link--button",

--- a/app/views/file_attachments/edit.html.erb
+++ b/app/views/file_attachments/edit.html.erb
@@ -1,5 +1,12 @@
 <% content_for :title, t("file_attachments.edit.title", title: @edition.title_or_fallback) %>
-<% content_for :back_link, render_back_link(href: file_attachments_path(@edition.document),
+
+<% back_link_path = if params[:wizard] == "featured"
+                      featured_attachments_path(@edition.document)
+                    else
+                      file_attachments_path(@edition.document)
+                    end %>
+
+<% content_for :back_link, render_back_link(href: back_link_path,
                                             data_attributes: { "modal-action": "back" }) %>
 
 <div class="govuk-grid-row">

--- a/app/views/file_attachments/edit.html.erb
+++ b/app/views/file_attachments/edit.html.erb
@@ -10,7 +10,7 @@
                                             data_attributes: { "modal-action": "back" }) %>
 
 <div class="govuk-grid-row">
-  <div class="govuk-grid-column-full">
+  <div class="<%= rendering_context == 'modal' ? 'govuk-grid-column-full' : 'govuk-grid-column-two-thirds' %>">
     <%= form_tag(
       edit_file_attachment_path(@edition.document, @attachment.file_attachment_id),
       method: :patch,

--- a/app/views/file_attachments/edit.html.erb
+++ b/app/views/file_attachments/edit.html.erb
@@ -13,6 +13,8 @@
         gtm: "save-attachment"
       },
     ) do %>
+      <%= hidden_field_tag(:wizard, params[:wizard]) %>
+
       <%= render "govuk_publishing_components/components/input", {
         label: {
           text: t("file_attachments.edit.attachment_title.heading"),

--- a/spec/features/editing_file_attachments/replace_file_attachment_file_spec.rb
+++ b/spec/features/editing_file_attachments/replace_file_attachment_file_spec.rb
@@ -1,8 +1,17 @@
 RSpec.feature "Replace a file attachment file", js: true do
-  scenario do
+  scenario "inline" do
     given_there_is_an_edition_with_an_attachment
     when_i_click_to_insert_an_attachment
     and_i_click_on_edit_file
+    and_i_upload_a_replacement_attachment_file
+    and_i_click_save
+    then_i_see_the_replacement_file
+    and_i_see_the_timeline_entry
+  end
+
+  scenario "featured" do
+    given_there_is_an_edition_with_featured_attachments
+    when_i_go_to_edit_an_attachment
     and_i_upload_a_replacement_attachment_file
     and_i_click_save
     then_i_see_the_replacement_file
@@ -19,11 +28,24 @@ RSpec.feature "Replace a file attachment file", js: true do
                       file_attachment_revisions: [@attachment_revision])
   end
 
+  def given_there_is_an_edition_with_featured_attachments
+    @attachment_revision = create(:file_attachment_revision)
+
+    @edition = create(:edition,
+                      document_type: build(:document_type, attachments: "featured"),
+                      file_attachment_revisions: [@attachment_revision])
+  end
+
   def when_i_click_to_insert_an_attachment
     visit content_path(@edition.document)
     find("markdown-toolbar details").click
     click_on "Attachment"
     expect(page).to have_content("74 Bytes")
+  end
+
+  def when_i_go_to_edit_an_attachment
+    visit featured_attachments_path(@edition.document)
+    click_on "Edit attachment"
   end
 
   def and_i_click_on_edit_file


### PR DESCRIPTION
Trello: https://trello.com/c/lZKUDZbj

# What's changed?

Adds an "Edit attachment" link to the featured attachment preview block on the attachments index page. Clicking on "Edit attachment" takes the user to existing edit page where they can edit the title or replace the file.

# Expected changes
![Screenshot 2020-03-12 at 16 27 02](https://user-images.githubusercontent.com/5793815/76546545-9ca87300-6483-11ea-884d-61c4540115d6.png)

![Screenshot 2020-03-13 at 11 23 09](https://user-images.githubusercontent.com/5793815/76618196-ddee6080-651f-11ea-9727-34d553ff4e21.png)

# Note to reviewer
These changes ignore the new designs for the edit attachment page. There is follow-up work to make this consistent between the modal for inline attachments and the page for featured attachments.