### PR TITLE
Only authenticate if warden is initialised

### DIFF
--- a/app/controllers/errors_controller.rb
+++ b/app/controllers/errors_controller.rb
@@ -7,7 +7,7 @@ class ErrorsController < ApplicationController
     # retrieves an existing sesssion for users if available. Unlike
     # `authenticate_user!` this does not redirect a user when they are not
     # authenticated.
-    warden.authenticate
+    warden&.authenticate
   end
 
   def bad_request

--- a/app/controllers/errors_controller.rb
+++ b/app/controllers/errors_controller.rb
@@ -4,7 +4,7 @@ class ErrorsController < ApplicationController
   skip_before_action :check_user_access
 
   before_action do
-    # retrieves an existing sesssion for users if available. Unlike
+    # retrieves an existing session for users if available. Unlike
     # `authenticate_user!` this does not redirect a user when they are not
     # authenticated.
     warden&.authenticate

--- a/spec/requests/errors_spec.rb
+++ b/spec/requests/errors_spec.rb
@@ -34,6 +34,15 @@ RSpec.describe "Errors" do
 
   describe "/500" do
     it_behaves_like "an error response", 500, :internal_server_error
+
+    it "copes if warden is unavailable" do
+      allow_any_instance_of(ErrorsController) # rubocop:disable RSpec/AnyInstance
+        .to receive(:warden)
+        .and_return(nil)
+      get "/500"
+      expect(response).to have_http_status(:internal_server_error)
+      expect(response.body).to include(I18n.t!("errors.internal_server_error.title"))
+    end
   end
 
   describe "GET /any-path-for-a-document" do


### PR DESCRIPTION
We learnt in a recent incident that broke sign-on that it is possible
for the application to error before warden is available as per the
following stack trace:

