### PR TITLE
Change rendering app for news_article to Frontend

### DIFF
--- a/config/document_types.yml
+++ b/config/document_types.yml
@@ -5,7 +5,7 @@ news_article: &news_article
   attachments: inline_file_only
   publishing_metadata:
     schema_name: news_article
-    rendering_app: government-frontend
+    rendering_app: frontend
   contents:
     - title_and_base_path
     - summary
@@ -76,10 +76,10 @@ document_types:
   - id: notice
     <<: *publication
     label: Notice
-        
+
   - id: guidance
     <<: *publication
-    label: Non statutory guidance  
+    label: Non statutory guidance
 
   - id: policy_paper
     <<: *publication


### PR DESCRIPTION
- this affects news_story and press_release
- 
https://trello.com/c/6qhFX0hH/524-move-newsarticle-from-government-frontend-to-frontend

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

Follow [these steps](https://guides.rubyonrails.org/upgrading_ruby_on_rails.html) if you are doing a Rails upgrade.
