### PR TITLE
Do not show non-action to 'Order a copy'

### DIFF
--- a/app/views/featured_attachments/_featured_attachment.html.erb
+++ b/app/views/featured_attachments/_featured_attachment.html.erb
@@ -41,6 +41,7 @@
   <%= render "govuk_publishing_components/components/attachment", {
     attachment: file_attachment_attributes(attachment, edition),
     hide_opendocument_metadata: true,
+    hide_order_copy_link: true,
     target: "_blank",
   } %>
 <% end %>


### PR DESCRIPTION
https://trello.com/c/3E2vqBkS/1507-support-official-documents-for-featured-file-attachments

We want to avoid showing this action in Content Publisher itself,
since it's only relevant for users on GOV.UK itself.