### PR TITLE
Remove support for request accessible format form pilot

### DIFF
--- a/lib/govspeak_document/in_app_options.rb
+++ b/lib/govspeak_document/in_app_options.rb
@@ -22,11 +22,7 @@ private
   def attachment_attributes(attachment_revision)
     alt_email = Organisations.new(edition).alternative_format_contact_email
     attributes = file_attachment_attributes(attachment_revision, edition)
-    attributes.merge(
-      alternative_format_contact_email: alt_email,
-      owning_document_content_id: edition.content_id,
-      attachment_id: attachment_revision.filename,
-    )
+    attributes.merge(alternative_format_contact_email: alt_email)
   end
 
   def image_attributes(image_revision)

--- a/lib/govspeak_document/payload_options.rb
+++ b/lib/govspeak_document/payload_options.rb
@@ -38,8 +38,6 @@ private
     attributes.merge(
       url: attachment_revision.asset_url,
       alternative_format_contact_email: alt_email,
-      owning_document_content_id: edition.content_id,
-      attachment_id: attachment_revision.filename,
     )
   end
 end

--- a/spec/lib/govspeak_document/in_app_options_spec.rb
+++ b/spec/lib/govspeak_document/in_app_options_spec.rb
@@ -46,14 +46,12 @@ RSpec.describe GovspeakDocument::InAppOptions do
       actual_attachment_options = in_app_options.to_h[:attachments].first
       expect(actual_attachment_options).to match(
         a_hash_including(
-          attachment_id: "13kb-1-page-attachment.pdf",
           filename: "13kb-1-page-attachment.pdf",
           title: "A title",
           content_type: "application/pdf",
           number_of_pages: 1,
           file_size: 13_264,
           url: preview_file_attachment_path(edition.document, attachment_revision.file_attachment),
-          owning_document_content_id: edition.content_id,
           alternative_format_contact_email: "foo@bar.com",
         ),
       )

--- a/spec/lib/govspeak_document/payload_options_spec.rb
+++ b/spec/lib/govspeak_document/payload_options_spec.rb
@@ -48,7 +48,6 @@ RSpec.describe GovspeakDocument::PayloadOptions do
       expect(actual_attachment_options).to match(
         a_hash_including(
           id: "13kb-1-page-attachment.pdf",
-          attachment_id: "13kb-1-page-attachment.pdf",
           filename: "13kb-1-page-attachment.pdf",
           title: "A title",
           content_type: "application/pdf",
@@ -56,7 +55,6 @@ RSpec.describe GovspeakDocument::PayloadOptions do
           file_size: 13_264,
           url: a_string_matching(%r{/media/.*/13kb-1-page-attachment.pdf}),
           alternative_format_contact_email: "foo@bar.com",
-          owning_document_content_id: edition.content_id,
         ),
       )
     end


### PR DESCRIPTION
Now that there are no longer any departments taking part, remove code
while we rethink.

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

https://trello.com/c/iZEzpeFy/1340-remove-dfe-from-the-accessible-format-pilot
