### PR TITLE
Add requirements checks for official docs

### DIFF
--- a/app/interactors/file_attachments/create_interactor.rb
+++ b/app/interactors/file_attachments/create_interactor.rb
@@ -25,8 +25,9 @@ private
   end
 
   def check_for_issues
-    issues = Requirements::FileAttachmentChecker.new(file: params[:file], title: params[:title])
-                                                .pre_upload_issues
+    issues = Requirements::FileAttachmentUploadChecker
+      .new(file: params[:file], title: params[:title]).pre_upload_issues
+
     context.fail!(issues: issues) if issues.any?
   end
 

--- a/app/interactors/file_attachments/update_file_interactor.rb
+++ b/app/interactors/file_attachments/update_file_interactor.rb
@@ -32,8 +32,8 @@ private
   end
 
   def check_for_issues
-    checker = Requirements::FileAttachmentChecker.new(file: attachment_params[:file],
-                                                      title: attachment_params[:title])
+    checker = Requirements::FileAttachmentUploadChecker.new(file: attachment_params[:file],
+                                                            title: attachment_params[:title])
     issues = checker.pre_update_issues
 
     context.fail!(issues: issues) if issues.any?

--- a/app/interactors/file_attachments/update_interactor.rb
+++ b/app/interactors/file_attachments/update_interactor.rb
@@ -32,9 +32,8 @@ private
   end
 
   def check_for_issues
-    checker = Requirements::FileAttachmentMetadataChecker.new(attachment_params)
-    issues = checker.pre_update_issues
-
+    checker = Requirements::FileAttachmentMetadataChecker.new
+    issues = checker.pre_update_issues(params.require(:file_attachment))
     context.fail!(issues: issues) if issues.any?
   end
 

--- a/app/views/documents/show/_requirements.html.erb
+++ b/app/views/documents/show/_requirements.html.erb
@@ -9,6 +9,10 @@
       image_id = context[:image_revision].image_id
       { href: edit_image_path(@edition.document, image_id, anchor: "alt-text") }
     end,
+    file_attachment_official_document_type: -> (context) do
+      attachment_id = context[:attachment_revision].file_attachment_id
+      { href: edit_file_attachment_path(@edition.document, attachment_id) }
+    end,
     topics: { href: topics_path(@edition.document) },
     primary_publishing_organisation: {
       href: tags_path(@edition.document, anchor: "primary_publishing_organisation")

--- a/app/views/file_attachments/edit/_act_paper.html.erb
+++ b/app/views/file_attachments/edit/_act_paper.html.erb
@@ -4,6 +4,7 @@
   },
   hint: t("file_attachments.edit.official_document.options.act_paper.input_hint_text"),
   name: "file_attachment[act_paper_number]",
+  error_items: issues&.items_for(:file_attachment_act_paper_number),
   value: params.dig(:file_attachment, :act_paper_number) ||
          (attachment.act_paper? && attachment.paper_number),
   width: 10

--- a/app/views/file_attachments/edit/_command_paper.html.erb
+++ b/app/views/file_attachments/edit/_command_paper.html.erb
@@ -4,6 +4,7 @@
   },
   hint: t("file_attachments.edit.official_document.options.command_paper.input_hint_text"),
   name: "file_attachment[command_paper_number]",
+  error_items: issues&.items_for(:file_attachment_command_paper_number),
   value: params.dig(:file_attachment, :command_paper_number) ||
          (attachment.command_paper? && attachment.paper_number),
   width: 10

--- a/config/locales/en/requirements.yml
+++ b/config/locales/en/requirements.yml
@@ -78,9 +78,13 @@ en:
     file_attachment_command_paper_number:
       blank:
         form_message: "Enter a command paper number"
+      invalid:
+        form_message: "Enter a valid command paper number"
     file_attachment_act_paper_number:
       blank:
         form_message: "Enter a House of Commons paper number"
+      invalid:
+        form_message: "Enter a valid House of Commons paper number"
     public_explanation:
       blank:
         form_message: Enter a public explanation

