### PR TITLE
Expand on time formatting work

### DIFF
--- a/app/views/debug/index.html.erb
+++ b/app/views/debug/index.html.erb
@@ -19,7 +19,7 @@
       Revision <%= revision.number %><%= edition_text %>
     </h2>
     <p class="govuk-caption-m govuk-!-margin-top-0">
-      Created at <%= revision.created_at.to_s(:date_at_time) %>
+      Created at <%= revision.created_at.to_s(:time_on_date) %>
       <% if revision.created_by %>
         by <%= name_or_fallback(revision.created_by) %>
       <% end %>
@@ -43,7 +43,7 @@
 
       status_change_summary = if status_changes.any?
                                 list = status_changes.map do |s|
-                                  "<li><code>#{s.state}</code> - created at #{s.created_at.to_s(:date_at_time)}</li>"
+                                  "<li><code>#{s.state}</code> - created at #{s.created_at.to_s(:time_on_date)}</li>"
                                 end
                                 [
                                   {
@@ -57,7 +57,7 @@
 
       inherited_status_summary = if inherited_statuses.any?
                                    list = inherited_statuses.map do |s|
-                                     "<li><code>#{s.state}</code> - created at #{s.created_at.to_s(:date_at_time)}</li>"
+                                     "<li><code>#{s.state}</code> - created at #{s.created_at.to_s(:time_on_date)}</li>"
                                    end
                                    [
                                      {

--- a/app/views/documents/history/_content_publisher_entry.html.erb
+++ b/app/views/documents/history/_content_publisher_entry.html.erb
@@ -38,9 +38,15 @@
   </h4>
 
   <div class="app-timeline-entry__dateline">
-    <%= entry.created_at.to_s(:date_at_time) %>
     <% if entry.created_by %>
-      <%= t "documents.history.by" %> <%= entry.created_by.name %>
+      <%= t "documents.history.dateline_user",
+          date: entry.created_at.to_s(:date),
+          time: entry.created_at.to_s(:time),
+          user: entry.created_by.name %>
+    <% else %>
+      <%= t "documents.history.dateline_no_user",
+          date: entry.created_at.to_s(:date),
+          time: entry.created_at.to_s(:time) %>
     <% end %>
   </div>
 

--- a/app/views/documents/history/_whitehall_entry.html.erb
+++ b/app/views/documents/history/_whitehall_entry.html.erb
@@ -26,9 +26,15 @@
     </h4>
 
     <div class="app-timeline-entry__dateline">
-      <%= entry.created_at.to_s(:date_at_time) %>
       <% if entry.created_by %>
-        <%= t "documents.history.by" %> <%= entry.created_by.name %>
+        <%= t "documents.history.dateline_user",
+            date: entry.created_at.to_s(:date),
+            time: entry.created_at.to_s(:time),
+            user: entry.created_by.name %>
+      <% else %>
+        <%= t "documents.history.dateline_no_user",
+            date: entry.created_at.to_s(:date),
+            time: entry.created_at.to_s(:time) %>
       <% end %>
     </div>
 

--- a/app/views/documents/show/_failed_to_publish_notice.html.erb
+++ b/app/views/documents/show/_failed_to_publish_notice.html.erb
@@ -2,9 +2,7 @@
   scheduling = @edition.status.details
   description_govspeak = t("documents.show.failed_to_publish.description_govspeak",
                            title: @edition.title,
-                           date: scheduling.publish_time.to_s(:date),
-                           time: scheduling.publish_time.to_s(:time))
-
+                           datetime: scheduling.publish_time.to_s(:time_on_date))
 %>
 <%= render "components/inset_prompt", {
   error: true,

--- a/app/views/documents/show/_proposed_scheduling_notice.html.erb
+++ b/app/views/documents/show/_proposed_scheduling_notice.html.erb
@@ -5,8 +5,7 @@
 <% proposed_scheduling_description = capture do %>
   <p class="govuk-body govuk-!-margin-bottom-1">
     <%= t("documents.show.proposed_scheduling_notice.title",
-          time: publish_time.to_s(:time),
-          date: publish_time.to_s(:date)) %>
+          datetime: publish_time.to_s(:time_on_date)) %>
   </p>
   <%= tag.p link_to("Change date",
               schedule_proposal_path(@edition.document),

--- a/app/views/documents/show/_scheduled_notice.html.erb
+++ b/app/views/documents/show/_scheduled_notice.html.erb
@@ -3,8 +3,7 @@
 <% scheduled_description = capture do %>
   <p class="govuk-body govuk-!-margin-bottom-1">
     <%= t("documents.show.scheduled_notice.title",
-          time: publish_time.to_s(:time),
-          date: publish_time.to_s(:date)) %>
+          datetime: publish_time.to_s(:time_on_date)) %>
   </p>
 
   <ul class="govuk-list govuk-!-margin-0">

--- a/app/views/publish_mailer/publish_email.text.erb
+++ b/app/views/publish_mailer/publish_email.text.erb
@@ -2,13 +2,11 @@
 
 <% if @edition.first? -%>
   <%= t("publish_mailer.publish_email.details.publish",
-        time: @status.created_at.to_s(:time),
-        date: @status.created_at.to_s(:date),
+        datetime: @status.created_at.to_s(:time_on_date),
         user: @status.created_by&.name || I18n.t!("documents.unknown_user")) %>
 <% else -%>
   <%= t("publish_mailer.publish_email.details.update",
-        time: @status.created_at.to_s(:time),
-        date: @status.created_at.to_s(:date),
+        datetime: @status.created_at.to_s(:time_on_date),
         user: @status.created_by&.name || I18n.t!("documents.unknown_user")) %>
 <% end -%>
 

--- a/app/views/schedule/new.html.erb
+++ b/app/views/schedule/new.html.erb
@@ -7,16 +7,13 @@
 <% end %>
 
 <% datetime = @edition.proposed_publish_time %>
-<% time = datetime.to_s(:time) %>
-<% date = datetime.to_s(:date) %>
-
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
     <%= form_tag new_schedule_path(@edition.document), data: { gtm: "confirm-schedule" } do %>
       <%= render "govuk_publishing_components/components/radio", {
         heading: t("schedule.new.title"),
         is_page_heading: true,
-        description: render_govspeak(t("schedule.new.hint_text", time: time, date: date)),
+        description: render_govspeak(t("schedule.new.hint_text", datetime: datetime.to_s(:time_on_date))),
         name: "review_status",
         error_items: @issues&.items,
         items: [

--- a/app/views/schedule/scheduled.html.erb
+++ b/app/views/schedule/scheduled.html.erb
@@ -2,8 +2,6 @@
 <% content_for :browser_title, t("schedule.scheduled.title") %>
 
 <% scheduling = @edition.status.details %>
-<% time = scheduling.publish_time.to_s(:time) %>
-<% date = scheduling.publish_time.to_s(:date) %>
 <% public_url = edition_public_url(@edition) %>
 
 <div class="govuk-grid-row">
@@ -12,7 +10,9 @@
       title: t("schedule.scheduled.title")
     } %>
 
-    <%= render_govspeak(t("schedule.scheduled.body_govspeak", title: @edition.title, time: time, date: date)) %>
+    <%= render_govspeak(t("schedule.scheduled.body_govspeak",
+                          title: @edition.title,
+                          datetime: scheduling.publish_time.to_s(:time_on_date))) %>
 
     <%= render "govuk_publishing_components/components/inset_text", {
       text: link_to(strip_scheme_from_url(public_url), public_url,

--- a/app/views/scheduled_publish_mailer/failure_email.text.erb
+++ b/app/views/scheduled_publish_mailer/failure_email.text.erb
@@ -1,8 +1,7 @@
 <%= t("scheduled_publish_mailer.failure_email.problem", title: @edition.title) %>
 
 <%= t("scheduled_publish_mailer.failure_email.schedule_date",
-      time: @scheduling.publish_time.to_s(:time),
-      date: @scheduling.publish_time.to_s(:date)) %>
+      datetime: @scheduling.publish_time.to_s(:time_on_date)) %>
 
 <%= t("scheduled_publish_mailer.failure_email.try_again") %>
 

--- a/app/views/scheduled_publish_mailer/success_email.text.erb
+++ b/app/views/scheduled_publish_mailer/success_email.text.erb
@@ -2,12 +2,10 @@
 
 <% if @edition.first? -%>
   <%= t("scheduled_publish_mailer.success_email.details.publish",
-        time: @status.created_at.to_s(:time),
-        date: @status.created_at.to_s(:date)) %>
+        datetime: @status.created_at.to_s(:time_on_date)) %>
 <% else -%>
   <%= t("scheduled_publish_mailer.success_email.details.update",
-        time: @status.created_at.to_s(:time),
-        date: @status.created_at.to_s(:date)) %>
+        datetime: @status.created_at.to_s(:time_on_date)) %>
 <% end -%>
 
 <% if @status.created_by -%>

--- a/config/initializers/time_formats.rb
+++ b/config/initializers/time_formats.rb
@@ -1,4 +1,3 @@
 Time::DATE_FORMATS[:date] = "%-d %B %Y"
 Time::DATE_FORMATS[:time] = "%-l:%M%P"
-Time::DATE_FORMATS[:date_at_time] = "%-d %B %Y at %-l:%M%P"
 Time::DATE_FORMATS[:time_on_date] = "%-l:%M%P on %-d %B %Y"

--- a/config/locales/en/documents/history.yml
+++ b/config/locales/en/documents/history.yml
@@ -5,7 +5,8 @@ en:
       edition_heading: "%{number} edition"
       add_internal_note: "Add internal note"
       page_info: "%{page} of %{pages}"
-      by: "by"
+      dateline_user: "%{date} at %{time} by %{user}"
+      dateline_no_user: "%{date} at %{time}"
       entry_types:
         created: "First created"
         submitted: "Submitted for review"

--- a/config/locales/en/documents/show.yml
+++ b/config/locales/en/documents/show.yml
@@ -28,7 +28,7 @@ en:
         title: There is a problem
         description_govspeak: |
           ‘%{title}’ has not been published.<br>
-          It was scheduled to publish at %{time} on %{date}
+          It was scheduled to publish at %{datetime}
 
           You can publish it now, schedule it to publish later, or edit it.
       featured_attachments:
@@ -87,9 +87,9 @@ en:
         last_edited_by: Last edited by
         withdrawn_by: Withdrawn by
       proposed_scheduling_notice:
-        title: Proposed to publish at %{time} on %{date}
+        title: Proposed to publish at %{datetime}
       scheduled_notice:
-        title: Scheduled to publish at %{time} on %{date}
+        title: Scheduled to publish at %{datetime}
       submitted_for_review:
         title: Content has been marked as ready for 2i review
         label: Send the Content Publisher link to another publisher for them to review. When content is ready you or they can publish it.

--- a/config/locales/en/publish_mailer/publish_email.yml
+++ b/config/locales/en/publish_mailer/publish_email.yml
@@ -6,8 +6,8 @@ en:
         published_but_needs_2i: "Published but needs 2i review: ‘%{title}’"
         update: "Update published: ‘%{title}’"
       details:
-        publish: "Published at %{time} on %{date} by %{user}"
-        update: "Update published at %{time} on %{date} by %{user}"
+        publish: "Published at %{datetime} by %{user}"
+        update: "Update published at %{datetime} by %{user}"
       delay_warning: It may take 5 minutes to appear live.
       page_address: Page address
       change_note: Public change note

--- a/config/locales/en/schedule/new.yml
+++ b/config/locales/en/schedule/new.yml
@@ -2,7 +2,7 @@ en:
   schedule:
     new:
       title: Schedule to publish
-      hint_text: "Publish at %{time} on %{date}."
+      hint_text: "Publish at %{datetime}."
       review_status:
         reviewed: This content has been reviewed and approved for publication
         not_reviewed: This content needs to be reviewed after it has been published

--- a/config/locales/en/schedule/scheduled.yml
+++ b/config/locales/en/schedule/scheduled.yml
@@ -3,6 +3,6 @@ en:
     scheduled:
       title: Content has been scheduled to publish
       body_govspeak: |
-        ‘%{title}’ will be automatically published at %{time} on %{date}.
+        ‘%{title}’ will be automatically published at %{datetime}.
 
         It may take 5 minutes to appear live.

--- a/config/locales/en/scheduled_publish_mailer/failure_email.yml
+++ b/config/locales/en/scheduled_publish_mailer/failure_email.yml
@@ -3,7 +3,7 @@ en:
     failure_email:
       subject: "Error publishing ‘%{title}’"
       problem: "There has been a problem publishing ‘%{title}’"
-      schedule_date: "Content was scheduled for %{time} on %{date} but has not gone live."
+      schedule_date: "Content was scheduled for %{datetime} but has not gone live."
       try_again: Please try again or raise a support request.
       edit_in_app: Edit in Content Publisher
       raise_ticket: "[Raise a support request](https://support.publishing.service.gov.uk/technical_fault_report/new)"

--- a/config/locales/en/scheduled_publish_mailer/success_email.yml
+++ b/config/locales/en/scheduled_publish_mailer/success_email.yml
@@ -6,8 +6,8 @@ en:
         published_but_needs_2i: "Published but needs 2i review: ‘%{title}’"
         update: "Update published: ‘%{title}’"
       details:
-        publish: "Published at %{time} on %{date}"
-        update: "Update published at %{time} on %{date}"
+        publish: "Published at %{datetime}"
+        update: "Update published at %{datetime}"
       delay_warning: It may take 5 minutes to appear live.
       page_address: Page address
       change_note: Public change note

--- a/spec/features/scheduling/clear_proposed_publish_time_spec.rb
+++ b/spec/features/scheduling/clear_proposed_publish_time_spec.rb
@@ -23,8 +23,7 @@ RSpec.feature "Clear proposed publish time" do
 
   def then_i_see_the_proposed_time
     @proposed_content = I18n.t!("documents.show.proposed_scheduling_notice.title",
-                                time: "12:00pm",
-                                date: "15 June 2019")
+                                datetime: @edition.proposed_publish_time.to_s(:time_on_date))
     expect(page).to have_content(@proposed_content)
   end
 

--- a/spec/features/scheduling/propose_publish_time_and_schedule_spec.rb
+++ b/spec/features/scheduling/propose_publish_time_and_schedule_spec.rb
@@ -39,8 +39,7 @@ RSpec.feature "Propose publish time and schedule" do
       .to have_content(I18n.t!("schedule.new.title"))
     expect(page)
       .to have_content(I18n.t!("schedule.new.hint_text",
-                               time: "3:30pm",
-                               date: "20 August 2019"))
+                               datetime: "3:30pm on 20 August 2019"))
   end
 
   def when_i_submit_a_review_option

