### PR TITLE
Embrace JasmineSeleniumRunner configuration

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -44,7 +44,7 @@ group :development, :test do
   gem "govuk_schemas", "~> 4.0"
   gem "govuk_test", "~> 1.0"
   gem "jasmine", "~> 3"
-  gem "jasmine_selenium_runner", "~> 3", require: false
+  gem "jasmine_selenium_runner", "~> 3"
   gem "json_matchers"
   gem "rspec-rails", "~> 4"
   gem "rubocop-govuk", "~> 3"

--- a/spec/javascripts/support/jasmine_helper.rb
+++ b/spec/javascripts/support/jasmine_helper.rb
@@ -1,11 +1,9 @@
-require "jasmine/runners/selenium"
+require "jasmine_selenium_runner/configure_jasmine"
 
-Jasmine.configure do |config|
-  config.runner = lambda { |formatter, jasmine_server_url|
-    options = Selenium::WebDriver::Chrome::Options.new
-    options.headless!
-
-    webdriver = Selenium::WebDriver.for(:chrome, options: options)
-    Jasmine::Runners::Selenium.new(formatter, jasmine_server_url, webdriver, 50)
-  }
+class ChromeHeadlessJasmineConfigurer < JasmineSeleniumRunner::ConfigureJasmine
+  def selenium_options
+    chrome_options = Selenium::WebDriver::Chrome::Options.new
+    chrome_options.headless!
+    { options: chrome_options }
+  end
 end

--- a/spec/javascripts/support/jasmine_selenium_runner.yml
+++ b/spec/javascripts/support/jasmine_selenium_runner.yml
@@ -1,0 +1,2 @@
+browser: chrome
+configuration_class: ChromeHeadlessJasmineConfigurer


### PR DESCRIPTION
Previously we worked around the configuration that JasmineSeleniumRunner
tries to do automatically by removing it from the require option. This
approach is counter to the configuration method the gem provides.

Now that we're recommending using the Content Publisher approach as a
GOV.UK convention it is less surprising to embrace the configuration
approach the gem provides and documents (even though it is a little
strange) rather than having lots of GOV.UK apps try to work around it.
This was prompted by govuk_publishing_components employing a workaround for
the gem `require: false` [1] which felt like a bit of a smell starting.

This functions the same as before (as far as I can tell) just uses the
configuration approach the gem recommends.

I did ponder about whether the Configurer class could live in the
govuk_test gem, however we probably don't want all the jasmine
dependencies to also travel there and it's such a small amount of code
that it didn't feel like a huge gain.

[1]: https://github.com/alphagov/govuk_publishing_components/pull/1598/files#diff-8b7db4d5cc4b8f6dc8feb7030baa2478R10-R14