--- a/config/locales/en/requirements.yml
+++ b/config/locales/en/requirements.yml
@@ -71,6 +71,15 @@ en:
     file_attachment_unique_reference:
       too_long:
         form_message: "Enter a unique reference that is fewer than %{max_length} characters long"
+    file_attachment_official_document_type:
+      blank:
+        form_message: "Choose if this is an official document"
+    file_attachment_command_paper_number:
+      blank:
+        form_message: "Enter a command paper number"
+    file_attachment_act_paper_number:
+      blank:
+        form_message: "Enter a House of Commons paper number"
     public_explanation:
       blank:
         form_message: Enter a public explanation

--- a/config/locales/en/requirements.yml
+++ b/config/locales/en/requirements.yml
@@ -74,6 +74,7 @@ en:
     file_attachment_official_document_type:
       blank:
         form_message: "Choose if this is an official document"
+        summary_message: "Choose if ‘%{filename}’ is an official document"
     file_attachment_command_paper_number:
       blank:
         form_message: "Enter a command paper number"

--- a/lib/requirements/edition_checker.rb
+++ b/lib/requirements/edition_checker.rb
@@ -20,6 +20,11 @@ module Requirements
 
     def pre_publish_issues(params = {})
       issues = CheckerIssues.new
+
+      edition.file_attachment_revisions.each do |attachment|
+        issues += FileAttachmentMetadataChecker.new.pre_publish_issues(attachment)
+      end
+
       issues += ContentChecker.new(edition).pre_publish_issues
       issues += TopicChecker.new(edition).pre_publish_issues(params)
       issues

--- a/lib/requirements/file_attachment_metadata_checker.rb
+++ b/lib/requirements/file_attachment_metadata_checker.rb
@@ -18,6 +18,21 @@ module Requirements
                       max_length: UNIQUE_REF_MAX_LENGTH)
       end
 
+      if params[:official_document_type].blank?
+        issues.create(:file_attachment_official_document_type,
+                      :blank)
+      end
+
+      if blank_paper_number?("command", params)
+        issues.create(:file_attachment_command_paper_number,
+                      :blank)
+      end
+
+      if blank_paper_number?("act", params)
+        issues.create(:file_attachment_act_paper_number,
+                      :blank)
+      end
+
       issues
     end
 
@@ -25,6 +40,11 @@ module Requirements
 
     def valid_isbn?(isbn)
       isbn.blank? || ISBN10_REGEX.match?(isbn) || ISBN13_REGEX.match?(isbn)
+    end
+
+    def blank_paper_number?(type, params)
+      params[:official_document_type] == "#{type}_paper" &&
+        params[:"#{type}_paper_number"].blank?
     end
   end
 end

--- a/lib/requirements/file_attachment_metadata_checker.rb
+++ b/lib/requirements/file_attachment_metadata_checker.rb
@@ -36,6 +36,19 @@ module Requirements
       issues
     end
 
+    def pre_publish_issues(attachment)
+      issues = CheckerIssues.new
+
+      if attachment.official_document_type.blank?
+        issues.create(:file_attachment_official_document_type,
+                      :blank,
+                      filename: attachment.filename,
+                      attachment_revision: attachment)
+      end
+
+      issues
+    end
+
   private
 
     def valid_isbn?(isbn)

--- a/lib/requirements/file_attachment_metadata_checker.rb
+++ b/lib/requirements/file_attachment_metadata_checker.rb
@@ -4,40 +4,27 @@ module Requirements
     ISBN10_REGEX = /^(?:\d[\ -]?){9}[\dX]$/i.freeze
     ISBN13_REGEX = /^(?:\d[\ -]?){13}$/i.freeze
 
-    attr_reader :isbn, :unique_reference
-
-    def initialize(params)
-      @isbn = params[:isbn]
-      @unique_reference = params[:unique_reference]
-    end
-
-    def pre_update_issues
-      isbn_issues + unique_reference_issues
-    end
-
-  private
-
-    def isbn_issues
+    def pre_update_issues(params)
       issues = CheckerIssues.new
 