--- a/spec/features/scheduling/propose_publish_time_spec.rb
+++ b/spec/features/scheduling/propose_publish_time_spec.rb
@@ -35,7 +35,6 @@ RSpec.feature "Propose publish time" do
   def then_i_see_there_is_a_proposed_publish_time
     expect(page)
       .to have_content(I18n.t!("documents.show.proposed_scheduling_notice.title",
-                               time: "9:00am",
-                               date: "14 June 2019"))
+                               datetime: "9:00am on 14 June 2019"))
   end
 end

--- a/spec/features/scheduling/scheduled_publishing_failed_spec.rb
+++ b/spec/features/scheduling/scheduled_publishing_failed_spec.rb
@@ -61,8 +61,7 @@ RSpec.feature "Scheduled publishing failed" do
 
     expect(message.body)
       .to have_content(I18n.t("scheduled_publish_mailer.failure_email.schedule_date",
-                              time: "3:00pm",
-                              date: "20 June 2019"))
+                              datetime: @edition.proposed_publish_time.to_s(:time_on_date)))
   end
 
   def when_i_visit_the_summary_page

--- a/spec/features/scheduling/scheduled_publishing_spec.rb
+++ b/spec/features/scheduling/scheduled_publishing_spec.rb
@@ -46,7 +46,9 @@ RSpec.feature "Scheduled publishing" do
     visit document_path(@edition.document)
 
     expect(page).to have_content(I18n.t!("user_facing_states.scheduled.name"))