```
{
  "exception_class": "Faraday::SSLError",
  "exception_message": "SSL_connect returned=1 errno=0 state=SSLv3 read server certificate B: certificate verify failed (certificate has expired)",
  "stacktrace": [
    "/usr/lib/rbenv/versions/2.6.6/lib/ruby/2.6.0/net/protocol.rb:44:in `connect_nonblock'",
    "/usr/lib/rbenv/versions/2.6.6/lib/ruby/2.6.0/net/protocol.rb:44:in `ssl_socket_connect'",
    "/usr/lib/rbenv/versions/2.6.6/lib/ruby/2.6.0/net/http.rb:996:in `connect'",
    "/usr/lib/rbenv/versions/2.6.6/lib/ruby/2.6.0/net/http.rb:930:in `do_start'",
    "/usr/lib/rbenv/versions/2.6.6/lib/ruby/2.6.0/net/http.rb:919:in `start'",
    "faraday (1.0.1) lib/faraday/adapter/net_http.rb:152:in `request_via_request_method'",
    "faraday (1.0.1) lib/faraday/adapter/net_http.rb:137:in `request_with_wrapped_block'",
    "faraday (1.0.1) lib/faraday/adapter/net_http.rb:128:in `perform_request'",
    "faraday (1.0.1) lib/faraday/adapter/net_http.rb:70:in `block in call'",
    "faraday (1.0.1) lib/faraday/adapter.rb:60:in `connection'",
    "faraday (1.0.1) lib/faraday/adapter/net_http.rb:68:in `call'",
    "faraday (1.0.1) lib/faraday/request/url_encoded.rb:25:in `call'",
    "faraday (1.0.1) lib/faraday/rack_builder.rb:153:in `build_response'",
    "faraday (1.0.1) lib/faraday/connection.rb:492:in `run_request'",
    "oauth2 (1.4.4) lib/oauth2/client.rb:99:in `request'",
    "oauth2 (1.4.4) lib/oauth2/client.rb:147:in `get_token'",
    "oauth2 (1.4.4) lib/oauth2/strategy/auth_code.rb:30:in `get_token'",
    "omniauth-oauth2 (1.3.1) lib/omniauth/strategies/oauth2.rb:93:in `build_access_token'",
    "omniauth-oauth2 (1.3.1) lib/omniauth/strategies/oauth2.rb:77:in `callback_phase'",
    "omniauth (1.9.1) lib/omniauth/strategy.rb:238:in `callback_call'",
    "omniauth (1.9.1) lib/omniauth/strategy.rb:189:in `call!'",
    "omniauth (1.9.1) lib/omniauth/strategy.rb:169:in `call'",
    "omniauth (1.9.1) lib/omniauth/builder.rb:45:in `call'",
    "rack (2.2.2) lib/rack/tempfile_reaper.rb:15:in `call'",
    "rack (2.2.2) lib/rack/etag.rb:27:in `call'",
    "rack (2.2.2) lib/rack/conditional_get.rb:27:in `call'",
    "rack (2.2.2) lib/rack/head.rb:12:in `call'",
    "actionpack (6.0.3.1) lib/action_dispatch/http/content_security_policy.rb:18:in `call'",
    "rack (2.2.2) lib/rack/session/abstract/id.rb:266:in `context'",
    "rack (2.2.2) lib/rack/session/abstract/id.rb:260:in `call'",
    "actionpack (6.0.3.1) lib/action_dispatch/middleware/cookies.rb:648:in `call'",
    "actionpack (6.0.3.1) lib/action_dispatch/middleware/callbacks.rb:27:in `block in call'",
    "activesupport (6.0.3.1) lib/active_support/callbacks.rb:101:in `run_callbacks'",
    "actionpack (6.0.3.1) lib/action_dispatch/middleware/callbacks.rb:26:in `call'",
    "actionpack (6.0.3.1) lib/action_dispatch/middleware/actionable_exceptions.rb:17:in `call'",
    "actionpack (6.0.3.1) lib/action_dispatch/middleware/debug_exceptions.rb:32:in `call'",
    "actionpack (6.0.3.1) lib/action_dispatch/middleware/show_exceptions.rb:33:in `call'",
    "logstasher (1.3.0) lib/logstasher/rails_ext/rack/logger.rb:14:in `call_app'",
    "railties (6.0.3.1) lib/rails/rack/logger.rb:26:in `block in call'",
    "activesupport (6.0.3.1) lib/active_support/tagged_logging.rb:80:in `block in tagged'",
    "activesupport (6.0.3.1) lib/active_support/tagged_logging.rb:28:in `tagged'",
    "activesupport (6.0.3.1) lib/active_support/tagged_logging.rb:80:in `tagged'",
    "railties (6.0.3.1) lib/rails/rack/logger.rb:26:in `call'",
    "actionpack (6.0.3.1) lib/action_dispatch/middleware/remote_ip.rb:81:in `call'",
    "request_store (1.5.0) lib/request_store/middleware.rb:19:in `call'",
    "actionpack (6.0.3.1) lib/action_dispatch/middleware/request_id.rb:27:in `call'",
    "rack (2.2.2) lib/rack/method_override.rb:24:in `call'",
    "rack (2.2.2) lib/rack/runtime.rb:22:in `call'",
    "activesupport (6.0.3.1) lib/active_support/cache/strategy/local_cache_middleware.rb:29:in `call'",
    "activesupport (6.0.3.1) lib/active_support/cache/strategy/local_cache_middleware.rb:29:in `call'",
    "actionpack (6.0.3.1) lib/action_dispatch/middleware/executor.rb:14:in `call'",
    "rack (2.2.2) lib/rack/sendfile.rb:110:in `call'",
    "actionpack (6.0.3.1) lib/action_dispatch/middleware/host_authorization.rb:76:in `call'",
    "sentry-raven (3.0.0) lib/raven/integrations/rack.rb:51:in `call'",
    "railties (6.0.3.1) lib/rails/engine.rb:527:in `call'",
    "unicorn (5.5.5) lib/unicorn/http_server.rb:605:in `process_client'",
    "unicorn (5.5.5) lib/unicorn/http_server.rb:701:in `worker_loop'",
    "unicorn (5.5.5) lib/unicorn/http_server.rb:548:in `spawn_missing_workers'",
    "unicorn (5.5.5) lib/unicorn/http_server.rb:144:in `start'",
    "unicorn (5.5.5) bin/unicorn:128:in `<top (required)>'",
    "/data/apps/content-publisher/shared/bundle/ruby/2.6.0/bin/unicorn:23:in `load'",
    "/data/apps/content-publisher/shared/bundle/ruby/2.6.0/bin/unicorn:23:in `<main>'"
  ]
}
```

This error occurred because an exception was raised in the
OmniAuth::Builder middleware which occurs before the Warden::Manager
middleware is called. When this occurs the warden method returns nil.

I'm not too sure how to mock this in a test without needing an
`allow_any_instance_of`. I tried mocking the middleware raising an error
as an approach but this doesn't produce a sufficiently testable outcome
(due to the DebugExceptions middleware in the test environment). It
seems pretty grizzly to mock out the whole controller.