-      unless isbn.blank? || ISBN10_REGEX.match?(isbn) || ISBN13_REGEX.match?(isbn)
-        issues.create(:file_attachment_isbn, :invalid)
+      unless valid_isbn?(params[:isbn])
+        issues.create(:file_attachment_isbn,
+                      :invalid)
       end
 
-      issues
-    end
-
-    def unique_reference_issues
-      issues = CheckerIssues.new
-
-      if unique_reference.present? &&
-          unique_reference.to_s.size > UNIQUE_REF_MAX_LENGTH
+      if params[:unique_reference].to_s.size > UNIQUE_REF_MAX_LENGTH
         issues.create(:file_attachment_unique_reference,
                       :too_long,
                       max_length: UNIQUE_REF_MAX_LENGTH)
       end
 
       issues
+    end
+
+  private
+
+    def valid_isbn?(isbn)
+      isbn.blank? || ISBN10_REGEX.match?(isbn) || ISBN13_REGEX.match?(isbn)
     end
   end
 end

--- a/lib/requirements/file_attachment_upload_checker.rb
+++ b/lib/requirements/file_attachment_upload_checker.rb
@@ -1,5 +1,5 @@
 module Requirements
-  class FileAttachmentChecker
+  class FileAttachmentUploadChecker
     TITLE_MAX_LENGTH = 255
     ALLOWED_FORMATS = [
       "text/csv", # csv

--- a/lib/whitehall_importer/create_file_attachment_revision.rb
+++ b/lib/whitehall_importer/create_file_attachment_revision.rb
@@ -53,7 +53,7 @@ module WhitehallImporter
     end
 
     def check_file_requirements(decorated_file)
-      upload_checker = Requirements::FileAttachmentChecker.new(
+      upload_checker = Requirements::FileAttachmentUploadChecker.new(
         file: decorated_file, title: whitehall_file_attachment["title"],
       ).pre_upload_issues
 

--- a/spec/interactors/file_attachments/create_interactor_spec.rb
+++ b/spec/interactors/file_attachments/create_interactor_spec.rb
@@ -80,9 +80,9 @@ RSpec.describe FileAttachments::CreateInteractor do
 
     context "when the uploaded file has issues" do
       it "fails with issues returned" do
-        checker = instance_double(Requirements::FileAttachmentChecker)
+        checker = instance_double(Requirements::FileAttachmentUploadChecker)
         allow(checker).to receive(:pre_upload_issues).and_return(%w(issue))
-        allow(Requirements::FileAttachmentChecker).to receive(:new).and_return(checker)
+        allow(Requirements::FileAttachmentUploadChecker).to receive(:new).and_return(checker)
         result = described_class.call(**args)
 
         expect(result).to be_failure

--- a/spec/interactors/file_attachments/update_interactor_spec.rb
+++ b/spec/interactors/file_attachments/update_interactor_spec.rb
@@ -26,7 +26,7 @@ RSpec.describe FileAttachments::UpdateInteractor do
     context "with unnumbered command papers" do
       it "overrides the official document type and number" do
         attachment_params.merge!(official_document_type: "unnumbered_command_paper",
-                                 command_paper_number: "1234")
+                                 command_paper_number: "CP 1234")
         result = described_class.call(params: params, user: user)
         expect(result.file_attachment_revision).to be_command_paper
         expect(result.file_attachment_revision.paper_number).to be_blank
@@ -46,7 +46,7 @@ RSpec.describe FileAttachments::UpdateInteractor do
     context "with unofficial documents" do
       it "overrides the official document type and number" do
         attachment_params.merge!(official_document_type: "unofficial",
-                                 command_paper_number: "1234")
+                                 command_paper_number: "CP 1234")
         result = described_class.call(params: params, user: user)
         expect(result.file_attachment_revision).to be_unofficial
         expect(result.file_attachment_revision.paper_number).to be_blank
@@ -56,10 +56,10 @@ RSpec.describe FileAttachments::UpdateInteractor do
     context "with numbered command papers" do
       it "overrides the official document type and number" do
         attachment_params.merge!(official_document_type: "command_paper",
-                                 command_paper_number: "1234")
+                                 command_paper_number: "CP 1234")
         result = described_class.call(params: params, user: user)
         expect(result.file_attachment_revision).to be_command_paper
