### PR TITLE
Add a default component for Attachment Meta component guide

### DIFF
--- a/app/views/components/docs/attachment_meta.yml
+++ b/app/views/components/docs/attachment_meta.yml
@@ -7,9 +7,7 @@ body: |
   not desired.
 part_of_admin_layout: true
 examples:
-  unofficial_document:
-    description: |
-      Unofficial document
+  default:
     data:
       attachment:
         title: "The government financial reporting review"


### PR DESCRIPTION
Components require a default rendering of a component, which is labeled with default. Without it errors occur when viewing a component preview [1].

I did wonder if there was a better way this could be handled in GOV.UK Publishing Components, as this just produces a cryptic exception when it fails. However both routes I considered seemed problematic:

1) Don't assume there is a "default" example and instead label all
   examples with their descriptions. This conflicts with various aspects
   of the design for component guide and would require some design
   changes
2) Have something that checks the YAML validity of this collection.
   There is no YAML checks in the component guide, so adding some in for
   this would be unconventional and adding it for the whole file would
   be a relatively large task.

Hence I took the simple option.

[1]: https://sentry.io/organizations/govuk/issues/3628526419/?referrer=slack

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️
