### PR TITLE
Favour GOV.UK Docker for running the app

### DIFF
--- a/Procfile.dev
+++ b/Procfile.dev
@@ -1,2 +1,0 @@
-web: BYEBUG_PORT=3237 bundle exec rails s -p 3221
-worker: BYEBUG_PORT=3238 bundle exec sidekiq -C ./config/sidekiq.yml

--- a/README.md
+++ b/README.md
@@ -11,16 +11,13 @@ A unified publishing application for content on GOV.UK
 
 ## Technical documentation
 
-This is a Ruby on Rails application. You can use the GOV.UK Docker environment to run the application and its tests with all the necessary dependencies; **see the [README](https://github.com/alphagov/govuk-docker#usage) for more details**.
+This is a Ruby on Rails app, and should follow [our Rails app conventions](https://docs.publishing.service.gov.uk/manual/conventions-for-rails-applications.html).
 
-### Dependencies
+You can use the [GOV.UK Docker environment](https://github.com/alphagov/govuk-docker) to run the application and its tests with all the necessary dependencies. Follow [the usage instructions](https://github.com/alphagov/govuk-docker#usage) to get started.
 
-- [postgresql][] - provides a backing database
-- [redis][] - used as a storage layer for asynchronous job processing
-- [yarn][] - package manager for JavaScripts
-- [imagemagick][] - image manipulation library
+**Use GOV.UK Docker to run any commands that follow.**
 
-### Running the application
+### Before running the app
 
 The first time you run this application for development, enable `debug` and `pre_release_features` permissions:
 

--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ A unified publishing application for content on GOV.UK
 
 ## Technical documentation
 
-This is a Ruby on Rails application.
+This is a Ruby on Rails application. You can use the GOV.UK Docker environment to run the application and its tests with all the necessary dependencies; **see the [README](https://github.com/alphagov/govuk-docker#usage) for more details**.
 
 ### Dependencies
 
@@ -33,8 +33,6 @@ To enable them for your GOV.UK account add them to your account in [Signon](http
 ### Running the test suite
 
 ```
-yarn install
-
 # ruby tests
 bundle exec rspec
 

--- a/startup.sh
+++ b/startup.sh
@@ -1,5 +1,0 @@
-#!/bin/bash
-
-bundle install
-gem install foreman --conservative
-foreman start -f Procfile.dev


### PR DESCRIPTION
https://trello.com/c/Psf7EzPB/204-move-away-from-startupsh

This removes legacy "startup.sh" files from this project in favour
of using GOV.UK Docker, which provides more functionality. In order
to keep the README environment-agnostic, we avoid prefixing commands
like "bundle exec rake" with "govuk-docker-run". However, any setup
commands are removed as these are covered by GOV.UK Docker Makefiles,
and are seldom sufficient for comprehensive local development.


⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️