### PR TITLE
Render index & show at 2/3 width when full screen

### DIFF
--- a/app/views/file_attachments/index.html.erb
+++ b/app/views/file_attachments/index.html.erb
@@ -1,7 +1,7 @@
 <% content_for :title, t("file_attachments.index.title", title: @edition.title_or_fallback) %>
 
 <div class="govuk-grid-row">
-  <div class="govuk-grid-column-full">
+  <div class="<%= rendering_context == 'modal' ? 'govuk-grid-column-full' : 'govuk-grid-column-two-thirds' %>">
     <div class="app-pane">
       <% upload_attachment_heading = capture do %>
         <h2 class="govuk-heading-m">

--- a/app/views/file_attachments/show.html.erb
+++ b/app/views/file_attachments/show.html.erb
@@ -3,7 +3,7 @@
                                             data_attributes: { "modal-action": "back" }) %>
 
 <div class="govuk-grid-row">
-  <div class="govuk-grid-column-full">
+  <div class="<%= rendering_context == 'modal' ? 'govuk-grid-column-full' : 'govuk-grid-column-two-thirds' %>">
     <%= render "govuk_publishing_components/components/attachment", {
       attachment: file_attachment_attributes(@attachment, @edition.document),
       target: "_blank",


### PR DESCRIPTION
Follows on from: https://github.com/alphagov/content-publisher/pull/1901

Render the file attachment and index and show pages at 2/3 width when JS is turned off (or not available)
and the page renders in the new screen rather than a modal

# Expected changes
## Index page
### Before
<img width="1532" alt="Screenshot 2020-03-16 at 12 04 59" src="https://user-images.githubusercontent.com/5793815/76757021-bba64e00-677e-11ea-9047-75d352ec94dd.png">



### After
![Screenshot 2020-03-16 at 12 00 44](https://user-images.githubusercontent.com/5793815/76756746-36229e00-677e-11ea-98e8-ce448dcbba40.png)

## Show page
### Before
<img width="1532" alt="Screenshot 2020-03-16 at 12 05 36" src="https://user-images.githubusercontent.com/5793815/76756987-b0532280-677e-11ea-9be6-b8e8e500302c.png">



### After
![Screenshot 2020-03-16 at 11 59 19](https://user-images.githubusercontent.com/5793815/76756756-39b62500-677e-11ea-82f0-f468892faa39.png)
