### PR TITLE
Manage featured attachment ordering

### DIFF
--- a/app/models/revision.rb
+++ b/app/models/revision.rb
@@ -78,7 +78,7 @@ class Revision < ApplicationRecord
 
   def featured_attachments
     file_attachment_revisions.sort_by do |attachment|
-      featured_attachment_ordering.find_index(attachment.featured_attachment_id).to_i
+      featured_attachment_ordering.find_index(attachment.featured_attachment_id) || Float::INFINITY
     end
   end
 end

--- a/spec/factories/edition_factory.rb
+++ b/spec/factories/edition_factory.rb
@@ -13,7 +13,6 @@ FactoryBot.define do
     transient do
       content_id { SecureRandom.uuid }
       locale { I18n.available_locales.sample }
-      document_type_id { document_type.id }
       document_type { build(:document_type, path_prefix: "/prefix") }
       featured_attachment_ordering { [] }
       state { "draft" }

--- a/spec/factories/revision_factory.rb
+++ b/spec/factories/revision_factory.rb
@@ -3,7 +3,8 @@ FactoryBot.define do
     transient do
       title { SecureRandom.alphanumeric(10) }
       base_path { title ? "/prefix/#{title.parameterize}" : nil }
-      document_type_id { build(:document_type, path_prefix: "/prefix").id }
+      document_type_id { document_type.id }
+      document_type { build(:document_type, path_prefix: "/prefix") }
       summary { nil }
       contents { {} }
       tags do

--- a/spec/lib/versioning/revision_updater/file_attachment_spec.rb
+++ b/spec/lib/versioning/revision_updater/file_attachment_spec.rb
@@ -17,12 +17,13 @@ RSpec.describe Versioning::RevisionUpdater::FileAttachment do
 
     it "appends to the ordering when there are featured attachments" do
       document_type = build :document_type, attachments: "featured"
-      ordering = [attachment_revision.featured_attachment_id]
+      attachments = [attachment_revision, create(:file_attachment_revision)]
+      ordering = attachments.map(&:featured_attachment_id)
       new_attachment = create :file_attachment_revision
 
       revision = create :revision,
                         document_type: document_type,
-                        file_attachment_revisions: [attachment_revision],
+                        file_attachment_revisions: attachments,
                         featured_attachment_ordering: ordering
 
       updater = Versioning::RevisionUpdater.new(revision, user)

--- a/spec/lib/versioning/revision_updater/file_attachment_spec.rb
+++ b/spec/lib/versioning/revision_updater/file_attachment_spec.rb
@@ -2,12 +2,9 @@ RSpec.describe Versioning::RevisionUpdater::FileAttachment do
   let(:user) { create :user }
   let(:attachment_revision) { create :file_attachment_revision }
 
-  let(:revision) do
-    create :revision, file_attachment_revisions: [attachment_revision]
-  end
-
   describe "#add_file_attachment" do
     it "extends file attachment revisions with a new file attachment" do
+      revision = create :revision, file_attachment_revisions: [attachment_revision]
       new_attachment = create :file_attachment_revision
 
       updater = Versioning::RevisionUpdater.new(revision, user)
@@ -19,6 +16,7 @@ RSpec.describe Versioning::RevisionUpdater::FileAttachment do
     end
 
     it "raises an error if a revision exists for the same attachment" do
+      revision = create :revision, file_attachment_revisions: [attachment_revision]
       updater = Versioning::RevisionUpdater.new(revision, user)
 
       expect { updater.add_file_attachment(attachment_revision) }
@@ -45,6 +43,7 @@ RSpec.describe Versioning::RevisionUpdater::FileAttachment do
       updated_attachment = create :file_attachment_revision,
                                   file_attachment_id: attachment_revision.file_attachment_id
 
+      revision = create :revision, file_attachment_revisions: [attachment_revision]
       updater = Versioning::RevisionUpdater.new(revision, user)
       updater.update_file_attachment(updated_attachment)
 

--- a/spec/models/revision_spec.rb
+++ b/spec/models/revision_spec.rb
@@ -7,16 +7,15 @@ RSpec.describe Revision do
     end
 
     it "copes if some attachments are not ordered" do
-      file_attachment1 = create(:file_attachment_revision)
-      file_attachment2 = create(:file_attachment_revision)
-      attachments = [file_attachment1, file_attachment2]
-      ordering = [file_attachment1.featured_attachment_id]
+      attachments = create_list :file_attachment_revision, 3
+      ordering = [attachments[0], attachments[2]].map(&:featured_attachment_id)
 
       revision = build(:revision,
                        file_attachment_revisions: attachments,
                        featured_attachment_ordering: ordering)
 
-      expect(revision.featured_attachments).to eq attachments
+      expected_ordering = [attachments[0], attachments[2], attachments[1]]
+      expect(revision.featured_attachments).to eq expected_ordering
     end
 
     it "returns attachments in featured order" do


### PR DESCRIPTION
https://trello.com/c/UDEgwkWF/1556-apply-featured-attachment-order-everywhere

This extends the updater module for file attachments to manage the featured
attachment ordering when file attachments are added or removed, so that it
is always representative of the file attachments that are currently
associated with a revision.

We have arbitrarily decided to append new file attachments to the existing
ordering. Please see the commits for more details.