### PR TITLE
Fix footer links

### DIFF
--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -125,7 +125,7 @@
             attributes: { "data-gtm": "footer-content-publishing-guidance" }
           },
           {
-            href: guidance_path,
+            href: "#{Plek.external_url_for('content-publisher')}#{guidance_path}",
             text: "What to publish on GOV.UK",
             attributes: { "data-gtm": "footer-what-to-publish"}
           }
@@ -135,27 +135,27 @@
         title: t("application.footer.documentation"),
         items: [
           {
-            href: how_to_use_publisher_path,
+            href: "#{Plek.external_url_for('content-publisher')}#{how_to_use_publisher_path}",
             text: "How to use Content Publisher",
             attributes: { "data-gtm": "footer-how-to-use-app" }
           },
           {
-            href: publisher_updates_path,
+            href: "#{Plek.external_url_for('content-publisher')}#{publisher_updates_path}",
             text: "What’s new in Content Publisher",
             attributes: { "data-gtm": "footer-view-whats-new" }
           },
           {
-            href: managing_editors_path,
+            href: "#{Plek.external_url_for('content-publisher')}#{managing_editors_path}",
             text: "What Managing Editors can do",
             attributes: { "data-gtm": "footer-what-managing-editors-can-do"}
           },
           {
-            href: beta_capabilities_path,
+            href: "#{Plek.external_url_for('content-publisher')}#{beta_capabilities_path}",
             text: "What the Beta can and cannot do",
             attributes: { "data-gtm": "footer-beta-capabilities" }
           },
           {
-            href: request_training_path,
+            href: "#{Plek.external_url_for('content-publisher')}#{request_training_path}",
             text: "Request Content Publisher training",
             attributes: { "data-gtm": "footer-beta-capabilities" }
           },


### PR DESCRIPTION
These footer links have been broken since version 37.1.1 of govuk_publishing_components, which automatically converts all footer links to absolute URLs, using `Plek.new.website_root`: https://github.com/alphagov/govuk_publishing_components/pull/3699

That corresponds to `https://www.gov.uk` on Production, but needs to be `https://content-publisher.publishing.service.gov.uk`.

No other publishing app passes custom links to the footer like Content Publisher does, so this appears to be the only app affected. With that in mind, the simplest fix is to specify the correct absolute URL rather than deferring to the component (as opposed to, say, changing the value of `Plek.new.website_root`, which may have unintended side-effects).

Tested in a Rails console on Production:

```
"#{Plek.external_url_for('content-publisher')}#{app.guidance_path}"
=> "https://content-publisher.publishing.service.gov.uk/documents/publishing-guidance"
```

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

Follow [these steps](https://guides.rubyonrails.org/upgrading_ruby_on_rails.html) if you are doing a Rails upgrade.
