### PR TITLE
Remove `is_page_heading` param from radio components

### DIFF
--- a/app/views/access_limit/edit.html.erb
+++ b/app/views/access_limit/edit.html.erb
@@ -29,7 +29,8 @@
                  data: { gtm: "confirm-access-limit" } do %>
       <%= render "govuk_publishing_components/components/radio", {
         heading: t("access_limit.edit.title"),
-        is_page_heading: true,
+        heading_level: 1,
+        heading_size: 'xl',
         description: t("access_limit.edit.description"),
         name: "limit_type",
         error_items: @issues&.items_for(:access_limit),

--- a/app/views/new_document/show.html.erb
+++ b/app/views/new_document/show.html.erb
@@ -7,7 +7,8 @@
     <%= form_tag new_document_path(type: @document_type_selection.id), data: { gtm: "confirm-document-type" } do %>
       <%= render "govuk_publishing_components/components/radio", {
         heading: t("document_type_selections.#{@document_type_selection.id}.label"),
-        is_page_heading: true,
+        heading_level: 1,
+        heading_size: 'xl',
         name: "selected_option_id",
         error_items: @issues&.items_for(:document_type_selection),
         items: @document_type_selection.options.each_with_object([]) do |option, memo|

--- a/app/views/publish/confirmation.html.erb
+++ b/app/views/publish/confirmation.html.erb
@@ -6,7 +6,8 @@
     <%= form_tag publish_confirmation_path(@edition.document), data: { gtm: "confirm-publish" } do %>
       <%= render "govuk_publishing_components/components/radio", {
         heading: t("publish.confirmation.title"),
-        is_page_heading: true,
+        heading_level: 1,
+        heading_size: 'xl',
         name: "review_status",
         error_items: @issues&.items_for(:review_status),
         items: [

--- a/app/views/schedule/new.html.erb
+++ b/app/views/schedule/new.html.erb
@@ -12,7 +12,8 @@
     <%= form_tag new_schedule_path(@edition.document), data: { gtm: "confirm-schedule" } do %>
       <%= render "govuk_publishing_components/components/radio", {
         heading: t("schedule.new.title"),
-        is_page_heading: true,
+        heading_level: 1,
+        heading_size: 'xl',
         description: render_govspeak(t("schedule.new.hint_text", datetime: datetime.to_s(:time_on_date))),
         name: "review_status",
         error_items: @issues&.items,


### PR DESCRIPTION
Changes are being implemented to retire the `is_page_heading` parameter,
using `heading_level`/`heading_size` to achieve the same effect instead.
The reasons behind this are described in more detail in [this issue](https://github.com/alphagov/govuk_publishing_components/issues/1953).

Replace the `is_page_heading:true` option with `heading_level: 1` and `heading_size: 'xl'`

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️
