### PR TITLE
Remove redundant interactor specs

### DIFF
--- a/spec/interactors/file_attachments/create_interactor_spec.rb
+++ b/spec/interactors/file_attachments/create_interactor_spec.rb
@@ -18,10 +18,6 @@ RSpec.describe FileAttachments::CreateInteractor do
     end
 
     context "when input is valid" do
-      it "is successful" do
-        expect(described_class.call(**args)).to be_success
-      end
-
       it "creates a new file attachment revision" do
         expect { described_class.call(**args) }
           .to change { FileAttachment::Revision.count }.by(1)
@@ -34,11 +30,16 @@ RSpec.describe FileAttachments::CreateInteractor do
         described_class.call(**args)
       end
 
-      it "delegates generating a unique filename to GenerateUniqueFilenameService" do
+      it "generates a unique filename for the attachment" do
+        other_attachment = create :file_attachment_revision
+        edition = create :edition, file_attachment_revisions: [other_attachment]
+        args[:params].merge!(document: edition.document.to_param)
+
         expect(GenerateUniqueFilenameService).to receive(:call)
-          .with(existing_filenames: edition.revision.file_attachment_revisions.map(&:filename),
+          .with(existing_filenames: [other_attachment.filename],
                 filename: file.original_filename)
           .and_call_original
+
         described_class.call(**args)
       end
 

--- a/spec/interactors/file_attachments/update_file_interactor_spec.rb
+++ b/spec/interactors/file_attachments/update_file_interactor_spec.rb
@@ -1,0 +1,39 @@
+RSpec.describe FileAttachments::UpdateFileInteractor do
+  describe ".call" do
+    let(:user) { create(:user) }
+    let(:attachment) { create(:file_attachment_revision) }
+    let(:file) { fixture_file_upload("files/13kb-1-page-attachment.pdf") }
+
+    let(:edition) do
+      create :edition, file_attachment_revisions: [attachment]
+    end
+
+    let(:params) do
+      ActionController::Parameters.new(
+        file_attachment: {
+          file: file,
+          title: "My title",
+        },
+        document: edition.document.to_param,
+        file_attachment_id: attachment.file_attachment_id,
+      )
+    end
+
+    before do
+      allow(FailsafeDraftPreviewService).to receive(:call)
+    end
+
+    it "generates a unique filename for the attachment" do
+      other_attachment = create :file_attachment_revision
+      edition = create :edition, file_attachment_revisions: [attachment, other_attachment]
+      params.merge!(document: edition.document.to_param)
+
+      expect(GenerateUniqueFilenameService).to receive(:call)
+        .with(existing_filenames: [other_attachment.filename],
+              filename: file.original_filename)
+        .and_call_original
+
+      described_class.call(params: params, user: user)
+    end
+  end
+end

--- a/spec/interactors/images/create_interactor_spec.rb
+++ b/spec/interactors/images/create_interactor_spec.rb
@@ -14,10 +14,6 @@ RSpec.describe Images::CreateInteractor do
     end
 
     context "when input is valid" do
-      it "is successful" do
-        expect(described_class.call(**args)).to be_success
-      end
-
       it "creates a new image revision" do
         expect { described_class.call(**args) }
           .to change { Image::Revision.count }.by(1)


### PR DESCRIPTION
https://trello.com/c/UDEgwkWF/1556-apply-featured-attachment-order-everywhere

This turned out to be wasted work, as I realised I was adding the specs in
the wrong place to complete the above card. However, I think it's an overall
improvement, and worth a review. Please see the commits for more details.