### PR TITLE
Increase the range for comparing first_published_at

### DIFF
--- a/lib/whitehall_importer/integrity_checker.rb
+++ b/lib/whitehall_importer/integrity_checker.rb
@@ -2,13 +2,14 @@ module WhitehallImporter
   class IntegrityChecker
     attr_reader :edition
 
-    def self.time_matches?(proposed_time, publishing_api_time)
+    def self.time_matches?(proposed_time, publishing_api_time, seconds_difference = 5)
       return true if proposed_time == publishing_api_time
 
       proposed_time = Time.zone.rfc3339(proposed_time)
       publishing_api_time = Time.zone.rfc3339(publishing_api_time)
 
-      proposed_time.between?(publishing_api_time - 5, publishing_api_time + 5)
+      proposed_time.between?(publishing_api_time - seconds_difference,
+                             publishing_api_time + seconds_difference)
     rescue ArgumentError
       false
     end
@@ -71,7 +72,7 @@ module WhitehallImporter
       proposed_first_published_at = proposed_payload["first_published_at"]
       first_public_at = publishing_api_content["details"]["first_public_at"]
 
-      unless time_matches?(proposed_first_published_at, first_public_at)
+      unless time_matches?(proposed_first_published_at, first_public_at, 60)
         problems << problem_description("our first_published_at doesn't match first_public_at",
                                         first_public_at,
                                         proposed_first_published_at)
@@ -88,8 +89,8 @@ module WhitehallImporter
       problems
     end
 
-    def time_matches?(proposed_time, publishing_api_time)
-      self.class.time_matches?(proposed_time, publishing_api_time)
+    def time_matches?(proposed_time, publishing_api_time, seconds_difference = 5)
+      self.class.time_matches?(proposed_time, publishing_api_time, seconds_difference)
     end
 
     def state_problems

--- a/spec/lib/whitehall_importer/integrity_checker_spec.rb
+++ b/spec/lib/whitehall_importer/integrity_checker_spec.rb
@@ -23,7 +23,7 @@ RSpec.describe WhitehallImporter::IntegrityChecker do
             state: state,
             document_type: document_type,
             published_at: "2020-03-11 12:00 UTC",
-            document: create(:document, first_published_at: "2020-03-11 12:00 UTC"),
+            document: create(:document, first_published_at: "2020-03-11 12:00:45 UTC"),
             tags: {
               primary_publishing_organisation: [SecureRandom.uuid],
               organisations: [SecureRandom.uuid],
@@ -31,7 +31,7 @@ RSpec.describe WhitehallImporter::IntegrityChecker do
     end
     let(:publishing_api_item) do
       default_publishing_api_item(edition,
-                                  public_updated_at: "2020-03-11T12:00:00Z",
+                                  public_updated_at: "2020-03-11T12:00:45Z",
                                   state_history: { "1" => "published" },
                                   publication_state: "published",
                                   details: {
@@ -90,7 +90,7 @@ RSpec.describe WhitehallImporter::IntegrityChecker do
     end
 
     it "returns true if public_updated_at times match" do
-      publishing_api_item[:public_updated_at] = "2020-03-11T12:00:00Z"
+      publishing_api_item[:public_updated_at] = "2020-03-11T12:00:45Z"
       stub_publishing_api_has_item(publishing_api_item)
 
       expect(integrity_check.valid?).to be true
@@ -613,7 +613,7 @@ RSpec.describe WhitehallImporter::IntegrityChecker do
         change_history: [
           {
             note: "First published.",
-            public_timestamp: Time.zone.rfc3339("2020-03-11T12:00:00.000+00:00"),
+            public_timestamp: Time.zone.rfc3339("2020-03-11T12:00:45.000+00:00"),
           },
         ],
       },


### PR DESCRIPTION
Annoyingly whitehall rounds down the first_published_at time after the
first edition to the nearest minute for the following editions. This is
reflected in the publishing-api's first_public_at timestamp and so we
have to take this into consideration when doing an integirty check.

```Examples of this behaviour are below:
irb(main):018:0> Document.last(1001).first.editions.order(:id).pluck(:first_published_at)
=> [Mon, 16 Mar 2020 11:00:03 GMT +00:00, Mon, 16 Mar 2020 11:00:00 GMT +00:00, Mon, 16 Mar 2020 11:00:00 GMT +00:00, Mon, 16 Mar 2020 11:00:00 GMT +00:00, Mon, 16 Mar 2020 11:00:00 GMT +00:00]
irb(main):019:0> Document.last(1002).first.editions.order(:id).pluck(:first_published_at)
=> [Sun, 15 Mar 2020 20:31:18 GMT +00:00, Sun, 15 Mar 2020 20:31:00 GMT +00:00]
irb(main):020:0> Document.last(1003).first.editions.order(:id).pluck(:first_published_at)
=> [Sun, 15 Mar 2020 17:53:51 GMT +00:00, Sun, 15 Mar 2020 17:53:00 GMT +00:00, Sun, 15 Mar 2020 17:53:00 GMT +00:00]