### PR TITLE
Remove unnecessarily strict time Cop

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -16,9 +16,5 @@ Rails/DynamicFindBy:
 Rails/SaveBang:
   Enabled: true
 
-Rails/TimeZone:
-  Enabled: true
-  EnforcedStyle: "strict"
-
 Style/DateTime:
   Enabled: true


### PR DESCRIPTION
https://github.com/alphagov/rubocop-govuk/issues/73

Previously we added this config on the basis that "Time.current"
was not a supported mode [1], but it is. This removes the custom
config, noting that this Cop is enabled by default [2].

[1]: https://github.com/alphagov/content-publisher/pull/1820
[2]: https://docs.rubocop.org/rubocop-rails/cops_rails.html#railstimezone