### PR TITLE
Fixes incorrectly applied .forEach

### DIFF
--- a/app/assets/javascripts/components/autocomplete.js
+++ b/app/assets/javascripts/components/autocomplete.js
@@ -36,7 +36,7 @@ window.GOVUK.Modules = window.GOVUK.Modules || {};
       id: $select.id,
       source: function (query, syncResults) {
         var results = []
-        $select.options.forEach(function ($el) {
+        Array.from($select.options).forEach(function ($el) {
           results.push({ text: $el.textContent, hint: $el.dataset.hint || '', value: $el.value })
         })
         var resultMatcher = function (result) {


### PR DESCRIPTION
`.forEach` was incorrectly made available to all DOM Iterators in core-js. This has now been fixed in the package: https://github.com/zloirock/core-js/issues/988

The recommended approach for HTMLCollections objects is to use `Array.from` (https://developer.mozilla.org/en-US/docs/Web/API/HTMLCollection). This has been applied to the code to support the `.forEach` function.

This was originally noticed when updating the yarn.lock file in PR #2551.

Credits: @ollietreend for finding the solution.

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️
