### PR TITLE
Rename official_document -> official_document_type

### DIFF
--- a/app/models/file_attachment/metadata_revision.rb
+++ b/app/models/file_attachment/metadata_revision.rb
@@ -2,9 +2,9 @@
 class FileAttachment::MetadataRevision < ApplicationRecord
   belongs_to :created_by, class_name: "User", optional: true
 
-  enum official_document: { unofficial: "unofficial",
-                            command_paper: "command_paper",
-                            act_paper: "act_paper" }
+  enum official_document_type: { unofficial: "unofficial",
+                                 command_paper: "command_paper",
+                                 act_paper: "act_paper" }
 
   def readonly?
     !new_record?

--- a/app/models/file_attachment/revision.rb
+++ b/app/models/file_attachment/revision.rb
@@ -19,7 +19,7 @@ class FileAttachment::Revision < ApplicationRecord
            :unofficial?,
            :command_paper?,
            :act_paper?,
-           :official_document,
+           :official_document_type,
            :parliamentary_session,
            to: :metadata_revision
 

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2020_03_12_132425) do
+ActiveRecord::Schema.define(version: 2020_03_13_130700) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -139,7 +139,7 @@ ActiveRecord::Schema.define(version: 2020_03_12_132425) do
     t.string "unique_reference"
     t.string "paper_number"
     t.string "parliamentary_session"
-    t.string "official_document", default: "unofficial", null: false
+    t.string "official_document_type", default: "unofficial", null: false
   end
 
   create_table "file_attachment_revisions", force: :cascade do |t|


### PR DESCRIPTION
https://trello.com/c/HRUXGp3K/1518-support-metadata-for-featured-file-attachments-db-modelling

This renames the attribute to better reflect it's value.