### PR TITLE
Upgrade govuk_publishing_components to v49.0.0

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -206,10 +206,11 @@ GEM
     govuk_personalisation (1.0.0)
       plek (>= 1.9.0)
       rails (>= 6, < 8)
-    govuk_publishing_components (43.3.0)
+    govuk_publishing_components (49.0.0)
       govuk_app_config
       govuk_personalisation (>= 0.7.0)
       kramdown
+      ostruct
       plek
       rails (>= 6)
       rouge
@@ -548,6 +549,7 @@ GEM
       opentelemetry-semantic_conventions
     opentelemetry-semantic_conventions (1.10.1)
       opentelemetry-api (~> 1.0)
+    ostruct (0.6.1)
     parallel (1.26.3)
     parser (3.3.5.0)
       ast (~> 2.4.1)
@@ -822,4 +824,4 @@ DEPENDENCIES
   with_advisory_lock
 
 BUNDLED WITH
-   2.3.23
+   2.4.19

--- a/app/views/file_attachments/_file_attachment.html.erb
+++ b/app/views/file_attachments/_file_attachment.html.erb
@@ -42,7 +42,7 @@
 <%= render "components/media_with_actions", actions: actions do %>
   <%= render "govuk_publishing_components/components/attachment", {
     attachment: file_attachment_attributes(attachment, edition),
-    data_attributes: {
+    url_data_attributes: {
       gtm: "preview-attachment-block"
     },
     hide_opendocument_metadata: true,

--- a/app/views/file_attachments/show.html.erb
+++ b/app/views/file_attachments/show.html.erb
@@ -7,7 +7,7 @@
     <%= render "govuk_publishing_components/components/attachment", {
       attachment: file_attachment_attributes(@attachment, @edition),
       target: "_blank",
-      data_attributes: {
+      url_data_attributes: {
         gtm: "preview-attachment-block"
       }
     } %>
@@ -43,7 +43,7 @@
       <%= render "govuk_publishing_components/components/attachment_link", {
         attachment: file_attachment_attributes(@attachment, @edition),
         target: "_blank",
-        data_attributes: { gtm: "preview-attachment-link" }
+        url_data_attributes: { gtm: "preview-attachment-link" }
       } %>
     </div>
     <% if rendering_context == "modal" %>


### PR DESCRIPTION
## What / Why
- Upgrades `govuk_publishing_components` to `v49.0.0`
- Changes `data_attributes` to `url_data_attributes` due to https://github.com/alphagov/govuk_publishing_components/pull/4545 and https://github.com/alphagov/govuk_publishing_components/pull/4549