### PR TITLE
Remove feedback form links from Content Publisher

### DIFF
--- a/app/views/layouts/_phase_banner_elements.html.erb
+++ b/app/views/layouts/_phase_banner_elements.html.erb
@@ -7,13 +7,6 @@
 </span>
 <span class="gem-c-phase-banner__banner-item">
   <a class="govuk-link govuk-link--no-visited-state"
-     href="https://support.publishing.service.gov.uk/general_request/new"
-     target="_blank"
-     rel="noopener"
-     data-gtm="send-feedback">Send us feedback</a>
-</span>
-<span class="gem-c-phase-banner__banner-item">
-  <a class="govuk-link govuk-link--no-visited-state"
      href="<%= publisher_updates_path %>"
      data-gtm="view-whats-new">What’s new</a>
 </span>

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -27,7 +27,6 @@
     navigation_items = [
       { text: "Switch app", href: Plek.external_url_for("signon") },
       { text: "Raise a support request", href: "https://support.publishing.service.gov.uk/technical_fault_report/new", show_only_in_collapsed_menu: true },
-      { text: "Send us feedback", href: "https://support.publishing.service.gov.uk/general_request/new", show_only_in_collapsed_menu: true },
       { text: "What’s new", href: publisher_updates_path, show_only_in_collapsed_menu: true },
       { text: "Request training", href: request_training_path, show_only_in_collapsed_menu: true },
     ]
@@ -114,12 +113,6 @@
             href: "https://support.publishing.service.gov.uk/technical_fault_report/new",
             text: "Raise a support request",
             attributes: { target: "_blank", "data-gtm": "footer-raise-support-request" }
-          },
-          {
-            href: "https://support.publishing.service.gov.uk/general_request/new",
-            text: "Send us feedback",
-            attributes: { target: "_blank", "data-gtm": "footer-send-feedback" }
-
           },
           {
             href: "https://status.publishing.service.gov.uk",

--- a/app/views/publisher_information/beta_capabilities.html.erb
+++ b/app/views/publisher_information/beta_capabilities.html.erb
@@ -4,6 +4,5 @@
   <div class="govuk-grid-column-two-thirds">
     <h1 class='govuk-heading-l'><%= t("publisher_information.beta_capabilities.title") %></h1>
     <%= render_govspeak(t("publisher_information.beta_capabilities.body_govspeak")) %>
-    <%= render_govspeak(t("publisher_information.request_feature_govspeak")) %>
   </div>
 </div>

--- a/app/views/publisher_information/how_to_use_publisher.html.erb
+++ b/app/views/publisher_information/how_to_use_publisher.html.erb
@@ -5,6 +5,5 @@
     <h1 class="govuk-heading-l"><%= t("publisher_information.how_to_use_publisher.title") %></h1>
 
     <%= render_govspeak(t("publisher_information.how_to_use_publisher.body_govspeak")) %>
-    <%= render_govspeak(t("publisher_information.request_feature_govspeak")) %>
   </div>
 </div>

--- a/app/views/publisher_information/publisher_updates.html.erb
+++ b/app/views/publisher_information/publisher_updates.html.erb
@@ -7,7 +7,5 @@
 
     <h2 class="govuk-heading-m govuk-visually-hidden"><%= t("publisher_information.publisher_updates.updates_heading") %></h2>
     <%= render_govspeak(t("publisher_information.publisher_updates.body_govspeak")) %>
-
-    <%= render_govspeak(t("publisher_information.request_feature_govspeak")) %>
   </div>
 </div>

--- a/config/locales/en/publisher_information.yml
+++ b/config/locales/en/publisher_information.yml
@@ -1,9 +1,0 @@
-en:
-  publisher_information:
-    request_feature_govspeak: |
-      ---
-
-      ## Request a feature
-      You can help us prioritise features by [sending us feedback](https://support.publishing.service.gov.uk/general_request/new).
-
-      You can also talk to us and other Beta users on the [Content Publisher Basecamp forum](https://basecamp.com/2308334/projects/15740446).


### PR DESCRIPTION
In https://github.com/alphagov/support/pull/1354, the Content Publisher specific feedback form was removed, and in #3138 the form link was updated to point to the General support form (not specifically designed for feedback).

Content Publisher is no longer actively maintained and it is [destined for archival](https://github.com/alphagov/govuk-rfcs/blob/main/rfc-161-technical-direction-in-publishing-2023.md) at some point. We are therefore not open to feedback requests and should not be pretending we are - so this commit removes references to giving feedback.

Users can still report technical problems via the linked "Raise a support request" technical fault form.

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

Follow [these steps](https://guides.rubyonrails.org/upgrading_ruby_on_rails.html) if you are doing a Rails upgrade.