-    expect(page).to have_content("Scheduled to publish at 9:00am on 22 June 2019")
+    expect(page)
+      .to have_content(I18n.t!("documents.show.scheduled_notice.title",
+                               datetime: @edition.proposed_publish_time.to_s(:time_on_date)))
   end
 
   def and_there_is_a_scheduled_timeline_entry
@@ -83,8 +85,7 @@ RSpec.feature "Scheduled publishing" do
     expect(message.body).to have_content("https://www.test.gov.uk/news/breaking-story")
     expect(message.body)
       .to have_content(I18n.t("scheduled_publish_mailer.success_email.details.publish",
-                              time: "9:00am",
-                              date: "22 June 2019"))
+                              datetime: @edition.proposed_publish_time.to_s(:time_on_date)))
   end
 
   def when_i_visit_the_summary_page

--- a/spec/features/scheduling/unschedule_spec.rb
+++ b/spec/features/scheduling/unschedule_spec.rb
@@ -13,11 +13,11 @@ RSpec.feature "Unschedule" do
   end
 
   def given_there_is_a_scheduled_edition
-    scheduling = create(:scheduling,
-                        reviewed: true,
-                        publish_time: Time.zone.parse("2019-06-14 23:00"))
+    @scheduling = create(:scheduling,
+                         reviewed: true,
+                         publish_time: Time.zone.parse("2019-06-14 23:00"))
 
