### PR TITLE
Fix link to docs in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,7 +48,7 @@ yarn run jasmine:ci
 ### Further documentation
 
 - [Approach to analytics](docs/approach-to-analytics.md)
-- [Editing change note history](docs/editing-change-note-history.md)
+- [Editing change note history](docs/edit-change-note-history.md)
 - [History mode](docs/history-mode.md)
 - [Importing documents from Whitehall](docs/import-from-whitehall.md)
 - [Removing documents](docs/removing-documents.md)


### PR DESCRIPTION
Change link from `https://github.com/alphagov/content-publisher/blob/main/docs/editing-change-note-history.md` to `https://github.com/alphagov/content-publisher/blob/main/docs/edit-change-note-history.md`

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

Follow [these steps](https://guides.rubyonrails.org/upgrading_ruby_on_rails.html) if you are doing a Rails upgrade.
