### PR TITLE
Allow users to add a unique reference to existing attachments

### DIFF
--- a/app/controllers/file_attachments_controller.rb
+++ b/app/controllers/file_attachments_controller.rb
@@ -112,6 +112,10 @@ class FileAttachmentsController < ApplicationController
 
     @attachment = @edition.file_attachment_revisions
       .find_by!(file_attachment_id: params[:file_attachment_id])
+
+    assert_edition_feature(@edition, assertion: "supports featured attachments") do
+      @edition.document_type.attachments.featured?
+    end
   end
 
   def update; end

--- a/app/controllers/file_attachments_controller.rb
+++ b/app/controllers/file_attachments_controller.rb
@@ -115,7 +115,7 @@ class FileAttachmentsController < ApplicationController
   end
 
   def update_file
-    result = FileAttachments::UpdateInteractor.call(params: params, user: current_user)
+    result = FileAttachments::UpdateFileInteractor.call(params: params, user: current_user)
     edition, attachment_revision, issues, unchanged =
       result.to_h.values_at(:edition, :file_attachment_revision, :issues, :unchanged)
 

--- a/app/controllers/file_attachments_controller.rb
+++ b/app/controllers/file_attachments_controller.rb
@@ -118,7 +118,12 @@ class FileAttachmentsController < ApplicationController
     end
   end
 
-  def update; end
+  def update
+    result = FileAttachments::UpdateInteractor.call(params: params, user: current_user)
+    edition = result.edition
+
+    redirect_to featured_attachments_path(edition.document)
+  end
 
   def replace
     @edition = Edition.find_current(document: params[:document])

--- a/app/controllers/file_attachments_controller.rb
+++ b/app/controllers/file_attachments_controller.rb
@@ -120,9 +120,20 @@ class FileAttachmentsController < ApplicationController
 
   def update
     result = FileAttachments::UpdateInteractor.call(params: params, user: current_user)
-    edition = result.edition
+    edition, attachment_revision, issues =
+      result.to_h.values_at(:edition, :file_attachment_revision, :issues)
 
-    redirect_to featured_attachments_path(edition.document)
+    if issues
+      flash.now["requirements"] = { "items" => issues.items }
+
+      render :edit,
+             assigns: { edition: edition,
+                        attachment: attachment_revision,
+                        issues: issues },
+             status: :unprocessable_entity
+    else
+      redirect_to featured_attachments_path(edition.document)
+    end
   end
 
   def replace

--- a/app/controllers/file_attachments_controller.rb
+++ b/app/controllers/file_attachments_controller.rb
@@ -106,6 +106,16 @@ class FileAttachmentsController < ApplicationController
     end
   end
 
+  def edit
+    @edition = Edition.find_current(document: params[:document])
+    assert_edition_state(@edition, &:editable?)
+
+    @attachment = @edition.file_attachment_revisions
+      .find_by!(file_attachment_id: params[:file_attachment_id])
+  end
+
+  def update; end
+
   def replace
     @edition = Edition.find_current(document: params[:document])
     assert_edition_state(@edition, &:editable?)

--- a/app/helpers/file_attachment_helper.rb
+++ b/app/helpers/file_attachment_helper.rb
@@ -14,6 +14,7 @@ module FileAttachmentHelper
       file_size: attachment_revision.byte_size,
       number_of_pages: attachment_revision.number_of_pages,
       url: preview_file_attachment_path(document, attachment_revision.file_attachment),
+      unique_reference: attachment_revision.unique_reference,
     }.compact
   end
 end

--- a/app/helpers/file_attachment_helper.rb
+++ b/app/helpers/file_attachment_helper.rb
@@ -6,7 +6,7 @@ module FileAttachmentHelper
   end
 
   def file_attachment_attributes(attachment_revision, edition)
-    {
+    attributes = {
       id: attachment_revision.filename,
       title: attachment_revision.title,
       filename: attachment_revision.filename,
@@ -14,7 +14,14 @@ module FileAttachmentHelper
       file_size: attachment_revision.byte_size,
       number_of_pages: attachment_revision.number_of_pages,
       url: preview_file_attachment_path(edition.document, attachment_revision.file_attachment),
-      unique_reference: attachment_revision.unique_reference,
-    }.compact
+    }
+
+    if edition.document_type.attachments.featured?
+      attributes.merge!(
+        unique_reference: attachment_revision.unique_reference,
+      )
+    end
+
+    attributes.compact
   end
 end

--- a/app/helpers/file_attachment_helper.rb
+++ b/app/helpers/file_attachment_helper.rb
@@ -5,7 +5,7 @@ module FileAttachmentHelper
     attachment_revision.asset_url + "?" + params
   end
 
