### PR TITLE
Remove 'TODO' to change RSpec/InstanceVariable

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -73,7 +73,6 @@ Capybara/FeatureMethods:
     - 'spec/features/**/*.rb'
 
 # Part of the GOV.UK feature spec style involves instance variables
-# TODO: Investigate if we can embrace this rule and use let/given methods
 RSpec/InstanceVariable:
   Exclude:
     - 'spec/features/**/*.rb'


### PR DESCRIPTION
https://trello.com/c/3B7k3YN1/1680-make-our-linting-config-for-rspec-the-standard-for-govuk

Previously we disabled this cop for feature specs with the intention to
explore using 'let' or 'given' instead of instance variables.

This removes the 'TODO', noting instance variables in our feature tests
are assigned *during the test*, so cannot be replaced by 'let' or
'given'. The documentation for this cop also indicates it's meant to be
specific to instance variables assigned in a 'before' block, which could
be replaced with 'let' or 'given'.

```
# bad
describe MyClass do
  before { @foo = [] }
  it { expect(@foo).to be_empty }
end

# good
describe MyClass do
  let(:foo) { [] }
  it { expect(foo).to be_empty }
end

# necessarily 'bad'
describe MyClass do
  it { <feature_steps> }
  def step_x; ... @foo = input_in_form; ... end
  def step_y; ... expect(result).to include @foo; end
end
```