### PR TITLE
Use 'top_level_description' to render view specs

### DIFF
--- a/spec/views/documents/history/_content_publisher_entry.html.erb_spec.rb
+++ b/spec/views/documents/history/_content_publisher_entry.html.erb_spec.rb
@@ -1,15 +1,15 @@
-RSpec.describe "documents/history/_content_publisher_entry.html.erb" do
+RSpec.describe "documents/history/content_publisher_entry.html.erb" do
   it "shows a timeline entry without an author" do
     timeline_entry = create(:timeline_entry,
                             created_by: nil)
-    render partial: "documents/history/content_publisher_entry", locals: { entry: timeline_entry }
+    render partial: self.class.top_level_description, locals: { entry: timeline_entry }
     expect(rendered).not_to have_content(I18n.t!("documents.history.by"))
     expect(rendered).to have_content(I18n.t!("documents.history.entry_types.created"))
   end
 
   it "shows a timeline entry with an author" do
     timeline_entry = create(:timeline_entry)
-    render partial: "documents/history/content_publisher_entry", locals: { entry: timeline_entry }
+    render partial: self.class.top_level_description, locals: { entry: timeline_entry }
     expect(rendered).to have_content(I18n.t!("documents.history.by") + " John Smith")
     expect(rendered).to have_content(I18n.t!("documents.history.entry_types.created"))
   end
@@ -18,7 +18,7 @@ RSpec.describe "documents/history/_content_publisher_entry.html.erb" do
     timeline_entry = create(:timeline_entry,
                             entry_type: :internal_note,
                             details: create(:internal_note))
-    render partial: "documents/history/content_publisher_entry", locals: { entry: timeline_entry }
+    render partial: self.class.top_level_description, locals: { entry: timeline_entry }
     expect(rendered).to have_selector(".app-timeline-entry__content",
                                       text: "Amazing internal note")
     expect(rendered).to have_content(I18n.t!("documents.history.entry_types.internal_note"))
@@ -30,7 +30,7 @@ RSpec.describe "documents/history/_content_publisher_entry.html.erb" do
       timeline_entry = create(:timeline_entry,
                               entry_type: :removed,
                               details: removal)
-      render partial: "documents/history/content_publisher_entry",
+      render partial: self.class.top_level_description,
              locals: { entry: timeline_entry }
       expect(rendered).to have_content("My note")
     end
@@ -40,7 +40,7 @@ RSpec.describe "documents/history/_content_publisher_entry.html.erb" do
       timeline_entry = create(:timeline_entry,
                               entry_type: :removed,
                               details: removal)
-      render partial: "documents/history/content_publisher_entry",
+      render partial: self.class.top_level_description,
              locals: { entry: timeline_entry }
       alternative_url = I18n.t!("documents.history.entry_content.alternative_url")
       expect(rendered).to have_content("#{alternative_url} https://example.com",
@@ -54,7 +54,7 @@ RSpec.describe "documents/history/_content_publisher_entry.html.erb" do
       timeline_entry = create(:timeline_entry,
                               entry_type: :removed,
                               details: removal)
-      render partial: "documents/history/content_publisher_entry",
+      render partial: self.class.top_level_description,
              locals: { entry: timeline_entry }
       expect(rendered).to have_link("https://www.test.gov.uk/path",
                                     href: "https://www.test.gov.uk/path")
@@ -65,7 +65,7 @@ RSpec.describe "documents/history/_content_publisher_entry.html.erb" do
       timeline_entry = create(:timeline_entry,
                               entry_type: :removed,
                               details: removal)
-      render partial: "documents/history/content_publisher_entry",
+      render partial: self.class.top_level_description,
              locals: { entry: timeline_entry }
       redirected_to = I18n.t!("documents.history.entry_content.redirected_to")
       expect(rendered).to have_content("#{redirected_to} https://example.com",

--- a/spec/views/documents/history/_whitehall_entry.html.erb_spec.rb
+++ b/spec/views/documents/history/_whitehall_entry.html.erb_spec.rb
@@ -1,10 +1,10 @@
-RSpec.describe "documents/history/_whitehall_entry.html.erb" do
+RSpec.describe "documents/history/whitehall_entry.html.erb" do
   it "shows an imported timeline entry without an author" do
     timeline_entry = create(:timeline_entry,
                             :whitehall_imported,
                             whitehall_entry_type: :new_edition,
                             created_by: nil)
-    render partial: "documents/history/whitehall_entry", locals: { entry: timeline_entry }
+    render partial: self.class.top_level_description, locals: { entry: timeline_entry }
     expect(rendered).not_to have_content(I18n.t!("documents.history.by"))
     expect(rendered).to have_content(I18n.t!("documents.history.entry_types.whitehall_migration.new_edition"))
   end
@@ -14,7 +14,7 @@ RSpec.describe "documents/history/_whitehall_entry.html.erb" do
                             :whitehall_imported,
                             whitehall_entry_type: :new_edition)
 
-    render partial: "documents/history/whitehall_entry", locals: { entry: timeline_entry }
+    render partial: self.class.top_level_description, locals: { entry: timeline_entry }
     expect(rendered).to have_content(I18n.t!("documents.history.by") + " John Smith")
     expect(rendered).to have_content(I18n.t!("documents.history.entry_types.whitehall_migration.new_edition"))
   end
@@ -25,8 +25,8 @@ RSpec.describe "documents/history/_whitehall_entry.html.erb" do
                             whitehall_entry_type: :internal_note)
     timeline_entry.details[:contents] = {}
 