-        expect(result.file_attachment_revision.paper_number).to eq "1234"
+        expect(result.file_attachment_revision.paper_number).to eq "CP 1234"
       end
     end
 

--- a/spec/lib/requirements/file_attachment_metadata_checker_spec.rb
+++ b/spec/lib/requirements/file_attachment_metadata_checker_spec.rb
@@ -31,11 +31,6 @@ RSpec.describe Requirements::FileAttachmentMetadataChecker do
       end
     end
 
-    it "returns no issues when isbn is omitted" do
-      issues = checker.pre_update_issues(isbn: nil)
-      expect(issues).to be_empty
-    end
-
     [
       "9788700631625",
       "1590599934",

--- a/spec/lib/requirements/file_attachment_metadata_checker_spec.rb
+++ b/spec/lib/requirements/file_attachment_metadata_checker_spec.rb
@@ -1,16 +1,17 @@
 RSpec.describe Requirements::FileAttachmentMetadataChecker do
   describe "#pre_update_issues" do
     let(:max_length) { Requirements::FileAttachmentMetadataChecker::UNIQUE_REF_MAX_LENGTH }
+    let(:checker) { described_class.new }
 
     it "returns no issues if there are none" do
       unique_reference = "z" * max_length
-      issues = described_class.new(unique_reference: unique_reference).pre_update_issues
+      issues = checker.pre_update_issues(unique_reference: unique_reference)
       expect(issues).to be_empty
     end
 
-    it "returns unique_reference issues when the unique_reference is too long" do
+    it "returns an issue when the unique_reference is too long" do
       unique_reference = "z" * (max_length + 1)
-      issues = described_class.new(unique_reference: unique_reference).pre_update_issues
+      issues = checker.pre_update_issues(unique_reference: unique_reference)
 
       expect(issues).to have_issue(:file_attachment_unique_reference,
                                    :too_long,
@@ -24,14 +25,14 @@ RSpec.describe Requirements::FileAttachmentMetadataChecker do
       "0-9722051-1-F",
       "ISBN 9788700631625",
     ].each do |invalid_isbn|
-      it "returns isbn issues when invalid isbn #{invalid_isbn.inspect} is provided" do
-        issues = described_class.new(isbn: invalid_isbn).pre_update_issues
+      it "returns an issue for invalid isbn #{invalid_isbn}" do
+        issues = checker.pre_update_issues(isbn: invalid_isbn)
         expect(issues).to have_issue(:file_attachment_isbn, :invalid)
       end
     end
 
     it "returns no issues when isbn is omitted" do
-      issues = described_class.new(isbn: nil).pre_update_issues
+      issues = checker.pre_update_issues(isbn: nil)
       expect(issues).to be_empty
     end
 
@@ -44,8 +45,8 @@ RSpec.describe Requirements::FileAttachmentMetadataChecker do
       "0-9722051-1-X",
       "0-9722051-1-x",
     ].each do |valid_isbn|
-      it "returns no issues when valid isbn #{valid_isbn.inspect} is provided" do
-        issues = described_class.new(isbn: valid_isbn).pre_update_issues
+      it "returns no issues for valid isbn #{valid_isbn}" do
+        issues = checker.pre_update_issues(isbn: valid_isbn)
         expect(issues).to be_empty
       end
     end

--- a/spec/lib/requirements/file_attachment_metadata_checker_spec.rb
+++ b/spec/lib/requirements/file_attachment_metadata_checker_spec.rb
@@ -2,10 +2,10 @@ RSpec.describe Requirements::FileAttachmentMetadataChecker do
   describe "#pre_update_issues" do
     let(:max_length) { Requirements::FileAttachmentMetadataChecker::UNIQUE_REF_MAX_LENGTH }
     let(:checker) { described_class.new }
+    let(:valid_params) { { official_document_type: "unofficial" } }
 
     it "returns no issues if there are none" do
