### PR TITLE
Include content type in the data passed to Asset Manager

### DIFF
--- a/app/services/preview_asset_service/payload.rb
+++ b/app/services/preview_asset_service/payload.rb
@@ -17,6 +17,9 @@ class PreviewAssetService::Payload
   end
 
   def for_upload(asset)
-    for_update.merge(file: PreviewAssetService::UploadedFile.new(asset))
+    for_update.merge(
+      file: PreviewAssetService::UploadedFile.new(asset),
+      content_type: asset.content_type,
+    )
   end
 end

--- a/spec/services/preview_asset_service/payload_spec.rb
+++ b/spec/services/preview_asset_service/payload_spec.rb
@@ -21,13 +21,16 @@ RSpec.describe PreviewAssetService::Payload do
   end
 
   describe "#for_upload" do
-    let(:asset) { double(:asset, bytes: "bytes") } # rubocop:disable RSpec/VerifiedDoubles
+    let(:asset) do
+      double(bytes: "bytes", content_type: "image/png") # rubocop:disable RSpec/VerifiedDoubles
+    end
 
     it "returns a payload hash" do
       edition = build :edition
       payload = described_class.new(edition).for_upload(asset)
 
       expect(payload).to match(
+        content_type: "image/png",
         draft: true,
         auth_bypass_ids: [edition.auth_bypass_id],
         file: instance_of(PreviewAssetService::UploadedFile),


### PR DESCRIPTION
https://trello.com/c/fHPHwU5H/980-look-into-content-publisher-xss-pdf-issue

This depends on: https://github.com/alphagov/asset-manager/pull/828

This tells Asset Manager a files content type when it is uploaded. This
is to resolve a previous problem where Content Publisher determines a
content type by inspecting a files contents, whereas Asset Manager uses
a file extension - when these disagree the output can be inconsistent.

Since Content Publisher already determines the content-type for
validation and storage it seems logical to me that this app tells Asset
Manager rather than leaving Asset Manager to determine itself, the
latter approach could have a few inconsistencies.

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️
