### PR TITLE
Revert "Bump govuk_publishing_components from 21.55.0 to 21.55.3"

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -12,7 +12,7 @@ gem "govspeak", "~> 6.5"
 gem "govuk_app_config", "~> 2"
 # This is fixed until https://github.com/alphagov/govuk_publishing_components/issues/1570
 # is resolved
-gem "govuk_publishing_components", "21.55.3"
+gem "govuk_publishing_components", "= 21.55.0"
 gem "govuk_sidekiq", "~> 3"
 gem "hashdiff", "~> 1.0"
 gem "image_processing", "~> 1"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -150,7 +150,7 @@ GEM
       sentry-raven (>= 2.7.1, < 3.1.0)
       statsd-ruby (~> 1.4.0)
       unicorn (>= 5.4, < 5.6)
-    govuk_publishing_components (21.55.3)
+    govuk_publishing_components (21.55.0)
       gds-api-adapters
       govuk_app_config
       kramdown
@@ -495,7 +495,7 @@ DEPENDENCIES
   gds-sso (~> 14)
   govspeak (~> 6.5)
   govuk_app_config (~> 2)
-  govuk_publishing_components (= 21.55.3)
+  govuk_publishing_components (= 21.55.0)
   govuk_schemas (~> 4.0)
   govuk_sidekiq (~> 3)
   govuk_test (~> 1.0)


### PR DESCRIPTION
Reverts alphagov/content-publisher#2091