### PR TITLE
Resolve yarn install issues

### DIFF
--- a/package.json
+++ b/package.json
@@ -40,7 +40,7 @@
   "dependencies": {
     "@webcomponents/custom-elements": "^1.4.1",
     "abortcontroller-polyfill": "^1.4.0",
-    "accessible-autocomplete": "git://github.com/kevindew/accessible-autocomplete.git",
+    "accessible-autocomplete": "kevindew/accessible-autocomplete",
     "core-js-bundle": "^3.6.5",
     "cropperjs": "^1.5.6",
     "es5-polyfill": "^0.0.6",

--- a/yarn.lock
+++ b/yarn.lock
@@ -103,9 +103,9 @@ accepts@~1.3.8:
     mime-types "~2.1.34"
     negotiator "0.6.3"
 
-"accessible-autocomplete@git://github.com/kevindew/accessible-autocomplete.git":
+accessible-autocomplete@kevindew/accessible-autocomplete:
   version "1.6.2"
-  resolved "git://github.com/kevindew/accessible-autocomplete.git#62b3992f9d3f2da6c7ea5bc0e302b9e453234271"
+  resolved "https://codeload.github.com/kevindew/accessible-autocomplete/tar.gz/62b3992f9d3f2da6c7ea5bc0e302b9e453234271"
   dependencies:
     preact "^8.3.1"
 


### PR DESCRIPTION
This fixes an issue we've seen in govuk-docker:

yarn install v1.22.17
[1/4] Resolving packages...
[2/4] Fetching packages...
error Command failed.
Exit code: 128
Command: git
Arguments: ls-remote --tags --heads git://github.com/kevindew/accessible-autocomplete.git
Directory: /govuk/content-publisher
Output:
fatal: remote error:
  The unauthenticated git protocol on port 9418 is no longer supported.
Please see https://github.blog/2021-09-01-improving-git-protocol-security-github/ for more information.
info Visit https://yarnpkg.com/en/docs/cli/install for documentation about this command.

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️
