### PR TITLE
Add a new feature to reorder featured attachments

### DIFF
--- a/app/controllers/featured_attachments_controller.rb
+++ b/app/controllers/featured_attachments_controller.rb
@@ -7,4 +7,19 @@ class FeaturedAttachmentsController < ApplicationController
       @edition.document_type.attachments.featured?
     end
   end
+
+  def reorder
+    @edition = Edition.find_current(document: params[:document])
+    assert_edition_state(@edition, &:editable?)
+
+    assert_edition_feature(@edition, assertion: "supports featured attachments") do
+      @edition.document_type.attachments.featured?
+    end
+  end
+
+  def update_order
+    result = FeaturedAttachments::UpdateOrderInteractor.call(params: params, user: current_user)
+    edition = result.edition
+    redirect_to featured_attachments_path(edition.document)
+  end
 end

--- a/app/interactors/featured_attachments/update_order_interactor.rb
+++ b/app/interactors/featured_attachments/update_order_interactor.rb
@@ -1,0 +1,54 @@
+class FeaturedAttachments::UpdateOrderInteractor < ApplicationInteractor
+  delegate :params,
+           :user,
+           :edition,
+           :attachments,
+           :updater,
+           to: :context
+
+  def call
+    Edition.transaction do
+      find_and_lock_edition
+      reorder_attachments
+      update_edition
+      create_timeline_entry
+      update_preview
+    end
+  end
+
+  def find_and_lock_edition
+    context.edition = Edition.lock.find_current(document: params[:document])
+    assert_edition_state(edition, &:editable?)
+
+    assert_edition_feature(edition, assertion: "supports featured attachments") do
+      edition.document_type.attachments.featured?
+    end
+  end
+
+  def reorder_attachments
+    new_ordering = edition.featured_attachments.sort_by do |attachment|
+      ordering_params[attachment.featured_attachment_id].to_i
+    end
+
+    context.updater = Versioning::RevisionUpdater.new(edition.revision, user)
+    updater.assign(featured_attachment_ordering: new_ordering.map(&:featured_attachment_id))
+    context.fail! unless updater.changed?
+  end
+
+  def update_edition
+    EditDraftEditionService.call(edition, user, revision: updater.next_revision)
+    edition.save!
+  end
+
+  def create_timeline_entry
+    TimelineEntry.create_for_revision(entry_type: :attachments_reordered, edition: edition)
+  end
+
+  def update_preview
+    FailsafeDraftPreviewService.call(edition)
+  end
+
+  def ordering_params
+    @ordering_params ||= params.require(:attachments).permit(ordering: {})[:ordering].to_h
+  end
+end

--- a/app/models/edition.rb
+++ b/app/models/edition.rb
@@ -78,6 +78,7 @@ class Edition < ApplicationRecord
            :supporting_organisation_ids,
            :backdated_to,
            :editor_political,
+           :featured_attachment_ordering,
            to: :revision
 
   scope :find_current, ->(id: nil, document: nil) do

--- a/app/models/edition.rb
+++ b/app/models/edition.rb
@@ -78,6 +78,7 @@ class Edition < ApplicationRecord
            :supporting_organisation_ids,
            :backdated_to,
            :editor_political,
+           :featured_attachments,
            :featured_attachment_ordering,
            to: :revision
 

--- a/app/models/file_attachment/revision.rb
+++ b/app/models/file_attachment/revision.rb
@@ -35,4 +35,8 @@ class FileAttachment::Revision < ApplicationRecord
   def readonly?
     !new_record?
   end
+
+  def featured_attachment_id
+    "FileAttachment#{file_attachment.id}"
+  end
 end

--- a/app/models/metadata_revision.rb
+++ b/app/models/metadata_revision.rb
@@ -5,6 +5,7 @@
 # This model is immutable.
 class MetadataRevision < ApplicationRecord
   validates :change_history, "metadata_revision/change_history" => true
+  validates :featured_attachment_ordering, "metadata_revision/featured_attachment_ordering" => true
 
   belongs_to :created_by, class_name: "User", optional: true
 

