### PR TITLE
Allow attachments to show accessible form link in preview

### DIFF
--- a/lib/govspeak_document/in_app_options.rb
+++ b/lib/govspeak_document/in_app_options.rb
@@ -22,7 +22,10 @@ private
   def attachment_attributes(attachment_revision)
     alt_email = Organisations.new(edition).alternative_format_contact_email
     attributes = file_attachment_attributes(attachment_revision, edition)
-    attributes.merge(alternative_format_contact_email: alt_email)
+    attributes[:alternative_format_contact_email] = alt_email
+    attributes[:owning_document_content_id] = edition.content_id
+    attributes[:attachment_id] = attachment_revision.file_attachment_id
+    attributes
   end
 
   def image_attributes(image_revision)

--- a/spec/lib/govspeak_document/in_app_options_spec.rb
+++ b/spec/lib/govspeak_document/in_app_options_spec.rb
@@ -44,16 +44,16 @@ RSpec.describe GovspeakDocument::InAppOptions do
 
       in_app_options = described_class.new("govspeak", edition)
       actual_attachment_options = in_app_options.to_h[:attachments].first
-
       expect(actual_attachment_options).to match(
         a_hash_including(
-          id: "13kb-1-page-attachment.pdf",
+          attachment_id: attachment_revision.file_attachment_id,
           filename: "13kb-1-page-attachment.pdf",
           title: "A title",
           content_type: "application/pdf",
           number_of_pages: 1,
           file_size: 13_264,
           url: preview_file_attachment_path(edition.document, attachment_revision.file_attachment),
+          owning_document_content_id: edition.content_id,
           alternative_format_contact_email: "foo@bar.com",
         ),
       )


### PR DESCRIPTION
In order for attachments to render a link to the request accessible format form, we need to supply the attachment_id and the owning_document_content_id. This commit adds these to the attachment_attributes hash so that the correct link may be displayed in the in-app preview.

Note: this change is dependant on [this update being made to govuk_publishing_components](https://github.com/alphagov/govuk_publishing_components/pull/2636)

[trello](https://trello.com/c/rKvWEhgJ/1095-accessible-format-request-content-publisher-add-parent-document-contentid-to-the-attachment-model)