### PR TITLE
Extend healthcheck to optionally check S3

### DIFF
--- a/app/controllers/healthcheck_controller.rb
+++ b/app/controllers/healthcheck_controller.rb
@@ -2,11 +2,13 @@ class HealthcheckController < ApplicationController
   skip_before_action :authenticate_user!
 
   def index
-    healthcheck = GovukHealthcheck.healthcheck([
+    checks = [
       GovukHealthcheck::SidekiqRedis,
       GovukHealthcheck::ActiveRecord,
       Healthcheck::GovernmentDataCheck,
-    ])
-    render json: healthcheck
+    ]
+
+    checks << Healthcheck::ActiveStorage if params[:storage]
+    render json: GovukHealthcheck.healthcheck(checks)
   end
 end

--- a/lib/healthcheck/active_storage.rb
+++ b/lib/healthcheck/active_storage.rb
@@ -1,0 +1,14 @@
+module Healthcheck
+  class ActiveStorage
+    def name
+      :active_storage
+    end
+
+    def status
+      ::ActiveStorage::Blob.service.exist?("does-not-exist")
+      GovukHealthcheck::OK
+    rescue StandardError
+      GovukHealthcheck::CRITICAL
+    end
+  end
+end

--- a/spec/lib/healthcheck/active_storage_spec.rb
+++ b/spec/lib/healthcheck/active_storage_spec.rb
@@ -1,0 +1,14 @@
+RSpec.describe Healthcheck::ActiveStorage do
+  describe "#status" do
+    it "returns OK when connected to the storage service" do
+      expect(described_class.new.status).to eq GovukHealthcheck::OK
+    end
+
+    it "returns CRITICAL when the storage connection fails" do
+      allow(ActiveStorage::Blob.service).to receive(:exist?)
+        .and_raise("connection failed")
+
+      expect(described_class.new.status).to eq GovukHealthcheck::CRITICAL
+    end
+  end
+end

--- a/spec/requests/healthcheck_spec.rb
+++ b/spec/requests/healthcheck_spec.rb
@@ -13,5 +13,13 @@ RSpec.describe "Healthcheck" do
       get healthcheck_path
       expect(JSON.parse(response.body)).to have_key("status")
     end
+
+    it "checks ActiveStorage if specified" do
+      get healthcheck_path
+      expect(JSON.parse(response.body)["checks"]).not_to have_key("active_storage")
+
+      get healthcheck_path, params: { storage: true }
+      expect(JSON.parse(response.body)["checks"]).to have_key("active_storage")
+    end
   end
 end


### PR DESCRIPTION
https://trello.com/c/ILpSOFhq/201-enable-cd-for-quick-win-and-possible-quick-win-apps

Please see the commit for more details.

I think the argument to make this an optional part of the healthcheck
is relatively weak, but I think it's worth highlighting the potential
concerns so we can explicitly decide if we want to check S3 connectivity
more frequently. Arguments for treating S3 like the other checks:

- Attachments (will) represent a relatively high proportion of user
journeys, so it's simpler to mark the app as unhealthy than let users
continue to use it and experience random errors.

- S3 request pricing is *very* cheap: with 3 backend machines, it amounts
to about £4pa, per app.

- We treat S3 as a robust service and do not handle any failure associated
with it; therefore, we should not expect it to fail, ever.

It's also worth noting the S3 request limit of 3500r/s per bucket means we
are in no danger whatsoever of going over the limit.