### PR TITLE
Confirm delete attachment

### DIFF
--- a/app/assets/javascripts/modules/inline-attachment-modal.js
+++ b/app/assets/javascripts/modules/inline-attachment-modal.js
@@ -34,7 +34,7 @@ InlineAttachmentModal.prototype.actionCallback = function (item) {
     'insert': function () {
       this.workflow.render(window.ModalFetch.getLink(item))
     },
-    'confirm-delete': function () { 
+    'confirm-delete': function () {
       this.workflow.render(window.ModalFetch.getLink(item))
     },
     'delete': function () {

--- a/app/assets/javascripts/modules/inline-attachment-modal.js
+++ b/app/assets/javascripts/modules/inline-attachment-modal.js
@@ -34,6 +34,9 @@ InlineAttachmentModal.prototype.actionCallback = function (item) {
     'insert': function () {
       this.workflow.render(window.ModalFetch.getLink(item))
     },
+    'confirm-delete': function () { 
+      this.workflow.render(window.ModalFetch.getLink(item))
+    },
     'delete': function () {
       this.workflow.render(window.ModalFetch.postForm(item))
     },
@@ -44,6 +47,9 @@ InlineAttachmentModal.prototype.actionCallback = function (item) {
       this.workflow.render(window.ModalFetch.postForm(item))
     },
     'back': function () {
+      this.workflow.render(window.ModalFetch.getLink(item))
+    },
+    'cancel': function () {
       this.workflow.render(window.ModalFetch.getLink(item))
     },
     'insert-attachment-block': function () {

--- a/app/assets/javascripts/modules/inline-attachment-modal.js
+++ b/app/assets/javascripts/modules/inline-attachment-modal.js
@@ -34,10 +34,10 @@ InlineAttachmentModal.prototype.actionCallback = function (item) {
     'insert': function () {
       this.workflow.render(window.ModalFetch.getLink(item))
     },
-    'confirm-delete': function () {
+    'delete': function () {
       this.workflow.render(window.ModalFetch.getLink(item))
     },
-    'delete': function () {
+    'confirm-delete': function () {
       this.workflow.render(window.ModalFetch.postForm(item))
     },
     'edit': function () {
@@ -47,9 +47,6 @@ InlineAttachmentModal.prototype.actionCallback = function (item) {
       this.workflow.render(window.ModalFetch.postForm(item))
     },
     'back': function () {
-      this.workflow.render(window.ModalFetch.getLink(item))
-    },
-    'cancel': function () {
       this.workflow.render(window.ModalFetch.getLink(item))
     },
     'insert-attachment-block': function () {

--- a/app/views/file_attachments/_file_attachment.html.erb
+++ b/app/views/file_attachments/_file_attachment.html.erb
@@ -31,11 +31,11 @@
 
 <% actions << link_to(
   "Delete attachment",
-    confirm_delete_file_attachment_path(document, attachment.file_attachment_id),
-    class: "govuk-link app-link--button app-link--destructive",
-    data: {
-      "modal-action": "confirm-delete",
-      gtm: "confirm-delete"
+  confirm_delete_file_attachment_path(edition.document, attachment.file_attachment_id),
+  class: "govuk-link app-link--button app-link--destructive",
+  data: {
+    "modal-action": "delete",
+    gtm: "delete-attachment"
   },
 ) %>
 

--- a/app/views/file_attachments/_file_attachment.html.erb
+++ b/app/views/file_attachments/_file_attachment.html.erb
@@ -29,19 +29,14 @@
   },
 ) %>
 
-<% actions << capture do %>
-  <%= form_tag(
-    file_attachment_path(edition.document, attachment.file_attachment_id),
-    method: :delete,
-    class: "app-inline-block",
+<% actions << link_to(
+  "Delete attachment",
+    confirm_delete_file_attachment_path(document, attachment.file_attachment_id),
+    class: "govuk-link app-link--button app-link--destructive",
     data: {
-      "modal-action": "delete",
-      gtm: "delete-attachment",
-    },
-  ) do %>
-    <button class="govuk-link app-link--button app-link--destructive">Delete attachment</button>
-  <% end %>
-<% end %>
+      "modal-action": "confirm-delete"
+  },
+) %>
 
 <%= render "components/attachment_meta", {
   attachment: file_attachment_attributes(attachment, edition),

--- a/app/views/file_attachments/_file_attachment.html.erb
+++ b/app/views/file_attachments/_file_attachment.html.erb
@@ -34,7 +34,8 @@
     confirm_delete_file_attachment_path(document, attachment.file_attachment_id),
     class: "govuk-link app-link--button app-link--destructive",
     data: {
-      "modal-action": "confirm-delete"
+      "modal-action": "confirm-delete",
+      gtm: "confirm-delete"
   },
 ) %>
 

--- a/app/views/file_attachments/confirm_delete.html.erb
+++ b/app/views/file_attachments/confirm_delete.html.erb
@@ -4,7 +4,7 @@
                       file_attachments_path(@edition.document)
                     end %>
 
-<% content_for :back_link, render_back_link(href: back_link_path) %>
+<% content_for :back_link, render_back_link(href: back_link_path, data_attributes: { "modal-action": "back" }) %>
 <% content_for :title, t("file_attachments.confirm_delete.title", title: @attachment.title) %>
 
 <div class="govuk-grid-row">
@@ -13,6 +13,10 @@
       file_attachment_path(@edition.document, wizard: params[:wizard]),
       method: :delete,
       multipart: true,
+      data: {
+        "modal-action": "delete",
+        gtm: "delete-attachment"
+      },
     ) do %>
       <%= render_govspeak(t("file_attachments.confirm_delete.description_govspeak")) %>
 
@@ -25,7 +29,8 @@
       <div class="govuk-body">
         <%= link_to "Cancel",
                   back_link_path,
-                  class: "govuk-link govuk-link--no-visited-state" %>
+                  class: "govuk-link govuk-link--no-visited-state", 
+                  data: { "modal-action": "cancel" } %>
       <% end %>
     </div>
   </div>

--- a/app/views/file_attachments/confirm_delete.html.erb
+++ b/app/views/file_attachments/confirm_delete.html.erb
@@ -30,7 +30,9 @@
         <%= link_to "Cancel",
                   back_link_path,
                   class: "govuk-link govuk-link--no-visited-state", 
-                  data: { "modal-action": "cancel" } %>
+                  data: { "modal-action": "cancel",
+                  gtm: "cancel-delete-attachment" 
+                  } %>                  
       <% end %>
     </div>
   </div>

--- a/app/views/file_attachments/confirm_delete.html.erb
+++ b/app/views/file_attachments/confirm_delete.html.erb
@@ -12,10 +12,10 @@
     <%= form_tag(
       file_attachment_path(@edition.document, wizard: params[:wizard]),
       method: :delete,
-      multipart: true,
+      multipart: true,  
       data: {
-        "modal-action": "delete",
-        gtm: "delete-attachment"
+        "modal-action": "confirm-delete",
+        gtm: "confirm-delete-attachment"
       },
     ) do %>
       <%= render_govspeak(t("file_attachments.confirm_delete.description_govspeak")) %>
@@ -28,11 +28,11 @@
 
       <div class="govuk-body">
         <%= link_to "Cancel",
-                  back_link_path,
-                  class: "govuk-link govuk-link--no-visited-state", 
-                  data: { "modal-action": "cancel",
-                  gtm: "cancel-delete-attachment" 
-                  } %>                  
+          back_link_path,
+          class: "govuk-link govuk-link--no-visited-state", 
+          data: { "modal-action": "back",
+          gtm: "cancel-delete-attachment" 
+        } %>                  
       <% end %>
     </div>
   </div>

--- a/spec/features/editing_file_attachments/delete_file_attachment_spec.rb
+++ b/spec/features/editing_file_attachments/delete_file_attachment_spec.rb
@@ -3,6 +3,7 @@ RSpec.feature "Delete a file attachment", js: true do
     given_there_is_an_edition_with_attachments
     when_i_insert_an_attachment
     and_i_delete_the_attachment
+    and_i_confirm_the_deletion
     then_i_am_told_the_attachment_is_gone
     and_i_see_the_attachment_is_gone
     and_i_see_the_timeline_entry

--- a/spec/javascripts/modules/inline-attachment-modal-spec.js
+++ b/spec/javascripts/modules/inline-attachment-modal-spec.js
@@ -86,7 +86,11 @@ describe('InlineAttachmentModal', function () {
   })
 
   describe('delete action', function () {
-    itBehavesLikeAFormAction('delete')
+    itBehavesLikeALinkAction('delete')
+  })
+
+  describe('confirm-delete action', function () {
+    itBehavesLikeAFormAction('confirm-delete')
   })
 
   describe('edit action', function () {


### PR DESCRIPTION
When interacting with attachments via the markdown editor the option to "Delete attachment" will now route the user to a confirmation page. Previously clicking this link would have deleted the attachment and displayed a flash message in the modal.  

<img width="779" alt="Screenshot 2020-03-18 at 11 26 08" src="https://user-images.githubusercontent.com/41922771/76956141-6186c380-690b-11ea-922c-e5b81eddde96.png">

Adding a confirmation page in this manner brings attachments in line with other delete actions. 

<img width="685" alt="Screenshot 2020-03-18 at 11 25 58" src="https://user-images.githubusercontent.com/41922771/76956137-60559680-690b-11ea-81ce-c83a120e4042.png">
