### PR TITLE
Upgrade accessible autocomplete multiselect to latest version

### DIFF
--- a/yarn.lock
+++ b/yarn.lock
@@ -136,8 +136,8 @@ accepts@~1.3.8:
     negotiator "0.6.3"
 
 accessible-autocomplete@alphagov/accessible-autocomplete-multiselect:
-  version "1.6.2"
-  resolved "https://codeload.github.com/alphagov/accessible-autocomplete-multiselect/tar.gz/62b3992f9d3f2da6c7ea5bc0e302b9e453234271"
+  version "2.0.4"
+  resolved "https://codeload.github.com/alphagov/accessible-autocomplete-multiselect/tar.gz/6b671690189f9a4b32940e60a7df781ed55d4dca"
   dependencies:
     preact "^8.3.1"
 


### PR DESCRIPTION
This will enable us to upgrade to Yarn 4
