### PR TITLE
Enable change history check to check non first drafts

### DIFF
--- a/lib/whitehall_importer/integrity_checker.rb
+++ b/lib/whitehall_importer/integrity_checker.rb
@@ -58,9 +58,9 @@ module WhitehallImporter
       ).sufficiently_similar?
 
       problems << "change history doesn't match" unless ChangeHistoryCheck.new(
+        edition,
         proposed_payload.dig("details", "change_history"),
         publishing_api_content["details"].fetch("change_history", []),
-        edition,
       ).match?
 
       problems

--- a/lib/whitehall_importer/integrity_checker/change_history_check.rb
+++ b/lib/whitehall_importer/integrity_checker/change_history_check.rb
@@ -2,27 +2,34 @@ module WhitehallImporter
   class IntegrityChecker::ChangeHistoryCheck
     attr_reader :edition, :proposed_change_history, :publishing_api_change_history
 
-    def initialize(proposed_change_history, publishing_api_change_history, edition)
-      @proposed_change_history = proposed_change_history
-      @publishing_api_change_history = publishing_api_change_history
+    def initialize(edition, proposed_change_history, publishing_api_change_history)
       @edition = edition
+      @proposed_change_history = trim_proposed_change_history(proposed_change_history)
+      @publishing_api_change_history = publishing_api_change_history
     end
 
     def match?
-      if publishing_api_change_history.empty?
+      if publishing_api_change_history.empty? && edition.live?
         return proposed_history_has_first_published_change_note?
       end
 
       return false unless history_length_matches?
 
-      if edition.live?
-        history_matches?(proposed_change_history, publishing_api_change_history)
-      else
-        history_excluding_first_timestamp_matches?
-      end
+      history_matches?(proposed_change_history, publishing_api_change_history)
     end
 
   private
+
+    def trim_proposed_change_history(proposed_change_history)
+      first_non_live_edition = !edition.live? && edition.first?
+      major_non_live_edition = edition.major? && edition.change_note && !edition.live?
+
+      if first_non_live_edition || major_non_live_edition
+        proposed_change_history.drop(1)
+      else
+        proposed_change_history
+      end
+    end
 
     def history_length_matches?
       proposed_change_history.length == publishing_api_change_history.length
@@ -38,16 +45,6 @@ module WhitehallImporter
         proposed_history["note"] == publishing_api_history["note"] &&
           IntegrityChecker.time_matches?(proposed_time, publishing_api_time, seconds_difference)
       end
-    end
-
-    def history_excluding_first_timestamp_matches?
-      proposed_head, *proposed_tail = proposed_change_history
-      publishing_api_head, *publishing_api_tail = publishing_api_change_history
-
-      first_note_matches = proposed_head["note"] == publishing_api_head["note"]
-      remaining_history_matches = history_matches?(proposed_tail, publishing_api_tail)
-
-      first_note_matches && remaining_history_matches
     end
 
     def proposed_history_has_first_published_change_note?

--- a/spec/lib/whitehall_importer/integrity_checker/change_history_check_spec.rb
+++ b/spec/lib/whitehall_importer/integrity_checker/change_history_check_spec.rb
@@ -1,51 +1,53 @@
 RSpec.describe WhitehallImporter::IntegrityChecker::ChangeHistoryCheck do
   describe "#match?" do
-    it "returns true if the proposed change history matches the Publishing API history for a non-draft edition" do
+    let(:published_edition) { create(:edition, :published) }
+
+    it "returns true if the proposed change history matches the Publishing API history for a live edition" do
       proposed_change_history = change_note("First published.", Date.yesterday.noon)
       publishing_api_change_history = change_note("First published.", Date.yesterday.noon)
 
       integrity_check = described_class.new(
+        published_edition,
         proposed_change_history,
         publishing_api_change_history,
-        create(:edition, :published),
-      )
-      expect(integrity_check.match?).to be true
-    end
-
-    it "returns true if the proposed change history matches for a draft edition with mismatched time stamps for first item" do
-      proposed_change_history = change_note("First published.", Date.yesterday.noon) +
-        change_note("Updated", Time.zone.now)
-
-      publishing_api_change_history = change_note("First published.", Time.zone.now) +
-        change_note("Updated", Time.zone.now)
-
-      integrity_check = described_class.new(
-        proposed_change_history,
-        publishing_api_change_history,
-        create(:edition),
       )
       expect(integrity_check.match?).to be true
     end
 
     it "returns true if proposed change history has a 'First published' change note and Publishing API has no change history" do
       proposed_change_history = change_note("First published.", Date.yesterday.noon)
-      integrity_check = described_class.new(proposed_change_history,
-                                            [],
-                                            create(:edition))
+      integrity_check = described_class.new(published_edition, proposed_change_history, [])
 
       expect(integrity_check.match?).to be true
     end
 
