### PR TITLE
Don't report postgres errors occurring during data sync

### DIFF
--- a/config/initializers/govuk_error.rb
+++ b/config/initializers/govuk_error.rb
@@ -1,3 +1,14 @@
 GovukError.configure do |config|
   config.excluded_exceptions << "ApplicationController::Forbidden"
+
+  # Don't capture postgres errors that occur during the time that the data sync
+  # is running in integration and staging environments
+  config.should_capture = ->(error) do
+    data_sync_ignored_error = error.is_a?(PG::Error)
+    data_sync_environment = ENV.fetch("SENTRY_CURRENT_ENV", "")
+                               .match(/integration|staging/)
+    data_sync_time = Time.zone.now.hour <= 5
+
+    !(data_sync_ignored_error && data_sync_environment && data_sync_time)
+  end
 end


### PR DESCRIPTION
Data is transferred from production to staging and integration each
night. This transfer involves dropping the database and creating a new
one, this leaves us vulnerable to errors for any scheduled tasks that
run which can cause unactionable noise in our sentry logs.

To try resolve these this change prevents the reporting of errors
to sentry for postgres errors from between midnight and 5am in
integration and staging.

I did hope that I could resolve this by doing configuration on sentry.io
however they don't provide any means to ignore specific errors at either
certain times or in certain environments.

Ideally too it'd be better if we didn't need to do this and had an env
sync process without this problem but that seems like something that is
unlikely to be resolved imminently.