### PR TITLE
Add explicit config for Dependabot

### DIFF
--- a/.dependabot/config.yml
+++ b/.dependabot/config.yml
@@ -1,0 +1,27 @@
+version: 1
+update_configs:
+  - package_manager: ruby:bundler
+    directory: /
+    update_schedule: daily
+    allowed_updates:
+      # Security updates - we should always do these
+      - match: { update_type: security }
+      - match: { dependency_name: brakeman }
+      # Internal gems - we should always update these
+      - match: { dependency_name: gds-api-adapters }
+      - match: { dependency_name: gds-sso }
+      - match: { dependency_name: govspeak }
+      - match: { dependency_name: govuk_app_config }
+      - match: { dependency_name: govuk_publishing_components }
+      - match: { dependency_name: govuk_schemas }
+      - match: { dependency_name: govuk_sidekiq }
+      - match: { dependency_name: govuk_test }
+      - match: { dependency_name: rubocop-govuk }
+      - match: { dependency_name: plek }
+      - match: { dependency_name: scss_lint-govuk }
+      # Framework gems - we use these to write lots of code
+      - match: { dependency_name: factory_bot_rails }
+      - match: { dependency_name: jasmine }
+      - match: { dependency_name: rails }
+      - match: { dependency_name: rspec-rails }
+      - match: { dependency_name: sass-rails }

--- a/.dependabot/config.yml
+++ b/.dependabot/config.yml
@@ -1,3 +1,7 @@
+# This overrides the config in the Dependabot UI.
+# We're trialling this to see if it can be used as
+# a way to reduce the number of Dependabot PRs for
+# gems where updates aren't so valuable.
 version: 1
 update_configs:
   - package_manager: ruby:bundler
@@ -25,3 +29,14 @@ update_configs:
       - match: { dependency_name: rails }
       - match: { dependency_name: rspec-rails }
       - match: { dependency_name: sass-rails }
+  - package_manager: javascript
+    directory: /
+    update_schedule: daily
+    allowed_updates:
+      # Security updates - we should always do these
+      - match: { update_type: security }
+      # Internal packages - we should always update these
+      - match: { dependency_name: accessible-autocomplete }
+      - match: { dependency_name: markdown-toolbar-element }
+      - match: { dependency_name: miller-columns-element }
+      - match: { dependency_name: paste-html-to-govspeak }


### PR DESCRIPTION
Previously we used the Dependabot UI to get top-level updates for
all gems in the Gemfile, which in turn leads to a lot of daily,
manual effort to review and deploy.

However, most of the gems we have in our repos contribute very little
to the codebase, and the risk of them being out-of-date is minimal,
provided we still get any security updates.

This adds an explicit config for Dependabot (to override the UI),
which specified the updates we actually want:

- Security updates. We want to protect are apps the best we can.
Dependabot PRs can help to notify us about vulernabilities, and
make it easy for us to incorporate these into our apps.

- Internal gem updates. We should always be using the latest version
of our internal gems, because they exist to provide consistency among
our apps, which we don't want to drift away from.

- Framework gem updates. We write a lot of code using the APIs and
DSLs of a few frameworks. If we don't keep up with them, it could
become prohibitively hard to update them in future.

Many of the remaining gems would be easy to update manually. There are
a few reasons why we might want to do this:

- The gem interacts with an external service or system package, which
no longer supports the old version of the gem.

- We want (e.g. for consistency with other apps), or need to use a
feature that's only available in a newer version of the gem.

At the time of writing, the following gems are not included in the
config for Dependabot to update automatically:

- "aws-sdk-s3" - this is only used in a small part of the codebase,
and we expect AWS APIs to be backwards compatible.

- "interactor" - although we have a lot of code that follows the
Interactor pattern, the API/DSL coupling is low.

- "pg" - although we do a lot of DB queries, most of these are done
through ActiveRecord, and is not coupled to this gem

- "webmock" - most of our use of this gem is through gds-api-adapters,
so we would expect any major changes to be applied there

- "bootsnap" - limited footprint
- "hashdiff" - limited footprint
- "image_processing" - limited footprint
- "kaminari" - limited footprint
- "mail-notify" - limited footprint
- "pdf-reader" - limited footprint
- "rinku" - limited footprint
- "rubyzip" - limited footprint
- "sanitize" - limited footprint
- "sidekiq-scheduler" - limited footprint
- "uglifier" - limited footprint
- "with_advisory_lock" - limited footprint
- "listen" - limited footprint
- "simplecov" - limited footprint
- "byebug" - limited footprint
- "climate_control" - limited footprint
- "jasmine_selenium_runner" - limited footprint
- "json_matchers" - limited footprint