### PR TITLE
Remove the word "placeholder" from image checker

### DIFF
--- a/lib/whitehall_importer/integrity_checker.rb
+++ b/lib/whitehall_importer/integrity_checker.rb
@@ -241,7 +241,7 @@ module WhitehallImporter
     def default_image?(proposed_image_payload, publishing_api_image, attribute)
       attribute == "alt_text" &&
         proposed_image_payload.empty? &&
-        publishing_api_image[attribute] == "placeholder"
+        publishing_api_image[attribute].empty?
     end
 
     def publishing_api_unpublishing

--- a/spec/lib/whitehall_importer/integrity_checker_spec.rb
+++ b/spec/lib/whitehall_importer/integrity_checker_spec.rb
@@ -76,7 +76,7 @@ RSpec.describe WhitehallImporter::IntegrityChecker do
 
     it "returns true if the Publishing API image is a placeholder and the imported edition has no image" do
       publishing_api_item[:details][:image] = {
-        alt_text: "placeholder",
+        alt_text: "",
       }
       stub_publishing_api_has_item(publishing_api_item)
 


### PR DESCRIPTION
The Whitehall to Content Publisher migration code uses the presence of the word "placeholder" to determine if we're using a default image.

Whitehall has [recently been updated](https://github.com/alphagov/whitehall/pull/5756) to remove "placeholder" as the
default for image alt text as this was an accessibility fail. The alt text field should now be blank by default