+    it "returns true for an edition with a major change & change_note which isn't live" do
+      draft_edition = create(:edition, change_note: "Major draft change note")
+      proposed_change_history = change_note("Major draft change note.", Date.yesterday.end_of_day) +
+        change_note("First published.", Date.yesterday.noon)
+      publishing_api_change_history = change_note("First published.", Date.yesterday.noon)
+
+      integrity_check = described_class.new(draft_edition, proposed_change_history, publishing_api_change_history)
+      expect(integrity_check.match?).to be true
+    end
+
+    it "returns true for an edition with a minor change which isn't live" do
+      draft_edition = create(:edition, number: 2, update_type: "minor")
+      proposed_change_history = change_note("First published.", Date.yesterday.noon)
+      publishing_api_change_history = change_note("First published.", Date.yesterday.noon)
+
+      integrity_check = described_class.new(draft_edition, proposed_change_history, publishing_api_change_history)
+      expect(integrity_check.match?).to be true
+    end
+
     it "returns true if first published timestamps are sufficiently similar" do
-      proposed_change_history = change_note("First published.",
-                                            Time.zone.now.beginning_of_minute)
-      publishing_api_change_history = change_note("First published.",
-                                                  Time.zone.now)
+      proposed_change_history = change_note("First published.", Time.zone.now.beginning_of_minute)
+      publishing_api_change_history = change_note("First published.", Time.zone.now)
 
       integrity_check = described_class.new(
+        published_edition,
         proposed_change_history,
         publishing_api_change_history,
-        create(:edition),
       )
       expect(integrity_check.match?).to be true
     end
@@ -57,9 +59,9 @@ RSpec.describe WhitehallImporter::IntegrityChecker::ChangeHistoryCheck do
         change_note("Updated", Time.zone.now)
 
       integrity_check = described_class.new(
+        published_edition,
         proposed_change_history,
         publishing_api_change_history,
-        create(:edition, :published),
       )
       expect(integrity_check.match?).to be false
     end
@@ -70,9 +72,9 @@ RSpec.describe WhitehallImporter::IntegrityChecker::ChangeHistoryCheck do
       publishing_api_change_history = change_note("Updated", Date.yesterday.noon)
 
       integrity_check = described_class.new(
+        published_edition,
         proposed_change_history,
         publishing_api_change_history,
-        create(:edition, :published),
       )
       expect(integrity_check.match?).to be false
     end
@@ -83,9 +85,9 @@ RSpec.describe WhitehallImporter::IntegrityChecker::ChangeHistoryCheck do
       publishing_api_change_history = change_note("First published.", Time.zone.now)
 
       integrity_check = described_class.new(
+        published_edition,
         proposed_change_history,
         publishing_api_change_history,
-        create(:edition, :published),
       )
       expect(integrity_check.match?).to be false
     end

--- a/spec/lib/whitehall_importer/integrity_checker_spec.rb
+++ b/spec/lib/whitehall_importer/integrity_checker_spec.rb
@@ -134,6 +134,7 @@ RSpec.describe WhitehallImporter::IntegrityChecker do
       it "returns true even if the public_updated_at times don't match" do
         publishing_api_item[:public_updated_at] = "2019-02-11T09:30:00Z"
         publishing_api_item[:publication_state] = "draft"
+        publishing_api_item[:details] = publishing_api_item[:details].except(:change_history)
         stub_publishing_api_has_item(publishing_api_item)
 
         expect(integrity_check.valid?).to be true
@@ -275,6 +276,7 @@ RSpec.describe WhitehallImporter::IntegrityChecker do
 
       it "returns true if there aren't any problems" do
         stub_publishing_api_has_links(content_id: edition.content_id)
+        publishing_api_item[:details] = publishing_api_item[:details].except(:change_history)
         stub_publishing_api_has_item(publishing_api_item)
 
         expect(integrity_check.valid?).to be true


### PR DESCRIPTION
Previously this code assumed that publishing-api would return
change_history for draft editions. This has turned out to be incorrect
as publishing-api only returns change_history for live editions. This
has lead to some discrepancies when checking the state of change history
between cp and pub-api.

The difference in behaviour is that content-publisher can return
change_history for non-live editions if the draft edition is a major
change with a change_note and is not the first edition. See ->
https://github.com/alphagov/content-publisher/commit/72b6556e218d66d49e4fd21f14743ea49926d36f#diff-4e6bc683d583eff1852c25cce42073d2R26

The above means that content_history can be different when comparing
drafts so we need to trim the latest draft change_note in cp to reflect
the state in publishing-api.

## Importing stuff 
```
# in whitehall
irb(main):007:0> Document.find(440172).editions.pluck(:state, :minor_change,  :change_note)
=> [["published", false, nil], ["draft", false, "Second Major change note"]]

# Importing doc with second major draft edition using check-non-first-drafts-change-history branch
irb(main):007:0> WhitehallMigration::DocumentImport.find_by_whitehall_document_id(440172).state
=> "imported"

# Importing doc with second major draft edition using master branch
irb(main):001:0> WhitehallMigration::DocumentImport.find_by_whitehall_document_id(440172).state
=> "import_aborted"
irb(main):002:0> WhitehallMigration::DocumentImport.find_by_whitehall_document_id(440172).integrity_check_problems
=> ["change history doesn't match"]

# after running NDA import locally with staging data using check-non-first-drafts-change-history branch (one aborts due to unrelated foreign locale error)
irb(main):029:0> WhitehallMigration::DocumentImport.group(:state).count
=> {"imported"=>131, "import_aborted"=>1}
```
Trello:
https://trello.com/c/1lgwEe6n/1636-update-change-history-checker-to-cater-for-non-first-drafts