### PR TITLE
Fix bug where you can't preview scheduled documents

### DIFF
--- a/app/interactors/preview/create_interactor.rb
+++ b/app/interactors/preview/create_interactor.rb
@@ -18,7 +18,7 @@ private
 
   def find_and_lock_edition
     context.edition = Edition.lock.find_current(document: params[:document])
-    assert_edition_state(edition, &:editable?)
+    assert_edition_state(edition, assertion: "not live") { !edition.live? }
   end
 
   def check_for_issues

--- a/spec/interactors/preview/create_interactor_spec.rb
+++ b/spec/interactors/preview/create_interactor_spec.rb
@@ -1,0 +1,51 @@
+RSpec.describe Preview::CreateInteractor do
+  describe ".call" do
+    let(:user) { create(:user) }
+    let(:edition) { create(:edition) }
+    let(:args) do
+      {
+        params: { document: edition.document.to_param },
+        user: user,
+      }
+    end
+
+    context "when input is valid" do
+      it "creates a preview" do
+        expect(PreviewDraftEditionService).to receive(:call).with(edition)
+        described_class.call(**args)
+      end
+    end
+
+    context "when the edition is live" do
+      let(:edition) { create(:edition, :published) }
+
+      it "raises a state error" do
+        expect { described_class.call(**args) }
+          .to raise_error(EditionAssertions::StateError, /not live/)
+      end
+    end
+
+    context "when the edition has issues" do
+      it "fails with issues returned" do
+        allow(Requirements::Preview::EditionChecker)
+          .to receive(:call).and_return(%w[issue])
+
+        result = described_class.call(**args)
+
+        expect(result).to be_failure
+        expect(result.issues).to eq %w[issue]
+      end
+    end
+
+    context "when the preview fails" do
+      it "fails with a preview_failed flag" do
+        allow(PreviewDraftEditionService).to receive(:call)
+                                         .and_raise(GdsApi::BaseError)
+        result = described_class.call(**args)
+
+        expect(result).to be_failure
+        expect(result.preview_failed).to be(true)
+      end
+    end
+  end
+end

--- a/spec/requests/preview_spec.rb
+++ b/spec/requests/preview_spec.rb
@@ -5,7 +5,21 @@ RSpec.describe "Preview" do
     let(:edition) { create(:edition, :published) }
   end
 
-  describe "POST /documents/:document/create-preview" do
+  describe "GET /documents/:document/preview" do
+    it "returns successfully with an editable edition" do
+      edition = create(:edition)
+      get preview_path(edition.document)
+      expect(response).to have_http_status(:ok)
+    end
+
+    it "returns successfully with a scheduled edition" do
+      edition = create(:edition, :scheduled)
+      get preview_path(edition.document)
+      expect(response).to have_http_status(:ok)
+    end
+  end
+
+  describe "POST /documents/:document/preview" do
     it "redirects to the preview page on success" do
       edition = create(:edition)
       stub_publishing_api_put_content(edition.content_id, {})


### PR DESCRIPTION
This resolves a bug where we asserting that an edition had to be
editable to be previewable, this is incorrect as you can preview
scheduled editions. This is easy enough to fix.

A bit more painful was deciding what process to take to add a regression
test for this - as this seemed a relatively easy mistake to make as most
work we do asserts an edition is editable rather than it being pre-live.
We don't really have a pattern to exhaustively test state assertions.

I added the interactor test for this action since there wasn't one
already and validated that the edition assertion test returned the
appropriate message. This seemed sufficient to me as you couldn't change
this without re-considering the logic of the condition.

I then added an explicit test at the request point for the GET endpoint
since this isn't tested at a unit level and this makes the need for this
feature explicit.