### PR TITLE
Fix missing link for image alt text issue

### DIFF
--- a/app/views/documents/show/_requirements.html.erb
+++ b/app/views/documents/show/_requirements.html.erb
@@ -5,17 +5,9 @@
     summary: { href: content_path(@edition.document, anchor: "summary") },
     body: { href: content_path(@edition.document, anchor: "body") },
     change_note: { href: content_path(@edition.document, anchor: "change-note") },
-    alt_text: -> (context) do
+    image_alt_text: -> (context) do
       image_id = context[:image_revision].image_id
       { href: edit_image_path(@edition.document, image_id, anchor: "alt-text") }
-    end,
-    credit: -> (context) do
-      image_id = context[:image_revision].image_id
-      { href: edit_image_path(@edition.document, image_id, anchor: "credit") }
-    end,
-    caption: -> (context) do
-      image_id = context[:image_revision].image_id
-      { href: edit_image_path(@edition.document, image_id, anchor: "caption") }
     end,
     topics: { href: topics_path(@edition.document) },
     primary_publishing_organisation: {

--- a/spec/views/documents/show/_requirements.html.erb_spec.rb
+++ b/spec/views/documents/show/_requirements.html.erb_spec.rb
@@ -1,0 +1,86 @@
+RSpec.describe "documents/show/_requirements" do
+  let(:image) { build :image_revision }
+  let(:edition) { create :edition, revision_synced: false, image_revisions: [image] }
+
+  before do
+    issues = Requirements::CheckerIssues.new
+
+    issues.create(:image_alt_text,
+                  :blank,
+                  image_revision: image,
+                  filename: "file")
+
+    checker = instance_double(Requirements::EditionChecker,
+                              pre_preview_issues: issues,
+                              pre_publish_issues: issues)
+
+    allow(Requirements::EditionChecker).to receive(:new).and_return(checker)
+    assign(:edition, edition)
+  end
+
+  describe "with preview issues" do
+    it "shows issues that are preventing preview" do
+      render template: described_template
+
+      expect(rendered).to have_content(
+        I18n.t!("documents.show.flashes.pre_preview_issues.warning"),
+      )
+    end
+
+    it "alerts about issues when trying to preview" do
+      render template: described_template,
+             locals: { flash: { tried_to_preview: true } }
+
+      expect(rendered).to have_content(
+        I18n.t!("documents.show.flashes.pre_preview_issues.error"),
+      )
+    end
+
+    it "shows nothing when the edition is previewable" do
+      assign(:edition, build(:edition))
+
+      render template: described_template
+
+      expect(rendered).not_to have_content(
+        I18n.t!("documents.show.flashes.pre_preview_issues.warning"),
+      )
+    end
+  end
+
+  context "with publish issues" do
+    it "shows issues that are preventing publish" do
+      render template: described_template
+
+      expect(rendered).to have_content(
+        I18n.t!("documents.show.flashes.pre_publish_issues.warning"),
+      )
+    end
+
+    it "alerts about issues when trying to publish" do
+      render template: described_template,
+             locals: { flash: { tried_to_publish: true } }
+
+      expect(rendered).to have_content(
+        I18n.t!("documents.show.flashes.pre_publish_issues.error"),
+      )
+    end
+
+    it "shows nothing if the edition isn't editable" do
+      assign(:edition, build(:edition, :published))
+      render template: described_template
+
+      expect(rendered).not_to have_content(
+        I18n.t!("documents.show.flashes.pre_publish_issues.warning"),
+      )
+    end
+  end
+
+  it "provides links to fix deeply nested issues" do
+    render template: described_template
+
+    expect(rendered).to have_link(
+      I18n.t!("requirements.image_alt_text.blank.summary_message", filename: "file"),
+      href: edit_image_path(edition.document, image.image_id, anchor: "alt-text"),
+    )
+  end
+end


### PR DESCRIPTION
This also adds a test for the 'requirements' partial. Although there
are lots of potential links to fix requirements, most of them are
shown elsewhere on the summary page, so are arguably for convenience
only. Previously, we found that an alt text issue was blocking for
users, without a link to the page to fix it.

This also removes redundant linking capability for 'credit' and
'caption', since issues for these fields will never appear on the
document summary.

Bug introduced in: 24dce0940cb7b1195a22bfe5226bb89872f5c313