### PR TITLE
Support ISBN for featured file attachments

### DIFF
--- a/app/helpers/file_attachment_helper.rb
+++ b/app/helpers/file_attachment_helper.rb
@@ -18,6 +18,7 @@ module FileAttachmentHelper
 
     if edition.document_type.attachments.featured?
       attributes.merge!(
+        isbn: attachment_revision.isbn,
         unique_reference: attachment_revision.unique_reference,
       )
     end

--- a/app/interactors/file_attachments/update_interactor.rb
+++ b/app/interactors/file_attachments/update_interactor.rb
@@ -32,7 +32,7 @@ private
   end
 
   def check_for_issues
-    checker = Requirements::FileAttachmentMetadataChecker.new(unique_reference: attachment_params[:unique_reference])
+    checker = Requirements::FileAttachmentMetadataChecker.new(attachment_params)
     issues = checker.pre_update_issues
 
     context.fail!(issues: issues) if issues.any?

--- a/app/interactors/file_attachments/update_interactor.rb
+++ b/app/interactors/file_attachments/update_interactor.rb
@@ -40,7 +40,7 @@ private
 
   def update_file_attachment
     updater = Versioning::FileAttachmentRevisionUpdater.new(file_attachment_revision, user)
-    revision_attributes = attachment_params.slice(:unique_reference)
+    revision_attributes = attachment_params.slice(:isbn, :unique_reference)
     updater.assign(revision_attributes)
 
     context.file_attachment_revision = updater.next_revision
@@ -66,6 +66,6 @@ private
   end
 
   def attachment_params
-    params.require(:file_attachment).permit(:unique_reference)
+    params.require(:file_attachment).permit(:isbn, :unique_reference)
   end
 end

