### PR TITLE
Bump GOVUK Publishing components version

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -180,12 +180,13 @@ GEM
     govuk_personalisation (0.11.2)
       plek (>= 1.9.0)
       rails (>= 6, < 8)
-    govuk_publishing_components (28.6.0)
+    govuk_publishing_components (28.8.0)
       govuk_app_config
       govuk_personalisation (>= 0.7.0)
       kramdown
       plek
-      rails (~> 6)
+      psych (>= 4)
+      rails (>= 6)
       rouge
       sprockets (< 4)
     govuk_schemas (4.3.0)
@@ -322,6 +323,8 @@ GEM
     pg (1.2.3)
     phantomjs (2.1.1.0)
     plek (4.0.0)
+    psych (4.0.3)
+      stringio
     public_suffix (4.0.6)
     puma (5.6.2)
       nio4r (~> 2.0)
@@ -483,6 +486,7 @@ GEM
       activesupport (>= 5.2)
       sprockets (>= 3.0.0)
     statsd-ruby (1.5.0)
+    stringio (3.0.1)
     thor (1.2.1)
     thwait (0.2.0)
       e2mmap

--- a/app/models/document_type.rb
+++ b/app/models/document_type.rb
@@ -16,7 +16,7 @@ class DocumentType
 
   def self.all
     @all ||= begin
-      hashes = YAML.load_file(Rails.root.join("config/document_types.yml"))["document_types"]
+      hashes = YAML.unsafe_load_file(Rails.root.join("config/document_types.yml"))["document_types"]
 
       hashes.map do |hash|
         hash["contents"] = hash["contents"].to_a.map do |field_id|

--- a/app/models/document_type_selection.rb
+++ b/app/models/document_type_selection.rb
@@ -10,7 +10,7 @@ class DocumentTypeSelection
 
   def self.all
     @all ||= begin
-      hashes = YAML.load_file(Rails.root.join("config/document_type_selections.yml"))
+      hashes = YAML.unsafe_load_file(Rails.root.join("config/document_type_selections.yml"))
 
       hashes.map do |hash|
         hash["options"].map! do |option|

--- a/lib/political_edition_identifier.rb
+++ b/lib/political_edition_identifier.rb
@@ -1,6 +1,6 @@
 class PoliticalEditionIdentifier
   def self.political_organisation_ids
-    @political_organisation_ids ||= YAML.load_file(
+    @political_organisation_ids ||= YAML.unsafe_load_file(
       Rails.root.join("config/political_organisations.yml"),
     )
   end

--- a/spec/models/document_type_selection_spec.rb
+++ b/spec/models/document_type_selection_spec.rb
@@ -1,7 +1,7 @@
 require "json"
 
 RSpec.describe DocumentTypeSelection do
-  let(:document_type_selections) { YAML.load_file(Rails.root.join("config/document_type_selections.yml")) }
+  let(:document_type_selections) { YAML.unsafe_load_file(Rails.root.join("config/document_type_selections.yml")) }
 
   describe "all configured document types selections are valid" do
     it "conforms to the document type selection schema" do

--- a/spec/models/document_type_spec.rb
+++ b/spec/models/document_type_spec.rb
@@ -1,7 +1,7 @@
 require "json"
 
 RSpec.describe DocumentType do
-  let(:document_types) { YAML.load_file(Rails.root.join("config/document_types.yml"))["document_types"] }
+  let(:document_types) { YAML.unsafe_load_file(Rails.root.join("config/document_types.yml"))["document_types"] }
 
   describe "all configured document types are valid" do
     it "conforms to the document type schema" do


### PR DESCRIPTION
Bumps GOVUK Publishing components version and updates the way we load YAML files.

Testing the new components version prior to updating the way we load YAML files caused Psych errors: https://sentry.io/organizations/govuk/issues/3061364084/?environment=integration-blue-aws&project=1242052&query=is%3Aunresolved. 

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️
