### PR TITLE
Adds attachment payload data and fix attachment id

### DIFF
--- a/lib/govspeak_document/in_app_options.rb
+++ b/lib/govspeak_document/in_app_options.rb
@@ -22,10 +22,11 @@ private
   def attachment_attributes(attachment_revision)
     alt_email = Organisations.new(edition).alternative_format_contact_email
     attributes = file_attachment_attributes(attachment_revision, edition)
-    attributes[:alternative_format_contact_email] = alt_email
-    attributes[:owning_document_content_id] = edition.content_id
-    attributes[:attachment_id] = attachment_revision.file_attachment_id
-    attributes
+    attributes.merge(
+      alternative_format_contact_email: alt_email,
+      owning_document_content_id: edition.content_id,
+      attachment_id: attachment_revision.filename,
+    )
   end
 
   def image_attributes(image_revision)

--- a/lib/govspeak_document/payload_options.rb
+++ b/lib/govspeak_document/payload_options.rb
@@ -38,6 +38,8 @@ private
     attributes.merge(
       url: attachment_revision.asset_url,
       alternative_format_contact_email: alt_email,
+      owning_document_content_id: edition.content_id,
+      attachment_id: attachment_revision.filename,
     )
   end
 end

--- a/spec/lib/govspeak_document/in_app_options_spec.rb
+++ b/spec/lib/govspeak_document/in_app_options_spec.rb
@@ -46,7 +46,7 @@ RSpec.describe GovspeakDocument::InAppOptions do
       actual_attachment_options = in_app_options.to_h[:attachments].first
       expect(actual_attachment_options).to match(
         a_hash_including(
-          attachment_id: attachment_revision.file_attachment_id,
+          attachment_id: "13kb-1-page-attachment.pdf",
           filename: "13kb-1-page-attachment.pdf",
           title: "A title",
           content_type: "application/pdf",

--- a/spec/lib/govspeak_document/payload_options_spec.rb
+++ b/spec/lib/govspeak_document/payload_options_spec.rb
@@ -48,6 +48,7 @@ RSpec.describe GovspeakDocument::PayloadOptions do
       expect(actual_attachment_options).to match(
         a_hash_including(
           id: "13kb-1-page-attachment.pdf",
+          attachment_id: "13kb-1-page-attachment.pdf",
           filename: "13kb-1-page-attachment.pdf",
           title: "A title",
           content_type: "application/pdf",
@@ -55,6 +56,7 @@ RSpec.describe GovspeakDocument::PayloadOptions do
           file_size: 13_264,
           url: a_string_matching(%r{/media/.*/13kb-1-page-attachment.pdf}),
           alternative_format_contact_email: "foo@bar.com",
+          owning_document_content_id: edition.content_id,
         ),
       )
     end


### PR DESCRIPTION
This commit does two things:

- Adds two attributes to the outgoing payload to Publishing API for
attachments. These are needed to view the new accessible format link
[1].

- Fixed the `attachment_id` for in_app (markdown preview) and
payload_options (Publishing API payload) which was previously pointing
at the incorrect ID, as the attachment ID is the filename in Content
Publisher [2].

[1]: https://github.com/alphagov/govuk_publishing_components/blob/8b8219aa9f8ca615d033c7fb3cd703b5f00e0bed/app/views/govuk_publishing_components/components/_attachment.html.erb#L86
[2]: https://github.com/alphagov/content-publisher/blob/f83065eea9d1e2c617d3c613d8842557af23ca7a/app/helpers/file_attachment_helper.rb#L9

## Screenshots 

### Link being displayed for document published by content publisher

<img width="1065" alt="Screenshot 2022-03-28 at 13 04 50" src="https://user-images.githubusercontent.com/24479188/160394215-1cf6c551-122d-4ee8-9763-d04a574a1bd4.png">

### Following the link starts the accessible format journey

<img width="1443" alt="Screenshot 2022-03-28 at 13 04 55" src="https://user-images.githubusercontent.com/24479188/160394222-9f5e55b2-f3f9-4d39-8d0e-8d0bebe18966.png">


⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️