--- a/app/models/metadata_revision.rb
+++ b/app/models/metadata_revision.rb
@@ -4,32 +4,7 @@
 #
 # This model is immutable.
 class MetadataRevision < ApplicationRecord
-  validates_each :change_history do |record, attribute, change_history|
-    uuid_regex = /\A[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}\Z/
-
-    previous_time = nil
-    change_history.each do |change_note|
-      unless change_note.keys.sort == %w(id note public_timestamp)
-        record.errors.add(attribute, "has an entry with invalid keys", strict: true)
-      end
-
-      unless change_note["id"].match?(uuid_regex)
-        record.errors.add(attribute, "has an entry with a non UUID id", strict: true)
-      end
-
-      begin
-        time = Time.zone.rfc3339(change_note["public_timestamp"])
-      rescue ArgumentError
-        record.errors.add(attribute, "has an entry with an invalid timestamp", strict: true)
-      end
-
-      if previous_time && previous_time < time
-        record.errors.add(attribute, "is not in a reverse chronological ordering", strict: true)
-      end
-
-      previous_time = time
-    end
-  end
+  validates :change_history, "metadata_revision/change_history" => true
 
   belongs_to :created_by, class_name: "User", optional: true
 

--- a/app/models/metadata_revision/change_history_validator.rb
+++ b/app/models/metadata_revision/change_history_validator.rb
@@ -1,0 +1,29 @@
+class MetadataRevision::ChangeHistoryValidator < ActiveModel::EachValidator
+  UUID_REGEX = /\A[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}\Z/.freeze
+
+  def validate_each(record, attribute, value)
+    previous_time = nil
+
+    value.each do |change_note|
+      unless change_note.keys.sort == %w(id note public_timestamp)
+        record.errors.add(attribute, "has an entry with invalid keys", strict: true)
+      end
+
+      unless change_note["id"].match?(UUID_REGEX)
+        record.errors.add(attribute, "has an entry with a non UUID id", strict: true)
+      end
+
+      begin
+        time = Time.zone.rfc3339(change_note["public_timestamp"])
+      rescue ArgumentError
+        record.errors.add(attribute, "has an entry with an invalid timestamp", strict: true)
+      end
+
+      if previous_time && previous_time < time
+        record.errors.add(attribute, "is not in a reverse chronological ordering", strict: true)
+      end
+
+      previous_time = time
+    end
+  end
+end

--- a/app/models/metadata_revision/featured_attachment_ordering_validator.rb
+++ b/app/models/metadata_revision/featured_attachment_ordering_validator.rb
@@ -1,0 +1,15 @@
+class MetadataRevision::FeaturedAttachmentOrderingValidator < ActiveModel::EachValidator
+  ORDER_ITEM_REGEX = /\AFileAttachment\d+\Z/.freeze
+
+  def validate_each(record, attribute, value)
+    value.each do |order_item|
+      unless order_item.match?(ORDER_ITEM_REGEX)
+        record.errors.add(attribute, "has an entry with a malformed ID", strict: true)
+      end
+    end
+
+    unless value.uniq == value
+      record.errors.add(attribute, "has a duplicate entry", strict: true)
+    end
+  end
+end

--- a/app/models/revision.rb
+++ b/app/models/revision.rb
@@ -56,6 +56,7 @@ class Revision < ApplicationRecord
            :backdated_to,
            :document_type,
            :editor_political,
+           :featured_attachment_ordering,
            to: :metadata_revision
 
   delegate :tags,

--- a/app/models/revision.rb
+++ b/app/models/revision.rb
@@ -75,4 +75,10 @@ class Revision < ApplicationRecord
   def assets
     image_revisions.flat_map(&:assets) + file_attachment_revisions.map(&:asset)
   end
+
+  def featured_attachments
+    file_attachment_revisions.sort_by do |attachment|
+      featured_attachment_ordering.find_index(attachment.featured_attachment_id).to_i
+    end
+  end
 end

