### PR TITLE
Support official document type and paper number

### DIFF
--- a/app/helpers/file_attachment_helper.rb
+++ b/app/helpers/file_attachment_helper.rb
@@ -17,10 +17,18 @@ module FileAttachmentHelper
     }
 
     if edition.document_type.attachments.featured?
-      attributes.merge!(
-        isbn: attachment_revision.isbn,
-        unique_reference: attachment_revision.unique_reference,
-      )
+      attributes[:isbn] = attachment_revision.isbn
+      attributes[:unique_reference] = attachment_revision.unique_reference
+
+      if attachment_revision.command_paper?
+        attributes[:unnumbered_command_paper] = true if attachment_revision.paper_number.blank?
+        attributes[:command_paper_number] = attachment_revision.paper_number.presence
+      end
+
+      if attachment_revision.act_paper?
+        attributes[:unnumbered_hoc_paper] = true if attachment_revision.paper_number.blank?
+        attributes[:hoc_paper_number] = attachment_revision.paper_number.presence
+      end
     end
 
     attributes.compact

--- a/app/interactors/file_attachments/update_interactor.rb
+++ b/app/interactors/file_attachments/update_interactor.rb
@@ -40,9 +40,7 @@ private
 
   def update_file_attachment
     updater = Versioning::FileAttachmentRevisionUpdater.new(file_attachment_revision, user)
-    revision_attributes = attachment_params.slice(:isbn, :unique_reference)
-    updater.assign(revision_attributes)
-
+    updater.assign(attachment_params)
     context.file_attachment_revision = updater.next_revision
   end
 
@@ -66,6 +64,26 @@ private
   end
 
   def attachment_params
-    params.require(:file_attachment).permit(:isbn, :unique_reference)
+    raw_params = params.require(:file_attachment)
+
+    { isbn: raw_params[:isbn],
+      unique_reference: raw_params[:unique_reference],
+      official_document_type: official_document_type(raw_params),
+      paper_number: paper_number(raw_params) }
+  end
+
+  def paper_number(params)
+    case params[:official_document_type]
+    when "command_paper" then params[:command_paper_number]
+    when "act_paper" then params[:act_paper_number]
+    end
+  end
+
+  def official_document_type(params)
+    case params[:official_document_type]
+    when "command_paper", "unnumbered_command_paper" then "command_paper"
+    when "act_paper", "unnumbered_act_paper" then "act_paper"
+    when "unofficial" then "unofficial"
+    end
   end
 end

--- a/app/views/file_attachments/edit.html.erb
+++ b/app/views/file_attachments/edit.html.erb
@@ -22,6 +22,8 @@
     ) do %>
       <%= render_govspeak(t("file_attachments.edit.description_govspeak")) %>
 