-    render partial: "documents/history/whitehall_entry",
-                    locals: { entry: timeline_entry }
+    render partial: self.class.top_level_description,
+           locals: { entry: timeline_entry }
     expect(rendered).not_to have_selector(".app-timeline-entry--highlighted")
   end
 
@@ -37,8 +37,8 @@ RSpec.describe "documents/history/_whitehall_entry.html.erb" do
                             whitehall_entry_type: :internal_note)
     timeline_entry.details[:contents] = { body: note }
 
-    render partial: "documents/history/whitehall_entry",
-                    locals: { entry: timeline_entry }
+    render partial: self.class.top_level_description,
+           locals: { entry: timeline_entry }
     expect(rendered).to have_content(note)
     expect(rendered).to have_selector(".app-timeline-entry--highlighted")
   end
@@ -49,8 +49,8 @@ RSpec.describe "documents/history/_whitehall_entry.html.erb" do
                             whitehall_entry_type: :fact_check_request)
     timeline_entry.details[:contents] = {}
 
-    render partial: "documents/history/whitehall_entry",
-                    locals: { entry: timeline_entry }
+    render partial: self.class.top_level_description,
+           locals: { entry: timeline_entry }
     expect(rendered).not_to have_selector(".app-timeline-entry--highlighted")
   end
 
@@ -65,8 +65,8 @@ RSpec.describe "documents/history/_whitehall_entry.html.erb" do
       instructions: instructions,
     }
 
-    render partial: "documents/history/whitehall_entry",
-                    locals: { entry: timeline_entry }
+    render partial: self.class.top_level_description,
+           locals: { entry: timeline_entry }
     expect(rendered).to have_content(email)
     expect(rendered).to have_content(instructions)
     expect(rendered).to have_selector(".app-timeline-entry--highlighted")
@@ -78,8 +78,8 @@ RSpec.describe "documents/history/_whitehall_entry.html.erb" do
                             whitehall_entry_type: :fact_check_response)
     timeline_entry.details[:contents] = {}
 
-    render partial: "documents/history/whitehall_entry",
-                    locals: { entry: timeline_entry }
+    render partial: self.class.top_level_description,
+           locals: { entry: timeline_entry }
     expect(rendered).not_to have_selector(".app-timeline-entry--highlighted")
   end
 
@@ -94,8 +94,8 @@ RSpec.describe "documents/history/_whitehall_entry.html.erb" do
       comments: comments,
     }
 
-    render partial: "documents/history/whitehall_entry",
-                    locals: { entry: timeline_entry }
+    render partial: self.class.top_level_description,
+           locals: { entry: timeline_entry }
     expect(rendered).to have_content(email)
     expect(rendered).to have_content(comments)
     expect(rendered).to have_selector(".app-timeline-entry--highlighted")

--- a/spec/views/documents/index/_filters.html.erb_spec.rb
+++ b/spec/views/documents/index/_filters.html.erb_spec.rb
@@ -1,4 +1,4 @@
-RSpec.describe "documents/index/_filters.html.erb" do
+RSpec.describe "documents/index/filters.html.erb" do
   describe "Organisation select" do
     context "when organisations are loaded from the Publishing API" do
       it "renders the organisations in the organisation filter" do
@@ -9,7 +9,7 @@ RSpec.describe "documents/index/_filters.html.erb" do
           ],
           document_type: "organisation",
         )
-        render partial: "documents/index/filters"
+        render partial: self.class.top_level_description
         expect(rendered).to have_select("organisation",
                                         options: ["", "Org 1", "Org 2"])
       end
@@ -18,7 +18,7 @@ RSpec.describe "documents/index/_filters.html.erb" do
     context "when organisations fail to load from the Publishing API" do
       it "renders an empty option in the organisation filter" do
         stub_publishing_api_isnt_available
-        render partial: "documents/index/filters"
+        render partial: self.class.top_level_description
         expect(rendered).to have_select("organisation", options: [""])
       end
     end
@@ -36,7 +36,7 @@ RSpec.describe "documents/index/_filters.html.erb" do
     end
 
     it "includes pre-release document types when the user has pre_release_features permissions" do
-      render partial: "documents/index/filters"
+      render partial: self.class.top_level_description
 
       expect(rendered).to include(pre_release_document_type.label)
     end
@@ -45,7 +45,7 @@ RSpec.describe "documents/index/_filters.html.erb" do
       user = build(:user, permissions: %w(signin))
       login_as(user)
 
-      render partial: "documents/index/filters"
+      render partial: self.class.top_level_description
       expect(rendered).not_to include(pre_release_document_type.label)
     end
   end

--- a/spec/views/documents/index/_results.html.erb_spec.rb
+++ b/spec/views/documents/index/_results.html.erb_spec.rb
@@ -1,11 +1,11 @@
-RSpec.describe "documents/index/_results.html.erb" do
+RSpec.describe "documents/index/results.html.erb" do
   describe "Results list" do
     it "shows a fallback for untitled documents" do
       edition = create(:edition, title: nil)
       assign(:editions, Kaminari.paginate_array([edition]).page)
       assign(:sort, "")
       assign(:filter_params, {})
-      render
+      render partial: self.class.top_level_description
       expect(rendered).to include(I18n.t!("documents.untitled_document"))
     end
   end


### PR DESCRIPTION
https://trello.com/c/3E2vqBkS/1507-support-official-documents-for-featured-file-attachments

This replaces the duplication of the partial to render with the
'top_level_description', which couples the partial rendered to the
described text of the view spec. Using 'top_level_description' is
more consistent with our other specs, where we use 'described_class'.

One caveat is that the description of the view specs is no longer
compatible with the direct use of 'render' (they now lack the '_'),
which seems reasonable, since we should be passing locals to partials,
instead of relying on instance variables in the parent view.