-    @edition = create(:edition, :scheduled, scheduling: scheduling)
+    @edition = create(:edition, :scheduled, scheduling: @scheduling)
   end
 
   def when_i_visit_the_summary_page
@@ -35,9 +35,9 @@ RSpec.feature "Unschedule" do
   end
 
   def and_the_proposed_publish_time_is_still_set
-    expect(page).to have_content(I18n.t!("documents.show.proposed_scheduling_notice.title",
-                                         time: "11:00pm",
-                                         date: "14 June 2019"))
+    expect(page)
+      .to have_content(I18n.t!("documents.show.proposed_scheduling_notice.title",
+                               datetime: @scheduling.publish_time.to_s(:time_on_date)))
   end
 
   def and_i_see_the_timeline_entry

--- a/spec/features/scheduling/update_proposed_publish_time_spec.rb
+++ b/spec/features/scheduling/update_proposed_publish_time_spec.rb
@@ -44,7 +44,6 @@ RSpec.feature "Update proposed publish time" do
   def then_i_see_the_new_proposed_time
     expect(page)
       .to have_content(I18n.t!("documents.show.proposed_scheduling_notice.title",
-                               time: "11:00pm",
-                               date: "15 June 2019"))
+                               datetime: "11:00pm on 15 June 2019"))
   end
 end

