### PR TITLE
Add data integrity validations for JSON columns

### DIFF
--- a/app/models/content_revision.rb
+++ b/app/models/content_revision.rb
@@ -3,6 +3,8 @@
 #
 # This model is immutable.
 class ContentRevision < ApplicationRecord
+  validates :contents, "content_revision/contents" => true
+
   belongs_to :created_by, class_name: "User", optional: true
 
   def readonly?

--- a/app/models/content_revision/contents_validator.rb
+++ b/app/models/content_revision/contents_validator.rb
@@ -1,0 +1,15 @@
+class ContentRevision::ContentsValidator < ActiveModel::EachValidator
+  CONTENTS_FIELDS = %w[body].freeze
+
+  def validate_each(record, attribute, value)
+    value.each do |key, content|
+      unless CONTENTS_FIELDS.include?(key.to_s)
+        record.errors.add(attribute, "has unknown content field ‘#{key}’", strict: true)
+      end
+
+      if key.to_s == "body" && !content.is_a?(String)
+        record.errors.add(attribute, "has non-string ‘body’ field", strict: true)
+      end
+    end
+  end
+end

--- a/app/models/document_type/multi_tag_field.rb
+++ b/app/models/document_type/multi_tag_field.rb
@@ -1,8 +1,6 @@
 class DocumentType::MultiTagField
-  def payload(edition)
-    return {} if edition.tags[id].blank?
-
-    { links: { id.to_sym => edition.tags[id] } }
+  def payload
+    raise "not implemented"
   end
 
   def updater_params(_edition, params)

--- a/app/models/document_type/topical_events_field.rb
+++ b/app/models/document_type/topical_events_field.rb
@@ -2,4 +2,10 @@ class DocumentType::TopicalEventsField < DocumentType::MultiTagField
   def id
     "topical_events"
   end
+
+  def payload(edition)
+    return {} if edition.tags[id].blank?
+
+    { links: { id.to_sym => edition.tags[id] } }
+  end
 end

--- a/app/models/document_type/world_locations_field.rb
+++ b/app/models/document_type/world_locations_field.rb
@@ -2,4 +2,10 @@ class DocumentType::WorldLocationsField < DocumentType::MultiTagField
   def id
     "world_locations"
   end
+
+  def payload(edition)
+    return {} if edition.tags[id].blank?
+
+    { links: { id.to_sym => edition.tags[id] } }
+  end
 end

--- a/app/models/tags_revision.rb
+++ b/app/models/tags_revision.rb
@@ -3,6 +3,8 @@
 #
 # This model is immutable.
 class TagsRevision < ApplicationRecord
+  validates :tags, "tags_revision/tags" => true
+
   belongs_to :created_by, class_name: "User", optional: true
 
   scope :tag_contains, ->(tag, value) do

--- a/app/models/tags_revision/tags_validator.rb
+++ b/app/models/tags_revision/tags_validator.rb
@@ -1,0 +1,27 @@
+class TagsRevision::TagsValidator < ActiveModel::EachValidator
+  UUID_REGEX = /\A[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}\Z/.freeze
+
+  TAG_FIELDS = %w[primary_publishing_organisation
+                  organisations
+                  world_locations
+                  role_appointments
+                  topical_events].freeze
+
+  def validate_each(record, attribute, value)
+    value.each do |key, tags|
+      unless TAG_FIELDS.include?(key.to_s)
+        record.errors.add(attribute, "has unknown tag field ‘#{key}’", strict: true)
+      end
+
+      unless tags.is_a? Array
+        record.errors.add(attribute, "has non-array field ‘#{key}’", strict: true)
+      end
+
+      tags.each do |tag|
+        unless UUID_REGEX.match?(tag)
+          record.errors.add(attribute, "has an invalid tag ID ‘#{tag}’", strict: true)
+        end
+      end
+    end
+  end
+end