--- a/app/models/timeline_entry.rb
+++ b/app/models/timeline_entry.rb
@@ -56,7 +56,8 @@ class TimelineEntry < ApplicationRecord
                      access_limit_updated: "access_limit_updated",
                      access_limit_removed: "access_limit_removed",
                      political_status_changed: "political_status_changed",
-                     whitehall_migration: "whitehall_migration" }
+                     whitehall_migration: "whitehall_migration",
+                     attachments_reordered: "attachments_reordered" }
 
   def self.create_for_status_change(entry_type:,
                                     status:,

--- a/app/views/components/_reorderable_list.html.erb
+++ b/app/views/components/_reorderable_list.html.erb
@@ -1,5 +1,6 @@
 <%
   items ||= []
+  input_name ||= "ordering"
   data_attributes ||= {}
   data_attributes[:module] = "reorderable-list"
 %>
@@ -17,7 +18,7 @@
             label: {
               text: sanitize("Position<span class='govuk-visually-hidden'> for #{item[:title]}</span>")
             },
-            name: "ordering[#{item[:order_id]}]",
+            name: "#{input_name}[#{item[:order_id]}]",
             type: "number",
             value: index + 1,
             width: 2

--- a/app/views/components/docs/reorderable_list.yml
+++ b/app/views/components/docs/reorderable_list.yml
@@ -51,3 +51,9 @@ examples:
         - title: "Table 2.2: Measures announced at Autumn Budget 2017 or earlier that will take effect from November 2018 or later (£ million)"
           description: "MS Excel Spreadsheet, 248KB"
           order_id: "217ab88f-74a9-41eb-ab47-428f54461c04"
+  with_custom_input_name:
+    data:
+      input_name: "attachments[ordering]"
+      items:
+        - title: "Budget 2018"
+          description: "PDF, 2.56MB, 48 pages"

--- a/app/views/featured_attachments/index.html.erb
+++ b/app/views/featured_attachments/index.html.erb
@@ -24,6 +24,15 @@
         <%= t("featured_attachments.index.featured_attachments.description_govspeak") %>
       </p>
 
+      <p class="govuk-body govuk-!-margin-bottom-8">
+        <%= link_to(
+          "Reorder attachments",
+          reorder_featured_attachments_path(@edition.document),
+          class: "govuk-link",
+          data: { gtm: "reorder-attachments" }
+        ) %>
+      </p>
+
       <% attachments.each do |attachment| %>
         <%= render "featured_attachment", document: @edition.document, attachment: attachment %>
       <% end %>

--- a/app/views/featured_attachments/index.html.erb
+++ b/app/views/featured_attachments/index.html.erb
@@ -13,7 +13,7 @@
       margin_bottom: true,
     } %>
 
-    <% attachments = @edition.file_attachment_revisions %>
+    <% attachments = @edition.featured_attachments %>
 
     <h2 class="govuk-heading-m">
       <%= t("featured_attachments.index.featured_attachments.title") %>

--- a/app/views/featured_attachments/reorder.html.erb
+++ b/app/views/featured_attachments/reorder.html.erb
@@ -1,0 +1,35 @@
+<% content_for :back_link, render_back_link(href: featured_attachments_path(@edition.document)) %>
+<% content_for :title, t("featured_attachments.reorder.title", title: @edition.title_or_fallback) %>
+
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-two-thirds">
+    <p class="govuk-body govuk-!-margin-bottom-8 app-js-only">
+      <%= t("featured_attachments.reorder.description") %>
+    </p>
+
+    <p class="govuk-body govuk-!-margin-bottom-8 app-no-js">
+      <%= t("featured_attachments.reorder.nojs_description") %>
+    </p>
+
+    <%= form_tag(
+      reorder_featured_attachments_path(@edition.document),
+      method: :patch,
+      data: { gtm: "save-attachment-order" },
+    ) do %>
+      <%= render "components/reorderable_list", {
+        input_name: "attachments[ordering]",
+        items: @edition.featured_attachments.map do |attachment|
+          {
+            title: attachment.title,
+            order_id: attachment.featured_attachment_id,
+          }
+        end
+      } %>
+
+      <%= render "govuk_publishing_components/components/button", {
+        text: "Save attachment order",
+        margin_bottom: true,
+      } %>
+    <% end %>
+  </div>
+</div>

