### PR TITLE
Fix allowing empty primary orgs

### DIFF
--- a/app/models/document_type/primary_publishing_organisation_field.rb
+++ b/app/models/document_type/primary_publishing_organisation_field.rb
@@ -8,7 +8,8 @@ class DocumentType::PrimaryPublishingOrganisationField
   end
 
   def updater_params(_edition, params)
-    { primary_publishing_organisation: params[:primary_publishing_organisation] }
+    value = params[id] && params[id].map(&:presence).compact
+    { id.to_sym => value }.compact
   end
 
   def pre_update_issues(_edition, params)

--- a/app/views/tags/edit/_multi_tag_field.html.erb
+++ b/app/views/tags/edit/_multi_tag_field.html.erb
@@ -8,7 +8,7 @@
   hint: t_doctype_field(edition, "#{tag_field_id}.hint"),
   select: {
     options: Linkables.new(tag_field_document_type).select_options,
-    selected: (params[:tags] || edition.tags)[tag_field_id],
+    selected: (params.key?(tag_field_id) ? params : edition.tags)[tag_field_id],
     multiple: true,
     size: 10,
   },

--- a/app/views/tags/edit/_primary_publishing_organisation_field.html.erb
+++ b/app/views/tags/edit/_primary_publishing_organisation_field.html.erb
@@ -4,17 +4,19 @@
   } %>
 <% end %>
 
+<% tag_field_id = "primary_publishing_organisation" %>
+
 <%= render "components/autocomplete", {
-  id: "primary_publishing_organisation-field",
-  name: "primary_publishing_organisation[]",
+  id: "#{tag_field_id}-field",
+  name: "#{tag_field_id}[]",
   label: {
-    text: t_doctype_field(edition, "primary_publishing_organisation.label"),
+    text: t_doctype_field(edition, "#{tag_field_id}.label"),
     bold: true,
   },
-  hint: t_doctype_field(edition, "primary_publishing_organisation.hint"),
+  hint: t_doctype_field(edition, "#{tag_field_id}.hint"),
   select: {
     options: [""] + Linkables.new("organisation").select_options,
-    selected: (params[:tags] || edition.tags)["primary_publishing_organisation"],
+    selected: (params.key?(tag_field_id) ? params : edition.tags)[tag_field_id]
   },
-  error_items: issues&.items_for(:primary_publishing_organisation),
+  error_items: issues&.items_for(tag_field_id.to_sym)
 } %>

--- a/spec/models/document_type/primary_publishing_organisation_field_spec.rb
+++ b/spec/models/document_type/primary_publishing_organisation_field_spec.rb
@@ -15,6 +15,20 @@ RSpec.describe DocumentType::PrimaryPublishingOrganisationField do
       updater_params = described_class.new.updater_params(edition, params)
       expect(updater_params).to eq(primary_publishing_organisation: %w[some_org_id])
     end
+
+    it "copes with empty values for the organisation ID" do
+      edition = build :edition
+      params = ActionController::Parameters.new(primary_publishing_organisation: [""])
+      updater_params = described_class.new.updater_params(edition, params)
+      expect(updater_params).to eq(primary_publishing_organisation: %w[])
+    end
+
+    it "copes when the field is not present in the params" do
+      edition = build :edition
+      params = ActionController::Parameters.new
+      updater_params = described_class.new.updater_params(edition, params)
+      expect(updater_params).to eq({})
+    end
   end
 
   describe "#pre_update_issues" do

--- a/spec/models/document_type/primary_publishing_organisation_field_spec.rb
+++ b/spec/models/document_type/primary_publishing_organisation_field_spec.rb
@@ -35,14 +35,19 @@ RSpec.describe DocumentType::PrimaryPublishingOrganisationField do
     let(:edition) { build(:edition) }
 
     it "returns no issues when there are none" do
-      params = { primary_publishing_organisation: SecureRandom.uuid }
+      params = { primary_publishing_organisation: [SecureRandom.uuid] }
       issues = described_class.new.pre_update_issues(edition, params)
       expect(issues).to be_empty
     end
 
     it "returns an issue if no primary publishing organisation is provided" do
-      params = {}
+      params = { primary_publishing_organisation: [] }
       issues = described_class.new.pre_update_issues(edition, params)
+      expect(issues).to have_issue(:primary_publishing_organisation, :blank, styles: %i[form summary])
+    end
+
+    it "returns an issue if the field is not in the params" do
+      issues = described_class.new.pre_update_issues(edition, {})
       expect(issues).to have_issue(:primary_publishing_organisation, :blank, styles: %i[form summary])
     end
   end

--- a/spec/requests/tags_spec.rb
+++ b/spec/requests/tags_spec.rb
@@ -40,7 +40,7 @@ RSpec.describe "Tags" do
       edition = create(:edition)
 
       patch tags_path(edition.document),
-            params: { tags: { field: [SecureRandom.uuid] } }
+            params: { field: [SecureRandom.uuid] }
 
       expect(response).to redirect_to(document_path(edition.document))
     end
@@ -55,7 +55,7 @@ RSpec.describe "Tags" do
         document_type: "organisation",
       )
 
-      patch tags_path(edition.document), params: { tags: {} }
+      patch tags_path(edition.document), params: {}
       expect(response).to have_http_status(:unprocessable_entity)
       expect(response.body).to have_content(
         I18n.t!("requirements.primary_publishing_organisation.blank.form_message"),


### PR DESCRIPTION
Previously we added validations on the JSON stored for the 'tags',
which has uncovered a bug where '[""]' was being stored when the
user had no primary publishing organisation (or cleared it). This
fixes the field to properly cleanup the input and also changes it
to behave similarly to a MultiTagField when the param isn't there.

Please see the commits for more details.