### PR TITLE
Allow official document type to be null

### DIFF
--- a/db/migrate/20200403165044_allow_official_document_type_to_be_null.rb
+++ b/db/migrate/20200403165044_allow_official_document_type_to_be_null.rb
@@ -1,0 +1,9 @@
+class AllowOfficialDocumentTypeToBeNull < ActiveRecord::Migration[6.0]
+  def up
+    change_column :file_attachment_metadata_revisions, :official_document_type, :string, null: true, default: nil
+  end
+
+  def down
+    change_column :file_attachment_metadata_revisions, :official_document_type, :string, null: false, default: "unofficial"
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2020_03_17_152759) do
+ActiveRecord::Schema.define(version: 2020_04_03_165044) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -139,7 +139,7 @@ ActiveRecord::Schema.define(version: 2020_03_17_152759) do
     t.string "unique_reference"
     t.string "paper_number"
     t.string "parliamentary_session"
-    t.string "official_document_type", default: "unofficial", null: false
+    t.string "official_document_type"
   end
 
   create_table "file_attachment_revisions", force: :cascade do |t|


### PR DESCRIPTION
https://trello.com/c/3E2vqBkS/1507-support-official-documents-for-featured-file-attachments

Previously we defaulted the official document type to 'unofficial',
but this is inconsistent with the design/intention to force users to
make an explicit selection. If the user aborts the upload workflow
for an attachment, it's also unclear if a selection was made or not.
This changes the column to default the official doc type to null.