### PR TITLE
Firm things up after incident

### DIFF
--- a/app/models/document_type/primary_publishing_organisation_field.rb
+++ b/app/models/document_type/primary_publishing_organisation_field.rb
@@ -8,7 +8,7 @@ class DocumentType::PrimaryPublishingOrganisationField
   end
 
   def updater_params(_edition, params)
-    { primary_publishing_organisation: params[:primary_publishing_organisation] }
+    { primary_publishing_organisation: params[:primary_publishing_organisation] }.compact
   end
 
   def pre_update_issues(_edition, params)

--- a/app/models/document_type/summary_field.rb
+++ b/app/models/document_type/summary_field.rb
@@ -10,7 +10,7 @@ class DocumentType::SummaryField
   end
 
   def updater_params(_edition, params)
-    { summary: params[:summary]&.strip }
+    { summary: params[:summary]&.strip }.compact
   end
 
   def pre_update_issues(_edition, params)

--- a/app/models/document_type/title_and_base_path_field.rb
+++ b/app/models/document_type/title_and_base_path_field.rb
@@ -18,7 +18,7 @@ class DocumentType::TitleAndBasePathField
   def updater_params(edition, params)
     title = params[:title]&.strip
     base_path = GenerateBasePathService.call(edition, title: title)
-    { title: title, base_path: base_path }
+    { title: title, base_path: base_path }.compact
   end
 
   def pre_update_issues(edition, params)

--- a/spec/models/document_type/organisations_field_spec.rb
+++ b/spec/models/document_type/organisations_field_spec.rb
@@ -38,5 +38,12 @@ RSpec.describe DocumentType::OrganisationsField do
       updater_params = described_class.new.updater_params(edition, params)
       expect(updater_params).to eq(organisations: %w[some_org_id])
     end
+
+    it "disallows incorect data" do
+      edition = build :edition
+      params = ActionController::Parameters.new(organisations: nil)
+      updater_params = described_class.new.updater_params(edition, params)
+      expect(updater_params).to be_empty
+    end
   end
 end

--- a/spec/models/document_type/primary_publishing_organisation_field_spec.rb
+++ b/spec/models/document_type/primary_publishing_organisation_field_spec.rb
@@ -15,6 +15,13 @@ RSpec.describe DocumentType::PrimaryPublishingOrganisationField do
       updater_params = described_class.new.updater_params(edition, params)
       expect(updater_params).to eq(primary_publishing_organisation: %w[some_org_id])
     end
+
+    it "disallows incorect data" do
+      edition = build :edition
+      params = ActionController::Parameters.new(organisations: nil)
+      updater_params = described_class.new.updater_params(edition, params)
+      expect(updater_params).to be_empty
+    end
   end
 
   describe "#pre_update_issues" do

--- a/spec/models/document_type/role_appointments_field_spec.rb
+++ b/spec/models/document_type/role_appointments_field_spec.rb
@@ -27,5 +27,12 @@ RSpec.describe DocumentType::RoleAppointmentsField do
       updater_params = described_class.new.updater_params(edition, params)
       expect(updater_params).to eq(role_appointments: %w[some_role_id])
     end
+
+    it "disallows incorect data" do
+      edition = build :edition
+      params = ActionController::Parameters.new(organisations: nil)
+      updater_params = described_class.new.updater_params(edition, params)
+      expect(updater_params).to be_empty
+    end
   end
 end

--- a/spec/models/document_type/summary_field_spec.rb
+++ b/spec/models/document_type/summary_field_spec.rb
@@ -14,6 +14,13 @@ RSpec.describe DocumentType::SummaryField do
       updater_params = described_class.new.updater_params(edition, params)
       expect(updater_params).to eq(summary: "summary")
     end
+
+    it "disallows incorect data" do
+      edition = build :edition
+      params = ActionController::Parameters.new(organisations: nil)
+      updater_params = described_class.new.updater_params(edition, params)
+      expect(updater_params).to be_empty
+    end
   end
 
   describe "#pre_update_issues" do

--- a/spec/models/document_type/topical_events_field_spec.rb
+++ b/spec/models/document_type/topical_events_field_spec.rb
@@ -15,5 +15,12 @@ RSpec.describe DocumentType::TopicalEventsField do
       updater_params = described_class.new.updater_params(edition, params)
       expect(updater_params).to eq(topical_events: %w[some_topical_event_id])
     end
+
+    it "disallows incorect data" do
+      edition = build :edition
+      params = ActionController::Parameters.new(organisations: nil)
+      updater_params = described_class.new.updater_params(edition, params)
+      expect(updater_params).to be_empty
+    end
   end
 end

--- a/spec/models/document_type/world_locations_field_spec.rb
+++ b/spec/models/document_type/world_locations_field_spec.rb
@@ -15,5 +15,12 @@ RSpec.describe DocumentType::WorldLocationsField do
       updater_params = described_class.new.updater_params(edition, params)
       expect(updater_params).to eq(world_locations: %w[some_world_location_id])
     end
+
+    it "disallows incorect data" do
+      edition = build :edition
+      params = ActionController::Parameters.new(organisations: nil)
+      updater_params = described_class.new.updater_params(edition, params)
+      expect(updater_params).to be_empty
+    end
   end
 end


### PR DESCRIPTION
Trello - https://trello.com/c/xkQzBiFE/1614-content-publisher-document-filter-incident-follow-up

This introduces testing for some incident related fixes. It also does some validation on a database level to stop potentially incident causing data to make its way in in the first place. 