### PR TITLE
Avoid outputting i18n report unless it is below 100%

### DIFF
--- a/lib/tasks/i18n_cov.rake
+++ b/lib/tasks/i18n_cov.rake
@@ -4,11 +4,10 @@ namespace :i18n_cov do
   desc "Prints I18n Coverage report and returns exit status"
   task ci: :environment do
     report = JSON.parse(File.read(I18nCov::REPORT_PATH))
-    puts JSON.pretty_generate(report)
-
     percent_coverage = report["stats"]["coverage"]
     Kernel.exit 0 if percent_coverage == 100
 
+    puts JSON.pretty_generate(report)
     puts "I18n coverage (#{percent_coverage}%) is below the expected minimum coverage (100%)"
     puts "I18nCov failed with exit 1\n"
 


### PR DESCRIPTION
Outputting the report is not useful if we already have 100%
coverage, and is momentarily confusing as you need to read
the text to establish whether or not the build succeeded.

By only displaying the report if we fall below 100% coverage,
it is immediately obvious when a local build fails and
requires attention.