--- a/spec/interactors/new_document/select_interactor_spec.rb
+++ b/spec/interactors/new_document/select_interactor_spec.rb
@@ -1,6 +1,6 @@
 RSpec.describe NewDocument::SelectInteractor do
   describe ".call" do
-    let(:user) { build(:user, organisation_content_id: "org-id") }
+    let(:user) { build(:user, organisation_content_id: SecureRandom.uuid) }
 
     it "succeeds with valid parameters" do
       result = described_class.call(params: { type: "root", selected_option_id: "news" })

--- a/spec/lib/versioning/revision_updater_spec.rb
+++ b/spec/lib/versioning/revision_updater_spec.rb
@@ -7,7 +7,7 @@ RSpec.describe Versioning::RevisionUpdater do
         :revision,
         number: 1,
         title: "old title",
-        tags: { old: "tag" },
+        tags: { organisations: [SecureRandom.uuid] },
         change_note: "old change note",
         lead_image_revision: (create :image_revision),
         image_revisions: [create(:image_revision)],
@@ -36,7 +36,7 @@ RSpec.describe Versioning::RevisionUpdater do
 
       new_fields = {
         title: "new title",
-        tags: { "new_tag" => [] },
+        tags: { "organisations" => [] },
         change_note: "new change note",
         lead_image_revision: nil,
         image_revisions: [],

--- a/spec/lib/whitehall_importer/create_revision_spec.rb
+++ b/spec/lib/whitehall_importer/create_revision_spec.rb
@@ -188,7 +188,7 @@ RSpec.describe WhitehallImporter::CreateRevision do
         contacts: [],
         images: ["foo.jpg"],
         attachments: ["attach.txt"],
-      )
+      ).and_call_original
       described_class.call(document_import, whitehall_edition)
     end
 

--- a/spec/models/content_revision/contents_validator_spec.rb
+++ b/spec/models/content_revision/contents_validator_spec.rb
@@ -1,0 +1,25 @@
+RSpec.describe ContentRevision::ContentsValidator do
+  describe "#validate_each" do
+    let(:record) { build :content_revision }
+    let(:attribute) { :contents }
+    let(:validator) { described_class.new(attributes: [attribute]) }
+
+    it "validates when the contents are valid" do
+      contents = { body: "some text" }
+      validator.validate_each(record, attribute, contents)
+      expect(record).to be_valid
+    end
+
+    it "fails if a field is not recognised" do
+      expect { validator.validate_each(record, attribute, { foo: "text" }) }
+        .to raise_error(ActiveModel::StrictValidationFailed,
+                        "Contents has unknown content field ‘foo’")
+    end
+
+    it "fails if the body field is not a string" do
+      expect { validator.validate_each(record, attribute, { body: nil }) }
+        .to raise_error(ActiveModel::StrictValidationFailed,
+                        "Contents has non-string ‘body’ field")
+    end
+  end
+end

--- a/spec/models/document_type/multi_tag_field_spec.rb
+++ b/spec/models/document_type/multi_tag_field_spec.rb
@@ -1,0 +1,22 @@
+RSpec.describe DocumentType::MultiTagField do
+  describe "#updater_params" do
+    let(:edition) { build :edition }
+    let(:field) { described_class.new }
+
+    before do
+      allow(field).to receive(:id).and_return(:tag_id)
+    end
+
+    it "returns a hash of the topical_events" do
+      params = ActionController::Parameters.new(tag_id: %w[some_tag_value])
+      updater_params = field.updater_params(edition, params)
+      expect(updater_params).to eq(tag_id: %w[some_tag_value])
+    end
+
+    it "removes nil values from the hash of tags" do
+      params = ActionController::Parameters.new(tag_id: nil)
+      updater_params = field.updater_params(edition, params)
+      expect(updater_params).to eq({})
+    end
+  end
+end

--- a/spec/models/document_type/organisations_field_spec.rb
+++ b/spec/models/document_type/organisations_field_spec.rb
@@ -30,13 +30,4 @@ RSpec.describe DocumentType::OrganisationsField do
       expect(payload[:links][:organisations]).to eq(org_ids)
     end
   end
