### PR TITLE
Fix app no longer being linted in CI

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -8,24 +8,8 @@ node {
 
   govuk.buildProject(
     beforeTest: {
-      stage("Lint Javascript") {
+      stage("Install node modules") {
         sh("yarn")
-        sh("yarn run lint")
-      }
-    },
-    rubyLintDiff: false,
-    rubyLintDirs: "",
-    overrideTestTask: {
-      stage("Run tests") {
-        govuk.runTests("spec jasmine:ci")
-      }
-    },
-    afterTest: {
-      stage("Lint FactoryBot") {
-        sh("bundle exec rake factorybot:lint RAILS_ENV=test")
-      }
-      stage("I18n Coverage") {
-        sh("bundle exec rake i18n_cov:ci")
       }
     }
   )

--- a/Rakefile
+++ b/Rakefile
@@ -7,4 +7,4 @@ Rails.application.load_tasks
 # RSpec shoves itself into the default task without asking, which confuses the ordering.
 # https://github.com/rspec/rspec-rails/blob/eb3377bca425f0d74b9f510dbb53b2a161080016/lib/rspec/rails/tasks/rspec.rake#L6
 Rake::Task[:default].clear
-task default: %i[spec i18n_cov:ci jasmine:ci lint brakeman]
+task default: %i[lint spec i18n_cov:ci jasmine:ci brakeman]

--- a/lib/tasks/lint.rake
+++ b/lib/tasks/lint.rake
@@ -1,6 +1,6 @@
 desc "lint Ruby, FactoryBot, Sass and Javascript"
 task lint: :environment do
-  sh "bundle exec rubocop --format clang"
-  sh "bundle exec rake factorybot:lint RAILS_ENV='test'"
+  sh "bundle exec rubocop"
   sh "yarn run lint"
+  sh "bundle exec rake factorybot:lint RAILS_ENV='test'"
 end

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "license": "MIT",
   "scripts": {
     "lint": "yarn run lint:js && yarn run lint:scss",
-    "lint:js": "standard app/assets/javascripts/{*.js,**/*.js} spec/javascripts/{*.js,**/*.js}",
+    "lint:js": "standard 'app/assets/javascripts/**/*.js' 'spec/javascripts/**/*.js'",
     "lint:scss": "stylelint app/assets/stylesheets/"
   },
   "standard": {


### PR DESCRIPTION
Trello: https://trello.com/c/5Gob6WUL/147-for-everyone-ensure-that-rubocop-runs-as-part-of-bundle-exec-rake-as-one-of-the-default-tasks

This app, like many, seemed to get missed in the transition towards removing the lint task in https://github.com/alphagov/govuk-jenkinslib/pull/74. I've also spruced up the rake and standard files a little.