### PR TITLE
Ignore errors caused by a PG::Error during data sync

### DIFF
--- a/config/initializers/govuk_error.rb
+++ b/config/initializers/govuk_error.rb
@@ -4,7 +4,7 @@ GovukError.configure do |config|
   # Don't capture postgres errors that occur during the time that the data sync
   # is running in integration and staging environments
   config.should_capture = ->(error) do
-    data_sync_ignored_error = error.is_a?(PG::Error)
+    data_sync_ignored_error = error.is_a?(PG::Error) || error.cause.is_a?(PG::Error)
     data_sync_environment = ENV.fetch("SENTRY_CURRENT_ENV", "")
                                .match(/integration|staging/)
     data_sync_time = Time.zone.now.hour <= 5


### PR DESCRIPTION
ActiveRecord can wrap PG:Error exceptions [1] which means that these
can still be sent to Sentry. By also checking the exception cause we can
identify these to ignore them.

Sentry does something a bit more complex than this to ignore exceptions
by building an array of exceptions based off traversing the tree of
causes [2]. Currently this doesn't seem necessary for the types of
exceptions that we're seeing.

[1]: https://github.com/rails/rails/blob/8d57cb39a88787bb6cfb7e1c481556ef6d8ede7a/activerecord/lib/active_record/connection_adapters/postgresql_adapter.rb#L51
[2]: https://github.com/getsentry/raven-ruby/blob/8c1e62ba5b8797ea7c16b36bfb7bd1f7af8c6132/lib/raven/configuration.rb#L370