--- a/app/views/file_attachments/edit.html.erb
+++ b/app/views/file_attachments/edit.html.erb
@@ -24,6 +24,16 @@
 
       <%= render "govuk_publishing_components/components/input", {
         label: {
+          text: t("file_attachments.edit.isbn.heading"),
+          bold: true
+        },
+        name: "file_attachment[isbn]",
+        value: params.dig(:file_attachment, :isbn) || @attachment.isbn,
+        hint: t("file_attachments.edit.isbn.hint_text"),
+      } %>
+
+      <%= render "govuk_publishing_components/components/input", {
+        label: {
           text: t("file_attachments.edit.unique_reference.heading"),
           bold: true
         },

--- a/app/views/file_attachments/edit.html.erb
+++ b/app/views/file_attachments/edit.html.erb
@@ -30,6 +30,7 @@
         name: "file_attachment[isbn]",
         value: params.dig(:file_attachment, :isbn) || @attachment.isbn,
         hint: t("file_attachments.edit.isbn.hint_text"),
+        error_items: @issues&.items_for(:file_attachment_isbn),
       } %>
 
       <%= render "govuk_publishing_components/components/input", {
@@ -40,6 +41,7 @@
         name: "file_attachment[unique_reference]",
         value: params.dig(:file_attachment, :unique_reference) || @attachment.unique_reference,
         hint: t("file_attachments.edit.unique_reference.hint_text"),
+        error_items: @issues&.items_for(:file_attachment_unique_reference),
       } %>
 
       <%= render "govuk_publishing_components/components/button", {

--- a/config/locales/en/file_attachments/edit.yml
+++ b/config/locales/en/file_attachments/edit.yml
@@ -4,6 +4,9 @@ en:
       title: "Update attachment details for ‘%{title}’"
       description_govspeak: |
         Include these details if the document contains them to help users find and identify the publication.
+      isbn:
+        heading: ISBN
+        hint_text: Add the International Standard Book Number (ISBN) if there is one.
       unique_reference:
         heading: Unique reference
         hint_text: Add your organisation's own reference if it has one.

--- a/config/locales/en/requirements.yml
+++ b/config/locales/en/requirements.yml
@@ -76,6 +76,9 @@ en:
         form_message: Enter a title
       too_long:
         form_message: "Enter a title that is fewer than %{max_length} characters long"
+    file_attachment_isbn:
+      invalid:
+        form_message: "Enter a valid ISBN"
     file_attachment_unique_reference:
       too_long:
         form_message: "Enter a unique reference that is fewer than %{max_length} characters long"

--- a/lib/requirements/file_attachment_metadata_checker.rb
+++ b/lib/requirements/file_attachment_metadata_checker.rb
@@ -1,18 +1,31 @@
 module Requirements
   class FileAttachmentMetadataChecker
     UNIQUE_REF_MAX_LENGTH = 255
+    ISBN10_REGEX = /^(?:\d[\ -]?){9}[\dX]$/i.freeze
+    ISBN13_REGEX = /^(?:\d[\ -]?){13}$/i.freeze
 
-    attr_reader :unique_reference
+    attr_reader :isbn, :unique_reference
 
-    def initialize(unique_reference: nil)
-      @unique_reference = unique_reference
+    def initialize(params)
+      @isbn = params[:isbn]
+      @unique_reference = params[:unique_reference]
     end
 
     def pre_update_issues
-      unique_reference_issues
+      isbn_issues + unique_reference_issues
     end
 
   private
+
+    def isbn_issues
+      issues = CheckerIssues.new
+
+      unless isbn.blank? || ISBN10_REGEX.match?(isbn) || ISBN13_REGEX.match?(isbn)
+        issues.create(:file_attachment_isbn, :invalid)
+      end
+
+      issues
+    end
 
     def unique_reference_issues
       issues = CheckerIssues.new

--- a/spec/factories/file_attachment_revision_factory.rb
+++ b/spec/factories/file_attachment_revision_factory.rb
@@ -6,6 +6,7 @@ FactoryBot.define do
     transient do
       filename { SecureRandom.hex(8) }
       number_of_pages { nil }
+      isbn { nil }
       unique_reference { nil }
       fixture { "text-file-74bytes.txt" }
       title { SecureRandom.hex(8) }
@@ -27,6 +28,7 @@ FactoryBot.define do
         revision.metadata_revision = evaluator.association(
           :file_attachment_metadata_revision,
           title: evaluator.title,
+          isbn: evaluator.isbn,
           unique_reference: evaluator.unique_reference,
         )
       end

--- a/spec/features/editing_file_attachments/edit_file_attachment_spec.rb
+++ b/spec/features/editing_file_attachments/edit_file_attachment_spec.rb
@@ -24,13 +24,16 @@ RSpec.feature "Edit a file attachment" do
     stub_publishing_api_put_content(@edition.content_id, {})
     stub_asset_manager_receives_an_asset
 
+    @isbn = "9788700631625"
     @unique_reference = "A unique reference"
 
+    fill_in "file_attachment[isbn]", with: @isbn
     fill_in "file_attachment[unique_reference]", with: @unique_reference
     click_on "Save"
   end
 
   def then_i_see_the_attachment_is_updated
+    expect(page).to have_content(@isbn)
     expect(page).to have_content(@unique_reference)
   end
 

--- a/spec/lib/publishing_api_payload/file_attachment_payload_spec.rb
+++ b/spec/lib/publishing_api_payload/file_attachment_payload_spec.rb
@@ -23,7 +23,7 @@ RSpec.describe PublishingApiPayload::FileAttachmentPayload do
 
     it "adds extra metadata if the document has featured attachments" do
       attachment = build(:file_attachment_revision,
-                         unique_reference: "unique ref")
+                         isbn: "9788700631625", unique_reference: "unique ref")
 
       edition = create(:edition,
                        document_type: build(:document_type, attachments: "featured"),
@@ -32,6 +32,7 @@ RSpec.describe PublishingApiPayload::FileAttachmentPayload do
       payload = described_class.new(attachment, edition).payload
 
       expected_payload = {
+        isbn: attachment.isbn,
         unique_reference: attachment.unique_reference,
       }
 

--- a/spec/lib/requirements/file_attachment_metadata_checker_spec.rb
+++ b/spec/lib/requirements/file_attachment_metadata_checker_spec.rb
@@ -8,7 +8,7 @@ RSpec.describe Requirements::FileAttachmentMetadataChecker do
       expect(issues).to be_empty
     end
 
-    it "returns unique_reference issues when the unique unique_reference is too long" do
+    it "returns unique_reference issues when the unique_reference is too long" do
       unique_reference = "z" * (max_length + 1)
       issues = described_class.new(unique_reference: unique_reference).pre_update_issues
 

--- a/spec/lib/requirements/file_attachment_metadata_checker_spec.rb
+++ b/spec/lib/requirements/file_attachment_metadata_checker_spec.rb
@@ -16,5 +16,38 @@ RSpec.describe Requirements::FileAttachmentMetadataChecker do
                                    :too_long,
                                    max_length: max_length)
     end
