### PR TITLE
Deprecate Content Publisher

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -4,7 +4,9 @@ updates:
     directory: /
     schedule:
       interval: daily
+    open-pull-requests-limit: 0
   - package-ecosystem: npm
     directory: /
     schedule:
       interval: daily
+    open-pull-requests-limit: 0

--- a/README.md
+++ b/README.md
@@ -1,4 +1,8 @@
-# Content Publisher
+# Content Publisher (DEPRECATED)
+
+> **NOTE**: This project is deprecated and is [planned to be retired](https://github.com/alphagov/govuk-rfcs/blob/main/rfc-161-technical-direction-in-publishing-2023.md).
+
+---
 
 A unified publishing application for content on GOV.UK
 


### PR DESCRIPTION
We're going to reduce the amount of time we spend maintaining this app. See commits for details.

Trello 1: https://trello.com/c/kpf7rWEq/2979-change-dependabot-configs-for-content-publisher-and-maslow
Trello 2: https://trello.com/c/SfO3TzQ3/3017-add-deprecated-notice-to-the-readmes-of-content-publisher-and-maslow

---

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

Follow [these steps](https://guides.rubyonrails.org/upgrading_ruby_on_rails.html) if you are doing a Rails upgrade.
