### PR TITLE
Add container image build for running on Kubernetes.

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,13 @@
+.dockerignore
+.git
+.gitignore
+Dockerfile
+Jenkinsfile
+Procfile
+README.md
+coverage
+docs
+log
+node_modules
+spec
+tmp

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,34 @@
+ARG ruby_version=3.1.2
+ARG base_image=ghcr.io/alphagov/govuk-ruby-base:$ruby_version
+ARG builder_image=ghcr.io/alphagov/govuk-ruby-builder:$ruby_version
+
+FROM $builder_image AS builder
+
+ENV JWT_AUTH_SECRET=unused_yet_required \
+    SECRET_KEY_BASE=unused_yet_required
+
+WORKDIR $APP_HOME
+COPY Gemfile Gemfile.lock .ruby-version ./
+RUN bundle install
+COPY package.json yarn.lock ./
+RUN yarn install --production --frozen-lockfile --non-interactive --link-duplicates
+COPY . ./
+RUN bundle exec bootsnap precompile --gemfile .
+RUN bundle exec rails assets:precompile && rm -fr log
+
+
+FROM $base_image
+
+ENV GOVUK_APP_NAME=content-publisher
+
+RUN install_packages imagemagick
+
+WORKDIR $APP_HOME
+COPY --from=builder /usr/bin/node* /usr/bin/
+COPY --from=builder /usr/lib/node_modules/ /usr/lib/node_modules/
+COPY --from=builder $BUNDLE_PATH/ $BUNDLE_PATH/
+COPY --from=builder $BOOTSNAP_CACHE_DIR/ $BOOTSNAP_CACHE_DIR/
+COPY --from=builder $APP_HOME ./
+
+USER app
+CMD ["puma"]

--- a/config/application.rb
+++ b/config/application.rb
@@ -64,6 +64,10 @@ module ContentPublisher
     # https://github.com/alphagov/govuk-frontend/issues/1350
     config.assets.css_compressor = nil
 
+    # Set asset path to be application specific so that we can put all GOV.UK
+    # assets into an S3 bucket and distinguish app by path.
+    config.assets.prefix = "/assets/content-publisher"
+
     unless Rails.application.secrets.jwt_auth_secret
       raise "JWT auth secret is not configured. See config/secrets.yml"
     end

--- a/config/sidekiq.yml
+++ b/config/sidekiq.yml
@@ -2,7 +2,9 @@
 :verbose: false
 :concurrency: 10
 :max_retries: 0
-:logfile: ./log/sidekiq.json.log
+<% if ENV.key?('SIDEKIQ_LOGFILE') %>
+:logfile: <%= ENV['SIDEKIQ_LOGFILE'] %>
+<% end %>
 development:
   :logfile: null
 :queues:

--- a/spec/support/jasmine-browser.json
+++ b/spec/support/jasmine-browser.json
@@ -1,5 +1,5 @@
 {
-  "srcDir": "public/assets",
+  "srcDir": "public/assets/content-publisher",
   "srcFiles": [
     "application-*.js"
   ],


### PR DESCRIPTION
- Add Dockerfile and .dockerignore
- Fix Rails assets path to include the app name so that assets remain namespaced when uploaded to S3.
- Have Sidekiq log to stdout by default.

Content Publisher is similar to Whitehall in that it has an image (JPEG, PNG etc.) upload feature and expects to be able to exec Imagemagick binaries but doesn't check for them on startup. It also uses Bootsnap and Yarn.

Tested: builds locally on Docker Desktop and runs as far as Puma startup (needs external dependencies to go further so makes sense to test on the integration cluster beyond that point).