### PR TITLE
Switch to using Michael Walker's fork of mimemagic

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -16,6 +16,7 @@ gem "inline_svg"
 gem "interactor"
 gem "kaminari"
 gem "mail-notify"
+gem "mimemagic", git: "https://github.com/barrucadu/mimemagic.git", ref: "e571894" # Use a GDS employee's fork until an upstream bug is fixed
 gem "pdf-reader"
 gem "pg"
 gem "plek"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,3 +1,11 @@
+GIT
+  remote: https://github.com/barrucadu/mimemagic.git
+  revision: e571894115c036143e4918545f340c6e9f7a5b81
+  ref: e571894
+  specs:
+    mimemagic (0.3.7)
+      nokogiri (~> 1.11.2)
+
 GEM
   remote: https://rubygems.org/
   specs:
@@ -252,7 +260,6 @@ GEM
     mime-types (3.3.1)
       mime-types-data (~> 3.2015)
     mime-types-data (3.2021.0225)
-    mimemagic (0.3.5)
     mini_magick (4.10.1)
     mini_mime (1.0.2)
     mini_portile2 (2.5.0)
@@ -517,6 +524,7 @@ DEPENDENCIES
   kaminari
   listen
   mail-notify
+  mimemagic!
   pdf-reader
   pg
   plek


### PR DESCRIPTION
This is to resolve a problem where this application is undeployable as
the relied upon gem has been yanked and the current release of the gem
(0.3.7) crashes when it runs.

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️
