### PR TITLE
Make new document types accessible to pre-release

### DIFF
--- a/config/document_type_selections.yml
+++ b/config/document_type_selections.yml
@@ -28,7 +28,7 @@
       hostname: whitehall-admin
       path: /government/admin/speeches/new
 
-- id: guidance_title
+- id: guidance_publications
   options:
     - id: detailed_guide
       type: managed_elsewhere
@@ -57,7 +57,7 @@
 
 - id: guidance_and_regulation
   options:
-    - id: guidance_title
+    - id: guidance_publications
       type: document_type_selection
     - id: form
       type: document_type
@@ -149,7 +149,7 @@
       type: managed_elsewhere
       hostname: whitehall-admin
       path: /government/admin/speeches/new
-    
+
 - id: statistics
   options:
     - id: official_statistics

--- a/config/document_type_selections.yml
+++ b/config/document_type_selections.yml
@@ -28,17 +28,21 @@
       hostname: whitehall-admin
       path: /government/admin/speeches/new
 
-- id: guidance
+- id: guidance_title
   options:
     - id: detailed_guide
       type: managed_elsewhere
       hostname: whitehall-admin
       path: /government/admin/detailed-guides/new
-    - id: non_statutory_guidance
+    - id: guidance
+      type: document_type
+    - id: guidance_managed_elsewhere
       type: managed_elsewhere
       hostname: whitehall-admin
       path: /government/admin/publications/new
     - id: statutory_guidance
+      type: document_type
+    - id: statutory_guidance_managed_elsewhere
       type: managed_elsewhere
       hostname: whitehall-admin
       path: /government/admin/publications/new
@@ -53,17 +57,23 @@
 
 - id: guidance_and_regulation
   options:
-    - id: guidance
+    - id: guidance_title
       type: document_type_selection
     - id: form
+      type: document_type
+    - id: form_managed_elsewhere
       type: managed_elsewhere
       hostname: whitehall-admin
       path: /government/admin/publications/new
     - id: regulation
+      type: document_type
+    - id: regulation_managed_elsewhere
       type: managed_elsewhere
       hostname: whitehall-admin
       path: /government/admin/publications/new
     - id: map
+      type: document_type
+    - id: map_managed_elsewhere
       type: managed_elsewhere
       hostname: whitehall-admin
       path: /government/admin/publications/new
@@ -109,10 +119,14 @@
 - id: specialist_notices
   options:
     - id: notice
+      type: document_type
+    - id: notice_managed_elsewhere
       type: managed_elsewhere
       hostname: whitehall-admin
       path: /government/admin/publications/new
     - id: decision
+      type: document_type
+    - id: decision_managed_elsewhere
       type: managed_elsewhere
       hostname: whitehall-admin
       path: /government/admin/publications/new

--- a/config/document_types.yml
+++ b/config/document_types.yml
@@ -45,9 +45,17 @@ document_types:
     <<: *publication
     label: Corporate report
 
+  - id: decision
+    <<: *publication
+    label: Decision
+
   - id: foi_release
     <<: *publication
     label: FOI Release
+
+  - id: form
+    <<: *publication
+    label: Form
 
   - id: impact_assessment
     <<: *publication
@@ -57,9 +65,21 @@ document_types:
     <<: *publication
     label: Independent report
 
+  - id: map
+    <<: *publication
+    label: Map
+
   - id: news_story
     <<: *news_article
     label: News story
+
+  - id: notice
+    <<: *publication
+    label: Notice
+        
+  - id: guidance
+    <<: *publication
+    label: Non statutory guidance  
 
   - id: policy_paper
     <<: *publication
@@ -73,9 +93,17 @@ document_types:
     <<: *publication
     label: Promotional material
 
+  - id: regulation
+    <<: *publication
+    label: Regulation
+
   - id: research
     <<: *publication
     label: Research and analysis
+
+  - id: statutory_guidance
+    <<: *publication
+    label: Statutory guidance
 
   - id: transparency
     <<: *publication

--- a/config/locales/en/document_type_selections.yml
+++ b/config/locales/en/document_type_selections.yml
@@ -30,6 +30,9 @@ en:
       label: Correspondence publication
       description: Minister or organisation responses (for example to campaign letters), correspondence to individuals, organisations and professionals, circulars, bulletins and newsletters.
     decision:
+      label: Decision publication (pre-release)
+      description: Formal decisions by tribunals, regulators or adjudicators (including courts and Secretaries of State).
+    decision_managed_elsewhere:
       label: Decision publication
       description: Formal decisions by tribunals, regulators or adjudicators (including courts and Secretaries of State).
     detailed_guide:
@@ -45,9 +48,12 @@ en:
       label: FOI release publication
       description: Responses to Freedom of Information (FOI) requests.
     form:
+      label: Form publication (pre-release)
+      description: Form documents that need to be completed by the users.
+    form_managed_elsewhere:
       label: Form publication
       description: Form documents that need to be completed by the users.
-    guidance:
+    guidance_title:
       label: Guidance
       description: Guidance to help the user do something or understand what they need to do.
     guidance_and_regulation:
@@ -75,6 +81,9 @@ en:
       label: Manual
       description: Long, complex guidance or legal documents for specialist users who are familiar with a topic, usually with named or numbered chapters or clauses.
     map:
+      label: Map publication (pre-release)
+      description: Drawn maps and geographical data.
+    map_managed_elsewhere:
       label: Map publication
       description: Drawn maps and geographical data.
     news:
@@ -90,12 +99,18 @@ en:
       label: I’m not sure if this should be on GOV.UK
       description: View this guide to see what should go on GOV.UK and where else you can publish content
     notice:
+      label: Notice publication (pre-release)
+      description: Permit and licence applications published temporarily for public awareness.
+    notice_managed_elsewhere:
       label: Notice publication
       description: Permit and licence applications published temporarily for public awareness.
     national_statistics:
       label: National statistics publication
       description: Official Statistics that have been produced in accordance with the Code of Practice for Official Statistics, which is indicated using the National Statistics quality mark.
-    non_statutory_guidance:
+    guidance:
+      label: Non-statutory guidance publication (pre-release)
+      description: Publications like manuals, handbooks, and other documents that offer advice. Use for content produced as a standalone hard-copy publicaton. For web-original content use 'detailed guide'.
+    guidance_managed_elsewhere:
       label: Non-statutory guidance publication
       description: Publications like manuals, handbooks, and other documents that offer advice. Use for content produced as a standalone hard-copy publicaton. For web-original content use 'detailed guide'.
     official_statistics:
@@ -126,6 +141,9 @@ en:
       label: Promotional material publication
       description: Leaflets, posters, factsheets and marketing materials.
     regulation:
+      label: Regulation publication (pre-release)
+      description: Regulations imposed by an independent regulatory authority.
+    regulation_managed_elsewhere:
       label: Regulation publication
       description: Regulations imposed by an independent regulatory authority.
     research:
@@ -156,6 +174,9 @@ en:
       label: Statistics announcement
       description: An announcement of national and official statistics releases to comply with the Code of Practice for Official Statistics.
     statutory_guidance:
+      label: Statutory guidance publication (pre-release)
+      description: Guidance which relevant users are legally obliged to follow.
+    statutory_guidance_managed_elsewhere:
       label: Statutory guidance publication
       description: Guidance which relevant users are legally obliged to follow.
     transparency:

--- a/config/locales/en/document_type_selections.yml
+++ b/config/locales/en/document_type_selections.yml
@@ -53,7 +53,7 @@ en:
     form_managed_elsewhere:
       label: Form publication
       description: Form documents that need to be completed by the users.
-    guidance_title:
+    guidance_publications:
       label: Guidance
       description: Guidance to help the user do something or understand what they need to do.
     guidance_and_regulation:

--- a/config/locales/en/document_types.yml
+++ b/config/locales/en/document_types.yml
@@ -68,6 +68,28 @@ en:
 
               [The style guide](https://www.gov.uk/guidance/style-guide){:target="_blank"}
 
+    decision:
+      fields:
+        title: 
+          guidance: 
+            title: Creating a title
+            body_govspeak: This does not have to be the full publication title. The title must be unique and specific, and make clear what the content offers users in their words. 
+        summary:
+          guidance:
+            title: Writing a summary
+            body_govspeak: The summary explains the main point of the content and it should end with a full stop. Keep it short, possibly under 160 characters, and avoid repeating the first line of the body.
+        body:
+          guidance: 
+            title: Writing the details for a decision 
+            body_govspeak: |
+              "Use short words, short sentences, and short paragraphs. Use subheadings in longer content.
+           
+              [Guidance on decision publications](https://www.gov.uk/guidance/content-design/content-types#decision){:target=""_blank""}
+              
+              [Writing for GOV.UK](https://www.gov.uk/guidance/content-design/writing-for-gov-uk#writing-to-govuk-style){:target=""_blank""}
+              
+              [The style guide](https://www.gov.uk/guidance/style-guide){:target=""_blank""}"
+
     foi_release:
       fields:
         title:
@@ -89,6 +111,50 @@ en:
               [Writing for GOV.UK](https://www.gov.uk/guidance/content-design/writing-for-gov-uk#writing-to-govuk-style){:target="_blank"}
 
               [The style guide](https://www.gov.uk/guidance/style-guide){:target="_blank"}
+
+    form:
+      fields:
+        title: 
+          guidance: 
+            title: Creating a title
+            body_govspeak: This does not have to be the full publication title. The title must be unique and specific, and make clear what the content offers users in their words. 
+        summary:
+          guidance:
+            title: Writing a summary
+            body_govspeak: The summary explains the main point of the content and it should end with a full stop. Keep it short, possibly under 160 characters, and avoid repeating the first line of the body.
+        body:
+          guidance:
+            title: Writing the details for a form
+            body_govspeak: |
+              "Use short words, short sentences, and short paragraphs. Use subheadings in longer content. 
+              
+              [Guidance on form publications](https://www.gov.uk/guidance/content-design/content-types#form){:target=""_blank""}
+              
+              [Writing for GOV.UK](https://www.gov.uk/guidance/content-design/writing-for-gov-uk#writing-to-govuk-style){:target=""_blank""}
+              
+              [The style guide](https://www.gov.uk/guidance/style-guide){:target=""_blank""}"
+
+    guidance:
+      fields:
+        title:
+          guidance:
+            title: Creating a title
+            body_govspeak: This does not have to be the full publication title. The title must be unique and specific, and make clear what the content offers users in their words. 
+        summary:
+          guidance:
+            title: Writing a summary
+            body_govspeak: The summary explains the main point of the content and it should end with a full stop. Keep it short, possibly under 160 characters, and avoid repeating the first line of the body.
+        body:
+          guidance:
+            title: Writing the details for non-statutory guidance
+            body_govspeak: |
+              "Use short words, short sentences, and short paragraphs. Use subheadings in longer content. 
+              
+              [Guidance on guidance publications](https://www.gov.uk/guidance/content-design/content-types#non-statutory-guidance){:target=""_blank""}
+        
+              [Writing for GOV.UK](https://www.gov.uk/guidance/content-design/writing-for-gov-uk#writing-to-govuk-style){:target=""_blank""}
+              
+              [The style guide](https://www.gov.uk/guidance/style-guide){:target=""_blank""}"
 
     impact_assessment:
       fields:
@@ -134,6 +200,26 @@ en:
 
               [The style guide](https://www.gov.uk/guidance/style-guide){:target="_blank"}
 
+    map:
+      fields:
+        title: 
+          guidance: 
+            title: Creating a title
+            body_govspeak: This does not have to be the full publication title. The title must be unique and specific, and make clear what the content offers users in their words. 
+        summary:
+          guidance:
+            title: Writing a summary
+            body_govspeak: The summary explains the main point of the content and it should end with a full stop. Keep it short, possibly under 160 characters, and avoid repeating the first line of the body.
+        body:
+          guidance:
+            title: Writing the details for a map
+            body_govspeak: |
+              "Use short words, short sentences, and short paragraphs. Use subheadings in longer content. 
+              
+              [Writing for GOV.UK](https://www.gov.uk/guidance/content-design/writing-for-gov-uk#writing-to-govuk-style){:target=""_blank""}
+        
+              [The style guide](https://www.gov.uk/guidance/style-guide){:target=""_blank""}"    
+
     news_story:
       fields:
         title:
@@ -155,6 +241,28 @@ en:
               [Writing for GOV.UK](https://www.gov.uk/guidance/content-design/writing-for-gov-uk#writing-to-govuk-style){:target="_blank"}
 
               [The style guide](https://www.gov.uk/guidance/style-guide){:target="_blank"}
+
+    notice:
+      fields:
+        title: 
+          guidance: 
+            title: Creating a title
+            body_govspeak: This does not have to be the full publication title. The title must be unique and specific, and make clear what the content offers users in their words. 
+        summary:
+          guidance:
+            title: Writing a summary
+            body_govspeak: The summary explains the main point of the content and it should end with a full stop. Keep it short, possibly under 160 characters, and avoid repeating the first line of the body.
+        body:
+          guidance:
+            title: Writing the details for a notice
+            body_govspeak: |
+              "Use short words, short sentences, and short paragraphs. Use subheadings in longer content. 
+              
+              [Guidance on notice publications](https://www.gov.uk/guidance/content-design/content-types#notice){:target=""_blank""}
+              
+              [Writing for GOV.UK](https://www.gov.uk/guidance/content-design/writing-for-gov-uk#writing-to-govuk-style){:target=""_blank""}
+              
+              [The style guide](https://www.gov.uk/guidance/style-guide){:target=""_blank""}"
 
     policy_paper:
       fields:
@@ -222,6 +330,28 @@ en:
 
               [The style guide](https://www.gov.uk/guidance/style-guide){:target="_blank"}
 
+    regulation:
+      fields:
+        title: 
+          guidance: 
+            title: Creating a title
+            body_govspeak: This does not have to be the full publication title. The title must be unique and specific, and make clear what the content offers users in their words. 
+        summary:
+          guidance:
+            title: Writing a summary
+            body_govspeak: The summary explains the main point of the content and it should end with a full stop. Keep it short, possibly under 160 characters, and avoid repeating the first line of the body.
+        body:
+          guidance:
+            title: Writing the details for regulation
+            body_govspeak: |
+              "Use short words, short sentences, and short paragraphs. Use subheadings in longer content. 
+              
+              [Guidance on regulation publications](https://www.gov.uk/guidance/content-design/content-types#publication-regulations){:target=""_blank""}
+              
+              [Writing for GOV.UK](https://www.gov.uk/guidance/content-design/writing-for-gov-uk#writing-to-govuk-style){:target=""_blank""}
+              
+              [The style guide](https://www.gov.uk/guidance/style-guide){:target=""_blank""}"
+
     research:
       fields:
         title:
@@ -244,6 +374,28 @@ en:
 
               [The style guide](https://www.gov.uk/guidance/style-guide){:target="_blank"}
 
+    statutory_guidance:
+      fields:
+        title: 
+          guidance: 
+            title: Creating a title
+            body_govspeak: This does not have to be the full publication title. The title must be unique and specific, and make clear what the content offers users in their words. 
+        summary:
+          guidance:
+            title: Writing a summary
+            body_govspeak: The summary explains the main point of the content and it should end with a full stop. Keep it short, possibly under 160 characters, and avoid repeating the first line of the body.
+        body:
+          guidance:
+            title: Writing the details for statutory guidance
+            body_govspeak: |
+              "Use short words, short sentences, and short paragraphs. Use subheadings in longer content. 
+              
+              [Guidance on statutory guidance publications](https://www.gov.uk/guidance/content-design/content-types#statutory-guidance){:target=""_blank""}
+              
+              [Writing for GOV.UK](https://www.gov.uk/guidance/content-design/writing-for-gov-uk#writing-to-govuk-style){:target=""_blank""}
+              
+              [The style guide](https://www.gov.uk/guidance/style-guide){:target=""_blank""}"
+
     transparency:
       fields:
         title:
@@ -265,3 +417,13 @@ en:
               [Writing for GOV.UK](https://www.gov.uk/guidance/content-design/writing-for-gov-uk#writing-to-govuk-style){:target="_blank"}
 
               [The style guide](https://www.gov.uk/guidance/style-guide){:target="_blank"}
+
+
+
+      
+            
+ 
+
+
+
+             


### PR DESCRIPTION
We want to enable Group 2 Publications for pre-release users so that they can publish them if they onlyneed to add file attachments.

In this PR I have made the following document types 'publishable' by pre-release users 

- Guidance 
- Statutory Guidance
- Decision
- Forms
- Maps
- Regulation
- Promotional material
- Notice

'Non-statutory guidance' is referred to as guidance in the Gov.uk schema, so i've had to rename any reference to 'non_statutory_guidance' to 'guidance.'

Some existing references to 'guidance' have had to be changed to 'guidance_title" in order not to
conflict with my changes made to the 'non_statutory_guidance' id