### PR TITLE
Skip accessible format notice in integrity checker

### DIFF
--- a/lib/whitehall_importer/integrity_checker/body_text_check.rb
+++ b/lib/whitehall_importer/integrity_checker/body_text_check.rb
@@ -2,18 +2,30 @@ module WhitehallImporter
   class IntegrityChecker::BodyTextCheck
     attr_reader :proposed_body_text, :publishing_api_body_text
 
+    ACCESSIBLE_FORMAT_NOTICE = / This file may not be suitable for users of assistive technology. (.*) It will help us if you say what assistive technology you use./.freeze
+
     def initialize(proposed_body_text, publishing_api_body_text)
       @proposed_body_text = proposed_body_text
       @publishing_api_body_text = publishing_api_body_text
     end
 
     def sufficiently_similar?
-      proposed_body = remove_attachment_file_size(proposed_body_text)
-      publishing_api_body = remove_attachment_file_size(publishing_api_body_text)
-      Sanitize.clean(publishing_api_body).squish == Sanitize.clean(proposed_body).squish
+      proposed_body = processed_body(proposed_body_text)
+      publishing_api_body = processed_body(publishing_api_body_text)
+
+      proposed_body == publishing_api_body
     end
 
   private
+
+    def processed_body(body_text)
+      processed_body = remove_attachment_file_size(body_text)
+      remove_accessible_format_notice(Sanitize.clean(processed_body).squish)
+    end
+
+    def remove_accessible_format_notice(sanitized_body)
+      sanitized_body.gsub(ACCESSIBLE_FORMAT_NOTICE, "")
+    end
 
     def remove_attachment_file_size(body)
       file_size_selector = ".attachment-inline .file-size, .gem-c-attachment-link .gem-c-attachment-link__attribute:nth-of-type(2)"

--- a/spec/lib/whitehall_importer/integrity_checker/body_text_check_spec.rb
+++ b/spec/lib/whitehall_importer/integrity_checker/body_text_check_spec.rb
@@ -45,5 +45,70 @@ RSpec.describe WhitehallImporter::IntegrityChecker::BodyTextCheck do
       integrity_check = described_class.new("Some text", "Some different text")
       expect(integrity_check.sufficiently_similar?).to be false
     end
+
+    it "returns true when both body texts include an accessibility notice" do
+      integrity_check = described_class.new(
+        proposed_body_with_accessibility_notice,
+        publishing_api_body_with_accessibility_notice,
+      )
+      expect(integrity_check.sufficiently_similar?).to be true
+    end
+
+    it "returns true when only one body text includes an accessibility notice" do
+      publishing_api_body = %(
+        <h2 class="title">
+          <a href="https://assets.publishing.service.gov.uk/government/uploads/system/uploads/attachment_data/file/294830/Improving_mat_care.pdf" class="govuk-link">
+            Improving Maternity Care Settings Funding Allocations
+          </a>
+        </h2>
+      )
+
+      integrity_check = described_class.new(
+        proposed_body_with_accessibility_notice,
+        publishing_api_body,
+      )
+      expect(integrity_check.sufficiently_similar?).to be true
+    end
+  end
+
+  def proposed_body_with_accessibility_notice
+    %(
+      <div class="gem-c-attachment__details">
+        <h2 class="gem-c-attachment__title">
+          <a class="govuk-link gem-c-attachment__link" target="_self" href="\">Improving Maternity Care Settings Funding Allocations</a>
+        </h2>
+        <p class="gem-c-attachment__metadata">
+          This file may not be suitable for users of assistive technology.
+        </p>
+        <details class="gem-c-details govuk-details govuk-!-margin-bottom-3" data-module="govuk-details">
+          <summary class="govuk-details__summary" data-details-track-click>
+            <span class="govuk-details__summary-text">
+              Request an accessible format.
+            </span>
+          </summary>
+          <div class="govuk-details__text">
+            If you use assistive technology (such as a screen reader) and need a version of this document in a more accessible format, please email <a href=\"mailto:publications@dhsc.gov.uk\" target=\"_blank\" class=\"govuk-link\">publications@dhsc.gov.uk</a>. Please tell us what format you need. It will help us if you say what assistive technology you use.
+          </div>
+        </details>
+      </div>
+    )
+  end
+
+  def publishing_api_body_with_accessibility_notice
+    %(
+      <h2 class="title">
+        <a href="https://assets.publishing.service.gov.uk/government/uploads/system/uploads/attachment_data/file/294830/Improving_mat_care.pdf" class="govuk-link">
+          Improving Maternity Care Settings Funding Allocations
+        </a>
+      </h2>
+      <h2>
+        This file may not be suitable for users of assistive technology.
+        <a class="govuk-link" href="#attachment-4080725-accessibility-request" data-controls="attachment-4080725-accessibility-request" data-expanded="false">Request an accessible format.</a>
+      </h2>
+      <p id="attachment-4080725-accessibility-request" class="js-hidden">
+        If you use assistive technology (such as a screen reader) and need a version of this document in a more accessible format, please email <a href=\"mailto:accessibleformats@digital.cabinet-office.gov.uk?body=Details%20of%20document%20required%3A%0A%0A%20%20Title%3A%20Peters%20attachment%0A%20%20Original%20format%3A%20pdf%0A%0APlease%20tell%20us%3A%0A%0A%20%201.%20What%20makes%20this%20format%20unsuitable%20for%20you%3F%0A%20%202.%20What%20format%20you%20would%20prefer%3F%0A%20%20%20%20%20%20&amp;subject=Request%20for%20%27Peters%20attachment%27%20in%20an%20alternative%20format\" class=\"govuk-link\">accessibleformats@digital.cabinet-office.gov.uk</a>.
+        Please tell us what format you need. It will help us if you say what assistive technology you use.
+      </p>
+    )
   end
 end


### PR DESCRIPTION
[Trello](https://trello.com/c/sSUQCIJp/1559-skip-accessible-format-notice-in-integrity-checker-dwp-dhsc)

There are instances where the proposed payload body for an attachment may include the 'request an accessible format' notice, whereas in the Publishing API body the attachment does not display this notice.

This notice occurs in Whitehall when a checkbox is selected, whereas in Content Publisher, the accessibility notice is determined by the file type.

It may be the case that Whitehall displays this notice, whereas Content Publisher may not. For example, a PDF in Content Publisher will always be deemed in-accessible, whereas in Whitehall, a publisher could mark the content as accessible.

Co-authored-by: 1pretz1 <peter.hartshorn@digital.cabinet-office.gov.uk>