### PR TITLE
Check for nil change_note when creating edition

### DIFF
--- a/app/services/create_next_edition_service.rb
+++ b/app/services/create_next_edition_service.rb
@@ -38,7 +38,7 @@ private
   end
 
   def change_history
-    if !current_edition.major? || current_edition.change_note.empty? || current_edition.first?
+    if !current_edition.major? || current_edition.change_note.blank? || current_edition.first?
       return current_edition.change_history
     end
 

--- a/spec/services/create_next_edition_service_spec.rb
+++ b/spec/services/create_next_edition_service_spec.rb
@@ -92,7 +92,7 @@ RSpec.describe CreateNextEditionService do
       current_edition = create(:edition,
                                :published,
                                number: 2,
-                               change_note: "")
+                               change_note: nil)
 
       next_edition = described_class.call(current_edition: current_edition,
                                           user: user)


### PR DESCRIPTION
When we create a new edition we previously threw a method error if the
current editions change note was nil as we were calling empty? on nil.

As imported editions can have a change note of nil (first edition) we
want to update the conditional to also cater for nil change notes.