### PR TITLE
Don't LoadError for i18n task in production

### DIFF
--- a/lib/tasks/i18n_cov.rake
+++ b/lib/tasks/i18n_cov.rake
@@ -1,3 +1,5 @@
+return unless defined?(I18n::Coverage)
+
 require "i18n/coverage/printers/file_printer"
 
 namespace :i18n_cov do


### PR DESCRIPTION
Since Rails will load this task automatically, we need to prevent
a LoadError in production, where the 'i18n-coverage' gem is not
available. This wraps the whole task definition in a conditional,
since it only makes sense to define the task in dev/test.