--- a/config/locales/en/documents/history.yml
+++ b/config/locales/en/documents/history.yml
@@ -41,6 +41,7 @@ en:
         access_limit_updated: "Access limit updated"
         access_limit_removed: "Access limit removed"
         political_status_changed: "History mode criteria updated"
+        attachments_reordered: "Attachments reordered"
         whitehall_migration:
           archived: "Archived"
           deleted: "First created"

--- a/config/locales/en/featured_attachments/reorder.yml
+++ b/config/locales/en/featured_attachments/reorder.yml
@@ -1,0 +1,6 @@
+en:
+  featured_attachments:
+    reorder:
+      title: "Reorder attachments for ‘%{title}’"
+      description: You can drag or drop to change the order of attachments or use the links to move them up or down the list, then save the changes.
+      nojs_description: Reorder position numbers to change the order in which you want attachments listed on GOV.UK. Position 1 will be the first attachment on the page.

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -93,6 +93,8 @@ Rails.application.routes.draw do
     post "/govspeak-preview" => "govspeak_preview#to_html", as: :govspeak_preview
 
     get "/attachments" => "featured_attachments#index", as: :featured_attachments
+    get "/attachments/reorder" => "featured_attachments#reorder", as: :reorder_featured_attachments
+    patch "/attachments/reorder" => "featured_attachments#update_order"
 
     get "/file-attachments" => "file_attachments#index", as: :file_attachments
     get "/file-attachments/new" => "file_attachments#new", as: :new_file_attachment

--- a/db/migrate/20200317152759_add_featured_attachment_ordering.rb
+++ b/db/migrate/20200317152759_add_featured_attachment_ordering.rb
@@ -1,0 +1,5 @@
+class AddFeaturedAttachmentOrdering < ActiveRecord::Migration[6.0]
+  def change
+    add_column :metadata_revisions, :featured_attachment_ordering, :string, array: true, default: [], null: false
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2020_03_13_130700) do
+ActiveRecord::Schema.define(version: 2020_03_17_152759) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -228,6 +228,7 @@ ActiveRecord::Schema.define(version: 2020_03_13_130700) do
     t.string "document_type_id", null: false
     t.boolean "editor_political"
     t.json "change_history", default: [], null: false
+    t.string "featured_attachment_ordering", default: [], null: false, array: true
   end
 
   create_table "removals", force: :cascade do |t|

--- a/spec/factories/edition_factory.rb
+++ b/spec/factories/edition_factory.rb
@@ -15,6 +15,7 @@ FactoryBot.define do
       locale { I18n.available_locales.sample }
       document_type_id { document_type.id }
       document_type { build(:document_type, path_prefix: "/prefix") }
+      featured_attachment_ordering { [] }
       state { "draft" }
       lead_image_revision { nil }
       image_revisions { [] }
@@ -62,6 +63,7 @@ FactoryBot.define do
           lead_image_revision: evaluator.lead_image_revision,
           image_revisions: image_revisions,
           file_attachment_revisions: evaluator.file_attachment_revisions,
+          featured_attachment_ordering: evaluator.featured_attachment_ordering,
           change_history: evaluator.change_history,
         )
       end

--- a/spec/factories/revision_factory.rb
+++ b/spec/factories/revision_factory.rb
@@ -19,6 +19,7 @@ FactoryBot.define do
       backdated_to { nil }
       editor_political { nil }
       change_history { [] }
+      featured_attachment_ordering { [] }
     end
   end
 
@@ -55,6 +56,7 @@ FactoryBot.define do
           document_type_id: evaluator.document_type_id,
           editor_political: evaluator.editor_political,
           change_history: evaluator.change_history,
