### PR TITLE
Upgrade to mimemagic-0.3.9

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -16,7 +16,6 @@ gem "inline_svg"
 gem "interactor"
 gem "kaminari"
 gem "mail-notify"
-gem "mimemagic", git: "https://github.com/barrucadu/mimemagic.git", ref: "e571894" # Use a GDS employee's fork until an upstream bug is fixed
 gem "pdf-reader"
 gem "pg"
 gem "plek"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,11 +1,3 @@
-GIT
-  remote: https://github.com/barrucadu/mimemagic.git
-  revision: e571894115c036143e4918545f340c6e9f7a5b81
-  ref: e571894
-  specs:
-    mimemagic (0.3.7)
-      nokogiri (~> 1.11.2)
-
 GEM
   remote: https://rubygems.org/
   specs:
@@ -260,6 +252,9 @@ GEM
     mime-types (3.3.1)
       mime-types-data (~> 3.2015)
     mime-types-data (3.2021.0225)
+    mimemagic (0.3.9)
+      nokogiri (~> 1)
+      rake
     mini_magick (4.10.1)
     mini_mime (1.0.2)
     mini_portile2 (2.5.0)
@@ -524,7 +519,6 @@ DEPENDENCIES
   kaminari
   listen
   mail-notify
-  mimemagic!
   pdf-reader
   pg
   plek


### PR DESCRIPTION
This release solves the parsing issue on Ubuntu 14.04.

---

[Trello card](https://trello.com/c/3EKxoz27/1123-the-mimemagic-situation)
