### PR TITLE
Go to new attachment metadata page after upload

### DIFF
--- a/app/controllers/file_attachments_controller.rb
+++ b/app/controllers/file_attachments_controller.rb
@@ -82,11 +82,11 @@ class FileAttachmentsController < ApplicationController
         ),
       }
 
-      render params[:wizard] == "new" ? :new : :index,
+      render params[:wizard] == "featured-attachment-upload" ? :new : :index,
              assigns: { edition: edition,
                         issues: issues },
              status: :unprocessable_entity
-    elsif params[:wizard] == "new"
+    elsif params[:wizard] == "featured-attachment-upload"
       redirect_to edit_file_attachment_path(edition.document, attachment_revision.file_attachment)
     else
       redirect_to file_attachment_path(edition.document, attachment_revision.file_attachment)
@@ -97,7 +97,7 @@ class FileAttachmentsController < ApplicationController
     result = FileAttachments::DestroyInteractor.call(params: params, user: current_user)
     attachment_revision = result.attachment_revision
 
-    if params[:wizard] == "featured"
+    if params[:wizard] == "featured-attachment-delete"
       redirect_to featured_attachments_path(params[:document])
     else
       redirect_to file_attachments_path(params[:document]),
@@ -165,7 +165,7 @@ class FileAttachmentsController < ApplicationController
                         issues: issues,
                         attachment: attachment_revision },
              status: :unprocessable_entity
-    elsif params[:wizard] == "featured"
+    elsif params[:wizard] == "featured-attachment-replace"
       redirect_to featured_attachments_path(edition.document)
     else
       flash[:notice] = I18n.t!("file_attachments.replace.flashes.update_confirmation") unless unchanged

--- a/app/controllers/file_attachments_controller.rb
+++ b/app/controllers/file_attachments_controller.rb
@@ -87,7 +87,7 @@ class FileAttachmentsController < ApplicationController
                         issues: issues },
              status: :unprocessable_entity
     elsif params[:wizard] == "new"
-      redirect_to featured_attachments_path(edition.document, attachment_revision.file_attachment)
+      redirect_to edit_file_attachment_path(edition.document, attachment_revision.file_attachment)
     else
       redirect_to file_attachment_path(edition.document, attachment_revision.file_attachment)
     end