--- a/spec/features/scheduling/update_publish_time_spec.rb
+++ b/spec/features/scheduling/update_publish_time_spec.rb
@@ -46,8 +46,7 @@ RSpec.feature "Update publish time" do
   def then_i_see_the_edition_is_rescheduled
     expect(page).to have_content(I18n.t!("user_facing_states.scheduled.name"))
     expect(page).to have_content(I18n.t!("documents.show.scheduled_notice.title",
-                                         time: "11:00pm",
-                                         date: "15 August 2019"))
+                                         datetime: @new_time.to_s(:time_on_date)))
   end
 
   def and_i_see_the_timeline_entry

--- a/spec/features/workflow/publish_spec.rb
+++ b/spec/features/workflow/publish_spec.rb
@@ -38,7 +38,7 @@ RSpec.feature "Publishing an edition" do
   end
 
   def and_i_publish_the_edition
-    travel_to(@publish_date = Time.zone.now) do
+    travel_to(@publish_time = Time.zone.now) do
       click_on "Publish"
       choose I18n.t!("publish.confirmation.has_been_reviewed")
       stub_any_publishing_api_put_content
@@ -76,10 +76,6 @@ RSpec.feature "Publishing an edition" do
     tos = ActionMailer::Base.deliveries.map(&:to)
     message = ActionMailer::Base.deliveries.first
 
-    publish_time = @publish_date.strftime("%-l:%M%P").strip
-    publish_date = @publish_date.strftime("%-d %B %Y")
-    publish_user = current_user.name
-
     expect(tos).to match_array [[@creator.email], [current_user.email]]
     expect(message.body).to have_content("https://www.test.gov.uk/news/banana-pricing-updates")
     expect(message.body).to have_content(document_path(@edition.document))
@@ -88,8 +84,7 @@ RSpec.feature "Publishing an edition" do
                                          title: @edition.title))
 
     expect(message.body).to have_content(I18n.t("publish_mailer.publish_email.details.publish",
-                                                time: publish_time,
-                                                date: publish_date,
-                                                user: publish_user))
+                                                datetime: @publish_time.to_s(:time_on_date),
+                                                user: current_user.name))
   end
 end

--- a/spec/features/workflow/publish_without_review_spec.rb
+++ b/spec/features/workflow/publish_without_review_spec.rb
@@ -30,13 +30,13 @@ RSpec.feature "Publish without review" do
   end
 
   def when_i_click_the_approve_button
-    travel_to(@publish_date + 1.hour) do
+    travel_to(@publish_time + 1.hour) do
       click_on "Approve"
     end
   end
 
   def and_i_publish_without_review
