### PR TITLE
Fix redirecting to external host on NewDocumentController

### DIFF
--- a/app/controllers/new_document_controller.rb
+++ b/app/controllers/new_document_controller.rb
@@ -30,7 +30,7 @@ class NewDocumentController < ApplicationController
                       new_document_path(type: selected_option.id)
                     end
 
-      redirect_to destination
+      redirect_to destination, allow_other_host: true
     end
   end
 end

--- a/spec/requests/new_document_spec.rb
+++ b/spec/requests/new_document_spec.rb
@@ -33,6 +33,12 @@ RSpec.describe "New Document" do
       expect(response).to redirect_to(guidance_url)
     end
 
+    it "can redirect a managed elsewhere link on a different host" do
+      post new_document_path, params: { type: "news", selected_option_id: "speech" }
+
+      expect(response).to redirect_to("https://whitehall-admin.test.gov.uk/government/admin/speeches/new")
+    end
+
     it "asks the user to refine their selection when the document type has subtypes" do
       post new_document_path, params: { type: "root", selected_option_id: "news" }
 


### PR DESCRIPTION
This controller redirects to both local and external hosts. This problem wasn't identified as the test only checked local requests.

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️
