### PR TITLE
Add "Request Content Publisher training" page

### DIFF
--- a/app/views/layouts/_phase_banner_elements.html.erb
+++ b/app/views/layouts/_phase_banner_elements.html.erb
@@ -3,22 +3,22 @@
      href="https://support.publishing.service.gov.uk/technical_fault_report/new"
      target="_blank"
      rel="noopener"
-     data-gtm="raise-support-request"><%= t("application.phase_banner.raise_a_support_request") %></a>
+     data-gtm="raise-support-request">Raise a support request</a>
 </span>
 <span class="gem-c-phase-banner__banner-item">
   <a class="govuk-link govuk-link--no-visited-state"
      href="https://support.publishing.service.gov.uk/content_publisher_feedback_request/new"
      target="_blank"
      rel="noopener"
-     data-gtm="send-feedback"><%= t("application.phase_banner.send_us_feedback") %></a>
+     data-gtm="send-feedback">Send us feedback</a>
 </span>
 <span class="gem-c-phase-banner__banner-item">
   <a class="govuk-link govuk-link--no-visited-state"
      href="<%= publisher_updates_path %>"
-     data-gtm="view-whats-new"><%= t("application.phase_banner.whats_new") %></a>
+     data-gtm="view-whats-new">What’s new</a>
 </span>
 <span class="gem-c-phase-banner__banner-item">
   <a class="govuk-link govuk-link--no-visited-state"
      href="<%= request_training_path %>"
-     data-gtm="view-request-training"><%= t("application.phase_banner.request_training") %></a>
+     data-gtm="view-request-training">Request training</a>
 </span>

--- a/app/views/layouts/_phase_banner_elements.html.erb
+++ b/app/views/layouts/_phase_banner_elements.html.erb
@@ -17,3 +17,8 @@
      href="<%= publisher_updates_path %>"
      data-gtm="view-whats-new"><%= t("application.phase_banner.whats_new") %></a>
 </span>
+<span class="gem-c-phase-banner__banner-item">
+  <a class="govuk-link govuk-link--no-visited-state"
+     href="<%= request_training_path %>"
+     data-gtm="view-request-training"><%= t("application.phase_banner.request_training") %></a>
+</span>

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -36,6 +36,7 @@
       { text: t("application.phase_banner.raise_a_support_request"), href: "https://support.publishing.service.gov.uk/technical_fault_report/new", show_only_in_collapsed_menu: true },
       { text: t("application.phase_banner.send_us_feedback"), href: "https://support.publishing.service.gov.uk/content_publisher_feedback_request/new", show_only_in_collapsed_menu: true },
       { text: t("application.phase_banner.whats_new"), href: publisher_updates_path, show_only_in_collapsed_menu: true },
+      { text: t("application.phase_banner.request_training"), href: request_training_path, show_only_in_collapsed_menu: true },
     ]
 
     if current_user
@@ -166,7 +167,12 @@
             href: beta_capabilities_path,
             text: t("application.footer.what_the_beta_can_do"),
             attributes: { "data-gtm": "footer-beta-capabilities" }
-          }
+          },
+          {
+            href: request_training_path,
+            text: t("application.footer.request_training"),
+            attributes: { "data-gtm": "footer-beta-capabilities" }
+          },
         ]
       },
     ]

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -33,10 +33,10 @@
   <%
     navigation_items = [
       { text: "Switch app", href: Plek.new.external_url_for("signon") },
-      { text: t("application.phase_banner.raise_a_support_request"), href: "https://support.publishing.service.gov.uk/technical_fault_report/new", show_only_in_collapsed_menu: true },
-      { text: t("application.phase_banner.send_us_feedback"), href: "https://support.publishing.service.gov.uk/content_publisher_feedback_request/new", show_only_in_collapsed_menu: true },
-      { text: t("application.phase_banner.whats_new"), href: publisher_updates_path, show_only_in_collapsed_menu: true },
-      { text: t("application.phase_banner.request_training"), href: request_training_path, show_only_in_collapsed_menu: true },
+      { text: "Raise a support request", href: "https://support.publishing.service.gov.uk/technical_fault_report/new", show_only_in_collapsed_menu: true },
+      { text: "Send us feedback", href: "https://support.publishing.service.gov.uk/content_publisher_feedback_request/new", show_only_in_collapsed_menu: true },
+      { text: "What’s new", href: publisher_updates_path, show_only_in_collapsed_menu: true },
+      { text: "Request training", href: request_training_path, show_only_in_collapsed_menu: true },
     ]
 
     if current_user
