### PR TITLE
Remove articles and correspondence group

### DIFF
--- a/config/document_type_selections.yml
+++ b/config/document_type_selections.yml
@@ -15,19 +15,6 @@
       type: managed_elsewhere
       path: /documents/publishing-guidance
 
-- id: articles_and_correspondence
-  options:
-    - id: correspondence
-      type: document_type
-    - id: correspondence_managed_elsewhere
-      type: managed_elsewhere
-      hostname: whitehall-admin
-      path: /government/admin/publications/new
-    - id: authored_article
-      type: managed_elsewhere
-      hostname: whitehall-admin
-      path: /government/admin/speeches/new
-
 - id: guidance_publications
   options:
     - id: detailed_guide
@@ -84,8 +71,6 @@
       type: document_type
     - id: press_release
       type: document_type
-    - id: articles_and_correspondence
-      type: document_type_selection
     - id: speech
       type: managed_elsewhere
       hostname: whitehall-admin
@@ -96,6 +81,10 @@
       type: managed_elsewhere
       hostname: whitehall-admin
       path: /government/admin/case-studies/new
+    - id: authored_article
+      type: managed_elsewhere
+      hostname: whitehall-admin
+      path: /government/admin/speeches/new
 
 - id: policy
   options:
@@ -188,6 +177,12 @@
     - id: research
       type: document_type
     - id: research_managed_elsewhere
+      type: managed_elsewhere
+      hostname: whitehall-admin
+      path: /government/admin/publications/new
+    - id: correspondence
+      type: document_type
+    - id: correspondence_managed_elsewhere
       type: managed_elsewhere
       hostname: whitehall-admin
       path: /government/admin/publications/new

--- a/config/locales/en/document_type_selections.yml
+++ b/config/locales/en/document_type_selections.yml
@@ -5,9 +5,6 @@ en:
     any_mainstream_publication:
       label: Mainstream guide
       description: Guidance for the general public, written for people not expected to have any previous experience or specialist knowledge.
-    articles_and_correspondence:
-      label: Articles and correspondence
-      description: Articles written by a minister or official, responses from the organisation or a minister, and circulars or newsletters.
     authored_article:
       label: Authored article
       description: Bylined articles written in the name of a minister or official, usually republished from elsewhere.


### PR DESCRIPTION
Move authored article to news and communications group and correspondence to transparency group because of evidence that users responding to a tree test expected to find correspondence in the transparency group.