### PR TITLE
Add tracking to reorderable list component

### DIFF
--- a/app/assets/javascripts/application.js
+++ b/app/assets/javascripts/application.js
@@ -31,6 +31,7 @@
 //= require modal/modal-workflow.js
 
 //= require modules/gtm-copy-paste-listener.js
+//= require modules/gtm-reorder-listener.js
 //= require modules/gtm-topics-listener.js
 //= require modules/contact-embed-modal.js
 //= require modules/inline-attachment-modal.js

--- a/app/assets/javascripts/components/reorderable-list.js
+++ b/app/assets/javascripts/components/reorderable-list.js
@@ -13,7 +13,10 @@ window.GOVUK.Modules = window.GOVUK.Modules || {};
     this.sortable = window.Sortable.create(this.$module, { // eslint-disable-line new-cap
       chosenClass: 'app-c-reorderable-list__item--chosen',
       dragClass: 'app-c-reorderable-list__item--drag',
-      onSort: this.updateOrderIndexes.bind(this)
+      onSort: function () {
+        this.updateOrderIndexes.bind(this)
+        this.triggerEvent(this.$module, 'reorder-drag')
+      }.bind(this)
     })
 
     if (typeof window.matchMedia === 'function') {
@@ -59,6 +62,7 @@ window.GOVUK.Modules = window.GOVUK.Modules || {};
         e.target.nextElementSibling.focus()
       }
     }
+    this.triggerEvent(e.target, 'reorder-move-up')
   }
 
   ReorderableList.prototype.onClickDownButton = function (e) {
@@ -76,6 +80,7 @@ window.GOVUK.Modules = window.GOVUK.Modules || {};
         e.target.previousElementSibling.focus()
       }
     }
+    this.triggerEvent(e.target, 'reorder-move-down')
   }
 
   ReorderableList.prototype.updateOrderIndexes = function () {
@@ -83,6 +88,20 @@ window.GOVUK.Modules = window.GOVUK.Modules || {};
     $orderInputs.forEach(function (input, index) {
       input.setAttribute('value', index + 1)
     })
+  }
+
+  ReorderableList.prototype.triggerEvent = function (element, eventName) {
+    var params = { bubbles: true, cancelable: true }
+    var event
+
+    if (typeof window.CustomEvent === 'function') {
+      event = new window.CustomEvent(eventName, params)
+    } else {
+      event = document.createEvent('CustomEvent')
+      event.initCustomEvent(eventName, params.bubbles, params.cancelable)
+    }
+
+    element.dispatchEvent(event)
   }
 
   Modules.ReorderableList = ReorderableList

--- a/app/assets/javascripts/modules/gtm-reorder-listener.js
+++ b/app/assets/javascripts/modules/gtm-reorder-listener.js
@@ -1,0 +1,14 @@
+var GtmReorderListener = {}
+
+GtmReorderListener.handleReorder = function (eventName, dataGtm) {
+  return function (event) {
+    window.dataLayer.push({
+      event: eventName,
+      dataGtm: dataGtm
+    })
+  }
+}
+
+window.addEventListener('reorder-move-up', GtmReorderListener.handleReorder('Click', 'reorder-move-up'))
+window.addEventListener('reorder-move-down', GtmReorderListener.handleReorder('Click', 'reorder-move-down'))
+window.addEventListener('reorder-drag', GtmReorderListener.handleReorder('Drag', 'reorder-drag'))

--- a/spec/javascripts/components/reorderable-list-spec.js
+++ b/spec/javascripts/components/reorderable-list-spec.js
@@ -1,5 +1,5 @@
 /* eslint-env jasmine, jquery */
-/* global GOVUK */
+/* global GOVUK, spyOnEvent */
 
 describe('Reorderable list component', function () {
   'use strict'
@@ -120,6 +120,7 @@ describe('Reorderable list component', function () {
       reorderableList = new GOVUK.Modules.ReorderableList()
       reorderableList.start($(element))
       firstItemDownButton = document.querySelector('li:nth-child(1) .js-reorderable-list-down')
+      spyOnEvent(firstItemDownButton, 'reorder-move-down')
       firstItemDownButton.click()
     })
 
@@ -136,6 +137,10 @@ describe('Reorderable list component', function () {
       expect(firstItemNewIndex).toEqual('1')
       expect(secondItemNewIndex).toEqual('2')
     })
+
+    it('should trigger a reorder-move-down event', function () {
+      expect('reorder-move-down').toHaveBeenTriggeredOn(firstItemDownButton)
+    })
   })
 
   describe('when clicking the Up button on the second item', function () {
@@ -145,6 +150,7 @@ describe('Reorderable list component', function () {
       reorderableList = new GOVUK.Modules.ReorderableList()
       reorderableList.start($(element))
       secondItemUpButton = document.querySelector('li:nth-child(2) .js-reorderable-list-up')
+      spyOnEvent(secondItemUpButton, 'reorder-move-up')
       secondItemUpButton.click()
     })
 
@@ -160,6 +166,10 @@ describe('Reorderable list component', function () {
       var secondItemNewIndex = document.querySelector('li:nth-child(2) input[type=text]').value
       expect(firstItemNewIndex).toEqual('1')
       expect(secondItemNewIndex).toEqual('2')
+    })
+
+    it('should trigger a reorder-move-up event', function () {
+      expect('reorder-move-up').toHaveBeenTriggeredOn(secondItemUpButton)
     })
   })
 })

--- a/spec/javascripts/modules/gtm-reorder-listener-spec.js
+++ b/spec/javascripts/modules/gtm-reorder-listener-spec.js
@@ -1,0 +1,38 @@
+/* eslint-env jasmine */
+
+describe('Gtm reorder listener', function () {
+  'use strict'
+
+  var container
+
+  beforeEach(function () {
+    container = document.createElement('div')
+    container.innerHTML = '<button type="button">Move</button>'
+
+    document.body.appendChild(container)
+    window.dataLayer = []
+  })
+
+  afterEach(function () {
+    document.body.removeChild(container)
+  })
+
+  describe('reorder-move events', function () {
+    it('should push to the dataLayer', function () {
+      var button = container.querySelector('button')
+      button.dispatchEvent(new window.CustomEvent('reorder-move-up', { bubbles: true }))
+      button.dispatchEvent(new window.CustomEvent('reorder-move-down', { bubbles: true }))
+
+      expect(window.dataLayer).toContain({ event: 'Click', dataGtm: 'reorder-move-up' })
+      expect(window.dataLayer).toContain({ event: 'Click', dataGtm: 'reorder-move-down' })
+    })
+  })
+
+  describe('reorder-drag events', function () {
+    it('should push to the dataLayer', function () {
+      container.dispatchEvent(new window.CustomEvent('reorder-drag', { bubbles: true }))
+
+      expect(window.dataLayer).toContain({ event: 'Drag', dataGtm: 'reorder-drag' })
+    })
+  })
+})


### PR DESCRIPTION
- Emit events when reordering items (via buttons or drag-and-drop)
- Add reorder listener script to capture these events and send them to GTM

Note: I'm not too opinionated about the structure of these events as long as they are consistent and usable for performance analysis.

[Trello card](https://trello.com/c/H3T7JWtS)