@@ -119,28 +119,28 @@
         items: [
           {
             href: "https://support.publishing.service.gov.uk/technical_fault_report/new",
-            text: t("application.footer.raise_a_support_request"),
+            text: "Raise a support request",
             attributes: { target: "_blank", "data-gtm": "footer-raise-support-request" }
           },
           {
             href: "https://support.publishing.service.gov.uk/content_publisher_feedback_request/new",
-            text: t("application.footer.send_us_feedback"),
+            text: "Send us feedback",
             attributes: { target: "_blank", "data-gtm": "footer-send-feedback" }
 
           },
           {
             href: "https://status.publishing.service.gov.uk",
-            text: t("application.footer.govuk_status"),
+            text: "GOV.UK status",
             attributes: { "data-gtm": "footer-view-govuk-status" }
           },
           {
             href: "https://www.gov.uk/government/content-publishing",
-            text: t("application.footer.how_to_write_content"),
+            text: "How to write, publish, and improve content",
             attributes: { "data-gtm": "footer-content-publishing-guidance" }
           },
           {
             href: guidance_path,
-            text: t("application.footer.what_to_publish"),
+            text: "What to publish on GOV.UK",
             attributes: { "data-gtm": "footer-what-to-publish"}
           }
         ]
@@ -150,27 +150,27 @@
         items: [
           {
             href: how_to_use_publisher_path,
-            text: t("application.footer.how_to_use_content_publisher"),
+            text: "How to use Content Publisher",
             attributes: { "data-gtm": "footer-how-to-use-app" }
           },
           {
             href: publisher_updates_path,
-            text: t("application.footer.whats_new_in_content_publisher"),
+            text: "What’s new in Content Publisher",
             attributes: { "data-gtm": "footer-view-whats-new" }
           },
           {
             href: managing_editors_path,
-            text: t("application.footer.what_managing_editors_can_do"),
+            text: "What Managing Editors can do",
             attributes: { "data-gtm": "footer-what-managing-editors-can-do"}
           },
           {
             href: beta_capabilities_path,
-            text: t("application.footer.what_the_beta_can_do"),
+            text: "What the Beta can and cannot do",
             attributes: { "data-gtm": "footer-beta-capabilities" }
           },
           {
             href: request_training_path,
-            text: t("application.footer.request_training"),
+            text: "Request Content Publisher training",
             attributes: { "data-gtm": "footer-beta-capabilities" }
           },
         ]

--- a/app/views/publisher_information/_publisher_info_nav.html.erb
+++ b/app/views/publisher_information/_publisher_info_nav.html.erb
@@ -26,6 +26,12 @@
         current: current_page == managing_editors_path,
         data_attributes: { gtm: "sidebar-view-what-managing-editors-can-do" }
       },
+      {
+        label: "Request Content Publisher training",
+        href: request_training_path,
+        current: current_page == request_training_path,
+        data_attributes: { gtm: "sidebar-view-request-training" }
+      },
     ]
   } %>
 </div>

--- a/app/views/publisher_information/request_training.html.erb
+++ b/app/views/publisher_information/request_training.html.erb
@@ -1,0 +1,9 @@
+<% content_for :browser_title, t("publisher_information.request_training.title") %>
+<div class="govuk-grid-row">
+  <%= render partial: "publisher_info_nav", locals: { current_page: request_training_path } %>
+  <div class="govuk-grid-column-two-thirds">
+    <h1 class="govuk-heading-l"><%= t("publisher_information.request_training.title") %></h1>
+
+    <%= render_govspeak(t("publisher_information.request_training.body_govspeak")) %>
+  </div>
+</div>

