### PR TITLE
Remove the ability for users to create new news articles

### DIFF
--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -7,6 +7,7 @@ class User < ApplicationRecord
   MANAGING_EDITOR_PERMISSION = "managing_editor".freeze
   ACCESS_LIMIT_OVERRIDE_PERMISSION = "access_limit_override".freeze
   MANAGE_LIVE_HISTORY_MODE = "manage_live_history_mode".freeze
+  CREATE_NEW_DOCUMENT_PERMISSION = "create_new_document".freeze
 
   def can_access?(edition)
     return true unless edition.access_limit

--- a/app/views/documents/index.html.erb
+++ b/app/views/documents/index.html.erb
@@ -1,11 +1,13 @@
 <% content_for :title, t("documents.index.title") %>
 
-<% content_for :title_side, render("govuk_publishing_components/components/button", {
-  text: "Create new document",
-  href: new_document_path,
-  margin_bottom: true,
-  data_attributes: { gtm: "new-document" }
-}) %>
+<% if current_user.has_permission?(User::CREATE_NEW_DOCUMENT_PERMISSION) %>
+  <% content_for :title_side, render("govuk_publishing_components/components/button", {
+    text: "Create new document",
+    href: new_document_path,
+    margin_bottom: true,
+    data_attributes: { gtm: "new-document" }
+  }) %>
+<% end %>
 
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-one-quarter">

--- a/spec/features/formats/news_article_spec.rb
+++ b/spec/features/formats/news_article_spec.rb
@@ -2,9 +2,14 @@ RSpec.describe "News article format" do
   include TopicsHelper
 
   scenario do
+    when_i_have_the_create_new_document_permission
     when_i_choose_this_document_type
     and_i_fill_in_the_form_fields
     then_the_document_should_be_previewable
+  end
+
+  def when_i_have_the_create_new_document_permission
+    current_user.update(permissions: [User::CREATE_NEW_DOCUMENT_PERMISSION])
   end
 
   def when_i_choose_this_document_type

--- a/spec/features/formats/publication_spec.rb
+++ b/spec/features/formats/publication_spec.rb
@@ -1,8 +1,13 @@
 RSpec.describe "Publication format" do
   scenario do
+    when_i_have_the_create_new_document_permission
     when_i_choose_this_document_type
     and_i_fill_in_the_form_fields
     then_the_document_should_be_previewable
+  end
+
+  def when_i_have_the_create_new_document_permission
+    current_user.update(permissions: [User::CREATE_NEW_DOCUMENT_PERMISSION, User::PRE_RELEASE_FEATURES_PERMISSION])
   end
 
   def when_i_choose_this_document_type

--- a/spec/features/workflow/create_document_spec.rb
+++ b/spec/features/workflow/create_document_spec.rb
@@ -1,5 +1,6 @@
 RSpec.feature "Create a document" do
   scenario do
+    when_i_have_the_create_new_document_permission
     given_i_am_on_the_home_page
     when_i_click_to_create_a_document
     and_i_select_a_supertype
@@ -7,6 +8,10 @@ RSpec.feature "Create a document" do
     and_i_fill_in_the_contents
     then_i_see_the_document_summary
     and_i_see_the_timeline_entry
+  end
+
+  def when_i_have_the_create_new_document_permission
+    current_user.update(permissions: [User::CREATE_NEW_DOCUMENT_PERMISSION])
   end
 
   def given_i_am_on_the_home_page


### PR DESCRIPTION
Users should still be able to edit existing documents. We want to reduce publishing news articles to zero, so that we can eventually retire content publisher.

[Trello card](https://trello.com/c/HLbTAFfK/1497-remove-the-ability-for-users-to-create-new-news-articles-in-content-publisher-or-banner)

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

Follow [these steps](https://guides.rubyonrails.org/upgrading_ruby_on_rails.html) if you are doing a Rails upgrade.
