### PR TITLE
Add health check for ActiveStorage service

### DIFF
--- a/app/controllers/healthcheck_controller.rb
+++ b/app/controllers/healthcheck_controller.rb
@@ -6,6 +6,7 @@ class HealthcheckController < ApplicationController
       GovukHealthcheck::SidekiqRedis,
       GovukHealthcheck::ActiveRecord,
       Healthcheck::GovernmentDataCheck,
+      Healthcheck::ActiveStorage,
     ])
     render json: healthcheck
   end

--- a/lib/healthcheck/active_storage.rb
+++ b/lib/healthcheck/active_storage.rb
@@ -1,0 +1,14 @@
+module Healthcheck
+  class ActiveStorage
+    def name
+      :active_storage
+    end
+
+    def status
+      ::ActiveStorage::Blob.service.exist?("does-not-exist")
+      GovukHealthcheck::OK
+    rescue StandardError
+      GovukHealthcheck::WARNING
+    end
+  end
+end

--- a/spec/lib/healthcheck/active_storage_spec.rb
+++ b/spec/lib/healthcheck/active_storage_spec.rb
@@ -1,0 +1,14 @@
+RSpec.describe Healthcheck::ActiveStorage do
+  describe "#status" do
+    it "returns OK when connected to the storage service" do
+      expect(described_class.new.status).to eq GovukHealthcheck::OK
+    end
+
+    it "returns WARNING when the storage connection fails" do
+      allow(ActiveStorage::Blob.service).to receive(:exist?)
+        .and_raise("connection failed")
+
+      expect(described_class.new.status).to eq GovukHealthcheck::WARNING
+    end
+  end
+end


### PR DESCRIPTION
https://trello.com/c/ILpSOFhq/201-enable-cd-for-quick-win-and-possible-quick-win-apps

This adds a new check to verify that the app is able to connect to
the backing service we use for ActiveStorage (S3). In order to avoid
any coupling with the contents of the bucket, the check simply makes
a connection to determine whether an item exists.

ActiveStorage plays a critical role in lots of user journeys for this
app. We assume the service is robust and don't provide any special
error handling for it, so we should be aware if it stops working. It's
worth noting a few potential pitfalls of this check:

- Amazon charge per-request to S3. However, request pricing is very cheap:
with 3 backend machines, and roughly 6 requests per minute, it amounts to
about £4pa, per app. I don't think this is a concern in practice.

- Connecting to S3 is over HTTP, which is more likely to intermittently
fail compared to our other healthchecks, which re-use long-lived pools
of connections. We don't expect this to be a problem in practice.

- The S3 request limit of 3500r/s per bucket means we are in no danger
whatsoever of going over the limit.

[1]: https://github.com/alphagov/govuk-rfcs/blob/master/rfc-128-continuous-deployment.md#check-app-is-healthy-ie-it-can-run-in-a-production-environment