### PR TITLE
Get tests to run locally

### DIFF
--- a/.github/workflows/rspec.yml
+++ b/.github/workflows/rspec.yml
@@ -65,6 +65,7 @@ jobs:
         env:
           RAILS_ENV: test
           GOVUK_CONTENT_SCHEMAS_PATH: vendor/publishing-api/content_schemas
+          GOVUK_HELM_CHARTS_PATH: vendor/govuk-helm-charts
           TEST_DATABASE_URL: ${{ steps.setup-postgres.outputs.db-url }}
         run: bundle exec rake spec
 

--- a/README.md
+++ b/README.md
@@ -29,6 +29,8 @@ To enable them for your GOV.UK account add them to your account in [Signon](http
 
 ### Running the test suite
 
+**Note:** You will need to checkout `govuk-helm-charts` into your `govuk` repository in order to have local tests passing. 
+
 ```
 bundle exec rake
 ```

--- a/spec/db/scrub_access_limited_spec.rb
+++ b/spec/db/scrub_access_limited_spec.rb
@@ -1,6 +1,7 @@
 RSpec.describe "Scrub Access Limited SQL Script" do
   def execute_sql
-    sql = File.read(Rails.root.join("vendor/govuk-helm-charts/charts/db-backup/scripts/content-publisher.sql"))
+    helm_charts_path = ENV.fetch("GOVUK_HELM_CHARTS_PATH", "../govuk-helm-charts")
+    sql = File.read(Rails.root.join("#{helm_charts_path}/charts/db-backup/scripts/content-publisher.sql"))
     ActiveRecord::Base.connection.execute(sql)
   end
 


### PR DESCRIPTION
The Github pipelines are checking out helm charts, whereas it is not doing so locally, so tests are failing locally.
 
Changing the test to look at a relative path version of helm-charts so it passes both locally and in CI. Unfortunately this means that we are tied to having the helm charts repo checked out to get it passing locally.

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

Follow [these steps](https://guides.rubyonrails.org/upgrading_ruby_on_rails.html) if you are doing a Rails upgrade.