-      unique_reference = "z" * max_length
-      issues = checker.pre_update_issues(unique_reference: unique_reference)
+      issues = checker.pre_update_issues(valid_params)
       expect(issues).to be_empty
     end
 
@@ -41,8 +41,20 @@ RSpec.describe Requirements::FileAttachmentMetadataChecker do
       "0-9722051-1-x",
     ].each do |valid_isbn|
       it "returns no issues for valid isbn #{valid_isbn}" do
-        issues = checker.pre_update_issues(isbn: valid_isbn)
+        issues = checker.pre_update_issues(valid_params.merge(isbn: valid_isbn))
         expect(issues).to be_empty
+      end
+    end
+
+    it "returns an issue when the official document type is blank" do
+      issues = checker.pre_update_issues({})
+      expect(issues).to have_issue(:file_attachment_official_document_type, :blank)
+    end
+
+    %w(command act).each do |type|
+      it "returns an issue when a numbered #{type} paper has no number" do
+        issues = checker.pre_update_issues(official_document_type: "#{type}_paper")
+        expect(issues).to have_issue(:"file_attachment_#{type}_paper_number", :blank)
       end
     end
   end

--- a/spec/lib/requirements/file_attachment_metadata_checker_spec.rb
+++ b/spec/lib/requirements/file_attachment_metadata_checker_spec.rb
@@ -78,5 +78,58 @@ RSpec.describe Requirements::FileAttachmentMetadataChecker do
         expect(issues).to have_issue(:"file_attachment_#{type}_paper_number", :blank)
       end
     end
+
+    [
+      "C. 123",
+      "Cd. 123-I",
+      "Cmd. 123-IV",
+      "Cmnd. 123-VIII",
+      "Cm. 123",
+      "CP 1",
+    ].each do |valid_number|
+      it "returns no issues for valid command paper number #{valid_number}" do
+        params = { official_document_type: "command_paper", command_paper_number: valid_number }
+        issues = checker.pre_update_issues(valid_params.merge(params))
+        expect(issues).to be_empty
+      end
+    end
+
+    [
+      "NA 123", # bad prefix
+      "C 123", # no dot
+      "C123", # no space
+      "CM. 123", # prefix casing
+      "CP. 123", # prefix casing
+      "C. 123-i", # lower case
+      "C. 123VIII", # no dash
+    ].each do |valid_number|
+      it "returns an issue for invalid command paper number #{valid_number}" do
+        params = { official_document_type: "command_paper", command_paper_number: valid_number }
+        issues = checker.pre_update_issues(params)
+        expect(issues).to have_issue(:file_attachment_command_paper_number, :invalid)
+      end
+    end
+
+    %w[
+      123
+      123-VIII
+    ].each do |valid_number|
+      it "returns no issues for valid act paper number #{valid_number}" do
+        params = { official_document_type: "act_paper", act_paper_number: valid_number }
+        issues = checker.pre_update_issues(valid_params.merge(params))
+        expect(issues).to be_empty
+      end
+    end
+
+    [
+      "123-i", # lower case
+      "123VIII", # no dash
+    ].each do |valid_number|
+      it "returns an issue for invalid act paper number #{valid_number}" do
+        params = { official_document_type: "act_paper", act_paper_number: valid_number }
+        issues = checker.pre_update_issues(params)
+        expect(issues).to have_issue(:file_attachment_act_paper_number, :invalid)
+      end
+    end
   end
 end

--- a/spec/lib/requirements/file_attachment_metadata_checker_spec.rb
+++ b/spec/lib/requirements/file_attachment_metadata_checker_spec.rb
@@ -1,4 +1,25 @@
 RSpec.describe Requirements::FileAttachmentMetadataChecker do
