### PR TITLE
Only show reorder action for multiple attachments

### DIFF
--- a/app/views/featured_attachments/index.html.erb
+++ b/app/views/featured_attachments/index.html.erb
@@ -24,14 +24,16 @@
         <%= t("featured_attachments.index.featured_attachments.description_govspeak") %>
       </p>
 
-      <p class="govuk-body govuk-!-margin-bottom-8">
-        <%= link_to(
-          "Reorder attachments",
-          reorder_featured_attachments_path(@edition.document),
-          class: "govuk-link",
-          data: { gtm: "reorder-attachments" }
-        ) %>
-      </p>
+      <% if attachments.count > 1 %>
+        <p class="govuk-body govuk-!-margin-bottom-8">
+          <%= link_to(
+            "Reorder attachments",
+            reorder_featured_attachments_path(@edition.document),
+            class: "govuk-link",
+            data: { gtm: "reorder-attachments" }
+          ) %>
+        </p>
+      <% end %>
 
       <% attachments.each do |attachment| %>
         <%= render "featured_attachment", document: @edition.document, attachment: attachment %>

--- a/spec/views/featured_attachments/index.html.erb_spec.rb
+++ b/spec/views/featured_attachments/index.html.erb_spec.rb
@@ -12,7 +12,18 @@ RSpec.describe "featured_attachments/index.html.erb" do
     it "shows a message when there aren't any attachments" do
       assign(:edition, create(:edition))
 
-      expect(render).to have_content(I18n.t("featured_attachments.index.no_attachments"))
+      expect(render).to have_content(I18n.t!("featured_attachments.index.no_attachments"))
+    end
+
+    it "only shows a reorder action for multiple attachments" do
+      edition = create(:edition)
+      edition.file_attachment_revisions << build(:file_attachment_revision)
+
+      assign(:edition, edition)
+      expect(render).not_to have_content("Reorder attachments")
+
+      edition.file_attachment_revisions << build(:file_attachment_revision)
+      expect(render).to have_content("Reorder attachments")
     end
   end
 end


### PR DESCRIPTION
https://trello.com/c/7NXYdxZV/1538-user-can-set-desired-featured-attachment-order

This is consistent with the prototype.