### PR TITLE
Fix ugly border that has crept into documents

### DIFF
--- a/app/views/documents/index/_results.html.erb
+++ b/app/views/documents/index/_results.html.erb
@@ -26,6 +26,7 @@
     <% @editions.each do |edition| %>
       <%= t.row do %>
         <%= t.cell render "govuk_publishing_components/components/document_list", {
+          remove_top_border: true,
           items: [
             {
               link: {


### PR DESCRIPTION
This was caused by a change to the underlying component to always insert
a top border. There was then a fix applied in https://github.com/alphagov/govuk_publishing_components/pull/1907
which needs to be manually applied.

Before:

![Screenshot 2021-02-26 at 18 19 55](https://user-images.githubusercontent.com/282717/109339350-70862d80-785f-11eb-91a3-b79096e0d58c.png)

After:

![Screenshot 2021-02-26 at 18 19 33](https://user-images.githubusercontent.com/282717/109339342-6c5a1000-785f-11eb-99b0-32a718de5256.png)

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️
