### PR TITLE
Add auth_bypass_id column to editions table

### DIFF
--- a/app/models/edition.rb
+++ b/app/models/edition.rb
@@ -9,6 +9,15 @@ class Edition < ApplicationRecord
     self.last_edited_at = Time.zone.now unless last_edited_at
   end
 
+  before_save do
+    # Temporary task to generate backwards compatible auth_bypass_id's for
+    # existing content, this is due to be replaced by a UUID value created by
+    # default for editions
+    unless auth_bypass_id
+      self.auth_bypass_id = PreviewAuthBypass.new(document).auth_bypass_id
+    end
+  end
+
   after_save do
     # Store the edition on the status to keep a history
     status.update!(edition: self) unless status.edition_id

--- a/db/migrate/20200701093902_add_auth_bypass_id_to_editions.rb
+++ b/db/migrate/20200701093902_add_auth_bypass_id_to_editions.rb
@@ -1,0 +1,5 @@
+class AddAuthBypassIdToEditions < ActiveRecord::Migration[6.0]
+  def change
+    add_column :editions, :auth_bypass_id, :uuid
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2020_04_11_150039) do
+ActiveRecord::Schema.define(version: 2020_07_01_093902) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -91,6 +91,7 @@ ActiveRecord::Schema.define(version: 2020_04_11_150039) do
     t.boolean "system_political", default: false, null: false
     t.uuid "government_id"
     t.datetime "published_at"
+    t.uuid "auth_bypass_id"
     t.index ["access_limit_id"], name: "index_editions_on_access_limit_id"
     t.index ["created_by_id"], name: "index_editions_on_created_by_id"
     t.index ["document_id", "current"], name: "index_editions_on_document_id_and_current", unique: true, where: "(current = true)"


### PR DESCRIPTION
Trello: https://trello.com/c/IQ26eiaW/240-make-content-publisher-use-changing-auth-bypass-tokens

This column is intended to be populated by a uuid that is created for
each edition. The value of this will be shared with the Publishing API
and used in the process to bypass authentication to the draft stack for
a particular content item.

This is introduced to replace the current approach where the documents
content id is used. This approach is flawed for the following reasons:

- It allows an old token to view later drafts of a piece of content
- It isn't practical to change the id in the event of a leak

In order for this system to be backwards compatible these
auth_bypass_id's are initially set-up to use the same algorithm as is
used currently to produce identical ids. Once this is applied we can
switch these to be based on UUID's generated at runtime.