### PR TITLE
Stopping create initial change note

### DIFF
--- a/app/services/create_document_service.rb
+++ b/app/services/create_document_service.rb
@@ -51,7 +51,6 @@ private
       number: 1,
       content_revision: ContentRevision.new(created_by: user),
       metadata_revision: MetadataRevision.new(
-        change_note: "First published.",
         update_type: "major",
         created_by: user,
         document_type_id: document_type_id,

--- a/spec/factories/revision_factory.rb
+++ b/spec/factories/revision_factory.rb
@@ -15,7 +15,7 @@ FactoryBot.define do
         end
       end
       update_type { "major" }
-      change_note { "First published." }
+      change_note { nil }
       proposed_publish_time { nil }
       backdated_to { nil }
       editor_political { nil }

--- a/spec/lib/publishing_api_payload/history_spec.rb
+++ b/spec/lib/publishing_api_payload/history_spec.rb
@@ -15,7 +15,7 @@ RSpec.describe PublishingApiPayload::History do
       second_edition = build(:edition, :published,
                              document: first_edition.document,
                              update_type: "major",
-                             first_published_at: "2020-02-22 11:00:00",
+                             change_note: "Content updated",
                              published_at: "2020-03-01 12:00:00")
 
       expect(described_class.new(second_edition).public_updated_at).to eq("2020-03-01 12:00:00")

--- a/spec/services/create_document_service_spec.rb
+++ b/spec/services/create_document_service_spec.rb
@@ -24,9 +24,8 @@ RSpec.describe CreateDocumentService do
       expect(document.current_edition.revision.number).to be(1)
     end
 
-    it "sets the initial change note details" do
+    it "sets the initial update type" do
       document = described_class.call(document_type_id: document_type.id)
-      expect(document.current_edition.change_note).to eq("First published.")
       expect(document.current_edition.update_type).to eq("major")
     end
 


### PR DESCRIPTION
Trello: https://trello.com/c/EPhrhTdz/1612-stretch-remove-the-first-published-change-note-from-content-publisher

Setting this no longer has any affect for users as the first change note
is dynamically created at the point of updating the Publishing API and
uses the PublishingApiPayload::History::FIRST_CHANGE_NOTE constant.