### PR TITLE
Revert "Bump govuk_publishing_components from 29.14.0 to 29.15.0"

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -162,7 +162,7 @@ GEM
     govuk_personalisation (0.12.0)
       plek (>= 1.9.0)
       rails (>= 6, < 8)
-    govuk_publishing_components (29.15.0)
+    govuk_publishing_components (29.14.0)
       govuk_app_config
       govuk_personalisation (>= 0.7.0)
       kramdown


### PR DESCRIPTION
Reverts alphagov/content-publisher#2539 due to backwards compatibility bug in 29.15.0. See: https://github.com/alphagov/govuk_publishing_components/issues/2861