--- a/app/views/featured_attachments/_featured_attachment.html.erb
+++ b/app/views/featured_attachments/_featured_attachment.html.erb
@@ -2,7 +2,9 @@
 
 <% actions << link_to(
   "Edit attachment",
-  replace_file_attachment_path(edition.document, attachment.file_attachment_id, wizard: "featured"),
+  replace_file_attachment_path(edition.document,
+                               attachment.file_attachment_id,
+                               wizard: "featured-attachment-replace"),
   class: "govuk-link govuk-link--no-visited-state app-link--button",
   data: {
     gtm: "edit-attachment",
@@ -29,7 +31,9 @@
 
 <% actions << link_to(
   "Delete attachment",
-  confirm_delete_file_attachment_path(edition.document, attachment.file_attachment_id, wizard: "featured"),
+  confirm_delete_file_attachment_path(edition.document,
+                                      attachment.file_attachment_id,
+                                      wizard: "featured-attachment-delete"),
   class: "govuk-link app-link--button app-link--destructive",
 ) %>
 

--- a/app/views/featured_attachments/index.html.erb
+++ b/app/views/featured_attachments/index.html.erb
@@ -9,7 +9,7 @@
 
     <%= render "govuk_publishing_components/components/button", {
       text: t("featured_attachments.index.upload.title"),
-      href: new_file_attachment_path(@edition.document, wizard: "new"),
+      href: new_file_attachment_path(@edition.document, wizard: "featured-attachment-upload"),
       margin_bottom: true,
     } %>
 

--- a/app/views/file_attachments/confirm_delete.html.erb
+++ b/app/views/file_attachments/confirm_delete.html.erb
@@ -1,4 +1,4 @@
-<% back_link_path = if params[:wizard] == "featured"
+<% back_link_path = if params[:wizard] == "featured-attachment-delete"
                       featured_attachments_path(@edition.document)
                     else
                       file_attachments_path(@edition.document)

--- a/app/views/file_attachments/edit.html.erb
+++ b/app/views/file_attachments/edit.html.erb
@@ -1,5 +1,14 @@
 <% content_for :title, t("file_attachments.edit.title", title: @edition.title_or_fallback) %>
-<% content_for :back_link, render_back_link(href: featured_attachments_path(@edition.document)) %>
+
+<% back_link_path = if params[:wizard] == 'new'
+                      replace_file_attachment_path(@edition.document,
+                                                   @attachment.file_attachment_id,
+                                                   wizard: params[:wizard])
+                    else
+                      featured_attachments_path(@edition.document)
+                    end %>
+
+<% content_for :back_link, render_back_link(href: back_link_path) %>
 
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">

--- a/app/views/file_attachments/edit.html.erb
+++ b/app/views/file_attachments/edit.html.erb
@@ -1,6 +1,6 @@
 <% content_for :title, t("file_attachments.edit.title", title: @edition.title_or_fallback) %>
 
-<% back_link_path = if params[:wizard] == 'new'
+<% back_link_path = if params[:wizard] == 'featured-attachment-upload'
                       replace_file_attachment_path(@edition.document,
                                                    @attachment.file_attachment_id,
                                                    wizard: params[:wizard])

--- a/app/views/file_attachments/edit.html.erb
+++ b/app/views/file_attachments/edit.html.erb
@@ -27,12 +27,6 @@
         margin_bottom: true,
         text: "Save",
       } %>
-
-      <div class="govuk-body">
-        <%= link_to "Cancel",
-                  featured_attachments_path(@edition.document),
-                  class: "govuk-link govuk-link--no-visited-state" %>
-      </div>
     <% end %>
   </div>
 </div>

--- a/app/views/file_attachments/replace.html.erb
+++ b/app/views/file_attachments/replace.html.erb
@@ -1,6 +1,6 @@
 <% content_for :title, t("file_attachments.replace.title", title: @edition.title_or_fallback) %>
 
-<% back_link_path = if params[:wizard] == "featured"
+<% back_link_path = if params[:wizard] == "featured-attachment-replace"
                       featured_attachments_path(@edition.document)
                     else
                       file_attachments_path(@edition.document)
@@ -54,7 +54,7 @@
 
       <%= render "govuk_publishing_components/components/button", {
         margin_bottom: true,
-        text: if params[:wizard] == "new"
+        text: if params[:wizard] == "featured-attachment-upload"
                 "Save and continue"
               else
                 "Save"

--- a/app/views/file_attachments/replace.html.erb
+++ b/app/views/file_attachments/replace.html.erb
@@ -54,7 +54,11 @@
 
       <%= render "govuk_publishing_components/components/button", {
         margin_bottom: true,
-        text: "Save",
+        text: if params[:wizard] == "new"
+                "Save and continue"
+              else
+                "Save"
+              end
       } %>
     <% end %>
   </div>

--- a/spec/features/editing_file_attachments/upload_file_attachment_spec.rb
+++ b/spec/features/editing_file_attachments/upload_file_attachment_spec.rb
@@ -5,8 +5,7 @@ RSpec.feature "Upload file attachment", js: true do
     and_i_go_to_insert_an_attachment
     and_i_select_a_file_to_upload
     and_i_upload_the_file_attachment
-    then_i_can_see_the_attachment
-    and_i_can_see_an_action_to_preview_the_attachment
+    then_i_can_insert_the_attachment
     and_i_see_the_timeline_entry
   end
 
@@ -16,7 +15,7 @@ RSpec.feature "Upload file attachment", js: true do
     and_i_go_to_change_an_attachment
     and_i_go_to_add_an_attachment
     and_i_select_a_file_to_upload
-    and_i_save_the_file_attachment
+    and_i_enter_attachment_metadata
     then_i_can_see_the_attachment
     and_i_see_the_timeline_entry
   end
@@ -68,23 +67,36 @@ RSpec.feature "Upload file attachment", js: true do
     click_on "Upload"
   end
 
-  def and_i_save_the_file_attachment
+  def and_i_enter_attachment_metadata
     click_on "Save and continue"
+    @metadata = "Ref: Unique ref"
+    fill_in "file_attachment[unique_reference]", with: "Unique ref"
+
+    stub_asset_manager_updates_any_asset
+    click_on "Save"
   end
 
   def then_i_can_see_the_attachment
-    @metadata = "PDF, 13 KB, 1 page"
+    file_metadata = "PDF, 13 KB, 1 page"
 
     within(".gem-c-attachment") do
       expect(page).to have_content(@title)
+      expect(page).to have_content(file_metadata)
       expect(page).to have_content(@metadata)
     end
   end
 
-  def and_i_can_see_an_action_to_preview_the_attachment
+  def then_i_can_insert_the_attachment
+    file_metadata = "PDF, 13 KB, 1 page"
+
+    within(".gem-c-attachment") do
+      expect(page).to have_content(@title)
+      expect(page).to have_content(file_metadata)
+    end
+
     within(".gem-c-attachment-link") do
       expect(page).to have_content(@title)
-      expect(page).to have_content(@metadata)
+      expect(page).to have_content(file_metadata)
     end
   end
 

--- a/spec/requests/file_attachments_spec.rb
+++ b/spec/requests/file_attachments_spec.rb
@@ -169,7 +169,7 @@ RSpec.describe "File Attachments" do
       stub_asset_manager_receives_an_asset(filename: "text-file-74bytes.txt")
 
       file = fixture_file_upload("files/text-file-74bytes.txt")
-      post file_attachments_path(edition.document, wizard: "new"),
+      post file_attachments_path(edition.document, wizard: "featured-attachment-upload"),
            params: { file: file, title: "File" }
 
       file_attachment = FileAttachment.last

--- a/spec/requests/file_attachments_spec.rb
+++ b/spec/requests/file_attachments_spec.rb
@@ -165,7 +165,7 @@ RSpec.describe "File Attachments" do
         .to redirect_to(file_attachment_path(edition.document, file_attachment))
     end
 
-    it "redirects to attachments index view when featured attachment is created successfully" do
+    it "redirects to the edit view when featured attachment is created successfully" do
       stub_asset_manager_receives_an_asset(filename: "text-file-74bytes.txt")
 
       file = fixture_file_upload("files/text-file-74bytes.txt")
@@ -174,7 +174,7 @@ RSpec.describe "File Attachments" do
 
       file_attachment = FileAttachment.last
       expect(response)
-        .to redirect_to(featured_attachments_path(edition.document, file_attachment))
+        .to redirect_to(edit_file_attachment_path(edition.document, file_attachment))
     end
 
     it "returns issues and an unprocessable response when there are requirement issues" do

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -67,5 +67,6 @@ RSpec.configure do |config|
 
   config.before :each, type: :view do
     allow(view).to receive(:current_user) { current_user }
+    allow(view).to receive(:rendering_context).and_return("application")
   end
 end

--- a/spec/views/file_attachments/replace.html.erb_spec.rb
+++ b/spec/views/file_attachments/replace.html.erb_spec.rb
@@ -1,0 +1,22 @@
+RSpec.describe "file_attachments/replace.html.erb" do
+  describe "file attachment replace" do
+    it "shows a 'Save' button by default" do
+      assign(:edition, build(:edition))
+      assign(:attachment, create(:file_attachment_revision))
+      render
+      expect(rendered).to have_button("Save")
+    end
+
+    context "when uploading and navigating back" do
+      it "shows a 'Save and continue' button" do
+        assign(:edition, build(:edition))
+        assign(:attachment, create(:file_attachment_revision))
+
+        render(template: "file_attachments/replace",
+               locals: { params: { wizard: "new" } })
+
+        expect(rendered).to have_button("Save and continue")
+      end
+    end
+  end
+end

--- a/spec/views/file_attachments/replace.html.erb_spec.rb
+++ b/spec/views/file_attachments/replace.html.erb_spec.rb
@@ -13,7 +13,7 @@ RSpec.describe "file_attachments/replace.html.erb" do
         assign(:attachment, create(:file_attachment_revision))
 
         render(template: "file_attachments/replace",
-               locals: { params: { wizard: "new" } })
+               locals: { params: { wizard: "featured-attachment-upload" } })
 
         expect(rendered).to have_button("Save and continue")
       end

--- a/spec/views/images/crop.html.erb_spec.rb
+++ b/spec/views/images/crop.html.erb_spec.rb
@@ -1,0 +1,38 @@
+RSpec.describe "images/crop.html.erb" do
+  describe "image crop" do
+    it "shows a 'Save' button with JS" do
+      assign(:image_revision, create(:image_revision))
+      assign(:edition, build(:edition))
+      render
+      expect(rendered).to have_button("Save")
+    end
+
+    it "shows a 'Continue' button without JS" do
+      assign(:image_revision, create(:image_revision))
+      assign(:edition, build(:edition))
+      render
+      expect(rendered).to have_selector(".app-no-js button", text: "Continue")
+    end
+
+    context "when the image has exact dimensions" do
+      it "shows a 'Continue' button instead" do
+        assign(:image_revision, create(:image_revision,
+                                       width: Image::WIDTH,
+                                       height: Image::HEIGHT))
+
+        assign(:edition, build(:edition))
+        render
+        expect(rendered).to have_selector(".app-js-only button", text: "Continue")
+      end
+    end
+
+    context "when uploading a new image" do
+      it "shows a 'Save and continue' button" do
+        assign(:image_revision, create(:image_revision))
+        assign(:edition, build(:edition))
+        render(template: "images/crop", locals: { params: { wizard: "upload" } })
+        expect(rendered).to have_button("Save and continue")
+      end
+    end
+  end
+end


### PR DESCRIPTION
https://trello.com/c/QZmkUoTr/1516-allow-users-to-add-the-unique-reference-as-metadata-for-featured-file-attachments

This changes the upload behaviour for a featured attachment, so that we now
redirect to the additional page for the user to enter metadata.

Please see the commits for more details.