### PR TITLE
Fix change_history bug

### DIFF
--- a/lib/whitehall_importer/integrity_checker.rb
+++ b/lib/whitehall_importer/integrity_checker.rb
@@ -58,7 +58,7 @@ module WhitehallImporter
 
       problems << "change history doesn't match" unless ChangeHistoryCheck.new(
         proposed_payload.dig("details", "change_history"),
-        publishing_api_content.dig("details", "change_history"),
+        publishing_api_content["details"].fetch("change_history", []),
         live_edition: edition.live?,
       ).match?
 

--- a/spec/lib/whitehall_importer/integrity_checker_spec.rb
+++ b/spec/lib/whitehall_importer/integrity_checker_spec.rb
@@ -109,6 +109,17 @@ RSpec.describe WhitehallImporter::IntegrityChecker do
       expect(integrity_check.valid?).to be true
     end
 
+    context "when checking the first edition" do
+      let(:state) { :scheduled }
+
+      it "returns true when there is no change history" do
+        publishing_api_item[:details] = publishing_api_item[:details].except(:change_history)
+        stub_publishing_api_has_item(publishing_api_item)
+
+        expect(integrity_check.valid?).to be true
+      end
+    end
+
     context "when checking an edition that isn't live" do
       let(:state) { :scheduled }
 


### PR DESCRIPTION
This fixes a bug introduced where by an error is thrown if there is no
change_history for the publishing_api_item, this occurs when the edition
is the first draft. The error is a method error when we call length on
the change_history from within ChangeHistoryCheck.

This commit sets the default change_history to an empty array if it's
not present so length now returns 0 instead of a method error.

The offending line is here - https://github.com/alphagov/content-publisher/blob/master/lib/whitehall_importer/integrity_checker/change_history_check.rb#L24