### PR TITLE
Update feedback link for content publisher

### DIFF
--- a/app/views/layouts/_phase_banner_elements.html.erb
+++ b/app/views/layouts/_phase_banner_elements.html.erb
@@ -7,7 +7,7 @@
 </span>
 <span class="gem-c-phase-banner__banner-item">
   <a class="govuk-link govuk-link--no-visited-state"
-     href="https://support.publishing.service.gov.uk/content_publisher_feedback_request/new"
+     href="https://support.publishing.service.gov.uk/general_request/new"
      target="_blank"
      rel="noopener"
      data-gtm="send-feedback">Send us feedback</a>

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -27,7 +27,7 @@
     navigation_items = [
       { text: "Switch app", href: Plek.external_url_for("signon") },
       { text: "Raise a support request", href: "https://support.publishing.service.gov.uk/technical_fault_report/new", show_only_in_collapsed_menu: true },
-      { text: "Send us feedback", href: "https://support.publishing.service.gov.uk/content_publisher_feedback_request/new", show_only_in_collapsed_menu: true },
+      { text: "Send us feedback", href: "https://support.publishing.service.gov.uk/general_request/new", show_only_in_collapsed_menu: true },
       { text: "What’s new", href: publisher_updates_path, show_only_in_collapsed_menu: true },
       { text: "Request training", href: request_training_path, show_only_in_collapsed_menu: true },
     ]
@@ -116,7 +116,7 @@
             attributes: { target: "_blank", "data-gtm": "footer-raise-support-request" }
           },
           {
-            href: "https://support.publishing.service.gov.uk/content_publisher_feedback_request/new",
+            href: "https://support.publishing.service.gov.uk/general_request/new",
             text: "Send us feedback",
             attributes: { target: "_blank", "data-gtm": "footer-send-feedback" }
 

--- a/config/locales/en/publisher_information.yml
+++ b/config/locales/en/publisher_information.yml
@@ -4,6 +4,6 @@ en:
       ---
 
       ## Request a feature
-      You can help us prioritise features by [sending us feedback](https://support.publishing.service.gov.uk/content_publisher_feedback_request/new).
+      You can help us prioritise features by [sending us feedback](https://support.publishing.service.gov.uk/general_request/new).
 
       You can also talk to us and other Beta users on the [Content Publisher Basecamp forum](https://basecamp.com/2308334/projects/15740446).


### PR DESCRIPTION
Content publisher no longer has it's own feedback form, following https://github.com/alphagov/support/pull/1354 so these links were going to 404 pages.

This updates the links to use the General feedback form, which is intended to be used for issues that don't fit into other categories. We probably don't get much feedback through this route, but broken links look bad. So let's fix 'em.

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️
