### PR TITLE
Actually shorten PR template

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,7 +1,1 @@
-:warning: This application is Continuously Deployed: :warning:
-
-- Merged changes are automatically deployed to staging and production.
-
-- Make sure you follow [the guidance for deployments](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) **before** you merge.
-
-- Check your branch is being deployed in the [Release app](https://release.publishing.service.gov.uk/applications/content-publisher), after merging.
+⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️


### PR DESCRIPTION
https://trello.com/c/ILpSOFhq/201-enable-cd-for-quick-win-and-possible-quick-win-apps

This got missed as part of the discussion on [1].

[1]: https://github.com/alphagov/content-publisher/pull/2207


⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️