+  let(:checker) { described_class.new }
+
+  describe "#pre_publish_issues" do
+    it "returns no issues if there are none" do
+      attachment_revision = build(:file_attachment_revision, official_document_type: "unofficial")
+      issues = checker.pre_publish_issues(attachment_revision)
+      expect(issues).to be_empty
+    end
+
+    it "returns an issue when the official document type is blank" do
+      attachment_revision = build(:file_attachment_revision)
+      issues = checker.pre_publish_issues(attachment_revision)
+
+      expect(issues).to have_issue(:file_attachment_official_document_type,
+                                   :blank,
+                                   styles: %i[summary],
+                                   filename: attachment_revision.filename,
+                                   attachment_revision: attachment_revision)
+    end
+  end
+
   describe "#pre_update_issues" do
     let(:max_length) { Requirements::FileAttachmentMetadataChecker::UNIQUE_REF_MAX_LENGTH }
     let(:checker) { described_class.new }

--- a/spec/lib/requirements/file_attachment_upload_checker_spec.rb
+++ b/spec/lib/requirements/file_attachment_upload_checker_spec.rb
@@ -1,4 +1,4 @@
-RSpec.describe Requirements::FileAttachmentChecker do
+RSpec.describe Requirements::FileAttachmentUploadChecker do
   describe "#pre_upload_issues" do
     it "returns no issues if there are none" do
       file = fixture_file_upload("files/text-file-74bytes.txt", "text/plain")
@@ -24,7 +24,7 @@ RSpec.describe Requirements::FileAttachmentChecker do
     end
 
     it "returns an issue when the title is too long" do
-      max_length = Requirements::FileAttachmentChecker::TITLE_MAX_LENGTH
+      max_length = Requirements::FileAttachmentUploadChecker::TITLE_MAX_LENGTH
       title = "z" * (max_length + 1)
       issues = described_class.new(file: nil, title: title).pre_upload_issues
       expect(issues).to have_issue(:file_attachment_title, :too_long, max_length: max_length)
@@ -56,7 +56,7 @@ RSpec.describe Requirements::FileAttachmentChecker do
     end
 
     it "returns title issues when only the title is provided" do
-      max_length = Requirements::FileAttachmentChecker::TITLE_MAX_LENGTH
+      max_length = Requirements::FileAttachmentUploadChecker::TITLE_MAX_LENGTH
       title = "z" * (max_length + 1)
       issues = described_class.new(title: title).pre_update_issues
       expect(issues).to have_issue(:file_attachment_title, :too_long, max_length: max_length)

--- a/spec/lib/whitehall_importer/create_file_attachment_revision_spec.rb
+++ b/spec/lib/whitehall_importer/create_file_attachment_revision_spec.rb
@@ -52,10 +52,12 @@ RSpec.describe WhitehallImporter::CreateFileAttachmentRevision do
   end
 
   context "when the file attachment does not satisfy requirements" do
-    let(:too_long_title) { (("A" * Requirements::FileAttachmentChecker::TITLE_MAX_LENGTH) + "A") }
+    let(:too_long_title) { (("A" * Requirements::FileAttachmentUploadChecker::TITLE_MAX_LENGTH) + "A") }
     let(:whitehall_file_attachment) { build(:whitehall_export_file_attachment, title: too_long_title) }
+
     let(:error_message) do
-      I18n.t!("requirements.title.too_long.form_message", max_length: Requirements::FileAttachmentChecker::TITLE_MAX_LENGTH)
+      I18n.t!("requirements.title.too_long.form_message",
+              max_length: Requirements::FileAttachmentUploadChecker::TITLE_MAX_LENGTH)
     end
 
     it_behaves_like "rejected file attachment"

--- a/spec/requests/file_attachments_spec.rb
+++ b/spec/requests/file_attachments_spec.rb
@@ -320,22 +320,19 @@ RSpec.describe "File Attachments" do
 
       patch edit_file_attachment_path(edition.document,
                                       file_attachment_revision.file_attachment_id),
-            params: { file_attachment: { isbn: "9788700631625" } }
+            params: { file_attachment: { official_document_type: "unofficial" } }
 
       expect(response).to redirect_to(featured_attachments_path(edition.document))
     end
 
     it "returns issues and an unprocessable response when there are requirement issues" do
-      max_length = Requirements::FileAttachmentRevisionChecker::UNIQUE_REF_MAX_LENGTH
-      too_long_unique_reference = "a" * (max_length + 1)
-
       patch edit_file_attachment_path(edition.document,
                                       file_attachment_revision.file_attachment_id),
