### PR TITLE
Rename file attachment routes

### DIFF
--- a/app/controllers/file_attachments_controller.rb
+++ b/app/controllers/file_attachments_controller.rb
@@ -106,7 +106,7 @@ class FileAttachmentsController < ApplicationController
     end
   end
 
-  def edit
+  def replace
     @edition = Edition.find_current(document: params[:document])
     assert_edition_state(@edition, &:editable?)
 
@@ -129,7 +129,7 @@ class FileAttachmentsController < ApplicationController
         ),
       }
 
-      render :edit,
+      render :replace,
              title: params.dig(:file_attachment, :title),
              assigns: { edition: edition,
                         issues: issues,

--- a/app/controllers/file_attachments_controller.rb
+++ b/app/controllers/file_attachments_controller.rb
@@ -138,7 +138,7 @@ class FileAttachmentsController < ApplicationController
     elsif params[:wizard] == "featured"
       redirect_to featured_attachments_path(edition.document)
     else
-      flash[:notice] = I18n.t!("file_attachments.edit.flashes.update_confirmation") unless unchanged
+      flash[:notice] = I18n.t!("file_attachments.replace.flashes.update_confirmation") unless unchanged
       redirect_to file_attachments_path(edition.document)
     end
   end

--- a/app/controllers/file_attachments_controller.rb
+++ b/app/controllers/file_attachments_controller.rb
@@ -114,7 +114,7 @@ class FileAttachmentsController < ApplicationController
       .find_by!(file_attachment_id: params[:file_attachment_id])
   end
 
-  def update
+  def update_file
     result = FileAttachments::UpdateInteractor.call(params: params, user: current_user)
     edition, attachment_revision, issues, unchanged =
       result.to_h.values_at(:edition, :file_attachment_revision, :issues, :unchanged)

--- a/app/views/featured_attachments/_featured_attachment.html.erb
+++ b/app/views/featured_attachments/_featured_attachment.html.erb
@@ -2,7 +2,7 @@
 
 <% actions << link_to(
   "Edit attachment",
-  edit_file_attachment_path(document, attachment.file_attachment_id, wizard: "featured"),
+  replace_file_attachment_path(document, attachment.file_attachment_id, wizard: "featured"),
   class: "govuk-link govuk-link--no-visited-state app-link--button",
   data: {
     gtm: "edit-attachment",

--- a/app/views/file_attachments/_file_attachment.html.erb
+++ b/app/views/file_attachments/_file_attachment.html.erb
@@ -21,7 +21,7 @@
 
 <% actions << link_to(
   "Edit file",
-  edit_file_attachment_path(document, attachment.file_attachment_id),
+  replace_file_attachment_path(document, attachment.file_attachment_id),
   class: "govuk-link govuk-link--no-visited-state app-link--button",
   data: {
     "modal-action": "edit",

--- a/app/views/file_attachments/replace.html.erb
+++ b/app/views/file_attachments/replace.html.erb
@@ -12,7 +12,7 @@
 <div class="govuk-grid-row">
   <div class="<%= rendering_context == 'modal' ? 'govuk-grid-column-full' : 'govuk-grid-column-two-thirds' %>">
     <%= form_tag(
-      edit_file_attachment_path(@edition.document, @attachment.file_attachment_id),
+      replace_file_attachment_path(@edition.document, @attachment.file_attachment_id),
       method: :patch,
       multipart: true,
       data: {

--- a/app/views/file_attachments/replace.html.erb
+++ b/app/views/file_attachments/replace.html.erb
@@ -1,4 +1,4 @@
-<% content_for :title, t("file_attachments.edit.title", title: @edition.title_or_fallback) %>
+<% content_for :title, t("file_attachments.replace.title", title: @edition.title_or_fallback) %>
 
 <% back_link_path = if params[:wizard] == "featured"
                       featured_attachments_path(@edition.document)
@@ -24,25 +24,25 @@
 
       <%= render "govuk_publishing_components/components/input", {
         label: {
-          text: t("file_attachments.edit.attachment_title.heading"),
+          text: t("file_attachments.replace.attachment_title.heading"),
           bold: true
         },
         name: "file_attachment[title]",
         value: params.dig(:file_attachment, :title) || @attachment.title,
-        hint: t("file_attachments.edit.attachment_title.hint_text"),
+        hint: t("file_attachments.replace.attachment_title.hint_text"),
       } %>
 
       <% file_upload_id = "file-upload-#{SecureRandom.hex(4)}" %>
       <%= render "govuk_publishing_components/components/label", {
-        text: t("file_attachments.edit.attachment_file.heading"),
+        text: t("file_attachments.replace.attachment_file.heading"),
         html_for: file_upload_id,
         bold: true,
       } %>
 
-      <%= render_govspeak(t("file_attachments.edit.attachment_file.description_govspeak")) %>
+      <%= render_govspeak(t("file_attachments.replace.attachment_file.description_govspeak")) %>
       <%= render "govuk_publishing_components/components/inset_text", {
         text: render_govspeak(
-          t("file_attachments.edit.attachment_file.filename_change_callout_govspeak",
+          t("file_attachments.replace.attachment_file.filename_change_callout_govspeak",
             filename: @attachment.filename)
         ),
       } %>

--- a/config/locales/en/file_attachments/replace.yml
+++ b/config/locales/en/file_attachments/replace.yml
@@ -1,6 +1,6 @@
 en:
   file_attachments:
-    edit:
+    replace:
       title: Edit attachment
       attachment_title:
         heading: Edit title

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -100,8 +100,8 @@ Rails.application.routes.draw do
     get "/file-attachments/:file_attachment_id" => "file_attachments#show", as: :file_attachment
     get "/file-attachments/:file_attachment_id/preview" => "file_attachments#preview", as: :preview_file_attachment
     get "/file-attachments/:file_attachment_id/download" => "file_attachments#download", as: :download_file_attachment
-    get "/file-attachments/:file_attachment_id/edit" => "file_attachments#edit", as: :edit_file_attachment
-    patch "/file-attachments/:file_attachment_id/edit" => "file_attachments#update"
+    get "/file-attachments/:file_attachment_id/replace" => "file_attachments#replace", as: :replace_file_attachment
+    patch "/file-attachments/:file_attachment_id/replace" => "file_attachments#update"
     delete "/file-attachments/:file_attachment_id" => "file_attachments#destroy"
     get "/file-attachments/:file_attachment_id/delete" => "file_attachments#confirm_delete", as: :confirm_delete_file_attachment
   end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -101,7 +101,7 @@ Rails.application.routes.draw do
     get "/file-attachments/:file_attachment_id/preview" => "file_attachments#preview", as: :preview_file_attachment
     get "/file-attachments/:file_attachment_id/download" => "file_attachments#download", as: :download_file_attachment
     get "/file-attachments/:file_attachment_id/replace" => "file_attachments#replace", as: :replace_file_attachment
-    patch "/file-attachments/:file_attachment_id/replace" => "file_attachments#update"
+    patch "/file-attachments/:file_attachment_id/replace" => "file_attachments#update_file"
     delete "/file-attachments/:file_attachment_id" => "file_attachments#destroy"
     get "/file-attachments/:file_attachment_id/delete" => "file_attachments#confirm_delete", as: :confirm_delete_file_attachment
   end

--- a/spec/requests/file_attachments_spec.rb
+++ b/spec/requests/file_attachments_spec.rb
@@ -227,7 +227,7 @@ RSpec.describe "File Attachments" do
       expect(response).to redirect_to(file_attachments_path(edition.document))
       follow_redirect!
       expect(response.body).to have_content(
-        I18n.t!("file_attachments.edit.flashes.update_confirmation"),
+        I18n.t!("file_attachments.replace.flashes.update_confirmation"),
       )
     end
 
@@ -238,7 +238,7 @@ RSpec.describe "File Attachments" do
       expect(response).to redirect_to(file_attachments_path(edition.document))
       follow_redirect!
       expect(response.body).not_to have_content(
-        I18n.t!("file_attachments.edit.flashes.update_confirmation"),
+        I18n.t!("file_attachments.replace.flashes.update_confirmation"),
       )
     end
 

--- a/spec/requests/file_attachments_spec.rb
+++ b/spec/requests/file_attachments_spec.rb
@@ -9,7 +9,7 @@ RSpec.describe "File Attachments" do
   it_behaves_like "requests that assert edition state",
                   "accessing a single file attachments for a non editable edition",
                   routes: { file_attachment_path: %i[get delete],
-                            edit_file_attachment_path: %i[get patch],
+                            replace_file_attachment_path: %i[get patch],
                             preview_file_attachment_path: %i[get],
                             confirm_delete_file_attachment_path: %i[get],
                             download_file_attachment_path: %i[get] } do
@@ -21,7 +21,7 @@ RSpec.describe "File Attachments" do
                   "when a file attachment revision belongs to a different edition",
                   status: :not_found,
                   routes: { file_attachment_path: %i[get delete],
-                            edit_file_attachment_path: %i[get patch],
+                            replace_file_attachment_path: %i[get patch],
                             preview_file_attachment_path: %i[get],
                             confirm_delete_file_attachment_path: %i[get],
                             download_file_attachment_path: %i[get] } do
@@ -193,7 +193,7 @@ RSpec.describe "File Attachments" do
     end
   end
 
-  describe "GET /documents/:document/file-attachments/:file_attachment_id/edit" do
+  describe "GET /documents/:document/file-attachments/:file_attachment_id/replace" do
     let(:file_attachment_revision) { create(:file_attachment_revision) }
 
     it "shows the file attachment when it exists on the edition" do
@@ -201,14 +201,14 @@ RSpec.describe "File Attachments" do
       edition = create(:edition,
                        file_attachment_revisions: [file_attachment_revision])
 
-      get edit_file_attachment_path(edition.document,
-                                    file_attachment_revision.file_attachment_id)
+      get replace_file_attachment_path(edition.document,
+                                       file_attachment_revision.file_attachment_id)
       expect(response).to have_http_status(:ok)
       expect(response.body).to have_content(file_attachment_revision.filename)
     end
   end
 
-  describe "PATCH /documents/:document/file-attachments/:file_attachment_id/edit" do
+  describe "PATCH /documents/:document/file-attachments/:file_attachment_id/replace" do
     before do
       stub_publishing_api_put_content(edition.content_id, {})
       stub_asset_manager_update_asset(file_attachment_revision.asset.asset_manager_id)
@@ -221,7 +221,7 @@ RSpec.describe "File Attachments" do
     end
 
     it "redirects to the file attachments index with a flash message when changed" do
-      patch edit_file_attachment_path(edition.document, file_attachment_id),
+      patch replace_file_attachment_path(edition.document, file_attachment_id),
             params: { file_attachment: { title: "New title" } }
 
       expect(response).to redirect_to(file_attachments_path(edition.document))
@@ -232,7 +232,7 @@ RSpec.describe "File Attachments" do
     end
 
     it "redirects to the file attachments index without a flash message when unchanged" do
-      patch edit_file_attachment_path(edition.document, file_attachment_id),
+      patch replace_file_attachment_path(edition.document, file_attachment_id),
             params: { file_attachment: { title: file_attachment_revision.title } }
 
       expect(response).to redirect_to(file_attachments_path(edition.document))
@@ -243,7 +243,7 @@ RSpec.describe "File Attachments" do
     end
 
     it "returns issues and an unprocessable response when there are requirement issues" do
-      patch edit_file_attachment_path(edition.document, file_attachment_id),
+      patch replace_file_attachment_path(edition.document, file_attachment_id),
             params: { file_attachment: { title: "" } }
 
       expect(response).to have_http_status(:unprocessable_entity)


### PR DESCRIPTION
Trello: https://trello.com/c/QZmkUoTr

# What's changed and why?

Renames the "edit" and "update" routes for file attachments to "replace" and "update_file" respectively.

In the next story we will be adding a page to add metadata about file attachments.
For images, metadata is added using the "edit" route and "POSTed" using the "update" route. To make file attachments more consistent with images, the "edit" and "update" routes are being renamed so that they can be used for the metadata paths later.