### PR TITLE
Remove redundant RuboCop config

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -1,36 +1,12 @@
-require: rubocop-rspec
-
 inherit_gem:
   rubocop-govuk:
     - config/default.yml
     - config/rails.yml
+    - config/rspec.yml
 
 inherit_mode:
   merge:
     - Exclude
-
-AllCops:
-  TargetRubyVersion: 2.5
-  Exclude:
-    - bin/**/*
-    - config.ru
-    - db/schema.rb
-    - tmp/**/*
-    - node_modules/**/*
-
-Metrics/BlockLength:
-  Exclude:
-    - 'config/environments/*.rb'
-    - 'config/routes.rb'
-    - 'lib/tasks/**/*.rake'
-    - 'spec/**/*.rb'
-    - 'db/migrate/*.rb'
-
-Rails/InverseOf:
-  Enabled: false
-
-Rails/HasManyOrHasOneDependent:
-  Enabled: false
 
 Rails/DynamicFindBy:
   Whitelist:
@@ -46,43 +22,3 @@ Rails/TimeZone:
 
 Style/DateTime:
   Enabled: true
-
-# Rubocop RSpec rules
-# We are trialling these set in app before intending to push the config to
-# rubocop-govuk
-
-# Don't require examples to be below a particular number of lines
-RSpec/ExampleLength:
-  Enabled: false
-
-# Don't force the top level describe to be a class, we tend to be good at
-# sticking to the class convention and only deviate for valid cases like rake
-# tasks
-RSpec/DescribeClass:
-  Enabled: false
-
-# We accept multiple expectations (within reason), preferring them to running
-# mulitple similar tests
-RSpec/MultipleExpectations:
-  Enabled: false
-
-# Within GOV.UK we use Capybara test method syntax of feature, scenario. We
-# don't want this outside of feature specs though
-Capybara/FeatureMethods:
-  Exclude:
-    - 'spec/features/**/*.rb'
-
-# Part of the GOV.UK feature spec style involves instance variables
-RSpec/InstanceVariable:
-  Exclude:
-    - 'spec/features/**/*.rb'
-
-# In GOV.UK we quite often test that a class received a particular method
-RSpec/MessageSpies:
-  Enabled: false
-
-# This prevents nesting context blocks. This practice is hard to understand
-# but unfortunately is in some GOV.UK apps.
-# TODO: Investigate if we can embrace this rule and remove our nesting
-RSpec/NestedGroups:
-  Enabled: false


### PR DESCRIPTION
https://github.com/alphagov/rubocop-govuk/issues/73

This is now provided by RuboCop GOV.UK.