### PR TITLE
Fix back link for featured attachment replace

### DIFF
--- a/app/views/file_attachments/replace.html.erb
+++ b/app/views/file_attachments/replace.html.erb
@@ -2,6 +2,8 @@
 
 <% back_link_path = if params[:wizard] == "featured-attachment-replace"
                       featured_attachments_path(@edition.document)
+                    elsif params[:wizard] == "featured-attachment-upload"
+                      featured_attachments_path(@edition.document)
                     else
                       file_attachments_path(@edition.document)
                     end %>


### PR DESCRIPTION
https://trello.com/c/rfna82RY/1712-our-back-actions-are-not-tested

I've chosen to make this an explicit conditional branch, so it's clear
which 'wizards' the logic applies to.