--- a/config/locales/en/application.yml
+++ b/config/locales/en/application.yml
@@ -3,21 +3,6 @@ en:
     modal_error:
       title: Something has gone wrong
       description_govspeak: Please try again or [raise a support request](https://support.publishing.service.gov.uk/technical_fault_report/new).
-    phase_banner:
-      raise_a_support_request: Raise a support request
-      send_us_feedback: Send us feedback
-      whats_new: What’s new
-      request_training: Request training
     footer:
       support_and_feedback: Support and feedback
       documentation: Documentation
-      raise_a_support_request: Raise a support request
-      send_us_feedback: Send us feedback
-      govuk_status: GOV.UK Status
-      how_to_write_content: How to write, publish, and improve content
-      what_the_beta_can_do: What the Beta can and cannot do
-      how_to_use_content_publisher: How to use Content Publisher
-      whats_new_in_content_publisher: What’s new in Content Publisher
-      what_to_publish: What to publish on GOV.UK
-      what_managing_editors_can_do: What Managing Editors can do
-      request_training: Request Content Publisher training

--- a/config/locales/en/application.yml
+++ b/config/locales/en/application.yml
@@ -7,6 +7,7 @@ en:
       raise_a_support_request: Raise a support request
       send_us_feedback: Send us feedback
       whats_new: What’s new
+      request_training: Request training
     footer:
       support_and_feedback: Support and feedback
       documentation: Documentation
@@ -19,3 +20,4 @@ en:
       whats_new_in_content_publisher: What’s new in Content Publisher
       what_to_publish: What to publish on GOV.UK
       what_managing_editors_can_do: What Managing Editors can do
+      request_training: Request Content Publisher training

--- a/config/locales/en/publisher_information/request_training.yml
+++ b/config/locales/en/publisher_information/request_training.yml
@@ -1,0 +1,21 @@
+en:
+  publisher_information:
+    request_training:
+      title: Request Content Publisher training
+      body_govspeak: |
+        Publishers who need access to Content Publisher must complete the Content Publisher training online.
+
+        Managing editors must approve training requests.
+
+        The course covers how to use Content Publisher to edit and publish content.
+
+        By the end of this course, publishers will be able to:
+
+        - create a news article
+        - insert content
+        - manage content
+        - share content for review
+        - publish content or schedule it to be published
+        - find guidance
+
+        [Request Content Publisher training](https://docs.google.com/forms/d/e/1FAIpQLSf3VXKUS0MHO3pXsUm7O5kmB87aqGFclDfJupMnx0a-nwdFbA/viewform) for a GOV.UK publisher.

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -116,6 +116,7 @@ Rails.application.routes.draw do
   get "/how-to-use-publisher" => "publisher_information#how_to_use_publisher", as: :how_to_use_publisher
   get "/beta-capabilities" => "publisher_information#beta_capabilities", as: :beta_capabilities
   get "/publisher-updates" => "publisher_information#publisher_updates", as: :publisher_updates
+  get "/request-training" => "publisher_information#request_training", as: :request_training
   get "/what-managing-editors-can-do" => "publisher_information#what_managing_editors_can_do", as: :managing_editors
 
   get "/video-embed" => "video_embed#new", as: :video_embed

--- a/spec/features/publisher_information/visit_publisher_information_pages_spec.rb
+++ b/spec/features/publisher_information/visit_publisher_information_pages_spec.rb
@@ -7,6 +7,8 @@ RSpec.feature "User can view the publisher information pages" do
     then_i_can_see_beta_capabilities_page
     when_i_click_on_the_how_to_use_publisher_link_in_footer
     then_i_can_see_how_to_use_publisher_page
+    when_i_click_on_the_request_training_link_in_footer
+    then_i_can_see_the_request_training_page
     when_i_click_on_the_what_managing_editors_can_do_link_in_footer
     then_i_can_see_the_what_managing_editors_can_do_page
     and_i_see_i_am_not_a_managing_editor
@@ -53,6 +55,18 @@ RSpec.feature "User can view the publisher information pages" do
   def then_i_can_see_how_to_use_publisher_page
     within("main h1") do
       expect(page).to have_content(I18n.t("publisher_information.how_to_use_publisher.title"))
+    end
+  end
+
+  def when_i_click_on_the_request_training_link_in_footer
+    within(".govuk-footer") do
+      click_on "Request Content Publisher training"
+    end
+  end
+
+  def then_i_can_see_the_request_training_page
+    within("main h1") do
+      expect(page).to have_content(I18n.t("publisher_information.request_training.title"))
     end
   end
 

--- a/spec/features/publisher_information/visit_publisher_information_pages_spec.rb
+++ b/spec/features/publisher_information/visit_publisher_information_pages_spec.rb
@@ -23,65 +23,45 @@ RSpec.feature "User can view the publisher information pages" do
   end
 
   def when_i_click_on_the_publisher_updates_link_in_footer
-    within(".govuk-footer") do
-      click_on "What’s new in Content Publisher"
-    end
+    click_footer_link("What’s new in Content Publisher")
   end
 
   def then_i_can_see_publisher_updates_page
-    within("main h1") do
-      expect(page).to have_content(I18n.t("publisher_information.publisher_updates.title"))
-    end
+    expect_page_to_have_h1(I18n.t("publisher_information.publisher_updates.title"))
   end
 
   def when_i_click_on_the_beta_capabilities_link_in_footer
-    within(".govuk-footer") do
-      click_on "What the Beta can and cannot do"
-    end
+    click_footer_link("What the Beta can and cannot do")
   end
 
   def then_i_can_see_beta_capabilities_page
-    within("main h1") do
-      expect(page).to have_content(I18n.t("publisher_information.beta_capabilities.title"))
-    end
+    expect_page_to_have_h1(I18n.t("publisher_information.beta_capabilities.title"))
   end
 
   def when_i_click_on_the_how_to_use_publisher_link_in_footer
-    within(".govuk-footer") do
-      click_on "How to use Content Publisher"
-    end
+    click_footer_link("How to use Content Publisher")
   end
 
   def then_i_can_see_the_how_to_use_publisher_page
-    within("main h1") do
-      expect(page).to have_content(I18n.t("publisher_information.how_to_use_publisher.title"))
-    end
+    expect_page_to_have_h1(I18n.t("publisher_information.how_to_use_publisher.title"))
   end
 
   def when_i_click_on_the_request_training_link_in_footer
-    within(".govuk-footer") do
-      click_on "Request Content Publisher training"
-    end
+    click_footer_link("Request Content Publisher training")
   end
 
   def then_i_can_see_the_request_training_page
-    within("main h1") do
-      expect(page).to have_content(I18n.t("publisher_information.request_training.title"))
-    end
+    expect_page_to_have_h1(I18n.t("publisher_information.request_training.title"))
   end
 
   def when_i_click_on_the_what_managing_editors_can_do_link_in_footer
-    within(".govuk-footer") do
-      click_on "What Managing Editors can do"
-    end
+    click_footer_link("What Managing Editors can do")
   end
 
   alias :and_i_click_on_the_what_managing_editors_can_do_link_in_footer :when_i_click_on_the_what_managing_editors_can_do_link_in_footer
 
   def then_i_can_see_the_what_managing_editors_can_do_page
-    within("main h1") do
-      expect(page).to have_content(I18n.t("publisher_information.what_managing_editors_can_do.title"))
-    end
+    expect_page_to_have_h1(I18n.t("publisher_information.what_managing_editors_can_do.title"))
   end
 
   def when_i_have_the_managing_editor_permission
@@ -94,5 +74,13 @@ RSpec.feature "User can view the publisher information pages" do
 
   def and_i_see_i_am_a_managing_editor
     expect(page).to have_content(I18n.t("publisher_information.what_managing_editors_can_do.user_status.with_managing_editor_status"))
+  end
+
+  def click_footer_link(text)
+    within(".govuk-footer") { click_on text }
+  end
+
+  def expect_page_to_have_h1(content)
+    within("main h1") { expect(page).to have_content(content) }
   end
 end

--- a/spec/features/publisher_information/visit_publisher_information_pages_spec.rb
+++ b/spec/features/publisher_information/visit_publisher_information_pages_spec.rb
@@ -6,7 +6,7 @@ RSpec.feature "User can view the publisher information pages" do
     when_i_click_on_the_beta_capabilities_link_in_footer
     then_i_can_see_beta_capabilities_page
     when_i_click_on_the_how_to_use_publisher_link_in_footer
-    then_i_can_see_how_to_use_publisher_page
+    then_i_can_see_the_how_to_use_publisher_page
     when_i_click_on_the_request_training_link_in_footer
     then_i_can_see_the_request_training_page
     when_i_click_on_the_what_managing_editors_can_do_link_in_footer
@@ -52,7 +52,7 @@ RSpec.feature "User can view the publisher information pages" do
     end
   end
 
-  def then_i_can_see_how_to_use_publisher_page
+  def then_i_can_see_the_how_to_use_publisher_page
     within("main h1") do
       expect(page).to have_content(I18n.t("publisher_information.how_to_use_publisher.title"))
     end


### PR DESCRIPTION
Trello: https://trello.com/c/3VHD9yYu/1642-add-request-content-publisher-training-page-to-the-publisher-information-section

This adds in the page to explain requesting training. It also has a couple of consistency fixes. See commits for more detail.

Screenshot:

![localhost_3221_request-training](https://user-images.githubusercontent.com/282717/80743865-a52d3980-8b15-11ea-9753-071efcad6106.png)
