### PR TITLE
Use array contains operator in contains query

### DIFF
--- a/app/models/tags_revision.rb
+++ b/app/models/tags_revision.rb
@@ -8,8 +8,8 @@ class TagsRevision < ApplicationRecord
   belongs_to :created_by, class_name: "User", optional: true
 
   scope :tag_contains, lambda { |tag, value|
-    where("exists(select 1 from json_array_elements(tags_revisions.tags->?) " \
-          "where array_to_json(array[value])->>0 = ?)", tag, value)
+    sql = "ARRAY(SELECT json_array_elements_text(tags_revisions.tags->?)) @> ARRAY[?]"
+    where(sql, tag, value)
   }
 
   scope :primary_organisation_is, lambda { |org_id|


### PR DESCRIPTION
This changes the query used to determine if a tag appears inside an
array of tags to use the rather cryptic "@>" operator that Postgres
provides.

My motivation for changing this is I had planned to explain a bug we
experienced based on the previous query and I realised I very much
struggled to understand how that worked, in particular where "value"
came from in the `array_to_json(array[value])->>0 = ?`.

I realise this is all rather subjective as it replaces a cryptic query
with another cryptic query but I hope the intent is clearer by use of
the contains operator.