### PR TITLE
Remove superfluous initial change note from revisions

### DIFF
--- a/db/migrate/20200411150039_remove_superfluous_initial_change_notes.rb
+++ b/db/migrate/20200411150039_remove_superfluous_initial_change_notes.rb
@@ -1,0 +1,6 @@
+class RemoveSuperfluousInitialChangeNotes < ActiveRecord::Migration[6.0]
+  def up
+    MetadataRevision.where(change_note: "First published.")
+                    .update_all(change_note: nil)
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2020_04_03_165044) do
+ActiveRecord::Schema.define(version: 2020_04_11_150039) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"


### PR DESCRIPTION
Trello: https://trello.com/c/EPhrhTdz/1612-stretch-remove-the-first-published-change-note-from-content-publisher

This removes all of the "First published." change notes that are stored
on revisions. This entry does not represent any user input as these were
set automatically when users created the document. These entries are now
superfluous as the initial change note is dynamically created using the
PaublishingApiPayload::History::FIRST_CHANGE_NOTE constant.

There is a risk that this would wipe any user specified change notes of
this note (as unusual as that would be) but as of 11th April 2020 there
are none:

```
MetadataRevision.joins("INNER JOIN revisions ON revisions.metadata_revision_id = metadata_revisions.id").joins("INNER JOIN editions_revisions ON editions_revisions.revision_id = revisions.id").joins("INNER JOIN editions ON editions.id = editions_revisions.edition_id").where("editions.number > 1").where(change_note: "First published.").count
```

Since this seems such an unlikely scenario I felt it was better to keep
the migration simple.