### PR TITLE
Import superseded editions with archived history events

### DIFF
--- a/lib/whitehall_importer/create_edition.rb
+++ b/lib/whitehall_importer/create_edition.rb
@@ -160,7 +160,7 @@ module WhitehallImporter
 
     def create_edition(status:, edition_number:, current:, revision:, create_event: nil, last_event: nil)
       create_event ||= history.create_event!
-      last_event ||= whitehall_edition["revision_history"].last
+      last_event ||= history.last_event
 
       editor_ids = history.editors.map { |editor| user_ids[editor] }.compact
       published_at = history.last_state_event!("published")["created_at"] if status.live? || status.superseded?

--- a/lib/whitehall_importer/create_edition.rb
+++ b/lib/whitehall_importer/create_edition.rb
@@ -147,7 +147,7 @@ module WhitehallImporter
     end
 
     def build_status(revision, state, details = nil)
-      last_state_event = history.last_state_event!(whitehall_edition["state"])
+      last_state_event = history.last_state_event!(event_state(state))
 
       Status.new(
         state: state,
@@ -262,6 +262,14 @@ module WhitehallImporter
         document: edition.document,
         details: details,
       )
+    end
+
+    def event_state(state)
+      if state == "superseded" && history.last_event["state"] == "archived"
+        "archived"
+      else
+        whitehall_edition["state"]
+      end
     end
   end
 end

--- a/lib/whitehall_importer/edition_history.rb
+++ b/lib/whitehall_importer/edition_history.rb
@@ -96,6 +96,10 @@ module WhitehallImporter
       end
     end
 
+    def last_event
+      revision_history.last
+    end
+
   private
 
     attr_reader :revision_history

--- a/spec/lib/whitehall_importer/edition_history_spec.rb
+++ b/spec/lib/whitehall_importer/edition_history_spec.rb
@@ -262,4 +262,16 @@ RSpec.describe WhitehallImporter::EditionHistory do
         .to raise_error(WhitehallImporter::AbortImportError)
     end
   end
+
+  describe "#last_event" do
+    it "returns the last event of the revision history" do
+      first_event = build(:whitehall_export_revision_history_event,
+                          state: "draft")
+      second_event = build(:whitehall_export_revision_history_event,
+                           event: "update", state: "published")
+      instance = described_class.new([first_event, second_event])
+
+      expect(instance.last_event).to eq(second_event)
+    end
+  end
 end


### PR DESCRIPTION
For https://trello.com/c/RfpyAbs1/1536-investigate-missing-superseded-event-cma-dwp-dhsc

While building the status for a number of imported superseded editions, an
error has been raised as there is no event with a "superseded" state in the
edition's revision history. After some investigation into the source data in
Whitehall, it transpires that we have instances where superseded editions have
a final event with the state "archived".  For example:

```
"document_id"=>124314,
"state"=>"superseded",
 ...
"revision_history"=>
  [{"event"=>"create",
    "created_at"=>"2013-03-06T09:37:56.000+00:00",
    "state"=>"imported",
    "whodunnit"=>256},
    ...
   {"event"=>"update",
   "created_at"=>"2013-09-23T13:27:42.000+01:00",
   "state"=>"archived",
   "whodunnit"=>817}],
```

"Archived" looks to be an old edition state which is no longer in use. It was
renamed "Withdrawn" in May 2015:
https://github.com/alphagov/whitehall/commit/95e11e3
However, the documents that we have investigated weren't withdrawn but were
simply superseded by another edition.

The last usage of the "archived" state for edition events was in June 2015, so
we suspect it may be a legacy state, though its unclear why it was being used
instead of 'superseded' in these cases: `Version.where(state:
"archived").maximum(:created_at) => Tue, 02 Jun 2015 16:20:31 BST +01:00`

In order to handle the import of these unusual events for superseded editions,
we have modified the `Create Edition` importer class to look up the last
"archived" event for superseded editions without a "superseded" event.