### PR TITLE
Restrict requirements to featured attachments

### DIFF
--- a/app/interactors/file_attachments/update_interactor.rb
+++ b/app/interactors/file_attachments/update_interactor.rb
@@ -32,7 +32,7 @@ private
   end
 
   def check_for_issues
-    checker = Requirements::FileAttachmentMetadataChecker.new
+    checker = Requirements::FileAttachmentMetadataChecker.new(edition)
     issues = checker.pre_update_issues(params.require(:file_attachment))
     context.fail!(issues: issues) if issues.any?
   end

--- a/lib/requirements/edition_checker.rb
+++ b/lib/requirements/edition_checker.rb
@@ -22,7 +22,7 @@ module Requirements
       issues = CheckerIssues.new
 
       edition.file_attachment_revisions.each do |attachment|
-        issues += FileAttachmentMetadataChecker.new.pre_publish_issues(attachment)
+        issues += FileAttachmentMetadataChecker.new(edition).pre_publish_issues(attachment)
       end
 
       issues += ContentChecker.new(edition).pre_publish_issues

--- a/lib/requirements/file_attachment_metadata_checker.rb
+++ b/lib/requirements/file_attachment_metadata_checker.rb
@@ -6,6 +6,12 @@ module Requirements
     ACT_PAPER_REGEX = /^\d+(-[IV]+)?$/.freeze
     COMMAND_PAPER_REGEX = /^(CP|C\.|Cd\.|Cmd\.|Cmnd\.|Cm\.)\s\d+(-[IV]+)?$/.freeze
 
+    attr_reader :edition
+
+    def initialize(edition)
+      @edition = edition
+    end
+
     def pre_update_issues(params)
       issues = CheckerIssues.new
 
@@ -37,6 +43,10 @@ module Requirements
 
     def pre_publish_issues(attachment)
       issues = CheckerIssues.new
+
+      unless edition.document_type.attachments.featured?
+        return issues
+      end
 
       if attachment.official_document_type.blank?
         issues.create(:file_attachment_official_document_type,

--- a/spec/lib/requirements/file_attachment_metadata_checker_spec.rb
+++ b/spec/lib/requirements/file_attachment_metadata_checker_spec.rb
@@ -1,14 +1,16 @@
 RSpec.describe Requirements::FileAttachmentMetadataChecker do
-  let(:checker) { described_class.new }
-
   describe "#pre_publish_issues" do
+    let(:document_type) { build :document_type, attachments: "featured" }
+
     it "returns no issues if there are none" do
+      checker = described_class.new(build(:edition, document_type: document_type))
       attachment_revision = build(:file_attachment_revision, official_document_type: "unofficial")
       issues = checker.pre_publish_issues(attachment_revision)
       expect(issues).to be_empty
     end
 
     it "returns an issue when the official document type is blank" do
+      checker = described_class.new(build(:edition, document_type: document_type))
       attachment_revision = build(:file_attachment_revision)
       issues = checker.pre_publish_issues(attachment_revision)
 
@@ -18,11 +20,18 @@ RSpec.describe Requirements::FileAttachmentMetadataChecker do
                                    filename: attachment_revision.filename,
                                    attachment_revision: attachment_revision)
     end
+
+    it "returns no issues unless the document type supports featured attachments" do
+      checker = described_class.new(build(:edition))
+      attachment_revision = build(:file_attachment_revision)
+      issues = checker.pre_publish_issues(attachment_revision)
+      expect(issues).to be_empty
+    end
   end
 
   describe "#pre_update_issues" do
     let(:max_length) { Requirements::FileAttachmentMetadataChecker::UNIQUE_REF_MAX_LENGTH }
-    let(:checker) { described_class.new }
+    let(:checker) { described_class.new(build(:edition)) }
     let(:valid_params) { { official_document_type: "unofficial" } }
 
     it "returns no issues if there are none" do


### PR DESCRIPTION
Previously we added new requirements checks that should only apply
to featured attachments, as defined by the type of document they're
associated with. Although the checks primarily run in the context
of the form, which is only available for featured attachments, we
also run these checks at the 'edition level' before publish. This
fixes the edition level check to reflect the type of attachment.