### PR TITLE
Clarify difference between the two removal tasks

### DIFF
--- a/docs/removing-documents.md
+++ b/docs/removing-documents.md
@@ -18,7 +18,11 @@ email address, for example:
 the change can be associated with you, the developer that performed the task,
 and attributed correctly in the document history.
 
-## Removing documents
+## Remove a document
+
+### Return a `410 Gone` response
+
+This will remove a document, and future requests for it will return a `410 Gone` response.
 
 Required parameters:
 
@@ -35,7 +39,9 @@ Optional parameters:
 rake remove:gone['a-content-id']
 ```
 
-## Redirect removed documents to another page on GOV.UK
+### Redirect to a different URL
+
+This will remove a document, and future requests for it will redirect to the specified URL.
 
 Required parameters:
 


### PR DESCRIPTION
This change clarifies the difference between the two `remove:` rake tasks in Content Publisher.

Whilst removing and redirecting a document, we found the instructions didn't clearly explain that the `remove:redirect` task would both remove AND redirect the document. It wasn't clear if `remove:gone` needed to be run first or not.

It turns out both tasks will remove the document – so I've tried to tweak the wording to make that more obvious.

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️
