### PR TITLE
Support unautheticated error viewing

### DIFF
--- a/app/controllers/errors_controller.rb
+++ b/app/controllers/errors_controller.rb
@@ -1,6 +1,14 @@
 class ErrorsController < ApplicationController
+  skip_before_action :authenticate_user!
   skip_before_action :verify_authenticity_token
   skip_before_action :check_user_access
+
+  before_action do
+    # retrieves an existing sesssion for users if available. Unlike
+    # `authenticate_user!` this does not redirect a user when they are not
+    # authenticated.
+    warden.authenticate
+  end
 
   def bad_request
     render status: :bad_request, formats: :html

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -6,8 +6,8 @@
 
   <script>
     var dataLayer = [{
-      'user-organisation': '<%= current_user.organisation_slug %>',
-      'cp-uid': '<%= current_user.uid %>',
+      'user-organisation': '<%= current_user&.organisation_slug %>',
+      'cp-uid': '<%= current_user&.uid %>',
       'page-name': '<%= "#{controller_name}-#{action_name}" %>'
     }];
     dataLayer.push({ 'gtm.blacklist': ['html', 'customScripts', 'nonGoogleScripts', 'customPixels'] });
@@ -30,17 +30,25 @@
 
   <%= render "govuk_publishing_components/components/skip_link" %>
 
-  <%= render "govuk_publishing_components/components/layout_header", {
-    environment: GovukPublishingComponents::AppHelpers::Environment.current_acceptance_environment,
-    navigation_items: [
+  <%
+    navigation_items = [
       { text: "Switch app", href: Plek.new.external_url_for("signon") },
       { text: t("application.phase_banner.raise_a_support_request"), href: "https://support.publishing.service.gov.uk/technical_fault_report/new", show_only_in_collapsed_menu: true },
       { text: t("application.phase_banner.send_us_feedback"), href: "https://support.publishing.service.gov.uk/content_publisher_feedback_request/new", show_only_in_collapsed_menu: true },
       { text: t("application.phase_banner.whats_new"), href: publisher_updates_path, show_only_in_collapsed_menu: true },
-      { text: current_user.name, href: Plek.new.external_url_for("signon") },
-      { text: "Log out", href: gds_sign_out_path }
     ]
-  }%>
+
+    if current_user
+      navigation_items += [
+        { text: current_user.name, href: Plek.new.external_url_for("signon") },
+        { text: "Log out", href: gds_sign_out_path },
+      ]
+    end
+  %>
+  <%= render "govuk_publishing_components/components/layout_header", {
+    environment: GovukPublishingComponents::AppHelpers::Environment.current_acceptance_environment,
+    navigation_items: navigation_items,
+  } %>
 
   <div class="govuk-width-container">
     <%= render "govuk_publishing_components/components/phase_banner", {

--- a/spec/requests/errors_spec.rb
+++ b/spec/requests/errors_spec.rb
@@ -1,42 +1,39 @@
 RSpec.describe "Errors" do
-  describe "/400" do
-    it "returns a bad request response" do
-      get "/400"
-      expect(response).to have_http_status(:bad_request)
-      expect(response.body).to include(I18n.t!("errors.bad_request.title"))
+  shared_examples "an error response" do |code, status|
+    title = "code #{status.to_s.titleize}"
+    it "returns a #{title} response" do
+      get "/#{code}"
+      expect(response).to have_http_status(status)
+      expect(response.body).to include(I18n.t!("errors.#{status}.title"))
     end
+
+    it "returns a #{title} for unauthenticated users" do
+      ClimateControl.modify GDS_SSO_MOCK_INVALID: "true" do
+        get "/#{code}"
+        expect(response).to have_http_status(status)
+        expect(response.body).to include(I18n.t!("errors.#{status}.title"))
+      end
+    end
+  end
+
+  describe "/400" do
+    it_behaves_like "an error response", 400, :bad_request
   end
 
   describe "/403" do
-    it "returns a forbidden response" do
-      get "/403"
-      expect(response).to have_http_status(:forbidden)
-      expect(response.body).to include(I18n.t!("errors.forbidden.title"))
-    end
+    it_behaves_like "an error response", 403, :forbidden
   end
 
   describe "/404" do
-    it "returns a not found response" do
-      get "/404"
-      expect(response).to have_http_status(:not_found)
-      expect(response.body).to include(I18n.t!("errors.not_found.title"))
-    end
+    it_behaves_like "an error response", 404, :not_found
   end
 
   describe "/422" do
-    it "returns an unprocessable entity response" do
-      get "/422"
-      expect(response).to have_http_status(:unprocessable_entity)
-      expect(response.body).to include(I18n.t!("errors.unprocessable_entity.title"))
-    end
+    it_behaves_like "an error response", 422, :unprocessable_entity
   end
 
   describe "/500" do
-    it "returns an internal server error response" do
-      get "/500"
-      expect(response).to have_http_status(:internal_server_error)
-      expect(response.body).to include(I18n.t!("errors.internal_server_error.title"))
-    end
+    it_behaves_like "an error response", 500, :internal_server_error
   end
 
   describe "GET /any-path-for-a-document" do


### PR DESCRIPTION
While looking at our previous incident I noticed we had a number of 500
responses for users being served a 404 page. These were occurring when
users were requesting a URL that Rails did not recognise and the
`authenticate_user!` action of warden was raising an exception, trace:

```
UncaughtThrowError
uncaught throw :warden
/data/vhost/content-publisher/shared/bundle/ruby/2.6.0/gems/warden-1.2.8/lib/warden/proxy.rb:134:in `throw'
/data/vhost/content-publisher/shared/bundle/ruby/2.6.0/gems/warden-1.2.8/lib/warden/proxy.rb:134:in `authenticate!'
/data/vhost/content-publisher/shared/bundle/ruby/2.6.0/gems/gds-sso-14.3.0/lib/gds-sso/controller_methods.rb:47:in `authenticate_user!'
/data/vhost/content-publisher/shared/bundle/ruby/2.6.0/gems/activesupport-6.0.2.1/lib/active_support/callbacks.rb:429:in `block in make_lambda
```

This suggests that the Rails exception handler is preventing the throw
mechanism that warden uses to require authentication.

To resolve this I've set up tests for the error actions without
authentication and modified the application layout to handle a user not
existing.