### PR TITLE
Confirm delete image

### DIFF
--- a/app/assets/javascripts/modules/inline-attachment-modal.js
+++ b/app/assets/javascripts/modules/inline-attachment-modal.js
@@ -37,7 +37,7 @@ InlineAttachmentModal.prototype.actionCallback = function (item) {
     'delete': function () {
       this.workflow.render(window.ModalFetch.getLink(item))
     },
-    'confirm-delete': function () {
+    'confirmDelete': function () {
       this.workflow.render(window.ModalFetch.postForm(item))
     },
     'edit': function () {

--- a/app/assets/javascripts/modules/inline-image-modal.js
+++ b/app/assets/javascripts/modules/inline-image-modal.js
@@ -35,16 +35,16 @@ InlineImageModal.prototype.actionCallback = function (item) {
     'upload': function () {
       this.workflow.render(window.ModalFetch.postForm(item))
     },
-    'cropBack': function () {
-      this.workflow.render(window.ModalFetch.getLink(item))
-    },
-    'metaBack': function () {
+    'back': function () {
       this.workflow.render(window.ModalFetch.getLink(item))
     },
     'crop': function () {
       this.workflow.render(window.ModalFetch.postForm(item))
     },
     'delete': function () {
+      this.workflow.render(window.ModalFetch.getLink(item))
+    },
+    'confirm-delete': function () {
       this.workflow.render(window.ModalFetch.postForm(item))
     },
     'meta': function () {

--- a/app/assets/javascripts/modules/inline-image-modal.js
+++ b/app/assets/javascripts/modules/inline-image-modal.js
@@ -44,7 +44,7 @@ InlineImageModal.prototype.actionCallback = function (item) {
     'delete': function () {
       this.workflow.render(window.ModalFetch.getLink(item))
     },
-    'confirm-delete': function () {
+    'confirmDelete': function () {
       this.workflow.render(window.ModalFetch.postForm(item))
     },
     'meta': function () {

--- a/app/controllers/images_controller.rb
+++ b/app/controllers/images_controller.rb
@@ -76,6 +76,12 @@ class ImagesController < ApplicationController
     end
   end
 
+  def confirm_delete
+    @edition = Edition.find_current(document: params[:document])
+    assert_edition_state(@edition, &:editable?)
+    @image_revision = @edition.image_revisions.find_by!(image_id: params[:image_id])
+  end
+
   def destroy
     result = Images::DestroyInteractor.call(params: params, user: current_user)
     image_revision, removed_lead = result.to_h.values_at(:image_revision, :removed_lead_image)

--- a/app/views/file_attachments/confirm_delete.html.erb
+++ b/app/views/file_attachments/confirm_delete.html.erb
@@ -14,7 +14,7 @@
       method: :delete,
       multipart: true,  
       data: {
-        "modal-action": "confirm-delete",
+        "modal-action": "confirmDelete",
         gtm: "confirm-delete-attachment"
       },
     ) do %>

--- a/app/views/images/_image.html.erb
+++ b/app/views/images/_image.html.erb
@@ -27,19 +27,9 @@
 
 <% end %>
 
-<% actions << capture do %>
-  <%= form_tag(
-    destroy_image_path(edition.document, image.image_id),
-    method: :delete,
-    data: {
-      "modal-action": "delete",
-      gtm: "delete-image"
-    },
-    class: "app-inline-block"
-  ) do %>
-    <button class="govuk-link app-link--button app-link--destructive">Delete image</button>
-  <% end %>
-<% end %>
+<% actions << link_to("Delete image", confirm_delete_image_path(edition.document, image.image_id),
+                      class: "govuk-link app-link--button app-link--destructive",
+                      data: { "modal-action": "delete", gtm: "delete-image" }) %>
 
 <% metadata_items = [
   {

--- a/app/views/images/_lead_image.html.erb
+++ b/app/views/images/_lead_image.html.erb
@@ -9,6 +9,10 @@
 
 <% unless rendering_context == "modal" %>
 
+  <% actions << link_to("Delete lead image", confirm_delete_image_path(@edition.document, lead_image.image_id),
+                      class: "govuk-link app-link--button app-link--destructive",
+                      data: { "modal-action": "delete", gtm: "delete-lead-image" }) %>
+
   <% actions << link_to("Edit details", edit_image_path(document, lead_image.image_id),
                         class: "govuk-link",
                         data: { "modal-action": "edit", gtm: "edit-lead-image" }) %>
@@ -23,15 +27,6 @@
         class: "app-inline-block",
         data: { gtm: "remove-lead-image" } do %>
       <button class="govuk-link app-link--button">Remove lead image</button>
-    <% end %>
-  <% end %>
-
-  <% actions << capture do %>
-    <%= form_tag destroy_image_path(document, lead_image.image_id),
-        method: :delete,
-        class: "app-inline-block",
-        data: { gtm: "delete-lead-image" } do %>
-      <button class="govuk-link app-link--button app-link--destructive">Delete lead image</button>
     <% end %>
   <% end %>
 <% end %>

--- a/app/views/images/confirm_delete.html.erb
+++ b/app/views/images/confirm_delete.html.erb
@@ -1,0 +1,33 @@
+<% content_for :title, t("images.confirm_delete.title", title: @image_revision.filename) %>
+<% content_for :back_link, render_back_link(href: images_path(@edition.document, @image_revision.image_id), data_attributes: { "modal-action": "back" }) %>
+
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-two-thirds">
+    <%= form_tag(
+      destroy_image_path(@edition.document, @image_revision.image_id),
+      method: :delete,
+      multipart: true,  
+      data: {
+        "modal-action": "confirmDelete",
+        gtm: "confirm-delete-image"
+      },
+    ) do %>
+      <%= render_govspeak(t("images.confirm_delete.description_govspeak")) %>
+
+      <%= render "govuk_publishing_components/components/button", {
+        text: "Yes, delete image",
+        destructive: true,
+        margin_bottom: true,
+      } %>
+
+      <div class="govuk-body">
+        <%= link_to "Cancel",
+          images_path(@edition.document, @image_revision.image_id),
+          class: "govuk-link govuk-link--no-visited-state", 
+          data: { "modal-action": "back",
+          gtm: "cancel-delete-image" 
+        } %>                  
+      <% end %>
+    </div>
+  </div>
+</div>

--- a/app/views/images/crop.html.erb
+++ b/app/views/images/crop.html.erb
@@ -6,7 +6,7 @@ content_for :title,t(title_key, title: @edition.title_or_fallback)
 <% content_for :back_link, render_back_link(
   href: images_path(@edition.document),
   data_attributes: {
-    "modal-action": "cropBack",
+    "modal-action": "back",
   }
 ) %>
 

--- a/app/views/images/edit.html.erb
+++ b/app/views/images/edit.html.erb
@@ -11,7 +11,7 @@ content_for :title, t(title_key, title: @edition.title_or_fallback)
 
 <% content_for :back_link, render_back_link(
   href: back_link_path,
-  data_attributes: { "modal-action": "metaBack" }
+  data_attributes: { "modal-action": "back" }
 ) %>
 
 <%= render "components/image_meta", {

--- a/config/locales/en/images/confirm_delete.yml
+++ b/config/locales/en/images/confirm_delete.yml
@@ -1,0 +1,8 @@
+en:
+  images:
+    confirm_delete:
+      title: "Delete image ‘%{title}’"
+      description_govspeak: |
+        Are you sure you want to delete this image?
+
+        This will delete the image and its details. This cannot be undone. 

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -68,6 +68,8 @@ Rails.application.routes.draw do
     get "/images/:image_id/edit" => "images#edit", as: :edit_image
     patch "/images/:image_id/edit" => "images#update"
     delete "/images/:image_id" => "images#destroy", as: :destroy_image
+    get "/images/:image_id/delete" => "images#confirm_delete", as: :confirm_delete_image
+
 
     post "/lead-image/:image_id" => "lead_image#choose", as: :choose_lead_image
     delete "/lead-image" => "lead_image#remove", as: :remove_lead_image

--- a/spec/features/editing_images/delete_image_spec.rb
+++ b/spec/features/editing_images/delete_image_spec.rb
@@ -3,6 +3,7 @@ RSpec.feature "Delete an image" do
     given_there_is_an_edition_with_images
     when_i_visit_the_images_page
     and_i_delete_the_image
+    and_i_confirm_the_deletion
     then_i_see_the_image_is_gone
     and_i_see_the_timeline_entry
   end
@@ -11,6 +12,7 @@ RSpec.feature "Delete an image" do
     given_there_is_an_edition_with_a_lead_image
     when_i_visit_the_images_page
     when_i_delete_the_lead_image
+    and_i_confirm_the_deletion
     then_i_see_the_lead_image_is_gone
     and_i_see_the_timeline_entry
   end
@@ -19,6 +21,7 @@ RSpec.feature "Delete an image" do
     given_there_is_an_edition_with_images
     when_i_insert_an_inline_image
     and_i_delete_the_image
+    and_i_confirm_the_deletion
     then_i_see_the_image_is_gone
     and_i_see_the_timeline_entry
   end
@@ -62,6 +65,10 @@ RSpec.feature "Delete an image" do
   def when_i_delete_the_lead_image
     stub_publishing_api_put_content(@edition.content_id, {})
     click_on "Delete lead image"
+  end
+
+  def and_i_confirm_the_deletion
+    click_on "Yes, delete image"
   end
 
   def then_i_see_the_image_is_gone

--- a/spec/javascripts/modules/inline-attachment-modal-spec.js
+++ b/spec/javascripts/modules/inline-attachment-modal-spec.js
@@ -89,8 +89,8 @@ describe('InlineAttachmentModal', function () {
     itBehavesLikeALinkAction('delete')
   })
 
-  describe('confirm-delete action', function () {
-    itBehavesLikeAFormAction('confirm-delete')
+  describe('confirmDelete action', function () {
+    itBehavesLikeAFormAction('confirmDelete')
   })
 
   describe('edit action', function () {

--- a/spec/javascripts/modules/inline-image-modal-spec.js
+++ b/spec/javascripts/modules/inline-image-modal-spec.js
@@ -107,8 +107,8 @@ describe('InlineImageModal', function () {
     itBehavesLikeALinkAction('delete')
   })
 
-  describe('confirm-delete action', function () {
-    itBehavesLikeAFormAction('confirm-delete')
+  describe('confirmDelete action', function () {
+    itBehavesLikeAFormAction('confirmDelete')
   })
 
   describe('meta action', function () {

--- a/spec/javascripts/modules/inline-image-modal-spec.js
+++ b/spec/javascripts/modules/inline-image-modal-spec.js
@@ -95,12 +95,8 @@ describe('InlineImageModal', function () {
     itBehavesLikeAFormAction('upload')
   })
 
-  describe('cropBack action', function () {
-    itBehavesLikeALinkAction('cropBack')
-  })
-
-  describe('metaBack action', function () {
-    itBehavesLikeALinkAction('metaBack')
+  describe('back action', function () {
+    itBehavesLikeALinkAction('back')
   })
 
   describe('crop action', function () {
@@ -108,7 +104,11 @@ describe('InlineImageModal', function () {
   })
 
   describe('delete action', function () {
-    itBehavesLikeAFormAction('delete')
+    itBehavesLikeALinkAction('delete')
+  })
+
+  describe('confirm-delete action', function () {
+    itBehavesLikeAFormAction('confirm-delete')
   })
 
   describe('meta action', function () {

--- a/spec/requests/images_spec.rb
+++ b/spec/requests/images_spec.rb
@@ -157,6 +157,15 @@ RSpec.describe "Images" do
     end
   end
 
+  describe "GET /documents/:document/images/:image_id/delete" do
+    it "returns successfully" do
+      image_revision = create(:image_revision)
+      edition = create(:edition, lead_image_revision: image_revision)
+      get confirm_delete_image_path(edition.document, image_revision.image_id)
+      expect(response).to have_http_status(:ok)
+    end
+  end
+
   describe "DELETE /documents/:document/images/:image_id" do
     before { stub_any_publishing_api_put_content }
 


### PR DESCRIPTION
Trello Card: https://trello.com/c/duxwb607/1443-confirm-before-deleting-an-image

When interacting with images via the markdown editor the option to "Delete image" will now route the user to a confirmation page. Previously clicking this link would have deleted the image and displayed a flash message in the modal. Adding a confirmation page for deletion is in keeping with changes made to other delete actions, such as deleting drafts and deleting attachments. 

<img width="981" alt="Screenshot 2020-03-30 at 14 52 35" src="https://user-images.githubusercontent.com/41922771/78007385-24bcc280-7336-11ea-9324-069fc25127b5.png">

The user will also be routed to this confirmation page in a non-modal context when deleting a lead image. 