### PR TITLE
Remove outdated pin and comment

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -15,7 +15,7 @@ gem "image_processing"
 gem "inline_svg"
 gem "interactor"
 gem "kaminari"
-gem "mail", "~> 2.8.0"  # TODO: remove once https://github.com/mikel/mail/issues/1489 is fixed.
+gem "mail"
 gem "mail-notify"
 gem "pdf-reader"
 gem "pg"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -544,7 +544,7 @@ DEPENDENCIES
   json_matchers
   kaminari
   listen
-  mail (~> 2.8.0)
+  mail
   mail-notify
   pdf-reader
   pg


### PR DESCRIPTION
These are no longer needed since https://github.com/mikel/mail/issues/1489 is fixed.

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

Follow [these steps](https://guides.rubyonrails.org/upgrading_ruby_on_rails.html) if you are doing a Rails upgrade.
