### PR TITLE
Flag that an updated revison is not in sync

### DIFF
--- a/app/services/edit_draft_edition_service.rb
+++ b/app/services/edit_draft_edition_service.rb
@@ -8,10 +8,7 @@ class EditDraftEditionService < ApplicationService
   def call
     raise "cannot edit a live edition" if edition.live?
 
-    edition.assign_attributes(
-      attributes.merge(last_edited_by: user, last_edited_at: Time.zone.now),
-    )
-
+    edition.assign_attributes(extended_attributes)
     determine_political
     associate_with_government
     edition.add_edition_editor(user)
@@ -20,6 +17,12 @@ class EditDraftEditionService < ApplicationService
 private
 
   attr_reader :edition, :user, :attributes
+
+  def extended_attributes
+    result = attributes.merge(last_edited_by: user, last_edited_at: Time.zone.now)
+    result[:revision_synced] = false if attributes.key?(:revision)
+    result
+  end
 
   def determine_political
     identifier = PoliticalEditionIdentifier.new(edition)

--- a/spec/services/edit_draft_edition_service_spec.rb
+++ b/spec/services/edit_draft_edition_service_spec.rb
@@ -1,6 +1,6 @@
 RSpec.describe EditDraftEditionService do
   describe ".call" do
-    let(:edition) { build(:edition) }
+    let(:edition) { build(:edition, revision_synced: true) }
     let(:user) { build(:user) }
 
     it "assigns attributes to an edition" do
@@ -40,6 +40,20 @@ RSpec.describe EditDraftEditionService do
         expect { described_class.call(edition, user) }
           .to change { edition.editors.size }
           .by(1)
+      end
+    end
+
+    describe "updates revision sync flag" do
+      it "flags the revision as out-of-sync if updated" do
+        revision = build(:revision)
+
+        expect { described_class.call(edition, user, revision: revision) }
+          .to change(edition, :revision_synced).to(false)
+      end
+
+      it "preserves revision sync flag if it's not updated" do
+        expect { described_class.call(edition, user) }
+          .not_to change(edition, :revision_synced)
       end
     end
 


### PR DESCRIPTION
https://trello.com/c/7NXYdxZV/1538-user-can-set-desired-featured-attachment-order

Previously we had repeated tests to check that an updated payload
had been sent when a revision-type change was made e.g. editing content
or tags. Later we decided these tests added little value, since we have
a fallback mechanism to support the user doing this manually if need be,
making the need to call the preview service everywhere 'optional'.

However, the fallback mechanism only works if the edition has flagged
that the revision is not in-sync, using the 'revision_synced' attribute.
This works if we encounter a requirements issue, but not if we just forget
to call the preview service in our code.

This updates the EditDraftEditionService to ensure the edition flags
that a revision is out-of-sync, so that the user sees a fallback
'Preview' button and is not blocked from previewing their changes. I
think this is easier than adding back all the repeated tests.

## How the fallback looks (for context)

![Screenshot 2020-03-18 at 18 13 32](https://user-images.githubusercontent.com/9029009/76993133-45ebdf00-6944-11ea-8237-4f1b998f6dae.png)
