### PR TITLE
Handle editions with no change history in Integrity Checker

### DIFF
--- a/lib/whitehall_importer/integrity_checker.rb
+++ b/lib/whitehall_importer/integrity_checker.rb
@@ -58,7 +58,7 @@ module WhitehallImporter
 
       problems << "change history doesn't match" unless ChangeHistoryCheck.new(
         proposed_payload.dig("details", "change_history"),
-        publishing_api_content.dig("details", "change_history"),
+        publishing_api_content["details"].fetch("change_history", []),
         live_edition: edition.live?,
       ).match?
 

--- a/lib/whitehall_importer/integrity_checker/change_history_check.rb
+++ b/lib/whitehall_importer/integrity_checker/change_history_check.rb
@@ -9,6 +9,10 @@ module WhitehallImporter
     end
 
     def match?
+      if publishing_api_change_history.empty?
+        return proposed_history_has_first_published_change_note?
+      end
+
       return false unless history_length_matches?
 
       if live_edition
@@ -42,6 +46,11 @@ module WhitehallImporter
       remaining_history_matches = history_matches?(proposed_tail, publishing_api_tail)
 
       first_note_matches && remaining_history_matches
+    end
+
+    def proposed_history_has_first_published_change_note?
+      proposed_change_history.one? &&
+        proposed_change_history.first["note"] == PublishingApiPayload::History::FIRST_CHANGE_NOTE
     end
   end
 end

--- a/spec/lib/whitehall_importer/integrity_checker/change_history_check_spec.rb
+++ b/spec/lib/whitehall_importer/integrity_checker/change_history_check_spec.rb
@@ -4,7 +4,6 @@ RSpec.describe WhitehallImporter::IntegrityChecker::ChangeHistoryCheck do
       proposed_change_history = change_note("First published.", Date.yesterday.noon)
       publishing_api_change_history = change_note("First published.", Date.yesterday.noon)
 
-
       integrity_check = described_class.new(
         proposed_change_history,
         publishing_api_change_history,
@@ -25,6 +24,15 @@ RSpec.describe WhitehallImporter::IntegrityChecker::ChangeHistoryCheck do
         publishing_api_change_history,
         live_edition: false,
       )
+      expect(integrity_check.match?).to be true
+    end
+
+    it "returns true if proposed change history has a 'First published' change note and Publishing API has no change history" do
+      proposed_change_history = change_note("First published.", Date.yesterday.noon)
+      integrity_check = described_class.new(proposed_change_history,
+                                            [],
+                                            live_edition: false)
+
       expect(integrity_check.match?).to be true
     end
 

--- a/spec/lib/whitehall_importer/integrity_checker_spec.rb
+++ b/spec/lib/whitehall_importer/integrity_checker_spec.rb
@@ -111,6 +111,13 @@ RSpec.describe WhitehallImporter::IntegrityChecker do
       expect(integrity_check.valid?).to be true
     end
 
+    it "returns true when there is no change history" do
+      publishing_api_item[:details] = publishing_api_item[:details].except(:change_history)
+      stub_publishing_api_has_item(publishing_api_item)
+
+      expect(integrity_check.valid?).to be true
+    end
+
     context "when checking an edition that is published_but_needs_2i" do
       let(:state) { :published_but_needs_2i }
 


### PR DESCRIPTION
https://trello.com/c/EDTO7mb0/1466-perform-integrity-check-on-the-changehistory-during-migration

We have found instances of Whitehall documents with no changes notes; somehow
these were first published in 2016 with no change note. This lack of history is
consistent with the edition representation in the Publishing API, which also
has no change notes. While at least there is consistency in the lack of change
history between Whitehall and Content Publisher, the Integrity Checker fails
for these documents because in the proposed payload we have generated a "First
published." change note which of course doesn't match with what's in the
Publishing API. We've decided it's ok to send the "First published." change
note to Publishing API after these documents have been imported since they
should have had it in the first place and at least it gives the document some
history. As such, we've had to introduce some logic to check that in the event
that the Publishing API has no change history, the proposed payload that has
been generated contains only the "First published." note.