-    travel_to(@publish_date = Time.zone.now) do
+    travel_to(@publish_time = Time.zone.now) do
       click_on "Publish"
       choose I18n.t!("publish.confirmation.should_be_reviewed")
       stub_any_publishing_api_put_content
@@ -75,10 +75,6 @@ RSpec.feature "Publish without review" do
     tos = ActionMailer::Base.deliveries.map(&:to)
     message = ActionMailer::Base.deliveries.first
 
-    publish_time = @publish_date.strftime("%-l:%M%P").strip
-    publish_date = @publish_date.strftime("%-d %B %Y")
-    publish_user = current_user.name
-
     expect(tos).to match_array [[@creator.email], [current_user.email]]
     expect(message.body).to have_content("https://www.test.gov.uk/news/banana-pricing-updates")
     expect(message.body).to have_content(document_path(@edition.document))
@@ -87,8 +83,7 @@ RSpec.feature "Publish without review" do
                                          title: @edition.title))
 
     expect(message.body).to have_content(I18n.t("publish_mailer.publish_email.details.publish",
-                                                time: publish_time,
-                                                date: publish_date,
-                                                user: publish_user))
+                                                datetime: @publish_time.to_s(:time_on_date),
+                                                user: current_user.name))
   end
 end

--- a/spec/mailers/publish_mailer_spec.rb
+++ b/spec/mailers/publish_mailer_spec.rb
@@ -22,8 +22,7 @@ RSpec.describe PublishMailer do
 
       mail = described_class.publish_email(recipient, edition, edition.status)
       publish_time = I18n.t!("publish_mailer.publish_email.details.publish",
-                             date: "17 June 2019",
-                             time: "9:00am",
+                             datetime: edition.published_at.to_s(:time_on_date),
                              user: recipient.name)
 
       expect(mail.body.to_s).to include(publish_time)
@@ -49,8 +48,7 @@ RSpec.describe PublishMailer do
 
         mail = described_class.publish_email(recipient, edition, edition.status)
         update_text = I18n.t!("publish_mailer.publish_email.details.update",
-                              date: "17 June 2019",
-                              time: "11:00pm",
+                              datetime: edition.published_at.to_s(:time_on_date),
                               user: recipient.name)
         mail_subject = I18n.t!("publish_mailer.publish_email.subject.update",
                                title: edition.title)

--- a/spec/mailers/scheduled_publish_mailer_spec.rb
+++ b/spec/mailers/scheduled_publish_mailer_spec.rb
@@ -21,8 +21,7 @@ RSpec.describe ScheduledPublishMailer do
       mail = described_class.success_email(recipient, edition, edition.status)
 
       publish_time = I18n.t!("scheduled_publish_mailer.success_email.details.publish",
-                             date: "17 June 2019",
-                             time: "9:00am")
+                             datetime: edition.published_at.to_s(:time_on_date))
       expect(mail.body.to_s).to include(publish_time)
     end
 
@@ -58,8 +57,7 @@ RSpec.describe ScheduledPublishMailer do
         mail = described_class.success_email(recipient, edition, edition.status)
 
         update_text = I18n.t!("scheduled_publish_mailer.success_email.details.update",
-                              date: "17 June 2019",
-                              time: "11:00pm")
+                              datetime: edition.published_at.to_s(:time_on_date))
         expect(mail.body.to_s).to include(update_text)
       end
 
@@ -111,8 +109,7 @@ RSpec.describe ScheduledPublishMailer do
       mail = described_class.failure_email(recipient, edition, edition.status)
 
       publish_time = I18n.t!("scheduled_publish_mailer.failure_email.schedule_date",
-                             date: "17 June 2019",
-                             time: "12:00pm")
+                             datetime: scheduling.publish_time.to_s(:time_on_date))
       expect(mail.body.to_s).to include(publish_time)
     end
   end

--- a/spec/views/documents/history/_content_publisher_entry.html.erb_spec.rb
+++ b/spec/views/documents/history/_content_publisher_entry.html.erb_spec.rb
@@ -1,17 +1,23 @@
 RSpec.describe "documents/history/_content_publisher_entry" do
   it "shows a timeline entry without an author" do