+      <%= render "file_attachments/edit/official_document", attachment: @attachment, issues: @issues %>
+
       <%= render "govuk_publishing_components/components/input", {
         label: {
           text: t("file_attachments.edit.isbn.heading"),

--- a/app/views/file_attachments/edit/_act_paper.html.erb
+++ b/app/views/file_attachments/edit/_act_paper.html.erb
@@ -1,0 +1,10 @@
+<%= render "govuk_publishing_components/components/input", {
+  label: {
+    text: t("file_attachments.edit.official_document.options.act_paper.input_label")
+  },
+  hint: t("file_attachments.edit.official_document.options.act_paper.input_hint_text"),
+  name: "file_attachment[act_paper_number]",
+  value: params.dig(:file_attachment, :act_paper_number) ||
+         (attachment.act_paper? && attachment.paper_number),
+  width: 10
+} %>

--- a/app/views/file_attachments/edit/_command_paper.html.erb
+++ b/app/views/file_attachments/edit/_command_paper.html.erb
@@ -1,0 +1,10 @@
+<%= render "govuk_publishing_components/components/input", {
+  label: {
+    text: t("file_attachments.edit.official_document.options.command_paper.input_label")
+  },
+  hint: t("file_attachments.edit.official_document.options.command_paper.input_hint_text"),
+  name: "file_attachment[command_paper_number]",
+  value: params.dig(:file_attachment, :command_paper_number) ||
+         (attachment.command_paper? && attachment.paper_number),
+  width: 10
+} %>

--- a/app/views/file_attachments/edit/_official_document.html.erb
+++ b/app/views/file_attachments/edit/_official_document.html.erb
@@ -1,0 +1,34 @@
+<%
+persisted_type_for_selection = if attachment.unofficial? then "unofficial"
+                               elsif attachment.paper_number.present? then attachment.official_document_type
+                               elsif attachment.act_paper? then "unnumbered_act_paper"
+                               elsif attachment.command_paper? then "unnumbered_command_paper"
+                               end
+
+selected_type = params.dig(:file_attachment, :official_document_type) || persisted_type_for_selection
+selection_types = %w[act_paper command_paper unnumbered_act_paper unnumbered_command_paper unofficial]
+
+selection_items = selection_types.map do |type|
+  {
+    value: type,
+    text: t("file_attachments.edit.official_document.options.#{type}.label"),
+    conditional: %w(command_paper act_paper).include?(type) && capture {
+      render "file_attachments/edit/#{type}", attachment: attachment, issues: issues
+    },
+    checked: selected_type == type.to_s,
+    data_attributes: {
+      gtm: "choose-attachment-official-document-type",
+      "gtm-value": t("file_attachments.edit.official_document.options.#{type}.label")
+    }
+  }
+end
+%>
+
+<%= render "govuk_publishing_components/components/radio", {
+  id: "official-document-type",
+  heading: t("file_attachments.edit.official_document.heading"),
+  description: render_govspeak(t("file_attachments.edit.official_document.hint_text")),
+  name: "file_attachment[official_document_type]",
+  items: selection_items,
+  error_items: issues&.items_for(:file_attachment_official_document_type),
+} %>

--- a/config/locales/en/file_attachments/edit.yml
+++ b/config/locales/en/file_attachments/edit.yml
@@ -10,3 +10,22 @@ en:
       unique_reference:
         heading: Unique reference
         hint_text: Add your organisation's own reference if it has one.
+      official_document:
+        heading: Is this an official document?
+        hint_text: |
+          ‘Official documents’ have been laid in Parliament. Check if your document contains ‘presented to Parliament’. If you choose yes, this document will show in the official document finder.
+        options:
+          command_paper:
+            label: Yes, this is a command paper
+            input_label: Command paper number
+            input_hint_text: For example, CP 521 or CP 521-IV.
+          unnumbered_command_paper:
+            label: Yes, this is an unnumbered command paper
+          act_paper:
+            label: Yes, this is a House of Commons paper
+            input_label: House of Commons paper number
+            input_hint_text: For example, 121 or 121-IV.
+          unnumbered_act_paper:
+            label: Yes, this is an unnumbered act paper
+          unofficial:
+            label: No, this document has not been laid in Parliament

--- a/spec/factories/file_attachment_revision_factory.rb
+++ b/spec/factories/file_attachment_revision_factory.rb
@@ -11,6 +11,8 @@ FactoryBot.define do
       fixture { "text-file-74bytes.txt" }
       title { SecureRandom.hex(8) }
       asset { nil }
+      official_document_type { nil }
+      paper_number { nil }
     end
 
     after(:build) do |revision, evaluator|
@@ -30,6 +32,8 @@ FactoryBot.define do
           title: evaluator.title,
           isbn: evaluator.isbn,
           unique_reference: evaluator.unique_reference,
+          official_document_type: evaluator.official_document_type,
+          paper_number: evaluator.paper_number,
         )
       end
     end
@@ -53,7 +57,10 @@ FactoryBot.define do
         revision.metadata_revision = evaluator.association(
           :file_attachment_metadata_revision,
           title: evaluator.title,
+          isbn: evaluator.isbn,
           unique_reference: evaluator.unique_reference,
+          official_document_type: evaluator.official_document_type,
+          paper_number: evaluator.paper_number,
         )
       end
     end

--- a/spec/features/editing_file_attachments/edit_file_attachment_spec.rb
+++ b/spec/features/editing_file_attachments/edit_file_attachment_spec.rb
@@ -26,10 +26,13 @@ RSpec.feature "Edit a file attachment" do
 
     unique_ref = "REF"
     isbn = "9788700631625"
+    paper_number = "1234"
     @metadata = "Ref: ISBN #{isbn}, #{unique_ref}"
 
     fill_in "file_attachment[unique_reference]", with: unique_ref
     fill_in "file_attachment[isbn]", with: isbn
+    choose I18n.t!("file_attachments.edit.official_document.options.act_paper.label")
+    fill_in "file_attachment[act_paper_number]", with: paper_number
     click_on "Save"
   end
 

--- a/spec/features/editing_file_attachments/edit_file_attachment_spec.rb
+++ b/spec/features/editing_file_attachments/edit_file_attachment_spec.rb
@@ -24,17 +24,17 @@ RSpec.feature "Edit a file attachment" do
     stub_publishing_api_put_content(@edition.content_id, {})
     stub_asset_manager_receives_an_asset
 
-    @isbn = "9788700631625"
-    @unique_reference = "A unique reference"
+    unique_ref = "REF"
+    isbn = "9788700631625"
+    @metadata = "Ref: ISBN #{isbn}, #{unique_ref}"
 
-    fill_in "file_attachment[isbn]", with: @isbn
-    fill_in "file_attachment[unique_reference]", with: @unique_reference
+    fill_in "file_attachment[unique_reference]", with: unique_ref
+    fill_in "file_attachment[isbn]", with: isbn
     click_on "Save"
   end
 
   def then_i_see_the_attachment_is_updated
-    expect(page).to have_content(@isbn)
-    expect(page).to have_content(@unique_reference)
+    expect(page).to have_content(@metadata)
   end
 
   def and_i_see_the_timeline_entry

--- a/spec/features/editing_file_attachments/upload_file_attachment_spec.rb
+++ b/spec/features/editing_file_attachments/upload_file_attachment_spec.rb
@@ -71,10 +71,13 @@ RSpec.feature "Upload file attachment", js: true do
     click_on "Save and continue"
     unique_ref = "REF"
     isbn = "9788700631625"
+    paper_number = "CP 1234"
     @metadata = "Ref: ISBN #{isbn}, #{unique_ref}"
 
     fill_in "file_attachment[unique_reference]", with: unique_ref
     fill_in "file_attachment[isbn]", with: isbn
+    choose I18n.t!("file_attachments.edit.official_document.options.command_paper.label")
+    fill_in "file_attachment[command_paper_number]", with: paper_number
 
     stub_asset_manager_updates_any_asset
     click_on "Save"

--- a/spec/features/editing_file_attachments/upload_file_attachment_spec.rb
+++ b/spec/features/editing_file_attachments/upload_file_attachment_spec.rb
@@ -69,8 +69,12 @@ RSpec.feature "Upload file attachment", js: true do
 
   def and_i_enter_attachment_metadata
     click_on "Save and continue"
-    @metadata = "Ref: Unique ref"
-    fill_in "file_attachment[unique_reference]", with: "Unique ref"
+    unique_ref = "REF"
+    isbn = "9788700631625"
+    @metadata = "Ref: ISBN #{isbn}, #{unique_ref}"
+
+    fill_in "file_attachment[unique_reference]", with: unique_ref
+    fill_in "file_attachment[isbn]", with: isbn
 
     stub_asset_manager_updates_any_asset
     click_on "Save"

--- a/spec/interactors/file_attachments/update_interactor_spec.rb
+++ b/spec/interactors/file_attachments/update_interactor_spec.rb
@@ -1,0 +1,76 @@
+RSpec.describe FileAttachments::UpdateInteractor do
+  describe ".call" do
+    let(:user) { create(:user) }
+    let(:attachment_params) { {} }
+    let(:attachment_revision) { build :file_attachment_revision, paper_number: "123" }
+
+    let(:edition) do
+      create(:edition,
+             document_type: build(:document_type, attachments: "featured"),
+             file_attachment_revisions: [attachment_revision])
+    end
+
+    let(:params) do
+      ActionController::Parameters.new(
+        document: edition.document.to_param,
+        file_attachment_id: attachment_revision.file_attachment_id,
+        file_attachment: attachment_params,
+      )
+    end
+
+    before do
+      stub_any_publishing_api_put_content
+      stub_asset_manager_receives_an_asset
+    end
+
+    context "with unnumbered command papers" do
+      it "overrides the official document type and number" do
+        attachment_params.merge!(official_document_type: "unnumbered_command_paper",
+                                 command_paper_number: "1234")
+        result = described_class.call(params: params, user: user)
+        expect(result.file_attachment_revision).to be_command_paper
+        expect(result.file_attachment_revision.paper_number).to be_blank
+      end
+    end
+
+    context "with unnumbered act papers" do
+      it "overrides the official document type and number" do
+        attachment_params.merge!(official_document_type: "unnumbered_act_paper",
+                                 act_paper_number: "1234")
+        result = described_class.call(params: params, user: user)
+        expect(result.file_attachment_revision).to be_act_paper
+        expect(result.file_attachment_revision.paper_number).to be_blank
+      end
+    end
+
+    context "with unofficial documents" do
+      it "overrides the official document type and number" do
+        attachment_params.merge!(official_document_type: "unofficial",
+                                 command_paper_number: "1234")
+        result = described_class.call(params: params, user: user)
+        expect(result.file_attachment_revision).to be_unofficial
+        expect(result.file_attachment_revision.paper_number).to be_blank
+      end
+    end
+
+    context "with numbered command papers" do
+      it "overrides the official document type and number" do
+        attachment_params.merge!(official_document_type: "command_paper",
+                                 command_paper_number: "1234")
+        result = described_class.call(params: params, user: user)
+        expect(result.file_attachment_revision).to be_command_paper
+        expect(result.file_attachment_revision.paper_number).to eq "1234"
+      end
+    end
+
+    context "with numbered act papers" do
+      it "overrides the official document type and number" do
+        attachment_params.merge!(official_document_type: "act_paper",
+                                 act_paper_number: "1234")
+        result = described_class.call(params: params, user: user)
+        expect(result.file_attachment_revision).to be_act_paper
+        expect(result.file_attachment_revision.paper_number).to eq "1234"
+      end
+    end
+  end
+end

--- a/spec/lib/publishing_api_payload/file_attachment_payload_spec.rb
+++ b/spec/lib/publishing_api_payload/file_attachment_payload_spec.rb
@@ -21,22 +21,56 @@ RSpec.describe PublishingApiPayload::FileAttachmentPayload do
       expect(payload).to match a_hash_including(expected_payload)
     end
 
-    it "adds extra metadata if the document has featured attachments" do
-      attachment = build(:file_attachment_revision,
-                         isbn: "9788700631625", unique_reference: "unique ref")
+    context "when the attachment has extra metadata fields" do
+      let(:edition) do
+        create(:edition, document_type: build(:document_type, attachments: "featured"))
+      end
 
-      edition = create(:edition,
-                       document_type: build(:document_type, attachments: "featured"),
-                       file_attachment_revisions: [attachment])
+      it "can add isbn and unique reference attributes" do
+        attachment = create(:file_attachment_revision,
+                            isbn: "9788700631625", unique_reference: "unique ref")
 
-      payload = described_class.new(attachment, edition).payload
+        payload = described_class.new(attachment, edition).payload
 
-      expected_payload = {
-        isbn: attachment.isbn,
-        unique_reference: attachment.unique_reference,
-      }
+        expect(payload).to match a_hash_including(
+          isbn: attachment.isbn,
+          unique_reference: attachment.unique_reference,
+        )
+      end
 
-      expect(payload).to match a_hash_including(expected_payload)
+      it "can add an unnumbered hoc paper attribute" do
+        attachment = create(:file_attachment_revision, official_document_type: "act_paper")
+        payload = described_class.new(attachment, edition).payload
+        expect(payload).to match a_hash_including(unnumbered_hoc_paper: true)
+        expect(payload.keys).not_to include(:hoc_paper_number)
+      end
+
+      it "can add an unnumbered command paper attribute" do
+        attachment = create(:file_attachment_revision, official_document_type: "command_paper")
+        payload = described_class.new(attachment, edition).payload
+        expect(payload).to match a_hash_including(unnumbered_command_paper: true)
+        expect(payload.keys).not_to include(:command_paper_number)
+      end
+
+      it "can add a numbered House of Commons paper attribute" do
+        attachment = create(:file_attachment_revision,
+                            official_document_type: "act_paper",
+                            paper_number: "123")
+        payload = described_class.new(attachment, edition).payload
+        expect(payload).to match a_hash_including(hoc_paper_number: "123")
+        expect(payload.keys).not_to include(:unnumbered_hoc_paper)
+        expect(payload.keys).not_to include(:command_paper_number)
+      end
+
+      it "can add a numbered command paper attribute" do
+        attachment = create(:file_attachment_revision,
+                            official_document_type: "command_paper",
+                            paper_number: "CP 123")
+        payload = described_class.new(attachment, edition).payload
+        expect(payload).to match a_hash_including(command_paper_number: "CP 123")
+        expect(payload.keys).not_to include(:unnumbered_command_paper)
+        expect(payload.keys).not_to include(:hoc_paper_number)
+      end
     end
   end
 end

--- a/spec/requests/file_attachments_spec.rb
+++ b/spec/requests/file_attachments_spec.rb
@@ -320,7 +320,7 @@ RSpec.describe "File Attachments" do
 
       patch edit_file_attachment_path(edition.document,
                                       file_attachment_revision.file_attachment_id),
-            params: { file_attachment: { isbn: "9788700631625", unique_reference: "Uniq Ref" } }
+            params: { file_attachment: { isbn: "9788700631625" } }
 
       expect(response).to redirect_to(featured_attachments_path(edition.document))
     end

--- a/spec/views/featured_attachments/_featured_attachment.html.erb_spec.rb
+++ b/spec/views/featured_attachments/_featured_attachment.html.erb_spec.rb
@@ -1,0 +1,34 @@
+RSpec.describe "featured_attachments/featured_attachment.html.erb" do
+  describe "official document metadata" do
+    let(:edition) do
+      create(:edition, document_type: build(:document_type, attachments: "featured"))
+    end
+
+    def render_with_attachment(attributes)
+      attachment = create(:file_attachment_revision, attributes)
+
+      render partial: self.class.top_level_description,
+             locals: { edition: edition, attachment: attachment }
+    end
+
+    it "renders a command paper with its number" do
+      render_with_attachment(official_document_type: "command_paper", paper_number: "123")
+      expect(rendered).to have_content("Ref: 123")
+    end
+
+    it "renders an act paper with its number" do
+      render_with_attachment(official_document_type: "act_paper", paper_number: "123")
+      expect(rendered).to have_content("Ref: HC 123")
+    end
+
+    it "renders an unnumbered command paper" do
+      render_with_attachment(official_document_type: "command_paper")
+      expect(rendered).to have_content("Unnumbered command paper")
+    end
+
+    it "renders an unnumbered act paper" do
+      render_with_attachment(official_document_type: "act_paper")
+      expect(rendered).to have_content("Unnumbered act paper")
+    end
+  end
+end

--- a/spec/views/file_attachments/edit.html.erb_spec.rb
+++ b/spec/views/file_attachments/edit.html.erb_spec.rb
@@ -1,0 +1,19 @@
+RSpec.describe "file_attachments/edit.html.erb" do
+  describe "official documents" do
+    it "renders official document types" do
+      assign(:edition, build(:edition))
+      assign(:attachment, create(:file_attachment_revision))
+      render
+
+      types = %i[command_paper
+                 unnumbered_command_paper
+                 act_paper
+                 unnumbered_act_paper
+                 unofficial]
+
+      types.each do |type|
+        expect(rendered).to have_selector("input[@type='radio'][@value='#{type}']")
+      end
+    end
+  end
+end


### PR DESCRIPTION
https://trello.com/c/hCrcFkHT/1514-render-featured-attachments-in-the-preview-of-a-publication

This extends the existing metadata page/feature with a new radio selection
for the official document type of the attachment, which includes a
conditional paper number. Please see the commits for more details.

Things still to do:

- [ ] Requirements checks for official documents
- [ ] Enforcing official doc selection on the summary