+          featured_attachment_ordering: evaluator.featured_attachment_ordering,
         )
       end
 

--- a/spec/features/editing_featured_attachments/reorder_attachments_spec.rb
+++ b/spec/features/editing_featured_attachments/reorder_attachments_spec.rb
@@ -1,0 +1,70 @@
+RSpec.feature "Reorder attachments" do
+  scenario "without javascript" do
+    given_there_is_an_edition_with_attachments
+    when_i_go_to_the_attachments_page
+    and_i_click_to_reorder_the_attachments
+    then_i_see_the_current_attachment_order
+    and_i_change_the_numeric_positions
+    then_i_see_the_order_is_updated
+    and_i_see_the_timeline_entry
+  end
+
+  scenario "with javascript", js: true do
+    given_there_is_an_edition_with_attachments
+    when_i_go_to_the_attachments_page
+    and_i_click_to_reorder_the_attachments
+    then_i_see_the_current_attachment_order
+    and_i_move_an_attachment_up
+    then_i_see_the_order_is_updated
+    and_i_see_the_timeline_entry
+  end
+
+  def given_there_is_an_edition_with_attachments
+    @attachment_revision1 = create(:file_attachment_revision)
+    @attachment_revision2 = create(:file_attachment_revision)
+
+    @edition = create(:edition,
+                      document_type: build(:document_type, attachments: "featured"),
+                      file_attachment_revisions: [@attachment_revision1, @attachment_revision2])
+  end
+
+  def when_i_go_to_the_attachments_page
+    visit featured_attachments_path(@edition.document)
+  end
+
+  def and_i_click_to_reorder_the_attachments
+    click_on "Reorder attachments"
+    stub_any_publishing_api_put_content
+    stub_asset_manager_receives_an_asset
+  end
+
+  def then_i_see_the_current_attachment_order
+    expect(all(".app-c-reorderable-list__title").map(&:text)).to eq([
+      @attachment_revision1.title, @attachment_revision2.title
+    ])
+  end
+
+  def and_i_change_the_numeric_positions
+    fill_in "Position for #{@attachment_revision1.title}", with: 2
+    fill_in "Position for #{@attachment_revision2.title}", with: 1
+    click_on "Save attachment order"
+  end
+
+  def and_i_move_an_attachment_up
+    all("button", text: "Up").last.click
+    click_on "Save attachment order"
+  end
+
+  def then_i_see_the_order_is_updated
+    expect(all(".gem-c-attachment__title").map(&:text)).to eq([
+      @attachment_revision2.title,
+      @attachment_revision1.title,
+    ])
+  end
+
+  def and_i_see_the_timeline_entry
+    visit document_path(@edition.document)
+    click_on "Document history"
+    expect(page).to have_content I18n.t!("documents.history.entry_types.attachments_reordered")
+  end
+end