-
-  describe "#updater_params" do
-    it "returns a hash of the organisations" do
-      edition = build :edition
-      params = ActionController::Parameters.new(organisations: %w[some_org_id])
-      updater_params = described_class.new.updater_params(edition, params)
-      expect(updater_params).to eq(organisations: %w[some_org_id])
-    end
-  end
 end

--- a/spec/models/document_type/role_appointments_field_spec.rb
+++ b/spec/models/document_type/role_appointments_field_spec.rb
@@ -19,13 +19,4 @@ RSpec.describe DocumentType::RoleAppointmentsField do
       )
     end
   end
-
-  describe "#updater_params" do
-    it "returns a hash of the role_appointments" do
-      edition = build :edition
-      params = ActionController::Parameters.new(role_appointments: %w[some_role_id])
-      updater_params = described_class.new.updater_params(edition, params)
-      expect(updater_params).to eq(role_appointments: %w[some_role_id])
-    end
-  end
 end

--- a/spec/models/document_type/topical_events_field_spec.rb
+++ b/spec/models/document_type/topical_events_field_spec.rb
@@ -7,13 +7,4 @@ RSpec.describe DocumentType::TopicalEventsField do
       expect(payload[:links][:topical_events]).to eq(topical_event_ids)
     end
   end
-
-  describe "#updater_params" do
-    it "returns a hash of the topical_events" do
-      edition = build :edition
-      params = ActionController::Parameters.new(topical_events: %w[some_topical_event_id])
-      updater_params = described_class.new.updater_params(edition, params)
-      expect(updater_params).to eq(topical_events: %w[some_topical_event_id])
-    end
-  end
 end

--- a/spec/models/tags_revision/tags_validator_spec.rb
+++ b/spec/models/tags_revision/tags_validator_spec.rb
@@ -1,0 +1,37 @@
+RSpec.describe TagsRevision::TagsValidator do
+  describe "#validate_each" do
+    let(:record) { build :metadata_revision }
+    let(:attribute) { :tags }
+    let(:validator) { described_class.new(attributes: [attribute]) }
+
+    it "validates when the tags are valid" do
+      tags = { organisations: [SecureRandom.uuid] }
+      validator.validate_each(record, attribute, tags)
+      expect(record).to be_valid
+    end
+
+    it "fails if a field is not recognised" do
+      expect { validator.validate_each(record, attribute, { foo: [] }) }
+        .to raise_error(ActiveModel::StrictValidationFailed,
+                        "Tags has unknown tag field ‘foo’")
+    end
+
+    it "fails if a tag list is not an array" do
+      expect { validator.validate_each(record, attribute, { organisations: "an-id" }) }
+        .to raise_error(ActiveModel::StrictValidationFailed,
+                        "Tags has non-array field ‘organisations’")
+    end
+
+    it "fails if a tag is not in UUID format" do
+      expect { validator.validate_each(record, attribute, { organisations: %w(an-id) }) }
+        .to raise_error(ActiveModel::StrictValidationFailed,
+                        "Tags has an invalid tag ID ‘an-id’")
+    end
+
+    it "fails if a tag is nil" do
+      expect { validator.validate_each(record, attribute, { organisations: [nil] }) }
+        .to raise_error(ActiveModel::StrictValidationFailed,
+                        "Tags has an invalid tag ID ‘’")
+    end
+  end
+end


### PR DESCRIPTION
https://trello.com/c/xkQzBiFE/1614-content-publisher-document-filter-incident-follow-up

This adds a custom validator around the 'contents' and 'tags'
columns, to ensure that we don't store syntactically invalid
data in these otherwise flexible JSON columns. With this change,
we now apply this schema-like approach to all JSON columns.

Note that, although we could use the document type to detect which
tag fields are permitted, this approach doesn't extend to validating
'contents', since the document type isn't accessible from the
associated ContentRevision.