### PR TITLE
Remove auto-tagging to legacy-taxons (aka specialist topics)

### DIFF
--- a/app/models/document_topics.rb
+++ b/app/models/document_topics.rb
@@ -42,7 +42,6 @@ class DocumentTopics
       document.content_id,
       links: {
         taxons: leaf_topic_content_ids + unknown_taxon_content_ids,
-        topics: legacy_topic_content_ids,
       },
       previous_version: version,
     )
@@ -57,9 +56,5 @@ private
   def leaf_topic_content_ids
     superfluous_topics = topics.map(&:ancestors).flatten
     (topics - superfluous_topics).map(&:content_id)
-  end
-
-  def legacy_topic_content_ids
-    []
   end
 end

--- a/app/models/document_topics.rb
+++ b/app/models/document_topics.rb
@@ -60,7 +60,6 @@ private
   end
 
   def legacy_topic_content_ids
-    breadcrumbs = topics.map(&:breadcrumb).flatten
-    breadcrumbs.map(&:legacy_topic_content_ids).flatten.uniq
+    []
   end
 end

--- a/app/models/topic.rb
+++ b/app/models/topic.rb
@@ -10,7 +10,7 @@ class Topic
     raw_topic ? new(raw_topic.merge(index: index)) : nil
   end
 
-  attr_accessor :title, :child_content_ids, :legacy_topic_content_ids, :parent_content_id, :content_id, :index
+  attr_accessor :title, :child_content_ids, :parent_content_id, :content_id, :index
 
   delegate :hash, to: :content_id
 

--- a/lib/topic_index.rb
+++ b/lib/topic_index.rb
@@ -19,7 +19,6 @@ private
         content_id: GOVUK_HOMEPAGE_CONTENT_ID,
         title: "GOV.UK Homepage",
         child_content_ids: raw_level_one_topics.map { |raw_topic| raw_topic["content_id"] },
-        legacy_topic_content_ids: [],
       }
 
       topic_index = { GOVUK_HOMEPAGE_CONTENT_ID => govuk_homepage_topic }
@@ -56,16 +55,11 @@ private
         title: raw_topic["title"],
         child_content_ids: raw_child_topics.map { |raw_child_topic| raw_child_topic["content_id"] },
         parent_content_id: raw_parent_topic["content_id"],
-        legacy_topic_content_ids: legacy_topic_content_ids(raw_topic),
       }
 
       topic_index[raw_topic["content_id"]] = topic
       unroll(topic_index, raw_child_topics, raw_topic)
     end
-  end
-
-  def legacy_topic_content_ids(_raw_topic)
-    []
   end
 
   def publishing_api

--- a/lib/topic_index.rb
+++ b/lib/topic_index.rb
@@ -64,10 +64,8 @@ private
     end
   end
 
-  def legacy_topic_content_ids(raw_topic)
-    legacy_taxons = raw_topic.dig("links", "legacy_taxons").to_a
-    legacy_taxons = legacy_taxons.select { |legacy_taxon| legacy_taxon["document_type"] == "topic" }
-    legacy_taxons.map { |legacy_taxon| legacy_taxon["content_id"] }
+  def legacy_topic_content_ids(_raw_topic)
+    []
   end
 
   def publishing_api

--- a/spec/features/editing_topics/edit_topics_search_spec.rb
+++ b/spec/features/editing_topics/edit_topics_search_spec.rb
@@ -58,7 +58,7 @@ RSpec.feature "Edit topics using search", js: true do
       @edition.content_id,
       "links" => {
         "taxons" => %w[level_two_topic],
-        "topics" => %w[specialist_sector_1 specialist_sector_2],
+        "topics" => %w[],
       },
       "previous_version" => 3,
     )

--- a/spec/features/editing_topics/edit_topics_search_spec.rb
+++ b/spec/features/editing_topics/edit_topics_search_spec.rb
@@ -58,7 +58,6 @@ RSpec.feature "Edit topics using search", js: true do
       @edition.content_id,
       "links" => {
         "taxons" => %w[level_two_topic],
-        "topics" => %w[],
       },
       "previous_version" => 3,
     )

--- a/spec/features/editing_topics/edit_topics_spec.rb
+++ b/spec/features/editing_topics/edit_topics_spec.rb
@@ -50,7 +50,6 @@ RSpec.feature "Edit topics" do
       @edition.content_id,
       "links" => {
         "taxons" => %w[level_two_topic],
-        "topics" => %w[],
       },
       "previous_version" => 3,
     )