-    timeline_entry = create(:timeline_entry,
-                            created_by: nil)
-    render template: described_template, locals: { entry: timeline_entry }
-    expect(rendered).not_to have_content(I18n.t!("documents.history.by"))
-    expect(rendered).to have_content(I18n.t!("documents.history.entry_types.created"))
+    freeze_time do
+      timeline_entry = create(:timeline_entry, created_by: nil)
+      render template: described_template, locals: { entry: timeline_entry }
+      expect(rendered).to have_content(I18n.t!("documents.history.dateline_no_user",
+                                               date: Time.zone.now.to_s(:date),
+                                               time: Time.zone.now.to_s(:time)))
+    end
   end
 
   it "shows a timeline entry with an author" do
-    timeline_entry = create(:timeline_entry)
-    render template: described_template, locals: { entry: timeline_entry }
-    expect(rendered).to have_content(I18n.t!("documents.history.by") + " John Smith")
-    expect(rendered).to have_content(I18n.t!("documents.history.entry_types.created"))
+    freeze_time do
+      timeline_entry = create(:timeline_entry)
+      render template: described_template, locals: { entry: timeline_entry }
+      expect(rendered).to have_content(I18n.t!("documents.history.dateline_user",
+                                               date: Time.zone.now.to_s(:date),
+                                               time: Time.zone.now.to_s(:time),
+                                               user: timeline_entry.created_by.name))
+    end
   end
 
   it "shows a timeline entry with content" do

--- a/spec/views/documents/history/_whitehall_entry.html.erb_spec.rb
+++ b/spec/views/documents/history/_whitehall_entry.html.erb_spec.rb
@@ -1,22 +1,31 @@
 RSpec.describe "documents/history/_whitehall_entry" do
   it "shows an imported timeline entry without an author" do
-    timeline_entry = create(:timeline_entry,
-                            :whitehall_imported,
-                            whitehall_entry_type: :new_edition,
-                            created_by: nil)
-    render template: described_template, locals: { entry: timeline_entry }
-    expect(rendered).not_to have_content(I18n.t!("documents.history.by"))
-    expect(rendered).to have_content(I18n.t!("documents.history.entry_types.whitehall_migration.new_edition"))
+    freeze_time do
+      timeline_entry = create(:timeline_entry,
+                              :whitehall_imported,
+                              whitehall_entry_type: :new_edition,
+                              created_by: nil)
+      render template: described_template, locals: { entry: timeline_entry }
+      expect(rendered)
+        .to have_content(I18n.t!("documents.history.dateline_no_user",
+                                 date: Time.zone.now.to_s(:date),
+                                 time: Time.zone.now.to_s(:time)))
+    end
   end
 
   it "shows an imported timeline entry with an author" do
-    timeline_entry = create(:timeline_entry,
-                            :whitehall_imported,
-                            whitehall_entry_type: :new_edition)
+    freeze_time do
+      timeline_entry = create(:timeline_entry,
+                              :whitehall_imported,
+                              whitehall_entry_type: :new_edition)
 
-    render template: described_template, locals: { entry: timeline_entry }
-    expect(rendered).to have_content(I18n.t!("documents.history.by") + " John Smith")
-    expect(rendered).to have_content(I18n.t!("documents.history.entry_types.whitehall_migration.new_edition"))
+      render template: described_template, locals: { entry: timeline_entry }
+      expect(rendered)
+        .to have_content(I18n.t!("documents.history.dateline_user",
+                                 date: Time.zone.now.to_s(:date),
+                                 time: Time.zone.now.to_s(:time),
+                                 user: timeline_entry.created_by.name))
+    end
   end
 
   it "does not highlight an imported internal note timeline entry without content" do


### PR DESCRIPTION
Following on from https://github.com/alphagov/content-publisher/pull/2002 this makes a number of improvements to time formatting:

- it changes the time handling in the debug view to use the more common approach of timestamp formatting of time_on_date;
- it removes the common repetition of passing time and date into translation strings only for them to be rendered with the time_on_date formatting within the translation string;
- it removes the date_at_time formatting rule and applies that manually in the one instance it is used (timeline entries) to remove it as a competing rule.

More information about each in the commits

I had hoped to entirely remove the date_at_time style of formatting but when considering it I felt this wasn't a decision that should be made without a designers involvement as it changes the precedence of date when reading this page (which felt like a bad thing).

I'd also hoped that I could get rid of the time formatting rule since it only seemed to be used as part of a time_on_date rule - however, I found out it is used to render times individually for scheduling.
