### PR TITLE
Only count calls to 'translate' for I18n coverage

### DIFF
--- a/config/locales/en/user_facing_states.yml
+++ b/config/locales/en/user_facing_states.yml
@@ -18,5 +18,3 @@ en:
       name: Removed
     discarded:
       name: Discarded
-    superseded:
-      name: Superseded

--- a/spec/features/withdrawing/unwithdraw_spec.rb
+++ b/spec/features/withdrawing/unwithdraw_spec.rb
@@ -5,6 +5,7 @@ RSpec.feature "Unwithdraw" do
     when_i_visit_the_summary_page
     and_i_undo_the_withdrawal
     then_i_see_the_edition_is_unwithdrawn
+    and_i_see_the_timeline_entry
   end
 
   def given_there_is_a_withdrawn_edition

--- a/spec/models/status_spec.rb
+++ b/spec/models/status_spec.rb
@@ -1,9 +1,0 @@
-RSpec.describe Status do
-  describe ".states" do
-    described_class.states.each_key do |state|
-      it "has a translation for `#{state}`" do
-        expect(I18n.exists?("user_facing_states.#{state}.name")).to be true
-      end
-    end
-  end
-end

--- a/spec/support/i18n_cov.rb
+++ b/spec/support/i18n_cov.rb
@@ -9,8 +9,8 @@ class I18nCov
   attr_reader :locales, :used_keys
 
   module I18nOverrides
-    def lookup(locale, key, scope = [], options = {})
-      I18nCov.log(key, scope)
+    def translate(*args)
+      I18nCov.log(args[1])
       super
     end
   end
@@ -20,14 +20,13 @@ class I18nCov
   end
 
   def start(locales = nil)
-    @used_keys = []
+    @used_keys = Set.new
     @locales = locales || in_app_locales
     I18n::Backend::Simple.include I18nOverrides
   end
 
-  def log(key, scope)
-    key = (Array(scope || []) + [key]).compact.join(".")
-    used_keys << key unless used_keys.include?(key)
+  def log(key)
+    used_keys << key.to_s
   end
 
   def report


### PR DESCRIPTION
Previously we counted a call to 'exists?' to say that a key was covered by
a spec, but this defeats the purpose of the coverage, which is to ensure
that all translations that exist are actually used i.e. translated. Turns
out some of ours are not. Please see the commits for more details.

## Translations not (actually) covered

- [ ]  "documents.history.entry_types.whitehall_migration.archived"
- [ ]  "documents.history.entry_types.whitehall_migration.deleted"
- [ ]  "documents.history.entry_types.whitehall_migration.document_updated"
- [ ]  "documents.history.entry_types.whitehall_migration.first_created"
- [ ]  "documents.history.entry_types.whitehall_migration.imported_from_whitehall"
- [ ]  "documents.history.entry_types.whitehall_migration.imported"
- [ ]  "documents.history.entry_types.whitehall_migration.published"
- [ ]  "documents.history.entry_types.whitehall_migration.rejected"
- [ ]  "documents.history.entry_types.whitehall_migration.removed"
- [ ]  "documents.history.entry_types.whitehall_migration.scheduled"
- [ ]  "documents.history.entry_types.whitehall_migration.submitted"
- [ ]  "documents.history.entry_types.whitehall_migration.withdrawn"
- [ ]  "user_facing_states.discarded.name"
- [ ]  "documents.history.entry_types.draft_discarded"