-            params: { file_attachment: { unique_reference: too_long_unique_reference } }
+            params: { file_attachment: { official_document_type: "" } }
 
       expect(response).to have_http_status(:unprocessable_entity)
       expect(response.body).to have_content(
-        I18n.t!("requirements.file_attachment_unique_reference.too_long.form_message", max_length: max_length),
+        I18n.t!("requirements.file_attachment_official_document_type.blank.form_message"),
       )
     end
   end

--- a/spec/requests/file_attachments_spec.rb
+++ b/spec/requests/file_attachments_spec.rb
@@ -326,7 +326,7 @@ RSpec.describe "File Attachments" do
     end
 
     it "returns issues and an unprocessable response when there are requirement issues" do
-      max_length = Requirements::FileAttachmentMetadataChecker::UNIQUE_REF_MAX_LENGTH
+      max_length = Requirements::FileAttachmentRevisionChecker::UNIQUE_REF_MAX_LENGTH
       too_long_unique_reference = "a" * (max_length + 1)
 
       patch edit_file_attachment_path(edition.document,

--- a/spec/views/documents/show/_requirements.html.erb_spec.rb
+++ b/spec/views/documents/show/_requirements.html.erb_spec.rb
@@ -1,6 +1,13 @@
 RSpec.describe "documents/show/_requirements" do
   let(:image) { build :image_revision }
-  let(:edition) { create :edition, revision_synced: false, image_revisions: [image] }
+  let(:file_attachment) { build :file_attachment_revision }
+
+  let(:edition) do
+    create(:edition,
+           revision_synced: false,
+           image_revisions: [image],
+           file_attachment_revisions: [file_attachment])
+  end
 
   before do
     issues = Requirements::CheckerIssues.new
@@ -8,6 +15,11 @@ RSpec.describe "documents/show/_requirements" do
     issues.create(:image_alt_text,
                   :blank,
                   image_revision: image,
+                  filename: "file")
+
+    issues.create(:file_attachment_official_document_type,
+                  :blank,
+                  attachment_revision: file_attachment,
                   filename: "file")
 
     checker = instance_double(Requirements::EditionChecker,
@@ -81,6 +93,11 @@ RSpec.describe "documents/show/_requirements" do
     expect(rendered).to have_link(
       I18n.t!("requirements.image_alt_text.blank.summary_message", filename: "file"),
       href: edit_image_path(edition.document, image.image_id, anchor: "alt-text"),
+    )
+
+    expect(rendered).to have_link(
+      I18n.t!("requirements.file_attachment_official_document_type.blank.summary_message", filename: "file"),
+      href: edit_file_attachment_path(edition.document, file_attachment.file_attachment_id),
     )
   end
 end


### PR DESCRIPTION
https://trello.com/c/3E2vqBkS/1507-support-official-documents-for-featured-file-attachments

Please see the commits for more details.

In doing the work for this PR, I noticed that the [EditionChecker](https://github.com/alphagov/content-publisher/blob/master/lib/requirements/edition_checker.rb) has no spec, despite not being (fully) covered at a higher level. It's difficult to add one due to the lack of a common interface for the checkers it delegates to. For the purpose of this PR, I've avoided making any changes to the structure of checkers, and will look at how to write a test for this in a subsequent PR.

- [ ] Work out how to test the [EditionChecker](https://github.com/alphagov/content-publisher/blob/master/lib/requirements/edition_checker.rb)

<img width="675" alt="Screenshot 2020-04-17 at 16 37 07" src="https://user-images.githubusercontent.com/9029009/79586995-c9c2f380-80c9-11ea-8391-645e1fd87942.png">
<img width="1033" alt="Screenshot 2020-04-17 at 16 37 27" src="https://user-images.githubusercontent.com/9029009/79586999-ca5b8a00-80c9-11ea-99f4-00543825ae26.png">
<img width="832" alt="Screenshot 2020-04-17 at 16 37 43" src="https://user-images.githubusercontent.com/9029009/79587001-caf42080-80c9-11ea-9461-f8e5719dfc29.png">
