### PR TITLE
Switch from Standard to Standardx for JS linting

### DIFF
--- a/app/assets/javascripts/components/markdown-editor.js
+++ b/app/assets/javascripts/components/markdown-editor.js
@@ -1,4 +1,3 @@
-/* global $ */
 //= require markdown-toolbar-element/dist/index.umd.js
 //= require paste-html-to-govspeak/dist/paste-html-to-markdown.js
 

--- a/app/assets/javascripts/modal/modal-workflow.js
+++ b/app/assets/javascripts/modal/modal-workflow.js
@@ -1,5 +1,3 @@
-/* global $ */
-
 function ModalWorkflow ($modal, actionCallback) {
   this.$modal = $modal
   this.actionCallback = actionCallback

--- a/package.json
+++ b/package.json
@@ -6,10 +6,10 @@
   "license": "MIT",
   "scripts": {
     "lint": "yarn run lint:js && yarn run lint:scss",
-    "lint:js": "standard 'app/assets/javascripts/**/*.js' 'spec/javascripts/**/*.js'",
+    "lint:js": "standardx 'app/assets/javascripts/**/*.js' 'spec/javascripts/**/*.js'",
     "lint:scss": "stylelint app/assets/stylesheets/"
   },
-  "standard": {
+  "standardx": {
     "ignore": [
       "/spec/javascripts/helpers/jasmine-jquery.js"
     ]
@@ -17,8 +17,13 @@
   "stylelint": {
     "extends": "stylelint-config-gds/scss"
   },
+  "eslintConfig": {
+    "rules": {
+      "no-var": 0
+    }
+  },
   "devDependencies": {
-    "standard": "^16.0.3",
+    "standardx": "^7.0.0",
     "stylelint": "^13.8.0",
     "stylelint-config-gds": "^0.1.0"
   },

--- a/package.json
+++ b/package.json
@@ -10,6 +10,14 @@
     "lint:scss": "stylelint app/assets/stylesheets/"
   },
   "standardx": {
+    "env": {
+      "browser": true,
+      "jquery": true,
+      "jasmine": true
+    },
+    "globals": [
+      "GOVUK"
+    ],
     "ignore": [
       "/spec/javascripts/helpers/jasmine-jquery.js"
     ]

--- a/spec/javascripts/components/contact-preview-spec.js
+++ b/spec/javascripts/components/contact-preview-spec.js
@@ -1,6 +1,3 @@
-/* eslint-env jasmine, jquery */
-/* global GOVUK */
-
 describe('Contact preview component', function () {
   'use strict'
 

--- a/spec/javascripts/components/input-length-suggester-spec.js
+++ b/spec/javascripts/components/input-length-suggester-spec.js
@@ -1,6 +1,3 @@
-/* eslint-env jasmine, jquery */
-/* global GOVUK */
-
 describe('Input length suggester component', function () {
   'use strict'
 

--- a/spec/javascripts/components/markdown-editor-spec.js
+++ b/spec/javascripts/components/markdown-editor-spec.js
@@ -1,4 +1,3 @@
-/* eslint-env jasmine */
 /* global spyOnEvent, buildMarkdownEditor, removeMarkdownEditor */
 
 describe('Markdown editor component', function () {

--- a/spec/javascripts/components/multi-section-viewer-spec.js
+++ b/spec/javascripts/components/multi-section-viewer-spec.js
@@ -1,6 +1,3 @@
-/* eslint-env jasmine, jquery */
-/* global GOVUK */
-
 describe('Multi section viewer', function () {
   'use strict'
 

--- a/spec/javascripts/components/reorderable-list-spec.js
+++ b/spec/javascripts/components/reorderable-list-spec.js
@@ -1,5 +1,4 @@
-/* eslint-env jasmine, jquery */
-/* global GOVUK, spyOnEvent */
+/* global spyOnEvent */
 
 describe('Reorderable list component', function () {
   'use strict'

--- a/spec/javascripts/components/toolbar-dropdown-spec.js
+++ b/spec/javascripts/components/toolbar-dropdown-spec.js
@@ -1,6 +1,3 @@
-/* eslint-env jasmine, jquery */
-/* global GOVUK */
-
 describe('Toolbar dropdown component', function () {
   'use strict'
 

--- a/spec/javascripts/components/url-preview-spec.js
+++ b/spec/javascripts/components/url-preview-spec.js
@@ -1,5 +1,4 @@
-/* eslint-env jasmine, jquery */
-/* global GOVUK, fetchMock */
+/* global fetchMock */
 
 describe('URL preview component', function () {
   'use strict'

--- a/spec/javascripts/helpers/fetch-mock.js
+++ b/spec/javascripts/helpers/fetch-mock.js
@@ -1,4 +1,3 @@
-/* eslint-env jasmine */
 /* global fetchMock */
 
 //= require fetch-mock/es5/client-bundle.js

--- a/spec/javascripts/helpers/gtm-mock.js
+++ b/spec/javascripts/helpers/gtm-mock.js
@@ -1,5 +1,3 @@
-/* eslint-env jasmine */
-
 beforeEach(function () {
   window.dataLayer = []
 })

--- a/spec/javascripts/helpers/markdown-editor.js
+++ b/spec/javascripts/helpers/markdown-editor.js
@@ -1,6 +1,3 @@
-/* eslint-env jquery */
-/* global GOVUK */
-
 window.buildMarkdownEditor = function buildMarkdownEditor () {
   var markdownEditor = document.createElement('div')
   markdownEditor.className = 'app-c-markdown-editor'

--- a/spec/javascripts/helpers/modal-dialogue.js
+++ b/spec/javascripts/helpers/modal-dialogue.js
@@ -1,5 +1,3 @@
-/* eslint-env jquery */
-
 window.buildModalDialogue = function buildModalDialogue () {
   window.removeModalDialogue()
   var modal = document.createElement('div')

--- a/spec/javascripts/modal/modal-editor-spec.js
+++ b/spec/javascripts/modal/modal-editor-spec.js
@@ -1,4 +1,3 @@
-/* eslint-env jasmine */
 /* global ModalEditor, buildMarkdownEditor, removeMarkdownEditor */
 
 describe('ModalEditor', function () {

--- a/spec/javascripts/modal/modal-fetch-spec.js
+++ b/spec/javascripts/modal/modal-fetch-spec.js
@@ -1,4 +1,3 @@
-/* eslint-env jasmine */
 /* global ModalFetch, fetchMock */
 
 describe('ModalFetch', function () {

--- a/spec/javascripts/modal/modal-workflow-spec.js
+++ b/spec/javascripts/modal/modal-workflow-spec.js
@@ -1,4 +1,3 @@
-/* eslint-env jasmine, jquery */
 /* global ModalWorkflow, buildModalDialogue, removeModalDialogue */
 
 describe('ModalWorkflow', function () {

--- a/spec/javascripts/modules/contact-embed-modal-spec.js
+++ b/spec/javascripts/modules/contact-embed-modal-spec.js
@@ -1,4 +1,3 @@
-/* eslint-env jasmine */
 /* global ContactEmbedModal, fetchMock, buildModalDialogue, removeModalDialogue */
 
 describe('ContactEmbedModal', function () {

--- a/spec/javascripts/modules/gtm-copy-paste-listener-spec.js
+++ b/spec/javascripts/modules/gtm-copy-paste-listener-spec.js
@@ -1,5 +1,3 @@
-/* eslint-env jasmine */
-
 describe('Gtm copy paste listener', function () {
   'use strict'
 

--- a/spec/javascripts/modules/gtm-reorder-listener-spec.js
+++ b/spec/javascripts/modules/gtm-reorder-listener-spec.js
@@ -1,5 +1,3 @@
-/* eslint-env jasmine */
-
 describe('Gtm reorder listener', function () {
   'use strict'
 

--- a/spec/javascripts/modules/gtm-topic-listener-spec.js
+++ b/spec/javascripts/modules/gtm-topic-listener-spec.js
@@ -1,5 +1,3 @@
-/* eslint-env jasmine */
-
 describe('Gtm topic listener', function () {
   'use strict'
 

--- a/spec/javascripts/modules/inline-attachment-modal-spec.js
+++ b/spec/javascripts/modules/inline-attachment-modal-spec.js
@@ -1,4 +1,3 @@
-/* eslint-env jasmine */
 /* global InlineAttachmentModal, fetchMock, buildModalDialogue, removeModalDialogue */
 
 describe('InlineAttachmentModal', function () {

--- a/spec/javascripts/modules/inline-image-modal-spec.js
+++ b/spec/javascripts/modules/inline-image-modal-spec.js
@@ -1,4 +1,3 @@
-/* eslint-env jasmine */
 /* global InlineImageModal, fetchMock, buildModalDialogue, removeModalDialogue */
 
 describe('InlineImageModal', function () {

--- a/spec/javascripts/modules/video-embed-modal-spec.js
+++ b/spec/javascripts/modules/video-embed-modal-spec.js
@@ -1,4 +1,3 @@
-/* eslint-env jasmine */
 /* global VideoEmbedModal, fetchMock, buildModalDialogue, removeModalDialogue */
 
 describe('VideoEmbedModal', function () {

--- a/spec/javascripts/modules/warn-before-unload-spec.js
+++ b/spec/javascripts/modules/warn-before-unload-spec.js
@@ -1,4 +1,3 @@
-/* global describe beforeEach afterEach it spyOn expect */
 /* global WarnBeforeUnload Event */
 
 describe('Warn before unload module', function () {

--- a/yarn.lock
+++ b/yarn.lock
@@ -2550,7 +2550,7 @@ standard-engine@^14.0.1:
     pkg-conf "^3.1.0"
     xdg-basedir "^4.0.0"
 
-standard@^16.0.3:
+standard@^16.0.1:
   version "16.0.3"
   resolved "https://registry.yarnpkg.com/standard/-/standard-16.0.3.tgz#a854c0dd2dea6b9f0b8d20c65260210bd0cee619"
   integrity sha512-70F7NH0hSkNXosXRltjSv6KpTAOkUkSfyu3ynyM5dtRUiLtR+yX9EGZ7RKwuGUqCJiX/cnkceVM6HTZ4JpaqDg==
@@ -2562,6 +2562,14 @@ standard@^16.0.3:
     eslint-plugin-node "~11.1.0"
     eslint-plugin-promise "~4.2.1"
     eslint-plugin-react "~7.21.5"
+    standard-engine "^14.0.1"
+
+standardx@^7.0.0:
+  version "7.0.0"
+  resolved "https://registry.yarnpkg.com/standardx/-/standardx-7.0.0.tgz#d00a6a7ed4589abb814bff8ec161c6e94cf5cd64"
+  integrity sha512-Uh2LIWyMD0pMFn+zoAS52dforkE8MUWP6hK48iQhiohTC5DRqBgTdXdJbhSGyjamRxCfETBdfvJ7hvtme2M3jg==
+  dependencies:
+    standard "^16.0.1"
     standard-engine "^14.0.1"
 
 string-width@^3.0.0:


### PR DESCRIPTION
This switches to StandardX so that we can quiet down the many warnings of: "Unexpected var, use let or const instead.". These are a bit misleading as GDS Frontend developers are still keen to use var for improved browser compatibility.

I've also set the eslint envs and globals in package.json to reduce the amount of declarations we need in JS files.

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️
