### PR TITLE
Bump govuk_app_config to v2.5.1

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -145,7 +145,7 @@ GEM
       nokogumbo (~> 2)
       rinku (~> 2.0)
       sanitize (>= 5.2.1, < 6)
-    govuk_app_config (2.5.0)
+    govuk_app_config (2.5.1)
       logstasher (>= 1.2.2, < 1.4.0)
       sentry-raven (~> 3.1.1)
       statsd-ruby (~> 1.4.0)


### PR DESCRIPTION
v2.5.1 changes how exceptions in `data_sync_excluded_exceptions`
are treated. They used to be evaluated purely on class name, i.e.
does `exception == "PG::Error"`, meaning if a subclass of the
exception is raised, the evaluation would return false
(`"PG::UndefinedTable" !== "PG::Error"`).

2.5.1 now treats exceptions polymorphically:
`exception.is_a?(PG::Error)`, which now includes subclasses
(`PG::UndefinedTable.new.is_a?(PG::Error) == true`).

The impact of this is that we can suppress the entire suite of
"PG::Error" errors that occur during a data sync, without having
to manually specify each subclass of exception.

See 2.5.1 changenote:
https://github.com/alphagov/govuk_app_config/blob/master/CHANGELOG.md#251

Trello: https://trello.com/c/rAlvGlSp/2123-5-ignore-data-sync-errors-in-govukappconfig