-  def file_attachment_attributes(attachment_revision, document)
+  def file_attachment_attributes(attachment_revision, edition)
     {
       id: attachment_revision.filename,
       title: attachment_revision.title,
@@ -13,7 +13,7 @@ module FileAttachmentHelper
       content_type: attachment_revision.content_type,
       file_size: attachment_revision.byte_size,
       number_of_pages: attachment_revision.number_of_pages,
-      url: preview_file_attachment_path(document, attachment_revision.file_attachment),
+      url: preview_file_attachment_path(edition.document, attachment_revision.file_attachment),
       unique_reference: attachment_revision.unique_reference,
     }.compact
   end

--- a/app/interactors/file_attachments/update_file_interactor.rb
+++ b/app/interactors/file_attachments/update_file_interactor.rb
@@ -1,4 +1,4 @@
-class FileAttachments::UpdateInteractor < ApplicationInteractor
+class FileAttachments::UpdateFileInteractor < ApplicationInteractor
   delegate :params,
            :user,
            :edition,

--- a/app/interactors/file_attachments/update_interactor.rb
+++ b/app/interactors/file_attachments/update_interactor.rb
@@ -1,0 +1,63 @@
+class FileAttachments::UpdateInteractor < ApplicationInteractor
+  delegate :params,
+           :user,
+           :edition,
+           :file_attachment_revision,
+           to: :context
+
+  def call
+    Edition.transaction do
+      find_and_lock_edition
+      find_file_attachment
+
+      update_file_attachment
+      update_edition
+
+      create_timeline_entry
+      update_preview
+    end
+  end
+
+private
+
+  def find_and_lock_edition
+    context.edition = Edition.lock.find_current(document: params[:document])
+    assert_edition_state(edition, &:editable?)
+  end
+
+  def find_file_attachment
+    context.file_attachment_revision = edition.file_attachment_revisions
+                                              .find_by!(file_attachment_id: params[:file_attachment_id])
+  end
+
+  def update_file_attachment
+    updater = Versioning::FileAttachmentRevisionUpdater.new(file_attachment_revision, user)
+    revision_attributes = attachment_params.slice(:unique_reference)
+    updater.assign(revision_attributes)
+
+    context.file_attachment_revision = updater.next_revision
+  end
+
+  def update_edition
+    updater = Versioning::RevisionUpdater.new(edition.revision, user)
+    updater.update_file_attachment(file_attachment_revision)
+
+    context.fail!(unchanged: true) unless updater.changed?
+
+    EditDraftEditionService.call(edition, user, revision: updater.next_revision)
+    edition.save!
+  end
+
+  def create_timeline_entry
+    TimelineEntry.create_for_revision(entry_type: :file_attachment_updated,
+                                      edition: edition)
+  end
+
+  def update_preview
+    FailsafeDraftPreviewService.call(edition)
+  end
+
+  def attachment_params
+    params.require(:file_attachment).permit(:unique_reference)
+  end
+end