+
+    [
+      "invalid",
+      "9788--0631625",
+      "9991a9010599938",
+      "0-9722051-1-F",
+      "ISBN 9788700631625",
+    ].each do |invalid_isbn|
+      it "returns isbn issues when invalid isbn #{invalid_isbn.inspect} is provided" do
+        issues = described_class.new(isbn: invalid_isbn).pre_update_issues
+        expect(issues).to have_issue(:file_attachment_isbn, :invalid)
+      end
+    end
+
+    it "returns no issues when isbn is omitted" do
+      issues = described_class.new(isbn: nil).pre_update_issues
+      expect(issues).to be_empty
+    end
+
+    [
+      "9788700631625",
+      "1590599934",
+      "159-059 9934",
+      "978-159059 9938",
+      "978-1-60746-006-0",
+      "0-9722051-1-X",
+      "0-9722051-1-x",
+    ].each do |valid_isbn|
+      it "returns no issues when valid isbn #{valid_isbn.inspect} is provided" do
+        issues = described_class.new(isbn: valid_isbn).pre_update_issues
+        expect(issues).to be_empty
+      end
+    end
   end
 end

--- a/spec/requests/file_attachments_spec.rb
+++ b/spec/requests/file_attachments_spec.rb
@@ -320,7 +320,7 @@ RSpec.describe "File Attachments" do
 
       patch edit_file_attachment_path(edition.document,
                                       file_attachment_revision.file_attachment_id),
-            params: { file_attachment: { unique_reference: "Uniq Ref" } }
+            params: { file_attachment: { isbn: "", unique_reference: "Uniq Ref" } }
 
       expect(response).to redirect_to(featured_attachments_path(edition.document))
     end

--- a/spec/requests/file_attachments_spec.rb
+++ b/spec/requests/file_attachments_spec.rb
@@ -320,7 +320,7 @@ RSpec.describe "File Attachments" do
 
       patch edit_file_attachment_path(edition.document,
                                       file_attachment_revision.file_attachment_id),
-            params: { file_attachment: { isbn: "", unique_reference: "Uniq Ref" } }
+            params: { file_attachment: { isbn: "9788700631625", unique_reference: "Uniq Ref" } }
 
       expect(response).to redirect_to(featured_attachments_path(edition.document))
     end


### PR DESCRIPTION
Trello: https://trello.com/c/vs8MEQKB/1519-support-isbn-for-featured-file-attachments

I wasn't too sure of the error message to use, as it's complicated to explain fully what an ISBN should look like. I'll check the error message with a content designer.

## Screenshots

### Error state

<img width="400" alt="Screenshot 2020-03-27 at 16 14 43" src="https://user-images.githubusercontent.com/5111927/77776745-64d62980-7046-11ea-9c94-d69d091b7bfb.png">

### Valid saved input, preview

<img width="400" alt="Screenshot 2020-03-27 at 09 50 30" src="https://user-images.githubusercontent.com/5111927/77743779-7a306100-7010-11ea-90e9-d131c6d1dd76.png">
