### PR TITLE
Backfill backwards compatible auth_bypass_id

### DIFF
--- a/db/migrate/20200701100346_backfill_auth_bypass_id.rb
+++ b/db/migrate/20200701100346_backfill_auth_bypass_id.rb
@@ -1,0 +1,25 @@
+class BackfillAuthBypassId < ActiveRecord::Migration[6.0]
+  disable_ddl_transaction!
+
+  class Edition < ApplicationRecord
+    belongs_to :document
+  end
+
+  def up
+    to_update = Edition.includes(:document).where(auth_bypass_id: nil)
+    to_update.find_each do |edition|
+      auth_bypass_id = generate_uuid_for_string(edition.document.content_id)
+      edition.update!(auth_bypass_id: auth_bypass_id)
+    end
+  end
+
+  # This method has been copied from lib/preview_auth_bypass for perpetuity
+  # in a migration, it provides a transformation algorithm used to predictably
+  # convert a string to a UUID to provide obfuscation.
+  def generate_uuid_for_string(string)
+    ary = Digest::SHA256.hexdigest(string).unpack("NnnnnN")
+    ary[2] = (ary[2] & 0x0fff) | 0x4000
+    ary[3] = (ary[3] & 0x3fff) | 0x8000
+    sprintf "%08x-%04x-%04x-%04x-%04x%08x", *ary
+  end
+end

--- a/db/migrate/20200701131534_auth_bypass_id_not_null.rb
+++ b/db/migrate/20200701131534_auth_bypass_id_not_null.rb
@@ -1,0 +1,5 @@
+class AuthBypassIdNotNull < ActiveRecord::Migration[6.0]
+  def change
+    change_column_null :editions, :auth_bypass_id, false
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2020_07_01_093902) do
+ActiveRecord::Schema.define(version: 2020_07_01_100346) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2020_07_01_100346) do
+ActiveRecord::Schema.define(version: 2020_07_01_131534) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -91,7 +91,7 @@ ActiveRecord::Schema.define(version: 2020_07_01_100346) do
     t.boolean "system_political", default: false, null: false
     t.uuid "government_id"
     t.datetime "published_at"
-    t.uuid "auth_bypass_id"
+    t.uuid "auth_bypass_id", null: false
     t.index ["access_limit_id"], name: "index_editions_on_access_limit_id"
     t.index ["created_by_id"], name: "index_editions_on_created_by_id"
     t.index ["document_id", "current"], name: "index_editions_on_document_id_and_current", unique: true, where: "(current = true)"


### PR DESCRIPTION
Trello: https://trello.com/c/IQ26eiaW/240-make-content-publisher-use-changing-auth-bypass-tokens

This is marked as draft until https://github.com/alphagov/content-publisher/pull/2105 has been merged and deployed to production.

This PR backfills the editions table to populate auth_bypass_id values for every row. Once this migration is complete all entries will have an auth_bypass_id so we can also set it with a NOT NULL db constraint.

In the next PR for this I'll make use of this column in code.