--- a/spec/interactors/featured_attachments/update_order_interactor_spec.rb
+++ b/spec/interactors/featured_attachments/update_order_interactor_spec.rb
@@ -1,0 +1,72 @@
+RSpec.describe FeaturedAttachments::UpdateOrderInteractor do
+  describe "#call" do
+    let(:user) { build(:user) }
+    let(:document_type) { build(:document_type, attachments: "featured") }
+    let(:attachments) { create_list(:file_attachment_revision, 2) }
+    let(:attachment_ids) { attachments.map(&:featured_attachment_id) }
+    let(:ordering_params) { {} }
+
+    let(:params) do
+      ActionController::Parameters.new(document: edition.document.to_param,
+                                       attachments: { ordering: ordering_params })
+    end
+
+    let(:edition) do
+      create :edition,
+             document_type: document_type,
+             file_attachment_revisions: attachments,
+             featured_attachment_ordering: attachment_ids
+    end
+
+    before do
+      stub_any_publishing_api_put_content
+      stub_asset_manager_receives_an_asset
+    end
+
+    context "when the ordering is a sequence" do
+      it "updates the edition with the new ordering" do
+        ordering_params.merge!(attachment_ids[0] => "2", attachment_ids[1] => "1")
+        described_class.call(params: params, user: user)
+        expect(edition.reload.featured_attachment_ordering).to eq attachment_ids.reverse
+      end
+    end
+
+    context "when the ordering is non-sequential" do
+      it "updates the edition with the new ordering" do
+        ordering_params.merge!(attachment_ids[0] => "100", attachment_ids[1] => "-2")
+        described_class.call(params: params, user: user)
+        expect(edition.reload.featured_attachment_ordering).to eq attachment_ids.reverse
+      end
+    end
+
+    context "when the ordering is duplicated" do
+      it "updates the edition with the new ordering" do
+        ordering_params.merge!(attachment_ids[0] => "1", attachment_ids[1] => "1")
+        described_class.call(params: params, user: user)
+        expect(edition.reload.featured_attachment_ordering).to eq attachment_ids
+      end
+    end
+
+    context "when the ordering is malformed" do
+      it "updates the edition with the new ordering" do
+        ordering_params.merge!("InvalidType1" => "1", attachment_ids[1] => "1")
+        described_class.call(params: params, user: user)
+        expect(edition.reload.featured_attachment_ordering).to eq attachment_ids
+      end
+    end
+
+    context "when the ordering is not a hash" do
+      it "updates the edition with the new ordering" do
+        params[:attachments][:ordering] = ""
+        described_class.call(params: params, user: user)
+        expect(edition.reload.featured_attachment_ordering).to eq attachment_ids
+      end
+    end
+
+    it "fails when the ordering is unchanged" do
+      ordering_params.merge!(attachment_ids[0] => "1", attachment_ids[1] => "2")
+      result = described_class.call(params: params, user: user)
+      expect(result).to be_failure
+    end
+  end
+end

--- a/spec/models/metadata_revision/change_history_validator_spec.rb
+++ b/spec/models/metadata_revision/change_history_validator_spec.rb
@@ -1,5 +1,9 @@
-RSpec.describe MetadataRevision do
-  describe "validating change_history" do
+RSpec.describe MetadataRevision::ChangeHistoryValidator do
+  describe "#validate_each" do
+    let(:record) { build :metadata_revision }
+    let(:attribute) { :change_history }
+    let(:validator) { described_class.new(attributes: [attribute]) }
+
     def change_history_item(id: SecureRandom.uuid,
                             note: "Note",
                             public_timestamp: Time.zone.today.rfc3339)
@@ -12,7 +16,8 @@ RSpec.describe MetadataRevision do
         change_history_item(public_timestamp: Time.zone.yesterday.rfc3339),
       ]
 
-      expect(build(:metadata_revision, change_history: change_history)).to be_valid
+      validator.validate_each(record, attribute, change_history)
+      expect(record).to be_valid
     end
 
     it "copes when two items have the same public_timestamp" do
@@ -21,13 +26,14 @@ RSpec.describe MetadataRevision do
         change_history_item(public_timestamp: Time.zone.yesterday.rfc3339),
       ]
 
-      expect(build(:metadata_revision, change_history: change_history)).to be_valid
+      validator.validate_each(record, attribute, change_history)
+      expect(record).to be_valid
     end
 
     it "fails validation if 'id' is missing" do
       change_history = [change_history_item.except("id")]
 
-      expect { build(:metadata_revision, change_history: change_history).valid? }
+      expect { validator.validate_each(record, attribute, change_history) }
         .to raise_error(ActiveModel::StrictValidationFailed,
                         "Change history has an entry with invalid keys")
     end
@@ -35,7 +41,7 @@ RSpec.describe MetadataRevision do
     it "fails validation if 'note' is missing" do
       change_history = [change_history_item.except("note")]
 
-      expect { build(:metadata_revision, change_history: change_history).valid? }
+      expect { validator.validate_each(record, attribute, change_history) }
         .to raise_error(ActiveModel::StrictValidationFailed,
                         "Change history has an entry with invalid keys")
     end
