### PR TITLE
Show message when there are no attachments

### DIFF
--- a/app/views/documents/show/_featured_attachments.html.erb
+++ b/app/views/documents/show/_featured_attachments.html.erb
@@ -1,4 +1,4 @@
-<%= render "govuk_publishing_components/components/summary_list", {
+<% attributes = {
   id: "attachments",
   title: t("documents.show.featured_attachments.title"),
   borderless: true,
@@ -7,9 +7,12 @@
       { href: featured_attachments_path(@edition.document),
         data_attributes: { gtm: "edit-attachments" } }
     end
-  ),
-  items: (
-    @edition.featured_attachments.each_with_index.map do |attachment, index|
+  )
+} %>
+
+<% if @edition.featured_attachments.any? %>
+  <%= render "govuk_publishing_components/components/summary_list", attributes.merge(
+    items: @edition.featured_attachments.each_with_index.map do |attachment, index|
       {
         field: index + 1,
         value: sanitize(
@@ -17,5 +20,9 @@
         ),
       }
     end
-  )
-} %>
+  ) %>
+<% else %>
+  <%= render "govuk_publishing_components/components/summary_list", attributes.merge(
+    block: t("documents.show.featured_attachments.none")
+  ) %>
+<% end %>

--- a/config/locales/en/documents/show.yml
+++ b/config/locales/en/documents/show.yml
@@ -32,6 +32,7 @@ en:
 
           You can publish it now, schedule it to publish later, or edit it.
       featured_attachments:
+        none: No attachments.
         title: Attachments
       flashes:
         pre_preview_issues:


### PR DESCRIPTION
https://trello.com/c/a5SwDzjX/1440-show-featured-attachment-metadata-when-reordering-and-on-the-document-summary

I've made the copy consistent with 'No topics', instead of using
what's in the prototype.