### PR TITLE
Update previews when changing schedule proposal

### DIFF
--- a/app/interactors/schedule_proposal/update_interactor.rb
+++ b/app/interactors/schedule_proposal/update_interactor.rb
@@ -13,6 +13,7 @@ class ScheduleProposal::UpdateInteractor < ApplicationInteractor
       parse_publish_time
       check_for_issues
       update_edition
+      update_preview
     end
   end
 
@@ -56,5 +57,9 @@ private
 
   def schedule_params
     params.require(:schedule).permit(:time, :action, date: %i[day month year])
+  end
+
+  def update_preview
+    FailsafeDraftPreviewService.call(edition)
   end
 end

--- a/spec/features/scheduling/propose_publish_time_and_schedule_spec.rb
+++ b/spec/features/scheduling/propose_publish_time_and_schedule_spec.rb
@@ -30,6 +30,7 @@ RSpec.feature "Propose publish time and schedule" do
   end
 
   def and_i_select_schedule_to_publish
+    stub_any_publishing_api_put_content
     choose "Schedule to publish"
     click_on "Continue"
   end
@@ -43,8 +44,7 @@ RSpec.feature "Propose publish time and schedule" do
   end
 
   def when_i_submit_a_review_option
-    @request = stub_any_publishing_api_put_intent
-
+    stub_any_publishing_api_put_intent
     choose I18n.t!("schedule.new.review_status.reviewed")
     click_on "Schedule"
   end

--- a/spec/features/scheduling/propose_publish_time_spec.rb
+++ b/spec/features/scheduling/propose_publish_time_spec.rb
@@ -28,6 +28,7 @@ RSpec.feature "Propose publish time" do
   end
 
   def and_i_select_save_proposed_time
+    stub_any_publishing_api_put_content
     choose "Save proposed date and time"
     click_on "Continue"
   end

--- a/spec/features/scheduling/update_proposed_publish_time_spec.rb
+++ b/spec/features/scheduling/update_proposed_publish_time_spec.rb
@@ -34,6 +34,7 @@ RSpec.feature "Update proposed publish time" do
   end
 
   def when_i_set_a_new_time
+    stub_any_publishing_api_put_content
     fill_in "schedule[date][day]", with: "15"
     fill_in "schedule[date][month]", with: "6"
     fill_in "schedule[date][year]", with: "2019"

--- a/spec/requests/schedule_proposal_spec.rb
+++ b/spec/requests/schedule_proposal_spec.rb
@@ -16,6 +16,8 @@ RSpec.describe "Schedule Proposal" do
   end
 
   describe "POST /documents/:document/schedule-proposal" do
+    before { stub_any_publishing_api_put_content }
+
     let(:edition) { create(:edition) }
     let(:schedule_params) do
       tomorrow = Time.zone.tomorrow
@@ -72,6 +74,8 @@ RSpec.describe "Schedule Proposal" do
   end
 
   describe "DELETE /documents/:document/schedule-proposal" do
+    before { stub_any_publishing_api_put_content }
+
     it "redirects to document summary" do
       edition = create(:edition)
       delete schedule_proposal_path(edition.document)


### PR DESCRIPTION
Since 9392d8dcd5a0524bfd2c21c8e8c485b57cd84cb3 we now mark all editions
with revision_synced of false when using the EditDraftEditionService.
This means that when we change proposed publish time we are shown the
actions view to indicate a preview was not successful.

Previously I believe that we didn't update the preview on these actions
as these changes didn't actually affect the Publishing API. However it's
probably best not to treat this as something special.