### PR TITLE
Pin ubuntu version in rspec workflow

### DIFF
--- a/.github/workflows/rspec.yml
+++ b/.github/workflows/rspec.yml
@@ -16,7 +16,7 @@ on:
 jobs:
   run-rspec:
     name: Run RSpec
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     steps:
       - name: Setup Postgres
         id: setup-postgres


### PR DESCRIPTION
The CI was failing due to ubuntu latest now being ubuntu-24.04, which does not have the ImageMagick library installed.

