### PR TITLE
Remove Jenkinsfile yarn install step

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -6,11 +6,5 @@ node {
   // This is required for assets:precompile which runs in rails production
   govuk.setEnvar("JWT_AUTH_SECRET", "secret")
 
-  govuk.buildProject(
-    beforeTest: {
-      stage("Install node modules") {
-        sh("yarn")
-      }
-    }
-  )
+  govuk.buildProject()
 }


### PR DESCRIPTION
This is no longer necessary following: https://github.com/alphagov/govuk-jenkinslib/pull/82

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️