@@ -43,7 +49,7 @@ RSpec.describe MetadataRevision do
     it "fails validation if 'public_timestamp' is missing" do
       change_history = [change_history_item.except("public_timestamp")]
 
-      expect { build(:metadata_revision, change_history: change_history).valid? }
+      expect { validator.validate_each(record, attribute, change_history) }
         .to raise_error(ActiveModel::StrictValidationFailed,
                         "Change history has an entry with invalid keys")
     end
@@ -51,7 +57,7 @@ RSpec.describe MetadataRevision do
     it "fails validation if the 'id' is not a valid UUID" do
       change_history = [change_history_item(id: "1234567-123-123-123-01234567890")]
 
-      expect { build(:metadata_revision, change_history: change_history).valid? }
+      expect { validator.validate_each(record, attribute, change_history) }
         .to raise_error(ActiveModel::StrictValidationFailed,
                         "Change history has an entry with a non UUID id")
     end
@@ -59,7 +65,7 @@ RSpec.describe MetadataRevision do
     it "fails validation if 'public_timestamp' is not a valid date" do
       change_history = [change_history_item(public_timestamp: "20201-13-32 29:61:61")]
 
-      expect { build(:metadata_revision, change_history: change_history).valid? }
+      expect { validator.validate_each(record, attribute, change_history) }
         .to raise_error(ActiveModel::StrictValidationFailed,
                         "Change history has an entry with an invalid timestamp")
     end
@@ -70,7 +76,7 @@ RSpec.describe MetadataRevision do
         change_history_item(public_timestamp: Time.zone.today.rfc3339),
       ]
 
-      expect { build(:metadata_revision, change_history: change_history).valid? }
+      expect { validator.validate_each(record, attribute, change_history) }
         .to raise_error(ActiveModel::StrictValidationFailed,
                         "Change history is not in a reverse chronological ordering")
     end

--- a/spec/models/metadata_revision/featured_attachment_ordering_validator_spec.rb
+++ b/spec/models/metadata_revision/featured_attachment_ordering_validator_spec.rb
@@ -1,0 +1,30 @@
+RSpec.describe MetadataRevision::FeaturedAttachmentOrderingValidator do
+  describe "#validate_each" do
+    let(:record) { build :metadata_revision }
+    let(:attribute) { :featured_attachment_ordering }
+    let(:validator) { described_class.new(attributes: [attribute]) }
+
+    it "validates when the ordering is valid" do
+      validator.validate_each(record, attribute, %w(FileAttachment1))
+      expect(record).to be_valid
+    end
+
+    it "fails if an order item ID is malformed" do
+      expect { validator.validate_each(record, attribute, ["FileAttachment1 "]) }
+        .to raise_error(ActiveModel::StrictValidationFailed,
+                        "Featured attachment ordering has an entry with a malformed ID")
+    end
+
+    it "fails if an order item type is malformed" do
+      expect { validator.validate_each(record, attribute, %w(InvalidType1)) }
+        .to raise_error(ActiveModel::StrictValidationFailed,
+                        "Featured attachment ordering has an entry with a malformed ID")
+    end
+
+    it "fails if there is a duplicate entry" do
+      expect { validator.validate_each(record, attribute, %w(FileAttachment1 FileAttachment1)) }
+        .to raise_error(ActiveModel::StrictValidationFailed,
+                        "Featured attachment ordering has a duplicate entry")
+    end
+  end
+end

