### PR TITLE
Check edition state in integrity check

### DIFF
--- a/lib/whitehall_importer/integrity_checker.rb
+++ b/lib/whitehall_importer/integrity_checker.rb
@@ -129,15 +129,7 @@ module WhitehallImporter
     def unpublishing_problems
       problems = []
       return problems unless edition.withdrawn? || edition.removed?
-
-      unless expected_state?
-        problems << problem_description(
-          "edition state isn't as expected",
-          "unpublished",
-          publishing_api_content.dig("publication_state"),
-        )
-        return problems
-      end
+      return problems << "publishing_api_unpublishing is missing" if publishing_api_unpublishing.blank?
 
       check = UnpublishingCheck.new(edition, publishing_api_unpublishing)
 
@@ -219,11 +211,6 @@ module WhitehallImporter
       attribute == "alt_text" &&
         proposed_image_payload.empty? &&
         publishing_api_image[attribute] == "placeholder"
-    end
-
-    def expected_state?
-      %w[withdrawn removed].include?(edition.state) &&
-        publishing_api_content.dig("publication_state") == "unpublished"
     end
 
     def publishing_api_unpublishing

--- a/lib/whitehall_importer/integrity_checker.rb
+++ b/lib/whitehall_importer/integrity_checker.rb
@@ -23,7 +23,7 @@ module WhitehallImporter
 
     def problems
       content_problems + image_problems + organisation_problems +
-        time_problems + unpublishing_problems
+        time_problems + state_problems + unpublishing_problems
     end
 
     def proposed_payload
@@ -86,6 +86,30 @@ module WhitehallImporter
       self.class.time_matches?(proposed_time, publishing_api_time)
     end
 
+    def state_problems
+      problems = []
+
+      unless publishing_api_content["publication_state"] == expected_state
+        problems << problem_description("publication_state isn't as expected",
+                                        publishing_api_content["publication_state"],
+                                        expected_state)
+      end
+
+      problems
+    end
+
+    def expected_state
+      if %w[removed withdrawn].include?(edition.state)
+        "unpublished"
+      elsif %w[published published_but_needs_2i].include?(edition.state)
+        "published"
+      elsif %w[scheduled submitted_for_review draft].include?(edition.state)
+        "draft"
+      else
+        "superseded"
+      end
+    end
+
     def image_problems
       proposed_image_payload = proposed_payload.dig("details", "image") || {}
       publishing_api_image = publishing_api_content.dig("details", "image") || {}
@@ -129,7 +153,7 @@ module WhitehallImporter
     def unpublishing_problems
       problems = []
       return problems unless edition.withdrawn? || edition.removed?
-      return problems << "publishing_api_unpublishing is missing" if publishing_api_unpublishing.blank?
+      return problems << "publishing api's unpublishing is missing" if publishing_api_unpublishing.blank?
 
       check = UnpublishingCheck.new(edition, publishing_api_unpublishing)
 

--- a/spec/lib/whitehall_importer/integrity_checker_spec.rb
+++ b/spec/lib/whitehall_importer/integrity_checker_spec.rb
@@ -417,16 +417,14 @@ RSpec.describe WhitehallImporter::IntegrityChecker do
         stub_publishing_api_has_item(publishing_api_item)
       end
 
-      it "returns a problem if the publication_state isn't 'unpublished' in Publishing API" do
+      it "returns a problem when the publishing_api_unpublishing is missing" do
         publishing_api_item = default_publishing_api_item(edition,
                                                           publication_state: "published")
         stub_publishing_api_has_item(publishing_api_item)
-        expected = "unpublished"
-        actual = publishing_api_item[:publication_state]
         integrity_check = described_class.new(edition)
 
         expect(integrity_check.problems).to include(
-          "edition state isn't as expected, expected: #{expected.inspect}, actual: #{actual.inspect}",
+          "publishing_api_unpublishing is missing",
         )
       end
 
@@ -469,19 +467,6 @@ RSpec.describe WhitehallImporter::IntegrityChecker do
 
       before do
         stub_publishing_api_has_item(publishing_api_item)
-      end
-
-      it "returns a problem if the publication_state isn't 'unpublished' in Publishing API" do
-        publishing_api_item = default_publishing_api_item(edition,
-                                                          publication_state: "published")
-        stub_publishing_api_has_item(publishing_api_item)
-        expected = "unpublished"
-        actual = publishing_api_item[:publication_state]
-        integrity_check = described_class.new(edition)
-
-        expect(integrity_check.problems).to include(
-          "edition state isn't as expected, expected: #{expected.inspect}, actual: #{actual.inspect}",
-        )
       end
 
       it "returns a problem when the unpublishing type isn't correct" do


### PR DESCRIPTION
We now want to check the editions state in the integrity checker to verify it's represented correctly between content-publisher and publishing-api. The states don't always have a 1 to 1 matching as content-publisher can have multiple internal states which are equivalent to a publishing-api state. E.g content-publisher's published_but_needs_2i and published map to publishing-api's published state.

Trello:
https://trello.com/c/nuK7ICOU/1591-integrity-check-for-edition-state