### PR TITLE
Don't compare attachment file sizes

### DIFF
--- a/lib/whitehall_importer/integrity_checker/body_text_check.rb
+++ b/lib/whitehall_importer/integrity_checker/body_text_check.rb
@@ -28,8 +28,14 @@ module WhitehallImporter
     end
 
     def remove_attachment_file_size(body)
-      file_size_selector = ".attachment-inline .file-size, .gem-c-attachment-link .gem-c-attachment-link__attribute:nth-of-type(2)"
-      remove_html_elements(body, file_size_selector)
+      file_size_selectors = [
+        ".attachment-inline .file-size",
+        ".metadata .file-size",
+        ".gem-c-attachment-link .gem-c-attachment-link__attribute:nth-of-type(2)",
+        ".gem-c-attachment__metadata .gem-c-attachment__attribute:nth-of-type(2)",
+      ]
+
+      remove_html_elements(body, file_size_selectors.join(","))
     end
 
     def remove_html_elements(body, selector)

--- a/spec/lib/whitehall_importer/integrity_checker/body_text_check_spec.rb
+++ b/spec/lib/whitehall_importer/integrity_checker/body_text_check_spec.rb
@@ -15,25 +15,52 @@ RSpec.describe WhitehallImporter::IntegrityChecker::BodyTextCheck do
       expect(integrity_check.sufficiently_similar?).to be true
     end
 
-    it "returns true even if there is a mismatch in inline atttachment URL filesize" do
+    it "returns true even if there is a mismatch in an attachment link filesize" do
       proposed_body = %(
-        <p>
-          <span class="gem-c-attachment-link">
-            <a class="govuk-link" href="filename.pdf" target="_blank">Test File</a>
-            (<span class="gem-c-attachment-link__attribute"><abbr title="Portable Document Format" class="gem-c-attachment-link__abbr">PDF</abbr></span>,
-              <span class="gem-c-attachment-link__attribute">391 KB</span>, <span class="gem-c-attachment-link__attribute">9 pages</span>)
-          </span>
+        <span class="gem-c-attachment-link">
+          <a class="govuk-link" href="filename.pdf" target="_blank">Test File</a>
+          (
+            <span class="gem-c-attachment-link__attribute">
+              <abbr title="Portable Document Format" class="gem-c-attachment-link__abbr">PDF</abbr></span>,
+            <span class="gem-c-attachment-link__attribute">391 KB</span>,
+            <span class="gem-c-attachment-link__attribute">9 pages</span>
+          )
+        </span>
+      )
+
+      publishing_api_body = %(
+        <span class="attachment-inline">
+          <a href="/filename.pdf">Test File</a>
+          (
+            <span class="type">PDF</span>,
+            <span class="file-size">391KB</span>,
+            <span class="page-length">9 pages</span>
+          )
+        </span>
+      )
+
+      integrity_check = described_class.new(proposed_body, publishing_api_body)
+      expect(integrity_check.sufficiently_similar?).to be true
+    end
+
+    it "returns true even if there is a mismatch in an attachment filesize" do
+      proposed_body = %(
+        <p class="gem-c-attachment__metadata">
+          <span class="gem-c-attachment__attribute">
+            <abbr title="Portable Document Format" class="gem-c-attachment__abbr">PDF</abbr>
+          </span>,
+          <span class="gem-c-attachment__attribute">391 KB</span>,
+          <span class="gem-c-attachment__attribute">9 pages</span>
         </p>
       )
 
       publishing_api_body = %(
-        <p>
-          <span class="attachment-inline">
-            <a href="/filename.pdf">Test File</a>
-            (<span class="type">PDF</span>,
-              <span class="file-size">391KB</span>,
-              <span class="page-length">9 pages</span>)
-          </span>
+        <p class="metadata">
+          <span class="type">
+            <abbr title="Portable Document Format">PDF</abbr>
+          </span>,
+          <span class="file-size">391KB</span>,
+          <span class="page-length">9 pages</span>
         </p>
       )
 


### PR DESCRIPTION
We need to exclude the file size of the document from both inline and linked inline attachments (those with an anchor tag associated) when comparing the output from Publishing API with that of the proposed Content Publisher output. The proposed will have a space between the size and
the size type, (i.e. 119 KB) and the output on Publishing API will not (i.e. 119KB).

First we need to find all possible attachment HTML blocks, their classes and markup for inline and linked inline attachments on Content Publisher and Publishing API. From there we can create appropriate tests and remove them from the comparison process.

Trello: https://trello.com/c/j3kBctLj/1543-dont-compare-inline-attachment-file-sizes-cma-dwp-dhsc