### PR TITLE
Fix 'Back' link to replace a just-uploaded file

### DIFF
--- a/app/controllers/file_attachments_controller.rb
+++ b/app/controllers/file_attachments_controller.rb
@@ -87,7 +87,9 @@ class FileAttachmentsController < ApplicationController
                         issues: issues },
              status: :unprocessable_entity
     elsif params[:wizard] == "featured-attachment-upload"
-      redirect_to edit_file_attachment_path(edition.document, attachment_revision.file_attachment)
+      redirect_to edit_file_attachment_path(edition.document,
+                                            attachment_revision.file_attachment,
+                                            wizard: params[:wizard])
     else
       redirect_to file_attachment_path(edition.document, attachment_revision.file_attachment)
     end
@@ -167,6 +169,10 @@ class FileAttachmentsController < ApplicationController
              status: :unprocessable_entity
     elsif params[:wizard] == "featured-attachment-replace"
       redirect_to featured_attachments_path(edition.document)
+    elsif params[:wizard] == "featured-attachment-upload"
+      redirect_to edit_file_attachment_path(edition.document,
+                                            attachment_revision.file_attachment,
+                                            wizard: params[:wizard])
     else
       flash[:notice] = I18n.t!("file_attachments.replace.flashes.update_confirmation") unless unchanged
       redirect_to file_attachments_path(edition.document)


### PR DESCRIPTION
https://trello.com/c/QZmkUoTr/1516-allow-users-to-add-the-unique-reference-as-metadata-for-featured-file-attachments

This fixes the 'Back' link on the new metadata page so that going back
and forth between this page and the replace page works correctly in the
context of replacing an uploaded file, while still in the upload workflow.

I've added some missing request tests to cover the (new) behaviour. We
don't have a precedent for testing the 'Back' links specifically, so I'm
going to defer testing that and write 'pain' card about that instead.

https://trello.com/c/rfna82RY/1712-our-back-actions-are-not-tested