### PR TITLE
Move google tag manager snippet

### DIFF
--- a/app/views/layouts/_google_tag_manager.html.erb
+++ b/app/views/layouts/_google_tag_manager.html.erb
@@ -1,0 +1,7 @@
+<% if ENV["GOOGLE_TAG_MANAGER_ID"] %>
+  <%= render "govuk_publishing_components/components/google_tag_manager_script", {
+    gtm_id: ENV["GOOGLE_TAG_MANAGER_ID"],
+    gtm_auth: ENV["GOOGLE_TAG_MANAGER_AUTH"],
+    gtm_preview: ENV["GOOGLE_TAG_MANAGER_PREVIEW"]
+  } %>
+<% end %>

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -13,13 +13,7 @@
     dataLayer.push({ 'gtm.blacklist': ['html', 'customScripts', 'nonGoogleScripts', 'customPixels'] });
   </script>
 
-  <% if ENV["GOOGLE_TAG_MANAGER_ID"] %>
-    <%= render "govuk_publishing_components/components/google_tag_manager_script", {
-      gtm_id: ENV["GOOGLE_TAG_MANAGER_ID"],
-      gtm_auth: ENV["GOOGLE_TAG_MANAGER_AUTH"],
-      gtm_preview: ENV["GOOGLE_TAG_MANAGER_PREVIEW"]
-    } %>
-  <% end %>
+<% render "layouts/google_tag_manager" %>
 
   <meta name="app-environment" content="<%= Rails.env %>">
 <% end %>


### PR DESCRIPTION
In order to be consistent with the other publishing apps we have moved the google tage snippet into a partial. This matches the way this was done in all the other publishing apps owned by the publishing experience team.

Google Tag Manager (GTM) can be included on all pages of the app by configuring the following environment variables:

GOOGLE_TAG_MANAGER_ID
GOOGLE_TAG_MANAGER_AUTH
GOOGLE_TAG_MANAGER_PREVIEW
All three variables are optional.

If none are set, GTM will not be included on the page.

If only GOOGLE_TAG_MANAGER_ID is set, the default environment of the GTM container will be used.

If GOOGLE_TAG_MANAGER_AUTH and GOOGLE_TAG_MANAGER_PREVIEW are set, the specified GTM container environment will be used. This is used for managing the rollout of changes to integration so they can be tested before rolling out to production.

Trello card: https://trello.com/c/Wcuq3R1S/2167-add-ga4-page-view-tracking-to-apps-that-we-own