--- a/spec/models/revision_spec.rb
+++ b/spec/models/revision_spec.rb
@@ -1,0 +1,35 @@
+RSpec.describe Revision do
+  describe "#featured_attachments" do
+    it "returns all attachments for the revision" do
+      file_attachment = build(:file_attachment_revision)
+      revision = build(:revision, file_attachment_revisions: [file_attachment])
+      expect(revision.featured_attachments).to eq [file_attachment]
+    end
+
+    it "copes if some attachments are not ordered" do
+      file_attachment1 = create(:file_attachment_revision)
+      file_attachment2 = create(:file_attachment_revision)
+      attachments = [file_attachment1, file_attachment2]
+      ordering = [file_attachment1.featured_attachment_id]
+
+      revision = build(:revision,
+                       file_attachment_revisions: attachments,
+                       featured_attachment_ordering: ordering)
+
+      expect(revision.featured_attachments).to eq attachments
+    end
+
+    it "returns attachments in featured order" do
+      file_attachment1 = create(:file_attachment_revision)
+      file_attachment2 = create(:file_attachment_revision)
+      attachments = [file_attachment1, file_attachment2]
+      ordering = attachments.map(&:featured_attachment_id).reverse
+
+      revision = build(:revision,
+                       file_attachment_revisions: attachments,
+                       featured_attachment_ordering: ordering)
+
+      expect(revision.featured_attachments).to eq attachments.reverse
+    end
+  end
+end

--- a/spec/requests/featured_attachments_spec.rb
+++ b/spec/requests/featured_attachments_spec.rb
@@ -1,14 +1,16 @@
 RSpec.describe "Featured Attachments" do
   it_behaves_like "requests that assert edition state",
                   "accessing featured attachments for a non editable edition",
-                  routes: { featured_attachments_path: %i[get] } do
+                  routes: { featured_attachments_path: %i[get],
+                            reorder_featured_attachments_path: %i[get patch] } do
     let(:edition) { create(:edition, :published) }
   end
 
   it_behaves_like "requests that return status",
                   "accessing featured attachments for an edition that doesn't allow them",
                   status: :not_found,
-                  routes: { featured_attachments_path: %i[get] } do
+                  routes: { featured_attachments_path: %i[get],
+                            reorder_featured_attachments_path: %i[get patch] } do
     let(:edition) { create(:edition) }
     let(:route_params) { [edition.document] }
   end
@@ -20,6 +22,33 @@ RSpec.describe "Featured Attachments" do
 
       get featured_attachments_path(edition.document)
       expect(response).to have_http_status(:ok)
+    end
+  end
+
+  describe "GET /documents/:document/attachments/reorder" do
+    it "returns successfully" do
+      document_type = build(:document_type, attachments: "featured")
+      edition = create(:edition, document_type: document_type)
+
+      get reorder_featured_attachments_path(edition.document)
+      expect(response).to have_http_status(:ok)
+    end
+  end
+
+  describe "PATCH /documents/:document/attachments/reorder" do
+    it "redirects to the attachments index" do
+      file_attachment = build(:file_attachment_revision)
+      document_type = build(:document_type, attachments: "featured")
+      stub_any_publishing_api_put_content
+      stub_asset_manager_receives_an_asset
+
+      edition = create(:edition, document_type: document_type,
+                       file_attachment_revisions: [file_attachment])
+
+      patch reorder_featured_attachments_path(edition.document),
+            params: { attachments: { ordering: { "FileAttachment1" => 2 } } }
+
+      expect(response).to redirect_to(featured_attachments_path(edition.document))
     end
   end
 end


### PR DESCRIPTION
https://trello.com/c/7NXYdxZV/1538-user-can-set-desired-featured-attachment-order

This adds a new 'reorder' page/route so a user can set the order of
featured attachments. Ordering for newly uploaded attachments is currently
undefined, and will be addressed in future work. Note that I'm leaving out the 
'Cancel' actions [pending a decision on this](https://trello.com/c/wmJzDSA1/1678-audit-the-use-of-cancel-actions-and-implement-a-policy-for-them).

Please see the commits for more details.

## JS
![Screenshot 2020-03-18 at 13 12 44](https://user-images.githubusercontent.com/9029009/76964307-6dc64d00-691a-11ea-845f-8088cdff1085.png)

## no-JS
![Screenshot 2020-03-18 at 13 15 15](https://user-images.githubusercontent.com/9029009/76964371-86366780-691a-11ea-872d-000bddf910b9.png)