--- a/spec/features/editing_topics/edit_topics_spec.rb
+++ b/spec/features/editing_topics/edit_topics_spec.rb
@@ -50,7 +50,7 @@ RSpec.feature "Edit topics" do
       @edition.content_id,
       "links" => {
         "taxons" => %w[level_two_topic],
-        "topics" => %w[specialist_sector_1 specialist_sector_2],
+        "topics" => %w[],
       },
       "previous_version" => 3,
     )

--- a/spec/models/document_topics_spec.rb
+++ b/spec/models/document_topics_spec.rb
@@ -69,7 +69,6 @@ RSpec.describe DocumentTopics do
         expected_links = {
           links: {
             taxons: %w[level_one_topic],
-            topics: %w[],
           },
           previous_version: 1,
         }
@@ -97,7 +96,6 @@ RSpec.describe DocumentTopics do
         expected_links = {
           links: {
             taxons: %w[level_two_topic],
-            topics: %w[],
           },
           previous_version: 1,
         }
@@ -125,7 +123,6 @@ RSpec.describe DocumentTopics do
         expected_links = {
           links: {
             taxons: %w[level_two_topic unknown_taxon_content_id],
-            topics: %w[],
           },
           previous_version: 1,
         }

--- a/spec/models/document_topics_spec.rb
+++ b/spec/models/document_topics_spec.rb
@@ -69,7 +69,7 @@ RSpec.describe DocumentTopics do
         expected_links = {
           links: {
             taxons: %w[level_one_topic],
-            topics: %w[specialist_sector_1],
+            topics: %w[],
           },
           previous_version: 1,
         }
@@ -97,7 +97,7 @@ RSpec.describe DocumentTopics do
         expected_links = {
           links: {
             taxons: %w[level_two_topic],
-            topics: %w[specialist_sector_1 specialist_sector_2],
+            topics: %w[],
           },
           previous_version: 1,
         }
@@ -125,7 +125,7 @@ RSpec.describe DocumentTopics do
         expected_links = {
           links: {
             taxons: %w[level_two_topic unknown_taxon_content_id],
-            topics: %w[specialist_sector_1 specialist_sector_2],
+            topics: %w[],
           },
           previous_version: 1,
         }

--- a/spec/requests/topics_spec.rb
+++ b/spec/requests/topics_spec.rb
@@ -51,11 +51,11 @@ RSpec.describe "Topics" do
     it "redirects to topics with an alert when there is a topic version conflict" do
       stub_publishing_api_patch_links_conflict(
         edition.content_id,
-        "links" => { "taxons" => [], "topics" => [] },
+        "links" => { "taxons" => [] },
         "previous_version" => 2,
       )
 
-      patch topics_path(edition.document), params: { topics: [], version: 2 }
+      patch topics_path(edition.document), params: { taxons: [], version: 2 }
 
       expect(response).to redirect_to(topics_path(edition.document))
       follow_redirect!

--- a/spec/support/topics_helper.rb
+++ b/spec/support/topics_helper.rb
@@ -26,15 +26,6 @@ module TopicsHelper
       {
         "content_id" => "level_one_topic",
         "expanded_links" => {
-          "legacy_taxons" => [
-            {
-              "content_id" => "specialist_sector_1",
-              "document_type" => "topic",
-            },
-            {
-              "content_id" => "another_legacy_taxon",
-            },
-          ],
           "child_taxons" => [
             {
               "content_id" => "level_two_topic",
@@ -45,12 +36,6 @@ module TopicsHelper
                     "content_id" => "level_three_topic",
                     "title" => "Level Three Topic",
                     "links" => {},
-                  },
-                ],
-                "legacy_taxons" => [
-                  {
-                    "content_id" => "specialist_sector_2",
-                    "document_type" => "topic",
                   },
                 ],
               },


### PR DESCRIPTION
## Old behaviour

When a user tags their document to the topic taxonomy, sometimes the document is auto-tagged to a specialist topic. This happens when the topic taxonomy tag (`taxon`) has been provided with a mapped legacy_taxon value in Content Tagger.

## New behaviour

Do not automatically tag documents to the specialist topic tree.

## No user facing changes

**Related PR and full explanation of why we are removing auto-tagging**: https://github.com/alphagov/whitehall/pull/6646

**Trello**: https://trello.com/c/u5dnc3HW/1285-remove-autotagging-to-legacy-taxons-from-content-publisher-m