### PR TITLE
Fix flakey reorderable-list tests

### DIFF
--- a/spec/javascripts/helpers/gtm-mock.js
+++ b/spec/javascripts/helpers/gtm-mock.js
@@ -1,0 +1,5 @@
+/* eslint-env jasmine */
+
+beforeEach(function () {
+  window.dataLayer = []
+})


### PR DESCRIPTION
### What
Attach dataLayer object to `window` to fix flakey `reorderable-list` tests

### Why
The events emitted by the reorderable-list component are picked up by listeners that expect a `dataLayer` object to exist.

Fix tested with `jasmine:ci[true,64655]` seed [which currently fails](https://ci.integration.publishing.service.gov.uk/job/content-publisher/job/missing-full-stop/1/console).