--- a/app/views/featured_attachments/_featured_attachment.html.erb
+++ b/app/views/featured_attachments/_featured_attachment.html.erb
@@ -2,7 +2,7 @@
 
 <% actions << link_to(
   "Edit attachment",
-  replace_file_attachment_path(document, attachment.file_attachment_id, wizard: "featured"),
+  replace_file_attachment_path(edition.document, attachment.file_attachment_id, wizard: "featured"),
   class: "govuk-link govuk-link--no-visited-state app-link--button",
   data: {
     gtm: "edit-attachment",
@@ -11,7 +11,7 @@
 
 <% actions << link_to(
   "Edit details",
-  edit_file_attachment_path(document, attachment.file_attachment_id),
+  edit_file_attachment_path(edition.document, attachment.file_attachment_id),
   class: "govuk-link govuk-link--no-visited-state app-link--button",
   data: {
     gtm: "edit-details",
@@ -20,7 +20,7 @@
 
 <% actions << link_to(
   "Download",
-  download_file_attachment_path(document, attachment.file_attachment),
+  download_file_attachment_path(edition.document, attachment.file_attachment),
   class: "govuk-link govuk-link--no-visited-state app-link--button",
   data: {
     gtm: "download-attachment"
@@ -29,11 +29,11 @@
 
 <% actions << link_to(
   "Delete attachment",
-  confirm_delete_file_attachment_path(document, attachment.file_attachment_id, wizard: "featured"),
+  confirm_delete_file_attachment_path(edition.document, attachment.file_attachment_id, wizard: "featured"),
   class: "govuk-link app-link--button app-link--destructive",
 ) %>
 
 <%= render "components/attachment_meta", {
-  attachment: file_attachment_attributes(attachment, document),
+  attachment: file_attachment_attributes(attachment, edition),
   actions: actions,
 } %>

--- a/app/views/featured_attachments/_featured_attachment.html.erb
+++ b/app/views/featured_attachments/_featured_attachment.html.erb
@@ -10,6 +10,15 @@
 ) %>
 
 <% actions << link_to(
+  "Edit details",
+  edit_file_attachment_path(document, attachment.file_attachment_id),
+  class: "govuk-link govuk-link--no-visited-state app-link--button",
+  data: {
+    gtm: "edit-details",
+  },
+) %>
+
+<% actions << link_to(
   "Download",
   download_file_attachment_path(document, attachment.file_attachment),
   class: "govuk-link govuk-link--no-visited-state app-link--button",

--- a/app/views/featured_attachments/index.html.erb
+++ b/app/views/featured_attachments/index.html.erb
@@ -25,7 +25,7 @@
       </p>
 
       <% attachments.each do |attachment| %>
-        <%= render "featured_attachment", document: @edition.document, attachment: attachment %>
+        <%= render "featured_attachment", edition: @edition, attachment: attachment %>
       <% end %>
     <% else %>
       <p class="govuk-body">

--- a/app/views/file_attachments/_file_attachment.html.erb
+++ b/app/views/file_attachments/_file_attachment.html.erb
@@ -2,7 +2,7 @@
 
 <% actions << link_to(
   "Insert attachment",
-  file_attachment_path(document, attachment.file_attachment),
+  file_attachment_path(edition.document, attachment.file_attachment),
   class: "govuk-link govuk-link--no-visited-state app-link--button",
   data: {
     "modal-action": "insert",
@@ -12,7 +12,7 @@
 
 <% actions << link_to(
   "Download",
-  download_file_attachment_path(document, attachment.file_attachment),
+  download_file_attachment_path(edition.document, attachment.file_attachment),
   class: "govuk-link govuk-link--no-visited-state app-link--button",
   data: {
     gtm: "download-attachment"
@@ -21,7 +21,7 @@
 
 <% actions << link_to(
   "Edit file",
-  replace_file_attachment_path(document, attachment.file_attachment_id),
+  replace_file_attachment_path(edition.document, attachment.file_attachment_id),
   class: "govuk-link govuk-link--no-visited-state app-link--button",
   data: {
     "modal-action": "edit",
@@ -31,7 +31,7 @@
 
 <% actions << capture do %>
   <%= form_tag(
-    file_attachment_path(document, attachment.file_attachment_id),
+    file_attachment_path(edition.document, attachment.file_attachment_id),
     method: :delete,
     class: "app-inline-block",
     data: {
@@ -44,7 +44,7 @@
 <% end %>
 
 <%= render "components/attachment_meta", {
-  attachment: file_attachment_attributes(attachment, document),
+  attachment: file_attachment_attributes(attachment, edition),
   data_attributes: {
     gtm: "preview-attachment-block"
   },

--- a/app/views/file_attachments/edit.html.erb
+++ b/app/views/file_attachments/edit.html.erb
@@ -1,4 +1,4 @@
-<% content_for :title, t("file_attachments.edit.update.title", title: @edition.title_or_fallback) %>
+<% content_for :title, t("file_attachments.edit.title", title: @edition.title_or_fallback) %>
 <% content_for :back_link, render_back_link(href: featured_attachments_path(@edition.document)) %>
 
 <div class="govuk-grid-row">

--- a/app/views/file_attachments/edit.html.erb
+++ b/app/views/file_attachments/edit.html.erb
@@ -1,0 +1,40 @@
+<% content_for :title, t("file_attachments.edit.update.title", title: @edition.title_or_fallback) %>
+<% content_for :back_link, render_back_link(href: featured_attachments_path(@edition.document),
+                                            data_attributes: { "modal-action": "back" }) %>
+
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-two-thirds">
+    <%= form_tag(
+      edit_file_attachment_path(@edition.document, @attachment.file_attachment_id),
+      method: :patch,
+      multipart: true,
+      data: {
+        "modal-action": "update",
+        gtm: "edit-details"
+      },
+    ) do %>
+      <%= render_govspeak(t("file_attachments.edit.description_govspeak")) %>
+
+      <%= render "govuk_publishing_components/components/input", {
+        label: {
+          text: t("file_attachments.edit.unique_reference.heading"),
+          bold: true
+        },
+        name: "file_attachment[unique_reference]",
+        value: params.dig(:file_attachment, :unique_reference) || @attachment.unique_reference,
+        hint: t("file_attachments.edit.unique_reference.hint_text"),
+      } %>
+
+      <%= render "govuk_publishing_components/components/button", {
+        margin_bottom: true,
+        text: "Save",
+      } %>
+
+      <div class="govuk-body">
+        <%= link_to "Cancel",
+                  featured_attachments_path(@edition.document),
+                  class: "govuk-link govuk-link--no-visited-state" %>
+      </div>
+    <% end %>
+  </div>
+</div>

--- a/app/views/file_attachments/edit.html.erb
+++ b/app/views/file_attachments/edit.html.erb
@@ -1,6 +1,5 @@
 <% content_for :title, t("file_attachments.edit.update.title", title: @edition.title_or_fallback) %>
-<% content_for :back_link, render_back_link(href: featured_attachments_path(@edition.document),
-                                            data_attributes: { "modal-action": "back" }) %>
+<% content_for :back_link, render_back_link(href: featured_attachments_path(@edition.document)) %>
 
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
@@ -9,8 +8,7 @@
       method: :patch,
       multipart: true,
       data: {
-        "modal-action": "update",
-        gtm: "edit-details"
+        gtm: "save-attachment-details"
       },
     ) do %>
       <%= render_govspeak(t("file_attachments.edit.description_govspeak")) %>

--- a/app/views/file_attachments/index.html.erb
+++ b/app/views/file_attachments/index.html.erb
@@ -48,7 +48,7 @@
       </h2>
 
       <% attachments.each do |attachment| %>
-        <%= render "file_attachment", document: @edition.document, attachment: attachment %>
+        <%= render "file_attachment", edition: @edition, attachment: attachment %>
       <% end %>
     <% end %>
   </div>

--- a/app/views/file_attachments/show.html.erb
+++ b/app/views/file_attachments/show.html.erb
@@ -5,7 +5,7 @@
 <div class="govuk-grid-row">
   <div class="<%= rendering_context == 'modal' ? 'govuk-grid-column-full' : 'govuk-grid-column-two-thirds' %>">
     <%= render "govuk_publishing_components/components/attachment", {
-      attachment: file_attachment_attributes(@attachment, @edition.document),
+      attachment: file_attachment_attributes(@attachment, @edition),
       target: "_blank",
       data_attributes: {
         gtm: "preview-attachment-block"
@@ -41,7 +41,7 @@
 
     <div class="govuk-body">
       <%= render "govuk_publishing_components/components/attachment_link", {
-        attachment: file_attachment_attributes(@attachment, @edition.document),
+        attachment: file_attachment_attributes(@attachment, @edition),
         target: "_blank",
         data_attributes: { gtm: "preview-attachment-link" }
       } %>

--- a/config/locales/en/file_attachments/edit.yml
+++ b/config/locales/en/file_attachments/edit.yml
@@ -1,0 +1,10 @@
+en:
+  file_attachments:
+    edit:
+      update:
+        title: "Update attachment details for ‘%{title}’"
+      description_govspeak: |
+        Include these details if the document contains them to help users find and identify the publication.
+      unique_reference:
+        heading: Unique reference
+        hint_text: Add your organisation's own reference if it has one.

--- a/config/locales/en/file_attachments/edit.yml
+++ b/config/locales/en/file_attachments/edit.yml
@@ -1,8 +1,7 @@
 en:
   file_attachments:
     edit:
-      update:
-        title: "Update attachment details for ‘%{title}’"
+      title: "Update attachment details for ‘%{title}’"
       description_govspeak: |
         Include these details if the document contains them to help users find and identify the publication.
       unique_reference:

--- a/config/locales/en/requirements.yml
+++ b/config/locales/en/requirements.yml
@@ -76,6 +76,9 @@ en:
         form_message: Enter a title
       too_long:
         form_message: "Enter a title that is fewer than %{max_length} characters long"
+    file_attachment_unique_reference:
+      too_long:
+        form_message: "Enter a unique reference that is fewer than %{max_length} characters long"
     public_explanation:
       blank:
         form_message: Enter a public explanation

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -102,6 +102,8 @@ Rails.application.routes.draw do
     get "/file-attachments/:file_attachment_id/download" => "file_attachments#download", as: :download_file_attachment
     get "/file-attachments/:file_attachment_id/replace" => "file_attachments#replace", as: :replace_file_attachment
     patch "/file-attachments/:file_attachment_id/replace" => "file_attachments#update_file"
+    get "/file-attachments/:file_attachment_id/edit" => "file_attachments#edit", as: :edit_file_attachment
+    patch "/file-attachments/:file_attachment_id/edit" => "file_attachments#update"
     delete "/file-attachments/:file_attachment_id" => "file_attachments#destroy"
     get "/file-attachments/:file_attachment_id/delete" => "file_attachments#confirm_delete", as: :confirm_delete_file_attachment
   end

--- a/lib/govspeak_document/in_app_options.rb
+++ b/lib/govspeak_document/in_app_options.rb
@@ -21,7 +21,7 @@ private
 
   def attachment_attributes(attachment_revision)
     alt_email = Organisations.new(edition).alternative_format_contact_email
-    attributes = file_attachment_attributes(attachment_revision, edition.document)
+    attributes = file_attachment_attributes(attachment_revision, edition)
     attributes.merge(alternative_format_contact_email: alt_email)
   end
 

--- a/lib/govspeak_document/payload_options.rb
+++ b/lib/govspeak_document/payload_options.rb
@@ -33,7 +33,7 @@ private
 
   def attachment_attributes(attachment_revision)
     alt_email = Organisations.new(edition).alternative_format_contact_email
-    attributes = file_attachment_attributes(attachment_revision, edition.document)
+    attributes = file_attachment_attributes(attachment_revision, edition)
 
     attributes.merge(
       url: attachment_revision.asset_url,

--- a/lib/publishing_api_payload.rb
+++ b/lib/publishing_api_payload.rb
@@ -92,7 +92,7 @@ private
     file_attachments = edition.file_attachment_revisions
 
     file_attachments.map do |attachment|
-      FileAttachmentPayload.new(attachment, edition.document).payload
+      FileAttachmentPayload.new(attachment, edition).payload
     end
   end
 end

--- a/lib/publishing_api_payload/file_attachment_payload.rb
+++ b/lib/publishing_api_payload/file_attachment_payload.rb
@@ -2,20 +2,20 @@ class PublishingApiPayload::FileAttachmentPayload
   include Rails.application.routes.url_helpers
   include FileAttachmentHelper
 
-  attr_reader :attachment, :document
+  attr_reader :attachment, :edition
 
-  def initialize(attachment, document)
+  def initialize(attachment, edition)
     @attachment = attachment
-    @document = document
+    @edition = edition
   end
 
   def payload
     payload = {
       attachment_type: "file",
-      locale: document.locale,
+      locale: edition.locale,
       url: attachment.asset_url,
     }
 
-    file_attachment_attributes(attachment, document).merge!(payload)
+    file_attachment_attributes(attachment, edition).merge!(payload)
   end
 end

--- a/lib/requirements/file_attachment_metadata_checker.rb
+++ b/lib/requirements/file_attachment_metadata_checker.rb
@@ -1,0 +1,30 @@
+module Requirements
+  class FileAttachmentMetadataChecker
+    UNIQUE_REF_MAX_LENGTH = 255
+
+    attr_reader :unique_reference
+
+    def initialize(unique_reference: nil)
+      @unique_reference = unique_reference
+    end
+
+    def pre_update_issues
+      unique_reference_issues
+    end
+
+  private
+
+    def unique_reference_issues
+      issues = CheckerIssues.new
+
+      if unique_reference.present? &&
+          unique_reference.to_s.size > UNIQUE_REF_MAX_LENGTH
+        issues.create(:file_attachment_unique_reference,
+                      :too_long,
+                      max_length: UNIQUE_REF_MAX_LENGTH)
+      end
+
+      issues
+    end
+  end
+end

--- a/spec/factories/file_attachment_metadata_revision_factory.rb
+++ b/spec/factories/file_attachment_metadata_revision_factory.rb
@@ -2,6 +2,5 @@ FactoryBot.define do
   factory :file_attachment_metadata_revision, class: "FileAttachment::MetadataRevision" do
     association :created_by, factory: :user
     title { SecureRandom.hex(8) }
-    unique_reference { SecureRandom.alphanumeric(10) }
   end
 end

--- a/spec/factories/file_attachment_metadata_revision_factory.rb
+++ b/spec/factories/file_attachment_metadata_revision_factory.rb
@@ -2,5 +2,6 @@ FactoryBot.define do
   factory :file_attachment_metadata_revision, class: "FileAttachment::MetadataRevision" do
     association :created_by, factory: :user
     title { SecureRandom.hex(8) }
+    unique_reference { SecureRandom.alphanumeric(10) }
   end
 end

--- a/spec/factories/file_attachment_revision_factory.rb
+++ b/spec/factories/file_attachment_revision_factory.rb
@@ -6,6 +6,7 @@ FactoryBot.define do
     transient do
       filename { SecureRandom.hex(8) }
       number_of_pages { nil }
+      unique_reference { nil }
       fixture { "text-file-74bytes.txt" }
       title { SecureRandom.hex(8) }
       asset { nil }
@@ -26,6 +27,7 @@ FactoryBot.define do
         revision.metadata_revision = evaluator.association(
           :file_attachment_metadata_revision,
           title: evaluator.title,
+          unique_reference: evaluator.unique_reference,
         )
       end
     end
@@ -49,6 +51,7 @@ FactoryBot.define do
         revision.metadata_revision = evaluator.association(
           :file_attachment_metadata_revision,
           title: evaluator.title,
+          unique_reference: evaluator.unique_reference,
         )
       end
     end

--- a/spec/features/editing_file_attachments/edit_file_attachment_file_spec.rb
+++ b/spec/features/editing_file_attachments/edit_file_attachment_file_spec.rb
@@ -3,7 +3,8 @@ RSpec.feature "Edit a file attachment file", js: true do
     given_there_is_an_edition_with_featured_attachments
     when_i_go_to_edit_an_attachment
     and_i_add_a_unique_reference
-    then_i_see_the_timeline_entry
+    then_i_see_the_unique_reference
+    and_i_see_the_timeline_entry
   end
 
   def given_there_is_an_edition_with_featured_attachments
@@ -23,11 +24,17 @@ RSpec.feature "Edit a file attachment file", js: true do
     stub_publishing_api_put_content(@edition.content_id, {})
     stub_asset_manager_receives_an_asset
 
-    fill_in "file_attachment[unique_reference]", with: "A unique reference"
+    @unique_reference = "A unique reference"
+
+    fill_in "file_attachment[unique_reference]", with: @unique_reference
     click_on "Save"
   end
 
-  def then_i_see_the_timeline_entry
+  def then_i_see_the_unique_reference
+    expect(page).to have_content(@unique_reference)
+  end
+
+  def and_i_see_the_timeline_entry
     visit document_path(@edition.document)
     click_on "Document history"
     expect(page).to have_content I18n.t!("documents.history.entry_types.file_attachment_updated")

--- a/spec/features/editing_file_attachments/edit_file_attachment_file_spec.rb
+++ b/spec/features/editing_file_attachments/edit_file_attachment_file_spec.rb
@@ -1,0 +1,35 @@
+RSpec.feature "Edit a file attachment file", js: true do
+  scenario do
+    given_there_is_an_edition_with_featured_attachments
+    when_i_go_to_edit_an_attachment
+    and_i_add_a_unique_reference
+    then_i_see_the_timeline_entry
+  end
+
+  def given_there_is_an_edition_with_featured_attachments
+    @attachment_revision = create(:file_attachment_revision)
+
+    @edition = create(:edition,
+                      document_type: build(:document_type, attachments: "featured"),
+                      file_attachment_revisions: [@attachment_revision])
+  end
+
+  def when_i_go_to_edit_an_attachment
+    visit featured_attachments_path(@edition.document)
+    click_on "Edit details"
+  end
+
+  def and_i_add_a_unique_reference
+    stub_publishing_api_put_content(@edition.content_id, {})
+    stub_asset_manager_receives_an_asset
+
+    fill_in "file_attachment[unique_reference]", with: "A unique reference"
+    click_on "Save"
+  end
+
+  def then_i_see_the_timeline_entry
+    visit document_path(@edition.document)
+    click_on "Document history"
+    expect(page).to have_content I18n.t!("documents.history.entry_types.file_attachment_updated")
+  end
+end

--- a/spec/features/editing_file_attachments/edit_file_attachment_spec.rb
+++ b/spec/features/editing_file_attachments/edit_file_attachment_spec.rb
@@ -1,4 +1,4 @@
-RSpec.feature "Edit a file attachment", js: true do
+RSpec.feature "Edit a file attachment" do
   scenario do
     given_there_is_an_edition_with_featured_attachments
     when_i_go_to_edit_an_attachment

--- a/spec/features/editing_file_attachments/edit_file_attachment_spec.rb
+++ b/spec/features/editing_file_attachments/edit_file_attachment_spec.rb
@@ -1,9 +1,9 @@
-RSpec.feature "Edit a file attachment file", js: true do
+RSpec.feature "Edit a file attachment", js: true do
   scenario do
     given_there_is_an_edition_with_featured_attachments
     when_i_go_to_edit_an_attachment
-    and_i_add_a_unique_reference
-    then_i_see_the_unique_reference
+    and_i_edit_the_attachment_metadata
+    then_i_see_the_attachment_is_updated
     and_i_see_the_timeline_entry
   end
 
@@ -20,7 +20,7 @@ RSpec.feature "Edit a file attachment file", js: true do
     click_on "Edit details"
   end
 
-  def and_i_add_a_unique_reference
+  def and_i_edit_the_attachment_metadata
     stub_publishing_api_put_content(@edition.content_id, {})
     stub_asset_manager_receives_an_asset
 
@@ -30,7 +30,7 @@ RSpec.feature "Edit a file attachment file", js: true do
     click_on "Save"
   end
 
-  def then_i_see_the_unique_reference
+  def then_i_see_the_attachment_is_updated
     expect(page).to have_content(@unique_reference)
   end
 

--- a/spec/lib/publishing_api_payload/file_attachment_payload_spec.rb
+++ b/spec/lib/publishing_api_payload/file_attachment_payload_spec.rb
@@ -16,6 +16,7 @@ RSpec.describe PublishingApiPayload::FileAttachmentPayload do
         number_of_pages: attachment.number_of_pages,
         title: attachment.title,
         url: attachment.asset_url,
+        unique_reference: attachment.unique_reference,
       }
 
       expect(payload).to match a_hash_including(expected_payload)

--- a/spec/lib/publishing_api_payload/file_attachment_payload_spec.rb
+++ b/spec/lib/publishing_api_payload/file_attachment_payload_spec.rb
@@ -16,6 +16,22 @@ RSpec.describe PublishingApiPayload::FileAttachmentPayload do
         number_of_pages: attachment.number_of_pages,
         title: attachment.title,
         url: attachment.asset_url,
+      }
+
+      expect(payload).to match a_hash_including(expected_payload)
+    end
+
+    it "adds extra metadata if the document has featured attachments" do
+      attachment = build(:file_attachment_revision,
+                         unique_reference: "unique ref")
+
+      edition = create(:edition,
+                       document_type: build(:document_type, attachments: "featured"),
+                       file_attachment_revisions: [attachment])
+
+      payload = described_class.new(attachment, edition).payload
+
+      expected_payload = {
         unique_reference: attachment.unique_reference,
       }
 

--- a/spec/lib/publishing_api_payload/file_attachment_payload_spec.rb
+++ b/spec/lib/publishing_api_payload/file_attachment_payload_spec.rb
@@ -4,7 +4,7 @@ RSpec.describe PublishingApiPayload::FileAttachmentPayload do
       attachment = build(:file_attachment_revision, number_of_pages: 1)
       edition = create(:edition, file_attachment_revisions: [attachment])
 
-      payload = described_class.new(attachment, edition.document).payload
+      payload = described_class.new(attachment, edition).payload
 
       expected_payload = {
         attachment_type: "file",

--- a/spec/lib/publishing_api_payload_spec.rb
+++ b/spec/lib/publishing_api_payload_spec.rb
@@ -66,7 +66,7 @@ RSpec.describe PublishingApiPayload do
 
       payload = described_class.new(edition).payload
       attachment_payload = PublishingApiPayload::FileAttachmentPayload
-                             .new(file_attachment_revision, edition.document)
+                             .new(file_attachment_revision, edition)
                              .payload
 
       expect(payload[:details][:attachments]).to contain_exactly(attachment_payload)

--- a/spec/lib/requirements/file_attachment_metadata_checker_spec.rb
+++ b/spec/lib/requirements/file_attachment_metadata_checker_spec.rb
@@ -1,0 +1,20 @@
+RSpec.describe Requirements::FileAttachmentMetadataChecker do
+  describe "#pre_update_issues" do
+    let(:max_length) { Requirements::FileAttachmentMetadataChecker::UNIQUE_REF_MAX_LENGTH }
+
+    it "returns no issues if there are none" do
+      unique_reference = "z" * max_length
+      issues = described_class.new(unique_reference: unique_reference).pre_update_issues
+      expect(issues).to be_empty
+    end
+
+    it "returns unique_reference issues when the unique unique_reference is too long" do
+      unique_reference = "z" * (max_length + 1)
+      issues = described_class.new(unique_reference: unique_reference).pre_update_issues
+
+      expect(issues).to have_issue(:file_attachment_unique_reference,
+                                   :too_long,
+                                   max_length: max_length)
+    end
+  end
+end

--- a/spec/requests/file_attachments_spec.rb
+++ b/spec/requests/file_attachments_spec.rb
@@ -33,6 +33,15 @@ RSpec.describe "File Attachments" do
   end
 
   it_behaves_like "requests that return status",
+                  "editing featured attachments for an edition that doesn't allow them",
+                  status: :not_found,
+                  routes: { edit_file_attachment_path: %i[get] } do
+    let(:edition) { create(:edition) }
+    let(:file_attachment_revision) { create(:file_attachment_revision) }
+    let(:route_params) { [edition.document, file_attachment_revision] }
+  end
+
+  it_behaves_like "requests that return status",
                   "adding featured attachments for an edition that doesn't allow them",
                   status: :not_found,
                   routes: { new_file_attachment_path: %i[get] } do
@@ -258,8 +267,10 @@ RSpec.describe "File Attachments" do
   describe "GET /documents/:document/file-attachments/:file_attachment_id/edit" do
     it "returns successfully" do
       file_attachment_revision = create(:file_attachment_revision)
+      document_type = build(:document_type, attachments: "featured")
       edition = create(:edition,
-                       file_attachment_revisions: [file_attachment_revision])
+                       file_attachment_revisions: [file_attachment_revision],
+                       document_type: document_type)
 
       get edit_file_attachment_path(edition.document,
                                     file_attachment_revision.file_attachment_id)

--- a/spec/requests/file_attachments_spec.rb
+++ b/spec/requests/file_attachments_spec.rb
@@ -12,7 +12,8 @@ RSpec.describe "File Attachments" do
                             replace_file_attachment_path: %i[get patch],
                             preview_file_attachment_path: %i[get],
                             confirm_delete_file_attachment_path: %i[get],
-                            download_file_attachment_path: %i[get] } do
+                            download_file_attachment_path: %i[get],
+                            edit_file_attachment_path: %i[get] } do
     let(:edition) { create(:edition, :published) }
     let(:route_params) { [edition.document, "file_attachment_id"] }
   end
@@ -24,7 +25,8 @@ RSpec.describe "File Attachments" do
                             replace_file_attachment_path: %i[get patch],
                             preview_file_attachment_path: %i[get],
                             confirm_delete_file_attachment_path: %i[get],
-                            download_file_attachment_path: %i[get] } do
+                            download_file_attachment_path: %i[get],
+                            edit_file_attachment_path: %i[get] } do
     let(:edition) { create(:edition) }
     let(:file_attachment_revision) { create(:file_attachment_revision) }
     let(:route_params) { [edition.document, file_attachment_revision] }
@@ -250,6 +252,18 @@ RSpec.describe "File Attachments" do
       expect(response.body).to have_content(
         I18n.t!("requirements.file_attachment_title.blank.form_message"),
       )
+    end
+  end
+
+  describe "GET /documents/:document/file-attachments/:file_attachment_id/edit" do
+    it "returns successfully" do
+      file_attachment_revision = create(:file_attachment_revision)
+      edition = create(:edition,
+                       file_attachment_revisions: [file_attachment_revision])
+
+      get edit_file_attachment_path(edition.document,
+                                    file_attachment_revision.file_attachment_id)
+      expect(response).to have_http_status(:ok)
     end
   end
 

--- a/spec/requests/file_attachments_spec.rb
+++ b/spec/requests/file_attachments_spec.rb
@@ -278,6 +278,25 @@ RSpec.describe "File Attachments" do
     end
   end
 
+  describe "PATCH /documents/:document/file-attachments/:file_attachment_id/edit" do
+    it "redirects to the featured attachments index page" do
+      stub_any_publishing_api_put_content
+      stub_asset_manager_receives_an_asset
+
+      file_attachment_revision = create(:file_attachment_revision)
+      document_type = build(:document_type, attachments: "featured")
+      edition = create(:edition,
+                       file_attachment_revisions: [file_attachment_revision],
+                       document_type: document_type)
+
+      patch edit_file_attachment_path(edition.document,
+                                      file_attachment_revision.file_attachment_id),
+            params: { file_attachment: { unique_reference: "Uniq Ref" } }
+
+      expect(response).to redirect_to(featured_attachments_path(edition.document))
+    end
+  end
+
   describe "GET /documents/:document/file_attachments/:file_attachment_id/download" do
     it "provides a file attachment download" do
       file_attachment_revision = create(:file_attachment_revision)


### PR DESCRIPTION
Trello: https://trello.com/c/QZmkUoTr

# What's changed?

Adds an edit page that allows users to add a unique reference to existing attachments. The work to allow users to add a unique reference to new attachments will follow in the next PR.

This PR focuses on setting up the architecture of the edit details page (controller actions, route, validations and tests) and should hopefully unblock the work to add the ISBN and Command Paper details.

# Expected changes

<img width="1532" alt="Screenshot 2020-03-20 at 09 36 33" src="https://user-images.githubusercontent.com/5793815/77151869-c4549800-6a8e-11ea-94ad-4f1171fcc68b.png">
<img width="1532" alt="Screenshot 2020-03-20 at 09 36 48" src="https://user-images.githubusercontent.com/5793815/77151868-c3bc0180-6a8e-11ea-8cd0-05927c7b8c0e.png">
<img width="1532" alt="Screenshot 2020-03-19 at 12 15 56" src="https://user-images.githubusercontent.com/5793815/77151860-c0287a80-6a8e-11ea-8158-80c2cc6f3d16.png">
