### PR TITLE
Enforce 100% I18n coverage from now on

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -24,6 +24,9 @@ node {
       stage("Lint FactoryBot") {
         sh("bundle exec rake factorybot:lint RAILS_ENV=test")
       }
+      stage("I18n Coverage") {
+        sh("bundle exec rake i18n_cov:ci")
+      }
     }
   )
 }

--- a/Rakefile
+++ b/Rakefile
@@ -2,10 +2,9 @@
 # for example lib/tasks/capistrano.rake, and they will automatically be available to Rake.
 
 require_relative "config/application"
-
 Rails.application.load_tasks
 
 # RSpec shoves itself into the default task without asking, which confuses the ordering.
 # https://github.com/rspec/rspec-rails/blob/eb3377bca425f0d74b9f510dbb53b2a161080016/lib/rspec/rails/tasks/rspec.rake#L6
 Rake::Task[:default].clear
-task default: %i(spec jasmine:ci lint brakeman)
+task default: %i(spec i18n_cov:ci jasmine:ci lint brakeman)

--- a/config/locales/en/document_type_selections.yml
+++ b/config/locales/en/document_type_selections.yml
@@ -5,9 +5,6 @@ en:
     any_mainstream_publication:
       label: Mainstream guide
       description: Guidance for the general public, written for people not expected to have any previous experience or specialist knowledge.
-    any_whitehall_publication:
-      label: Publication
-      description: Standalone government documents that are issued and not usually updated
     articles_and_correspondence:
       label: Articles and correspondence
       description: Articles written by a minister or official, responses from the organisation or a minister, and circulars or newsletters.

--- a/lib/tasks/i18n_cov.rake
+++ b/lib/tasks/i18n_cov.rake
@@ -1,0 +1,17 @@
+require_relative Rails.root.join("spec/support/i18n_cov.rb")
+
+namespace :i18n_cov do
+  desc "Prints I18n Coverage report and returns exit status"
+  task ci: :environment do
+    report = JSON.parse(File.read(I18nCov::REPORT_PATH))
+    puts JSON.pretty_generate(report)
+
+    percent_coverage = report["stats"]["coverage"]
+    Kernel.exit 0 if percent_coverage == 100
+
+    puts "I18n coverage (#{percent_coverage}%) is below the expected minimum coverage (100%)"
+    puts "I18nCov failed with exit 1\n"
+
+    Kernel.exit 1
+  end
+end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -14,9 +14,7 @@ require "govuk_sidekiq/testing"
 require "json_matchers/rspec"
 
 Dir[Rails.root.join("spec/support/**/*.rb")].sort.each { |f| require f }
-SimpleCov.start
 GovukTest.configure
-I18nCov.start
 WebMock.disable_net_connect!(allow_localhost: true)
 Capybara.automatic_label_click = true
 ActiveRecord::Migration.maintain_test_schema!
@@ -37,6 +35,11 @@ RSpec.configure do |config|
   config.include AuthenticationHelper, type: ->(spec) { spec.in?(%i[feature request view]) }
   config.include BulkDataHelper
   config.include Capybara::RSpecMatchers, type: :request
+
+  unless config.files_to_run.one?
+    I18nCov.start
+    SimpleCov.start
+  end
 
   config.before :suite do
     Rails.application.load_seed

--- a/spec/views/documents/index/_results.html.erb_spec.rb
+++ b/spec/views/documents/index/_results.html.erb_spec.rb
@@ -1,0 +1,12 @@
+RSpec.describe "documents/index/_results.html.erb" do
+  describe "Results list" do
+    it "shows a fallback for untitled documents" do
+      edition = create(:edition, title: nil)
+      assign(:editions, Kaminari.paginate_array([edition]).page)
+      assign(:sort, "")
+      assign(:filter_params, {})
+      render
+      expect(rendered).to include(I18n.t!("documents.untitled_document"))
+    end
+  end
+end

--- a/spec/views/documents/show.html.erb_spec.rb
+++ b/spec/views/documents/show.html.erb_spec.rb
@@ -5,6 +5,7 @@ RSpec.describe "documents/show.html.erb" do
   describe "document summary" do
     it "shows the document and edition metadata" do
       edition = create(:edition,
+                       title: "Title",
                        summary: "Summary",
                        last_edited_by: create(:user, name: "User 1"),
                        created_by: create(:user, name: "User 2"))
@@ -15,6 +16,13 @@ RSpec.describe "documents/show.html.erb" do
         .to include("Summary")
         .and have_content(/#{I18n.t!("documents.show.metadata.created_by")}:\s*User 2/)
         .and have_content(/#{I18n.t!("documents.show.metadata.last_edited_by")}:\s*User 1/)
+    end
+
+    it "shows a fallback title if there is none" do
+      edition = create(:edition, title: nil)
+      assign(:edition, edition)
+      render template: "documents/show", layout: "layouts/application"
+      expect(rendered).to include(I18n.t!("documents.untitled_document"))
     end
   end
 


### PR DESCRIPTION
https://trello.com/c/BhRV4Sqy/1679-increase-our-i18n-coverage-to-100

This add an extra step in our internal I18n coverage checker, which will
return a non-zero (error) exit code if the coverage is below 100%. While
this will be the case when running specific tests, it won't interfere with
the test runner e.g.

     Finished in 0.56256 seconds (files took 6.93 seconds to load)
     1 example, 0 failures

     Coverage report generated for I18n to /govuk/content-publisher/coverage/i18n. 7 / 648 keys (1.08%) covered.
     I18n coverage (1.08%) is below the expected minimum coverage (100%)
     I18nCov failed with exit 1
     Coverage report generated for RSpec to /govuk/content-publisher/coverage. 296 / 528 LOC (56.06%) covered.
     SimpleCov failed with exit

Please see the commits for more details.