### PR TITLE
Fix Sentry should capture block

### DIFF
--- a/config/initializers/govuk_error.rb
+++ b/config/initializers/govuk_error.rb
@@ -3,8 +3,11 @@ GovukError.configure do |config|
 
   # Don't capture postgres errors that occur during the time that the data sync
   # is running in integration and staging environments
-  config.should_capture = ->(error) do
-    data_sync_ignored_error = error.is_a?(PG::Error) || error.cause.is_a?(PG::Error)
+  # This lambda is called with Ruby Exception objects, Raven::Event objects
+  # and may be called with other types.
+  config.should_capture = ->(error_or_event) do
+    data_sync_ignored_error = error_or_event.is_a?(PG::Error) ||
+      (error_or_event.respond_to?(:cause) && error_or_event.cause.is_a?(PG::Error))
     data_sync_environment = ENV.fetch("SENTRY_CURRENT_ENV", "")
                                .match(/integration|staging/)
     data_sync_time = Time.zone.now.hour <= 5


### PR DESCRIPTION
It transpires that this block is called not just with an exception
class in the report of an error it is also called with a Raven::Event
which does not respond to a cause event.

This updates the error filtering to be resilient to the object being
passed in to not conform to a particular interface.

Expected type inputs to this lambda would be a Ruby Exception, a
Raven::Event and a String.

Testing on integration to demonstrate problem before and resolved:

before error: https://deploy.integration.publishing.service.gov.uk/job/run-rake-task/137787/
after resolved: https://deploy.integration.publishing.service.gov.uk/job/run-rake-task/137789/