### PR TITLE
Fix flakey tests and some other test cleanup

### DIFF
--- a/spec/lib/whitehall_importer/create_edition_spec.rb
+++ b/spec/lib/whitehall_importer/create_edition_spec.rb
@@ -237,16 +237,19 @@ RSpec.describe WhitehallImporter::CreateEdition do
     end
 
     context "when the document is withdrawn" do
-      let(:published_at) { Time.zone.now.yesterday.rfc3339 }
+      let(:published_at) { Time.zone.now.yesterday.midday }
       let(:whitehall_edition) do
         build(:whitehall_export_edition,
               state: "withdrawn",
               revision_history: [
                 build(:whitehall_export_revision_history_event),
                 build(:whitehall_export_revision_history_event,
-                      event: "update", state: "published", created_at: published_at),
+                      event: "update",
+                      state: "published",
+                      created_at: published_at.rfc3339),
                 build(:whitehall_export_revision_history_event,
-                      event: "update", state: "withdrawn"),
+                      event: "update",
+                      state: "withdrawn"),
               ],
               unpublishing: build(:whitehall_export_unpublishing))
       end
@@ -276,19 +279,19 @@ RSpec.describe WhitehallImporter::CreateEdition do
     end
 
     context "when an unpublished edition has not been edited" do
-      let(:created_at) { Time.zone.now.last_week.rfc3339 }
-      let(:published_at) { Time.zone.now.yesterday.rfc3339 }
-      let(:updated_at) { Time.zone.now.rfc3339 }
+      let(:created_at) { Time.zone.now.last_week }
+      let(:published_at) { Time.zone.now.yesterday.midday }
+      let(:updated_at) { Time.zone.now.midday }
       let(:whitehall_edition) do
         build(:whitehall_export_edition,
               revision_history: [
                 build(:whitehall_export_revision_history_event,
-                      created_at: created_at),
+                      created_at: created_at.rfc3339),
                 build(:whitehall_export_revision_history_event,
                       event: "update", state: "published",
-                      created_at: published_at),
+                      created_at: published_at.rfc3339),
                 build(:whitehall_export_revision_history_event,
-                      event: "update", state: "draft", created_at: updated_at),
+                      event: "update", state: "draft", created_at: updated_at.rfc3339),
               ],
               unpublishing: build(:whitehall_export_unpublishing,
                                   alternative_path: "/gators",
@@ -324,21 +327,24 @@ RSpec.describe WhitehallImporter::CreateEdition do
     end
 
     context "when an unpublished edition has been edited" do
-      let(:created_at) { Time.zone.now.rfc3339 }
-      let(:published_at) { Time.zone.now.yesterday.rfc3339 }
+      let(:created_at) { Time.zone.now.midday }
+      let(:published_at) { Time.zone.now.yesterday.midday }
       let(:whitehall_edition) do
         build(:whitehall_export_edition,
               revision_history: [
                 build(:whitehall_export_revision_history_event),
                 build(:whitehall_export_revision_history_event,
-                      event: "update", state: "published",
-                      created_at: published_at),
+                      event: "update",
+                      state: "published",
+                      created_at: published_at.rfc3339),
                 build(:whitehall_export_revision_history_event,
                       event: "update",
                       state: "draft",
                       created_at: 5.minutes.ago.rfc3339),
                 build(:whitehall_export_revision_history_event,
-                      event: "update", state: "draft", created_at: created_at),
+                      event: "update",
+                      state: "draft",
+                      created_at: created_at.rfc3339),
               ],
               unpublishing: build(:whitehall_export_unpublishing,
                                   alternative_path: "/flextension",
@@ -392,9 +398,11 @@ RSpec.describe WhitehallImporter::CreateEdition do
           revision_history: [
             build(:whitehall_export_revision_history_event),
             build(:whitehall_export_revision_history_event,
-                  event: "update", state: "published"),
+                  event: "update",
+                  state: "published"),
             build(:whitehall_export_revision_history_event,
-                  event: "update", state: "archived"),
+                  event: "update",
+                  state: "archived"),
           ],
         )
 
@@ -410,7 +418,8 @@ RSpec.describe WhitehallImporter::CreateEdition do
           revision_history: [
             build(:whitehall_export_revision_history_event),
             build(:whitehall_export_revision_history_event,
-                  event: "update", state: "published"),
+                  event: "update",
+                  state: "published"),
           ],
         )
 
@@ -427,9 +436,11 @@ RSpec.describe WhitehallImporter::CreateEdition do
         revision_history: [
           build(:whitehall_export_revision_history_event),
           build(:whitehall_export_revision_history_event,
-                event: "update", state: "published"),
+                event: "update",
+                state: "published"),
           build(:whitehall_export_revision_history_event,
-                event: "update", state: "withdrawn"),
+                event: "update",
+                state: "withdrawn"),
         ],
         unpublishing: nil,
       )

--- a/spec/lib/whitehall_importer/create_edition_spec.rb
+++ b/spec/lib/whitehall_importer/create_edition_spec.rb
@@ -273,7 +273,7 @@ RSpec.describe WhitehallImporter::CreateEdition do
       it "sets a previous status of the edition of the publishing status " do
         edition = perform_call(whitehall_edition: whitehall_edition)
 
-        previous_status, current_status = edition.statuses
+        previous_status, current_status = edition.statuses.order(created_at: :desc)
         expect(previous_status).to be_published
         expect(current_status.details.published_status).to eq(previous_status)
       end


### PR DESCRIPTION
This is an attempt to fix the test failures seem in https://ci.integration.publishing.service.gov.uk/job/content-publisher/job/master/1860/console. I've identified that the cause of these was expecting the database to return a consistent order (the source of so many test failures).

I also did some cleaning in this epic 500 line spec to make things a bit more consistent and concise.