### PR TITLE
Add resiliency to missing level_one_taxons

### DIFF
--- a/lib/topic_index.rb
+++ b/lib/topic_index.rb
@@ -33,7 +33,7 @@ private
       start_time = Time.zone.now
 
       topics = publishing_api.get_expanded_links(GOVUK_HOMEPAGE_CONTENT_ID)
-        .dig("expanded_links", "level_one_taxons")
+        .dig("expanded_links", "level_one_taxons").to_a
 
       topics.each do |raw_topic|
         raise GdsApi::TimedOutException.new if Time.zone.now - start_time > TOPIC_INDEX_TIMEOUT


### PR DESCRIPTION
In Content Publisher we expect that the Publishing API has level one
taxons for the homepage and this is needed to render a taxonomy. Today,
however, we experienced the very strange scenario that in integration
the homepage no longer had any links. This caused Content Publisher to
begin to raising syntax errors for running methods on nil.

As this is a very bizarre situation I don't particularly want to write
custom code for handling this but I do think it's better that, in the
event of this situation, the app doesn't raise syntax errors.