### PR TITLE
Lock to govuk_publishing_components 21.55.0

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -10,7 +10,9 @@ gem "gds-api-adapters", "~> 67"
 gem "gds-sso", "~> 14"
 gem "govspeak", "~> 6.5"
 gem "govuk_app_config", "~> 2"
-gem "govuk_publishing_components", "~> 21.55"
+# This is fixed until https://github.com/alphagov/govuk_publishing_components/issues/1570
+# is resolved
+gem "govuk_publishing_components", "= 21.55.0"
 gem "govuk_sidekiq", "~> 3"
 gem "hashdiff", "~> 1.0"
 gem "image_processing", "~> 1"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -150,7 +150,7 @@ GEM
       sentry-raven (>= 2.7.1, < 3.1.0)
       statsd-ruby (~> 1.4.0)
       unicorn (>= 5.4, < 5.6)
-    govuk_publishing_components (21.55.2)
+    govuk_publishing_components (21.55.0)
       gds-api-adapters
       govuk_app_config
       kramdown
@@ -341,7 +341,7 @@ GEM
       netrc (~> 0.8)
     rexml (3.2.4)
     rinku (2.0.6)
-    rouge (3.19.0)
+    rouge (3.20.0)
     rspec-core (3.9.2)
       rspec-support (~> 3.9.3)
     rspec-expectations (3.9.2)
@@ -495,7 +495,7 @@ DEPENDENCIES
   gds-sso (~> 14)
   govspeak (~> 6.5)
   govuk_app_config (~> 2)
-  govuk_publishing_components (~> 21.55)
+  govuk_publishing_components (= 21.55.0)
   govuk_schemas (~> 4.0)
   govuk_sidekiq (~> 3)
   govuk_test (~> 1.0)


### PR DESCRIPTION
21.55.1 introduced a bug which causes the component-guide to crash in
Content Publisher.

Issue: https://github.com/alphagov/govuk_publishing_components/issues/1570