### PR TITLE
Add rake task to repopulate scheduled jobs

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,6 +52,7 @@ bundle exec rake jasmine
 - [History mode](docs/history-mode.md)
 - [Importing documents from Whitehall](docs/import-from-whitehall.md)
 - [Removing documents](docs/removing-documents.md)
+- [Scheduled publishing](docs/scheduled-publishing.md)
 - [Testing strategy](docs/testing-strategy.md)
 - [User permissions](docs/user-permissions.md)
 

--- a/docs/scheduled-publishing.md
+++ b/docs/scheduled-publishing.md
@@ -1,0 +1,27 @@
+# Scheduled publishing
+
+Editions in Content Publisher can be scheduled to publish at a designated
+time. This is done by scheduling an [ActiveJob][] which queues a job for
+the specified time in Redis. A risk with the scheduling publishing system
+is that if the data in Redis is lost the job won't run and the publishing
+won't occur.
+
+## Repopulate all scheduling jobs
+
+We have a rake task that will re-populate the scheduling for all editions that
+are scheduled to be published (including those where the time has already
+passed). This can be used if the data of scheduled jobs in Redis is lost or
+is invalid.
+
+```
+rake scheduling:repopulate
+```
+
+## Fixing a single failed scheduled publishing
+
+If a single edition fails to be published then this edition can be resolved
+through the publisher interface. This is done by finding the edition, stopping
+the scheduling publishing, clearing the proposed publish time and then
+publishing it.
+
+[ActiveJob]: https://guides.rubyonrails.org/v6.0/active_job_basics.html

--- a/lib/tasks/scheduling.rake
+++ b/lib/tasks/scheduling.rake
@@ -1,0 +1,14 @@
+namespace :scheduling do
+  desc "Re-populate all the scheduling jobs in Sidekiq"
+  task repopulate: :environment do
+    scheduled_scope = Edition.joins(:status)
+                             .merge(Status.scheduled)
+                             .where(current: true)
+
+    scheduled_scope.find_each do |edition|
+      scheduling = edition.status.details
+      ScheduledPublishingJob.set(wait_until: scheduling.publish_time)
+                            .perform_later(edition.id)
+    end
+  end
+end

--- a/spec/lib/tasks/scheduling_spec.rb
+++ b/spec/lib/tasks/scheduling_spec.rb
@@ -1,0 +1,20 @@
+RSpec.describe "Scheduling tasks" do
+  include ActiveJob::TestHelper
+
+  describe "scheduling:repopulate" do
+    before { Rake::Task["scheduling:repopulate"].reenable }
+
+    it "schedules ScheduledPublishingJob workers on current, scheduled editions" do
+      publish_time = Date.tomorrow.noon
+      scheduled_edition = create(:edition, :scheduled, publish_time: publish_time)
+      create(:edition, :scheduled, current: false)
+      create(:edition)
+
+      Rake::Task["scheduling:repopulate"].invoke
+
+      expect(enqueued_jobs.count).to eq 1
+      expect(enqueued_jobs.first)
+        .to match(hash_including(args: [scheduled_edition.id], at: publish_time.to_i))
+    end
+  end
+end


### PR DESCRIPTION
This can be used to add any schedulings for publishing to Sidekiq and
has been prepared in anticipation of losing Redis data during a server
migration.

If there are already jobs scheduled this will add them again, this won't
cause any actual problems since the publishing job is idempotent.
However, if we were to run this a lot we'd create rather a lot of noise
in Redis so this isn't advised.

I've included some documentation for this which includes info of our
common risk with scheduled publishing that has mostly lived in status
docs before. I've included some rather cumbersome instructions on how to
fix a failed scheduled publishing were one of those to occur. It seemed
more prudent to provide cumbersome UI steps than to suggest running code
since the task can be achieved with the UI and the usage is expected to
be rare.