### PR TITLE
Tweak guidance on running JS tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,12 +30,17 @@ To enable them for your GOV.UK account add them to your account in [Signon](http
 ### Running the test suite
 
 ```
-# ruby tests
-bundle exec rspec
+bundle exec rake
+```
 
-# JS tests (in console, or in browser)
-bundle exec rake jasmine:ci
+To run JavaScript tests (only):
+
+```
+# run JS tests in browser
 bundle exec rake jasmine
+
+# run JS tests on command line
+bundle exec rake jasmine:ci
 ```
 
 > [Our test environment is setup to render 'real' error pages, instead of raising an exception](https://github.com/alphagov/content-publisher/commit/184a93d23551161125c1ac6ff3d9287eafabbc3d). This can make it hard to debug a test failure, as the actual error won't appear in the test output. Instead, you can see it in `log/test.log`.


### PR DESCRIPTION
In response to: https://github.com/alphagov/govuk_publishing_components/pull/2060#discussion_r631761457

This makes the format consistent with other repos. I've also changed
the overall test command to "rake", which is what we have in all our
other repos. If we need to tell people how to check which framework
is being used, we should do this centrally.


⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️