### PR TITLE
Attempt to fix the Google Analytics

### DIFF
--- a/app/views/layouts/_google_tag_manager.html.erb
+++ b/app/views/layouts/_google_tag_manager.html.erb
@@ -1,7 +1,9 @@
 <% if ENV["GOOGLE_TAG_MANAGER_ID"] %>
-  <%= render "govuk_publishing_components/components/google_tag_manager_script", {
-    gtm_id: ENV["GOOGLE_TAG_MANAGER_ID"],
-    gtm_auth: ENV["GOOGLE_TAG_MANAGER_AUTH"],
-    gtm_preview: ENV["GOOGLE_TAG_MANAGER_PREVIEW"]
-  } %>
+  <% content_for :head do %>
+    <%= render "govuk_publishing_components/components/google_tag_manager_script", {
+      gtm_id: ENV["GOOGLE_TAG_MANAGER_ID"],
+      gtm_auth: ENV["GOOGLE_TAG_MANAGER_AUTH"],
+      gtm_preview: ENV["GOOGLE_TAG_MANAGER_PREVIEW"],
+    } %>
+  <% end %>
 <% end %>

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -13,10 +13,9 @@
     dataLayer.push({ 'gtm.blacklist': ['html', 'customScripts', 'nonGoogleScripts', 'customPixels'] });
   </script>
 
-<% render "layouts/google_tag_manager" %>
-
   <meta name="app-environment" content="<%= Rails.env %>">
 <% end %>
+<% render "layouts/google_tag_manager" %>
 
 <%= render 'govuk_publishing_components/components/layout_for_admin',
   environment: GovukPublishingComponents::AppHelpers::Environment.current_acceptance_environment,


### PR DESCRIPTION
Making Content Publisher consistent with a few other publishing apps by rendering the partial outside `content_for` method. Assumption is that problems might have been caused by having partials rendered inside a method block which might not work as expected? Testing in integration

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

Follow [these steps](https://guides.rubyonrails.org/upgrading_ruby_on_rails.html) if you are doing a Rails upgrade.
