### PR TITLE
Change order in which document types are listed

### DIFF
--- a/config/document_type_selections.yml
+++ b/config/document_type_selections.yml
@@ -17,19 +17,23 @@
 
 - id: articles_and_correspondence
   options:
-    - id: authored_article
-      type: managed_elsewhere
-      hostname: whitehall-admin
-      path: /government/admin/speeches/new
     - id: correspondence
       type: document_type
     - id: correspondence_managed_elsewhere
       type: managed_elsewhere
       hostname: whitehall-admin
       path: /government/admin/publications/new
+    - id: authored_article
+      type: managed_elsewhere
+      hostname: whitehall-admin
+      path: /government/admin/speeches/new
 
 - id: guidance
   options:
+    - id: detailed_guide
+      type: managed_elsewhere
+      hostname: whitehall-admin
+      path: /government/admin/detailed-guides/new
     - id: non_statutory_guidance
       type: managed_elsewhere
       hostname: whitehall-admin
@@ -42,10 +46,6 @@
       type: managed_elsewhere
       hostname: support
       path: /content_advice_request/new
-    - id: detailed_guide
-      type: managed_elsewhere
-      hostname: whitehall-admin
-      path: /government/admin/detailed-guides/new
     - id: any_mainstream_publication
       type: managed_elsewhere
       hostname: support
@@ -55,11 +55,11 @@
   options:
     - id: guidance
       type: document_type_selection
-    - id: regulation
+    - id: form
       type: managed_elsewhere
       hostname: whitehall-admin
       path: /government/admin/publications/new
-    - id: form
+    - id: regulation
       type: managed_elsewhere
       hostname: whitehall-admin
       path: /government/admin/publications/new
@@ -74,13 +74,13 @@
       type: document_type
     - id: press_release
       type: document_type
+    - id: articles_and_correspondence
+      type: document_type_selection
     - id: speech
       type: managed_elsewhere
       hostname: whitehall-admin
       path: /government/admin/speeches/new
     - id: statement_to_parliament
-      type: document_type_selection
-    - id: articles_and_correspondence
       type: document_type_selection
     - id: case_study
       type: managed_elsewhere
@@ -127,15 +127,15 @@
 
 - id: statement_to_parliament
   options:
-    - id: oral_statement
-      type: managed_elsewhere
-      hostname: whitehall-admin
-      path: /government/admin/speeches/new
     - id: written_statement
       type: managed_elsewhere
       hostname: whitehall-admin
       path: /government/admin/speeches/new
-
+    - id: oral_statement
+      type: managed_elsewhere
+      hostname: whitehall-admin
+      path: /government/admin/speeches/new
+    
 - id: statistics
   options:
     - id: official_statistics
@@ -159,15 +159,9 @@
   options:
     - id: statistics
       type: document_type_selection
-    - id: independent_report
+    - id: transparency
       type: document_type
-    - id: independent_report_managed_elsewhere
-      type: managed_elsewhere
-      hostname: whitehall-admin
-      path: /government/admin/publications/new
-    - id: foi_release
-      type: document_type
-    - id: foi_release_managed_elsewhere
+    - id: transparency_managed_elsewhere
       type: managed_elsewhere
       hostname: whitehall-admin
       path: /government/admin/publications/new
@@ -177,15 +171,21 @@
       type: managed_elsewhere
       hostname: whitehall-admin
       path: /government/admin/publications/new
-    - id: transparency
-      type: document_type
-    - id: transparency_managed_elsewhere
-      type: managed_elsewhere
-      hostname: whitehall-admin
-      path: /government/admin/publications/new
     - id: research
       type: document_type
     - id: research_managed_elsewhere
+      type: managed_elsewhere
+      hostname: whitehall-admin
+      path: /government/admin/publications/new
+    - id: foi_release
+      type: document_type
+    - id: foi_release_managed_elsewhere
+      type: managed_elsewhere
+      hostname: whitehall-admin
+      path: /government/admin/publications/new
+    - id: independent_report
+      type: document_type
+    - id: independent_report_managed_elsewhere
       type: managed_elsewhere
       hostname: whitehall-admin
       path: /government/admin/publications/new


### PR DESCRIPTION
https://trello.com/c/ZXpB0fBH/1493-reorder-document-types-based-on-usage

This orders document types by the most commonly created in the 'create new document' flow.