### PR TITLE
Remove redundant RuboCop config

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -8,17 +8,8 @@ inherit_mode:
   merge:
     - Exclude
 
+# This app has custom find_by methods
 Rails/DynamicFindBy:
   Whitelist:
     - find_by_param
     - find_by_document
-
-Rails/SaveBang:
-  Enabled: true
-
-Rails/TimeZone:
-  Enabled: true
-  EnforcedStyle: "strict"
-
-Style/DateTime:
-  Enabled: true


### PR DESCRIPTION
https://github.com/alphagov/rubocop-govuk/issues/73

    This is now enabled by default [1].
    
    [1]: https://github.com/alphagov/rubocop-govuk/pull/98